### PR TITLE
feat: schedule pilot ticks with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
+正常运行使用 systemd user timer，每 5 分钟自动执行一次：
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp systemd/muyan-pilot.service systemd/muyan-pilot.timer ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now muyan-pilot.timer
+systemctl --user list-timers muyan-pilot.timer
+```
+
+手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
+
 前置条件：
 
 - `gh auth status` 成功；
@@ -27,4 +39,4 @@ skills = []
 context_files = []
 ```
 
-bootstrap 是一次处理一个 Issue 的临时入口。它成功后由 Pi 自己开发持续 daemon；不在这里提前加入队列、数据库、重试或复杂恢复。
+Runner 每次处理一个 Issue 后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -65,7 +65,8 @@ def validate_config(config: dict) -> None:
 
 def run_command(command: list[str], *, cwd: Path | None = None,
                 timeout: int = COMMAND_TIMEOUT,
-                log_command: list[str] | None = None) -> str:
+                log_command: list[str] | None = None,
+                log_stdout: bool = False) -> str:
     """Run one external command; log context and fail fast on any error."""
     LOGGER.info(
         "command=%s cwd=%s",
@@ -99,6 +100,8 @@ def run_command(command: list[str], *, cwd: Path | None = None,
         raise
     if result.stderr:
         LOGGER.info("stderr=%s", result.stderr.rstrip())
+    if log_stdout and result.stdout:
+        LOGGER.info("stdout=%s", result.stdout.rstrip())
     return result.stdout.strip()
 
 
@@ -190,10 +193,15 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str, *,
         "pi", *skill_args, "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
+    LOGGER.info(
+        "pi_session=%s issue=%s source_repo=%s",
+        worktree / ".pi-session", issue["number"], source_repo,
+    )
     return run_command(
         command,
         cwd=worktree,
         timeout=timeout,
+        log_stdout=True,
         log_command=[
             "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
             "--system-prompt", "<redacted>", "<issue-context-redacted>",

--- a/prompt.md
+++ b/prompt.md
@@ -16,7 +16,7 @@ Read every configured context file, the target repository's `AGENTS.md`,
 README, build files, tests, and relevant history before changing code.
 
 This project is intentionally an MVP. Do not invent a task platform, database,
-queue framework, policy engine, risk model, multi-agent DAG, or fallback path.
+queue framework, policy engine, risk model, multi-agent DAG, daemon loop, or fallback path.
 Use the existing GitHub Issue task pool and fail fast with useful logs.
 
 Use the configured skills for implementation. Use TDD, 100% line and branch coverage for Python code,

--- a/systemd/muyan-pilot.service
+++ b/systemd/muyan-pilot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Muyan Pilot — process one ready GitHub Issue
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Documents/muyan/muyan-pilot
+Environment="PATH=%h/.npm-global/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="MUYAN_PILOT_CONFIG=%h/Documents/muyan/muyan-pilot/muyan-pilot.toml"
+TimeoutStartSec=1800
+ExecStart=/usr/bin/python3 %h/Documents/muyan/muyan-pilot/bootstrap_runner.py
+StandardOutput=journal
+StandardError=journal

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Muyan Pilot — poll both GitHub Issue sources
+
+[Timer]
+OnCalendar=*-*-* 01..06:00/5:00
+AccuracySec=30s
+Persistent=false
+Unit=muyan-pilot.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -118,6 +118,15 @@ def test_run_command_logs_stderr(monkeypatch, tmp_path, caplog):
     assert "stderr=warning" in caplog.text
 
 
+def test_run_command_can_log_success_stdout(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(
+        runner.subprocess, "run", Mock(return_value=Mock(stdout="agent output\n", stderr="")),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.run_command(["pi"], cwd=tmp_path, log_stdout=True) == "agent output"
+    assert "stdout=agent output" in caplog.text
+
+
 def test_run_command_logs_called_process_error_and_reraises(tmp_path, caplog):
     error = subprocess.CalledProcessError(
         2, ["gh", "issue", "list"], output="out", stderr="bad",
@@ -286,6 +295,7 @@ def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
     assert kwargs["timeout"] == 99
+    assert kwargs["log_stdout"] is True
     assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
 
 


### PR DESCRIPTION
Closes #2.

## What changed
- Run one bootstrap tick from a systemd user service.
- Schedule ticks every five minutes from 01:00 through 06:55 local time.
- Keep the Python runner one-shot; systemd owns scheduling.
- Log Pi session path and successful Agent output while retaining fail-fast errors.

## Verification
- 41 tests passed
- 100% line coverage
- 100% branch coverage
- `systemd-analyze calendar --iterations=3 "*-*-* 01..06:00/5:00"` verified the schedule.