### PR TITLE
feat: configure two-source bootstrap queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
 # Muyan Pilot
 
-最小 bootstrap：从 `xqliu/muyan-ceo` 领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR。
+最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR。
 
 ## 当前运行
 
 ```bash
-/usr/bin/python3 bootstrap_runner.py
+/usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
 前置条件：
 
 - `gh auth status` 成功；
 - `pi --version` 成功；
-- 当前目录是一个已初始化并有 remote 的 Git 仓库；
-- `prompt.md` 存在。
+- 配置文件存在且包含 `source_repos`；
+- 配置中的 repo、workspace、prompt 和 context 路径正确。
+
+配置使用 TOML，由人维护，AI 通过 PR 修改：
+
+```toml
+source_repos = ["owner/pilot", "owner/backlog"]
+repo_dir = "."
+workspace_root = ".."
+prompt = "prompt.md"
+timeout = 1800
+skills = []
+context_files = []
+```
 
 bootstrap 是一次处理一个 Issue 的临时入口。它成功后由 Pi 自己开发持续 daemon；不在这里提前加入队列、数据库、重试或复杂恢复。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -11,31 +11,92 @@ import argparse
 import json
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
+import tomllib
 from pathlib import Path
 
 
-DEFAULT_SOURCE_REPO = "xqliu/muyan-ceo"
-DEFAULT_REPO_DIR = Path("/home/xqianliu/Documents/muyan/muyan-pilot")
-DEFAULT_PROMPT = Path(__file__).with_name("prompt.md")
 COMMAND_TIMEOUT = 1800
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
 
 
+def _config_path(value: str, base: Path) -> Path:
+    path = Path(os.path.expandvars(os.path.expanduser(value)))
+    return (path if path.is_absolute() else base / path).resolve()
+
+
+def load_config(path: Path) -> dict:
+    """Load the human-maintained TOML config and resolve its paths."""
+    base = path.resolve().parent
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    source_repos = data.get("source_repos")
+    if not isinstance(source_repos, list) or not source_repos:
+        raise ValueError("source_repos must be a non-empty list")
+    if not all(isinstance(repo, str) and repo for repo in source_repos):
+        raise ValueError("source_repos must contain non-empty strings")
+    return {
+        "source_repos": source_repos,
+        "repo_dir": _config_path(data.get("repo_dir", "."), base),
+        "workspace_root": _config_path(data.get("workspace_root", ".."), base),
+        "prompt": _config_path(data.get("prompt", "prompt.md"), base),
+        "timeout": int(data.get("timeout", COMMAND_TIMEOUT)),
+        "skills": [_config_path(item, base) for item in data.get("skills", [])],
+        "context_files": [
+            _config_path(item, base) for item in data.get("context_files", [])
+        ],
+    }
+
+
+def render_prompt(template: str, values: dict[str, str]) -> str:
+    rendered = template
+    for key, value in values.items():
+        rendered = rendered.replace("{{" + key + "}}", value)
+    return rendered
+
+
+def validate_config(config: dict) -> None:
+    if not config["repo_dir"].is_dir():
+        raise FileNotFoundError(config["repo_dir"])
+    for path in [config["prompt"], *config["skills"], *config["context_files"]]:
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+
 def run_command(command: list[str], *, cwd: Path | None = None,
-                timeout: int = COMMAND_TIMEOUT) -> str:
+                timeout: int = COMMAND_TIMEOUT,
+                log_command: list[str] | None = None) -> str:
     """Run one external command; log context and fail fast on any error."""
-    LOGGER.info("command=%s cwd=%s", " ".join(command), cwd or Path.cwd())
-    result = subprocess.run(
-        command,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=timeout,
+    LOGGER.info(
+        "command=%s cwd=%s",
+        " ".join(log_command or command), cwd or Path.cwd(),
     )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as exc:
+        LOGGER.error(
+            "command_failed returncode=%s stdout=%s stderr=%s",
+            exc.returncode, (exc.stdout or "").rstrip(),
+            (exc.stderr or "").rstrip(),
+        )
+        raise
+    except subprocess.TimeoutExpired as exc:
+        LOGGER.error(
+            "command_timeout timeout=%s stdout=%s stderr=%s",
+            timeout, (exc.stdout or "").rstrip(),
+            (exc.stderr or "").rstrip(),
+        )
+        raise
+    except OSError as exc:
+        LOGGER.error("command_spawn_failed error=%s", exc)
+        raise
     if result.stderr:
         LOGGER.info("stderr=%s", result.stderr.rstrip())
     return result.stdout.strip()
@@ -57,6 +118,15 @@ def pick_issue(repo: str) -> dict | None:
         "--json", "number,title,body", "--limit", "1",
     ])
     return parse_issue_list(raw)
+
+
+def pick_next_issue(repos: list[str]) -> tuple[str, dict] | None:
+    """Scan sources in order; return the first ready issue and its source."""
+    for repo in repos:
+        issue = pick_issue(repo)
+        if issue is not None:
+            return repo, issue
+    return None
 
 
 def edit_issue(number: int, *, repo: str, add: str | None = None,
@@ -89,19 +159,41 @@ def create_worktree(repo_dir: Path, number: int) -> Path:
     return path
 
 
-def run_pi(issue: dict, worktree: Path, prompt_path: Path, *,
+def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str, *,
            timeout: int = COMMAND_TIMEOUT) -> str:
-    system_prompt = prompt_path.read_text(encoding="utf-8")
+    system_prompt = render_prompt(
+        config["prompt"].read_text(encoding="utf-8"),
+        {
+            "SOURCE_REPO": source_repo,
+            "SOURCE_REPOS": ", ".join(config["source_repos"]),
+            "ISSUE_NUMBER": str(issue["number"]),
+            "ISSUE_TITLE": issue["title"],
+            "ISSUE_BODY": issue.get("body", ""),
+            "WORKSPACE_ROOT": str(config["workspace_root"]),
+            "CONTEXT_FILES": "\n".join(str(path) for path in config["context_files"]),
+            "SKILLS": "\n".join(str(path) for path in config["skills"]),
+        },
+    )
     context = (
         f"Issue #{issue['number']}: {issue['title']}\n\n"
         f"Issue body:\n{issue.get('body', '')}\n\n"
         f"Worktree: {worktree}\n"
         "Complete the delivery process in the system prompt."
     )
-    return run_command([
-        "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
-        "--system-prompt", system_prompt, context,
-    ], cwd=worktree, timeout=timeout)
+    skill_args = [item for skill in config["skills"] for item in ("--skill", str(skill))]
+    command = [
+        "pi", *skill_args, "--print", "--session-dir",
+        str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
+    ]
+    return run_command(
+        command,
+        cwd=worktree,
+        timeout=timeout,
+        log_command=[
+            "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
+            "--system-prompt", "<redacted>", "<issue-context-redacted>",
+        ],
+    )
 
 
 def verify_pr(worktree: Path, branch: str) -> str:
@@ -125,14 +217,13 @@ def verify_pr(worktree: Path, branch: str) -> str:
     return url
 
 
-def process_issue(issue: dict, repo_dir: Path, prompt_path: Path,
-                  source_repo: str, *, timeout: int = COMMAND_TIMEOUT) -> str:
+def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     branch = f"muyan-pilot/issue-{number}"
     edit_issue(number, repo=source_repo, add="ai-in-progress")
     try:
-        worktree = create_worktree(repo_dir, number)
-        run_pi(issue, worktree, prompt_path, timeout=timeout)
+        worktree = create_worktree(config["repo_dir"], number)
+        run_pi(issue, worktree, config, source_repo, timeout=config["timeout"])
         pr_url = verify_pr(worktree, branch)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
@@ -145,36 +236,37 @@ def process_issue(issue: dict, repo_dir: Path, prompt_path: Path,
         return pr_url
     except Exception as exc:
         LOGGER.exception("issue=%s failed", number)
-        edit_issue(
-            number, repo=source_repo, add="ai-blocked",
-            remove="ai-in-progress",
-        )
-        comment_issue(
-            number, repo=source_repo,
-            body=f"Muyan Pilot failed: {exc}",
-        )
+        try:
+            edit_issue(
+                number, repo=source_repo, add="ai-blocked",
+                remove="ai-in-progress",
+            )
+            comment_issue(
+                number, repo=source_repo,
+                body=f"Muyan Pilot failed: {exc}",
+            )
+        except Exception:
+            LOGGER.exception("issue=%s failure reporting failed", number)
         raise
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo-dir", type=Path, default=DEFAULT_REPO_DIR)
-    parser.add_argument("--prompt", type=Path, default=DEFAULT_PROMPT)
-    parser.add_argument("--source-repo", default=DEFAULT_SOURCE_REPO)
-    parser.add_argument("--timeout", type=int, default=COMMAND_TIMEOUT)
+    parser.add_argument(
+        "--config", type=Path,
+        default=Path(os.environ.get("MUYAN_PILOT_CONFIG", "muyan-pilot.toml")),
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-    issue = pick_issue(args.source_repo)
-    if issue is None:
-        LOGGER.info("source_repo=%s outcome=no_ready_issue", args.source_repo)
+    config = load_config(args.config)
+    validate_config(config)
+    selected = pick_next_issue(config["source_repos"])
+    if selected is None:
+        LOGGER.info("source_repos=%s outcome=no_ready_issue", config["source_repos"])
         return 0
-    if not args.prompt.is_file():
-        raise FileNotFoundError(args.prompt)
-    process_issue(
-        issue, args.repo_dir, args.prompt, args.source_repo,
-        timeout=args.timeout,
-    )
+    source_repo, issue = selected
+    process_issue(issue, config, source_repo)
     return 0
 
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -144,15 +144,20 @@ def comment_issue(number: int, *, repo: str, body: str) -> None:
                  "--body", body])
 
 
-def worktree_path(number: int) -> Path:
-    return Path(tempfile.gettempdir()) / f"muyan-pilot-issue-{number}"
+def task_branch(source_repo: str, number: int) -> str:
+    return f"muyan-pilot/{source_repo.replace('/', '-')}-issue-{number}"
 
 
-def create_worktree(repo_dir: Path, number: int) -> Path:
-    path = worktree_path(number)
+def worktree_path(source_repo: str, number: int) -> Path:
+    slug = source_repo.replace("/", "-")
+    return Path(tempfile.gettempdir()) / f"muyan-pilot-{slug}-issue-{number}"
+
+
+def create_worktree(repo_dir: Path, source_repo: str, number: int) -> Path:
+    path = worktree_path(source_repo, number)
     if path.exists():
         raise RuntimeError(f"worktree path already exists: {path}")
-    branch = f"muyan-pilot/issue-{number}"
+    branch = task_branch(source_repo, number)
     run_command([
         "git", "worktree", "add", "-b", branch, str(path), "HEAD",
     ], cwd=repo_dir)
@@ -219,10 +224,10 @@ def verify_pr(worktree: Path, branch: str) -> str:
 
 def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
-    branch = f"muyan-pilot/issue-{number}"
+    branch = task_branch(source_repo, number)
     edit_issue(number, repo=source_repo, add="ai-in-progress")
     try:
-        worktree = create_worktree(config["repo_dir"], number)
+        worktree = create_worktree(config["repo_dir"], source_repo, number)
         run_pi(issue, worktree, config, source_repo, timeout=config["timeout"])
         pr_url = verify_pr(worktree, branch)
         edit_issue(

--- a/muyan-pilot.toml
+++ b/muyan-pilot.toml
@@ -1,0 +1,19 @@
+source_repos = [
+  "xqliu/muyan-pilot",
+  "xqliu/muyan-ceo",
+]
+
+repo_dir = "."
+workspace_root = ".."
+prompt = "prompt.md"
+timeout = 1800
+
+skills = [
+  "~/.agents/skills/tdd-dev/SKILL.md",
+  "~/Documents/agent-skills/skills/code-review/SKILL.md",
+  "~/Documents/agent-skills/skills/review-fix-loop/SKILL.md",
+]
+
+context_files = [
+  "../muyan-ceo/MUYAN-PILOT-CONTEXT.md",
+]

--- a/prompt.md
+++ b/prompt.md
@@ -1,10 +1,30 @@
 # Muyan Pilot Bootstrap Agent
 
-You are the software delivery agent for Muyan.
+You are the software delivery agent for the configured project.
+
+Runtime context supplied by the runner:
+
+- Source repository: `{{SOURCE_REPO}}`
+- All source repositories: `{{SOURCE_REPOS}}`
+- Workspace root: `{{WORKSPACE_ROOT}}`
+- Context files to read first:
+  `{{CONTEXT_FILES}}`
+- Skills configured for this run:
+  `{{SKILLS}}`
+
+Read every configured context file, the target repository's `AGENTS.md`,
+README, build files, tests, and relevant history before changing code.
+
+This project is intentionally an MVP. Do not invent a task platform, database,
+queue framework, policy engine, risk model, multi-agent DAG, or fallback path.
+Use the existing GitHub Issue task pool and fail fast with useful logs.
+
+Use the configured skills for implementation. Use TDD, 100% line and branch coverage for Python code,
+then perform the complete review-fix loop before declaring the PR ready.
 
 Work through this exact loop:
 
-1. Read the GitHub Issue and inspect the relevant repository under `/home/xqianliu/Documents/muyan`.
+1. Read the GitHub Issue and inspect the relevant repository under the configured workspace root. The runner supplies the source repository and its context.
 2. Write `plan.md` with the goal, inspected context, repository decision, tasks, and verification commands.
 3. Implement the smallest complete change.
 4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -220,26 +220,31 @@ def test_edit_issue_allows_no_label_change(monkeypatch):
 def test_create_worktree_rejects_existing_path(monkeypatch, tmp_path):
     existing = tmp_path / "issue-3"
     existing.mkdir()
-    monkeypatch.setattr(runner, "worktree_path", lambda number: existing)
+    monkeypatch.setattr(runner, "worktree_path", lambda repo, number: existing)
     with pytest.raises(RuntimeError, match="worktree path already exists"):
-        runner.create_worktree(tmp_path, 3)
+        runner.create_worktree(tmp_path, "owner/repo", 3)
 
 
 def test_create_worktree_runs_git_add(monkeypatch, tmp_path):
     path = tmp_path / "issue-3"
-    monkeypatch.setattr(runner, "worktree_path", lambda number: path)
+    monkeypatch.setattr(runner, "worktree_path", lambda repo, number: path)
     calls = []
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)))
-    assert runner.create_worktree(tmp_path, 3) == path
+    assert runner.create_worktree(tmp_path, "owner/repo", 3) == path
     assert calls == [(
-        ["git", "worktree", "add", "-b", "muyan-pilot/issue-3", str(path), "HEAD"],
+        ["git", "worktree", "add", "-b", "muyan-pilot/owner-repo-issue-3", str(path), "HEAD"],
         {"cwd": tmp_path},
     )]
 
 
 def test_worktree_path_uses_temp_directory(monkeypatch):
     monkeypatch.setattr(runner.tempfile, "gettempdir", lambda: "/tmp")
-    assert runner.worktree_path(3) == Path("/tmp/muyan-pilot-issue-3")
+    assert runner.worktree_path("owner/repo", 3) == Path("/tmp/muyan-pilot-owner-repo-issue-3")
+
+
+def test_task_branch_includes_source_repo_to_avoid_same_number_collision():
+    assert runner.task_branch("owner/pilot", 1) == "muyan-pilot/owner-pilot-issue-1"
+    assert runner.task_branch("owner/pilot", 1) != runner.task_branch("owner/ceo", 1)
 
 
 def test_comment_issue_runs_gh_comment(monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -22,6 +22,83 @@ def test_parse_issue_list_rejects_non_list():
         runner.parse_issue_list("{}")
 
 
+def test_load_config_resolves_relative_paths_and_values(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        """source_repos = [\"owner/pilot\", \"owner/backlog\"]\nrepo_dir = \"repo\"\nworkspace_root = \"..\"\nprompt = \"prompt.md\"\ntimeout = 42\nskills = [\"skill.md\"]\ncontext_files = [\"context.md\"]\n""",
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["source_repos"] == ["owner/pilot", "owner/backlog"]
+    assert config["repo_dir"] == (tmp_path / "repo").resolve()
+    assert config["workspace_root"] == tmp_path.parent.resolve()
+    assert config["prompt"] == (tmp_path / "prompt.md").resolve()
+    assert config["timeout"] == 42
+    assert config["skills"] == [(tmp_path / "skill.md").resolve()]
+    assert config["context_files"] == [(tmp_path / "context.md").resolve()]
+
+
+def test_load_config_requires_source_repos(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text("timeout = 42\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="source_repos must be a non-empty list"):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_empty_source_repo_name(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo", ""]\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="source_repos must contain non-empty strings"):
+        runner.load_config(config_path)
+
+
+def test_render_prompt_replaces_context_values():
+    rendered = runner.render_prompt(
+        "{{SOURCE_REPO}} #{{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{CONTEXT_FILES}}",
+        {
+            "SOURCE_REPO": "owner/repo",
+            "ISSUE_NUMBER": "3",
+            "ISSUE_TITLE": "Fix",
+            "CONTEXT_FILES": "context.md",
+        },
+    )
+    assert rendered == "owner/repo #3 Fix context.md"
+
+
+def test_validate_config_accepts_existing_files(tmp_path):
+    prompt = tmp_path / "prompt.md"
+    skill = tmp_path / "skill.md"
+    context = tmp_path / "context.md"
+    for path in (prompt, skill, context):
+        path.write_text("ok", encoding="utf-8")
+    runner.validate_config({
+        "repo_dir": tmp_path,
+        "prompt": prompt,
+        "skills": [skill],
+        "context_files": [context],
+    })
+
+
+def test_validate_config_fails_before_issue_claim_when_path_missing(tmp_path):
+    with pytest.raises(FileNotFoundError, match="missing.md"):
+        runner.validate_config({
+            "repo_dir": tmp_path,
+            "prompt": tmp_path / "missing.md",
+            "skills": [],
+            "context_files": [],
+        })
+
+
+def test_validate_config_rejects_missing_repo_dir(tmp_path):
+    with pytest.raises(FileNotFoundError, match="missing-repo"):
+        runner.validate_config({
+            "repo_dir": tmp_path / "missing-repo",
+            "prompt": tmp_path / "prompt.md",
+            "skills": [],
+            "context_files": [],
+        })
+
+
 def test_run_command_returns_stdout(monkeypatch, tmp_path):
     completed = Mock(stdout=" output \n", stderr="")
     monkeypatch.setattr(runner.subprocess, "run", Mock(return_value=completed))
@@ -41,6 +118,35 @@ def test_run_command_logs_stderr(monkeypatch, tmp_path, caplog):
     assert "stderr=warning" in caplog.text
 
 
+def test_run_command_logs_called_process_error_and_reraises(tmp_path, caplog):
+    error = subprocess.CalledProcessError(
+        2, ["gh", "issue", "list"], output="out", stderr="bad",
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(runner.subprocess, "run", Mock(side_effect=error))
+        with caplog.at_level("ERROR"), pytest.raises(subprocess.CalledProcessError):
+            runner.run_command(["gh", "issue", "list"], cwd=tmp_path)
+    assert "command_failed returncode=2 stdout=out stderr=bad" in caplog.text
+
+
+def test_run_command_logs_timeout_and_reraises(tmp_path, caplog):
+    error = subprocess.TimeoutExpired(["pi"], 4, output="partial", stderr="wait")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(runner.subprocess, "run", Mock(side_effect=error))
+        with caplog.at_level("ERROR"), pytest.raises(subprocess.TimeoutExpired):
+            runner.run_command(["pi"], cwd=tmp_path, timeout=4)
+    assert "command_timeout timeout=4 stdout=partial stderr=wait" in caplog.text
+
+
+def test_run_command_logs_spawn_error_and_reraises(tmp_path, caplog):
+    error = FileNotFoundError("pi")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(runner.subprocess, "run", Mock(side_effect=error))
+        with caplog.at_level("ERROR"), pytest.raises(FileNotFoundError):
+            runner.run_command(["pi"], cwd=tmp_path)
+    assert "command_spawn_failed error=pi" in caplog.text
+
+
 def test_pick_issue_uses_github_queue(monkeypatch):
     issue = {"number": 9, "title": "task", "body": "body"}
     calls = []
@@ -57,6 +163,41 @@ def test_pick_issue_uses_github_queue(monkeypatch):
         "label:ai-ready -label:ai-in-progress -label:ai-pr-opened -label:ai-blocked",
         "--json", "number,title,body", "--limit", "1",
     ]]
+
+
+def test_pick_next_issue_returns_first_ready_source(monkeypatch):
+    issue = {"number": 1, "title": "pilot", "body": ""}
+    calls = []
+
+    def pick(repo):
+        calls.append(repo)
+        return issue if repo == "xqliu/muyan-ceo" else None
+
+    monkeypatch.setattr(runner, "pick_issue", pick)
+    assert runner.pick_next_issue(["xqliu/muyan-ceo", "xqliu/muyan-pilot"]) == (
+        "xqliu/muyan-ceo", issue,
+    )
+    assert calls == ["xqliu/muyan-ceo"]
+
+
+def test_pick_next_issue_falls_through_to_second_source(monkeypatch):
+    issue = {"number": 2, "title": "pilot", "body": ""}
+    calls = []
+
+    def pick(repo):
+        calls.append(repo)
+        return issue if repo == "xqliu/muyan-pilot" else None
+
+    monkeypatch.setattr(runner, "pick_issue", pick)
+    assert runner.pick_next_issue(["xqliu/muyan-ceo", "xqliu/muyan-pilot"]) == (
+        "xqliu/muyan-pilot", issue,
+    )
+    assert calls == ["xqliu/muyan-ceo", "xqliu/muyan-pilot"]
+
+
+def test_pick_next_issue_returns_none_when_all_sources_empty(monkeypatch):
+    monkeypatch.setattr(runner, "pick_issue", lambda repo: None)
+    assert runner.pick_next_issue(["xqliu/muyan-ceo", "xqliu/muyan-pilot"]) is None
 
 
 def test_edit_issue_builds_add_and_remove_command(monkeypatch):
@@ -111,19 +252,52 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     ]]
 
 
-def test_run_pi_loads_prompt_and_invokes_pi(monkeypatch, tmp_path):
+def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
-    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    prompt_path.write_text(
+        "SYSTEM {{SOURCE_REPO}} {{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{ISSUE_BODY}} "
+        "{{WORKSPACE_ROOT}} {{CONTEXT_FILES}} {{SKILLS}}",
+        encoding="utf-8",
+    )
     calls = []
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
     issue = {"number": 4, "title": "Fix title", "body": "Fix body"}
-    assert runner.run_pi(issue, tmp_path, prompt_path, timeout=99) == "done"
+    config = {
+        "prompt": prompt_path,
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [tmp_path / "context.md"],
+        "skills": [tmp_path / "skill.md"],
+    }
+    assert runner.run_pi(issue, tmp_path, config, "owner/repo", timeout=99) == "done"
     command, kwargs = calls[0]
-    assert command[:5] == ["pi", "--print", "--session-dir", str(tmp_path / ".pi-session"), "--system-prompt"]
-    assert command[5] == "SYSTEM"
-    assert "Issue #4: Fix title" in command[6]
-    assert "Fix body" in command[6]
-    assert kwargs == {"cwd": tmp_path, "timeout": 99}
+    assert command[:4] == ["pi", "--skill", str(tmp_path / "skill.md"), "--print"]
+    assert "owner/repo" in command[7]
+    assert " 4 " in command[7]
+    assert "Fix title" in command[7]
+    assert "Fix body" in command[7]
+    assert str(tmp_path / "context.md") in command[7]
+    assert str(tmp_path / "skill.md") in command[7]
+    assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["timeout"] == 99
+    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+
+
+def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path):
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("PRIVATE SYSTEM {{ISSUE_BODY}}", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
+    runner.run_pi(
+        {"number": 5, "title": "secret", "body": "token"}, tmp_path,
+        {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
+        "owner/repo",
+    )
+    command, kwargs = calls[0]
+    assert "PRIVATE SYSTEM" in command[5]
+    assert "token" in command[5]
+    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
 
 
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
@@ -170,7 +344,8 @@ def test_process_issue_success(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     issue = {"number": 4, "title": "Fix", "body": "Body"}
-    assert runner.process_issue(issue, tmp_path, tmp_path / "prompt.md", "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "timeout": 10}
+    assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
     assert calls[1][0] == "edit"
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
@@ -183,27 +358,63 @@ def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     with pytest.raises(RuntimeError, match="git failed"):
-        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, tmp_path, tmp_path / "prompt.md", "xqliu/muyan-ceo")
+        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "timeout": 10}, "xqliu/muyan-ceo")
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
     assert calls[2][0] == "comment"
 
 
+def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
+    edit_calls = []
+
+    def edit(*args, **kwargs):
+        edit_calls.append(kwargs)
+        if len(edit_calls) == 2:
+            raise RuntimeError("github report failed")
+
+    monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
+        runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "timeout": 10}, "xqliu/muyan-ceo")
+    assert "failure reporting failed" in caplog.text
+
+
 def test_main_returns_zero_when_queue_empty(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: None)
-    assert runner.main(["--repo-dir", str(tmp_path), "--prompt", str(tmp_path / "prompt.md")]) == 0
+    monkeypatch.setattr(runner, "pick_next_issue", lambda repos: None)
+    config = tmp_path / "muyan-pilot.toml"
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
+    assert runner.main(["--config", str(config)]) == 0
 
 
 def test_main_processes_one_issue(monkeypatch, tmp_path):
     issue = {"number": 12, "title": "task", "body": "body"}
     calls = []
     (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: issue)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"owner/repo\"]\nprompt = \"prompt.md\"\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "pick_next_issue", lambda repos: ("xqliu/muyan-pilot", issue))
     monkeypatch.setattr(runner, "process_issue", lambda *args, **kwargs: calls.append((args, kwargs)) or "https://github.com/x/y/pull/12")
-    assert runner.main(["--repo-dir", str(tmp_path), "--prompt", str(tmp_path / "prompt.md")]) == 0
+    assert runner.main(["--config", str(config)]) == 0
     assert calls[0][0][0] == issue
 
 
+def test_main_accepts_repeated_source_repo(monkeypatch, tmp_path):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("prompt", encoding="utf-8")
+    seen = []
+    issue = {"number": 14, "title": "task"}
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "pick_next_issue", lambda repos: seen.append(repos) or (repos[0], issue))
+    monkeypatch.setattr(runner, "process_issue", lambda *args, **kwargs: "https://github.com/x/y/pull/14")
+    assert runner.main([
+        "--config", str(config),
+    ]) == 0
+    assert seen == [["xqliu/muyan-pilot", "xqliu/muyan-ceo"]]
+
+
 def test_main_requires_prompt_file(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: {"number": 1, "title": "task"})
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     with pytest.raises(FileNotFoundError):
-        runner.main(["--repo-dir", str(tmp_path), "--prompt", str(tmp_path / "missing.md")])
+        runner.main(["--config", str(config)])


### PR DESCRIPTION
Closes #1.

## What changed
- Read source repos, workspace, prompt, skills, context files, and timeout from TOML.
- Scan `xqliu/muyan-pilot` before `xqliu/muyan-ceo`.
- Inject configured context into the Pi prompt.
- Keep bootstrap fail-fast with command output logging.

## Verification
- `/usr/bin/python3 -m pytest -q tests/test_bootstrap_runner.py`
- 39 tests passed
- 100% line coverage
- 100% branch coverage
- No hardcoded local paths in code or prompt.