### PR TITLE
fix: let pilot service run without systemd startup limit

### DIFF
--- a/systemd/muyan-pilot.service
+++ b/systemd/muyan-pilot.service
@@ -8,6 +8,8 @@ Type=simple
 WorkingDirectory=%h/Documents/muyan/muyan-pilot
 Environment="PATH=%h/.npm-global/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="MUYAN_PILOT_CONFIG=%h/Documents/muyan/muyan-pilot/muyan-pilot.toml"
+# Deployment adapter only: disable systemd's default startup kill limit.
+TimeoutStartSec=infinity
 ExecStart=/usr/bin/python3 %h/Documents/muyan/muyan-pilot/bootstrap_runner.py
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Closes #3.

The first automatic tick was killed by systemd's implicit default startup limit. Keep the Runner free of task timeouts and explicitly disable only the systemd default so Pi can run until it exits.

Verification: service unit syntax and existing 40-test 100% coverage suite.