### PR TITLE
fix: keep command timeout optional

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -62,6 +62,7 @@ def validate_config(config: dict) -> None:
 
 
 def run_command(command: list[str], *, cwd: Path | None = None,
+                timeout: int | None = None,
                 log_command: list[str] | None = None,
                 log_stdout: bool = False) -> str:
     """Run one external command; log context and fail fast on any error."""
@@ -76,11 +77,19 @@ def run_command(command: list[str], *, cwd: Path | None = None,
             capture_output=True,
             text=True,
             check=True,
+            timeout=timeout,
         )
     except subprocess.CalledProcessError as exc:
         LOGGER.error(
             "command_failed returncode=%s stdout=%s stderr=%s",
             exc.returncode, (exc.stdout or "").rstrip(),
+            (exc.stderr or "").rstrip(),
+        )
+        raise
+    except subprocess.TimeoutExpired as exc:
+        LOGGER.error(
+            "command_timeout timeout=%s stdout=%s stderr=%s",
+            timeout, (exc.stdout or "").rstrip(),
             (exc.stderr or "").rstrip(),
         )
         raise
@@ -156,7 +165,8 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int) -> Path:
     return path
 
 
-def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str) -> str:
+def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
+           timeout: int | None = None) -> str:
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -188,6 +198,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str) -> str:
     return run_command(
         command,
         cwd=worktree,
+        timeout=timeout,
         log_stdout=True,
         log_command=[
             "pi", "--print", "--session-dir", str(worktree / ".pi-session"),

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -104,7 +104,7 @@ def test_run_command_returns_stdout(monkeypatch, tmp_path):
     assert runner.run_command(["git", "status"], cwd=tmp_path) == "output"
     runner.subprocess.run.assert_called_once_with(
         ["git", "status"], cwd=tmp_path, capture_output=True,
-        text=True, check=True,
+        text=True, check=True, timeout=None,
     )
 
 
@@ -144,6 +144,15 @@ def test_run_command_logs_spawn_error_and_reraises(tmp_path, caplog):
         with caplog.at_level("ERROR"), pytest.raises(FileNotFoundError):
             runner.run_command(["pi"], cwd=tmp_path)
     assert "command_spawn_failed error=pi" in caplog.text
+
+
+def test_run_command_logs_optional_timeout_and_reraises(tmp_path, caplog):
+    error = subprocess.TimeoutExpired(["command"], 7, output="partial", stderr="wait")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(runner.subprocess, "run", Mock(side_effect=error))
+        with caplog.at_level("ERROR"), pytest.raises(subprocess.TimeoutExpired):
+            runner.run_command(["command"], cwd=tmp_path, timeout=7)
+    assert "command_timeout timeout=7 stdout=partial stderr=wait" in caplog.text
 
 
 def test_pick_issue_uses_github_queue(monkeypatch):
@@ -284,6 +293,7 @@ def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
     assert str(tmp_path / "skill.md") in command[7]
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
+    assert kwargs["timeout"] is None
     assert kwargs["log_stdout"] is True
     assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
 


### PR DESCRIPTION
Keep timeout handling only as an optional low-level command execution parameter.

The Pi task has no business timeout and the TOML config has no timeout field.

Verification: 41 tests passed, 100% line and branch coverage.