### PR TITLE
feat: add muyan-pilot add and status commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 .coverage
 htmlcov/
 .muyan-pilot/
+.pi-session/
 muyan-pilot.toml

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ systemctl --user list-timers muyan-pilot.timer
 
 手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
 
+## 任务派发与状态
+
+`muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
+
+```bash
+# 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
+python3 muyan_pilot.py add "任务标题" --body "任务描述" --config muyan-pilot.toml
+
+# 派发到指定 source repo（必须在配置 source_repos 中）
+python3 muyan_pilot.py add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
+
+# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和最近结果（ai-pr-opened / ai-blocked）
+python3 muyan_pilot.py status --config muyan-pilot.toml
+```
+
+`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
+
 前置条件：
 
 - `gh auth status` 成功；

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -103,11 +103,17 @@ def run_command(command: list[str], *, cwd: Path | None = None,
     return result.stdout.strip()
 
 
-def parse_issue_list(raw: str) -> dict | None:
-    """Return the first issue from gh's JSON array, or None when idle."""
+def parse_issue_array(raw: str) -> list[dict]:
+    """Return the issue array from gh's JSON output."""
     issues = json.loads(raw)
     if not isinstance(issues, list):
         raise ValueError("issue list must be a JSON array")
+    return issues
+
+
+def parse_issue_list(raw: str) -> dict | None:
+    """Return the first issue from gh's JSON array, or None when idle."""
+    issues = parse_issue_array(raw)
     return issues[0] if issues else None
 
 

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Muyan Pilot task dispatch and status CLI.
+
+`add` creates an Issue in a configured source repo and labels it `ai-ready`.
+`status` reports the current in-progress Issue, the next ready Issue, and the
+most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
+
+GitHub Issues and labels are the only state store. There is no database,
+queue, or web UI. Command failures are logged and raised by the reused
+bootstrap_runner.run_command; there is no fallback.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+
+from bootstrap_runner import (
+    load_config,
+    parse_issue_array,
+    run_command,
+    validate_config,
+)
+
+LOGGER = logging.getLogger("muyan_pilot.cli")
+
+ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
+READY_LABEL = "ai-ready"
+IN_PROGRESS_LABEL = "ai-in-progress"
+RESULT_LABELS = ("ai-pr-opened", "ai-blocked")
+
+
+def issue_number(url: str) -> int:
+    """Extract the Issue number from a GitHub Issue URL."""
+    match = ISSUE_URL_PATTERN.search(url)
+    if not match:
+        raise ValueError(f"no issue number in URL: {url}")
+    return int(match.group(1))
+
+
+def create_issue(repo: str, title: str, body: str) -> str:
+    """Create an Issue via gh and return its URL."""
+    return run_command([
+        "gh", "issue", "create", "--repo", repo,
+        "--title", title, "--body", body,
+    ])
+
+
+def dispatch_issue(repo: str, title: str, body: str) -> str:
+    """Create an Issue and mark it `ai-ready`; return the Issue URL."""
+    url = create_issue(repo, title, body)
+    run_command([
+        "gh", "issue", "edit", str(issue_number(url)), "--repo", repo,
+        "--add-label", READY_LABEL,
+    ])
+    return url
+
+
+def list_labeled_issues(repo: str, label: str, state: str = "open",
+                        search: str | None = None) -> list[dict]:
+    """Return the newest Issues matching a label search (gh lists newest first)."""
+    raw = run_command([
+        "gh", "issue", "list", "--repo", repo, "--state", state,
+        "--search", search or f"label:{label}",
+        "--json", "number,title,url,state", "--limit", "1",
+    ])
+    return parse_issue_array(raw)
+
+
+def current_issue(repo: str) -> dict | None:
+    issues = list_labeled_issues(repo, IN_PROGRESS_LABEL)
+    return issues[0] if issues else None
+
+
+def ready_issue(repo: str) -> dict | None:
+    issues = list_labeled_issues(
+        repo, READY_LABEL, search=f"label:{READY_LABEL} -label:{IN_PROGRESS_LABEL}",
+    )
+    return issues[0] if issues else None
+
+
+def recent_result(repo: str) -> dict | None:
+    """Return the newest `ai-pr-opened` or `ai-blocked` Issue, any state."""
+    newest = None
+    for label in RESULT_LABELS:
+        for issue in list_labeled_issues(repo, label, state="all"):
+            if newest is None or int(issue["number"]) > int(newest["number"]):
+                newest = issue
+    return newest
+
+
+def format_issue(issue: dict) -> str:
+    return f"#{issue['number']} {issue['title']} {issue['url']}"
+
+
+def status_report(config: dict) -> str:
+    lines = []
+    for repo in config["source_repos"]:
+        lines.append(f"source: {repo}")
+        for name, lookup in (
+            ("current", current_issue),
+            ("ready", ready_issue),
+            ("result", recent_result),
+        ):
+            issue = lookup(repo)
+            lines.append(f"  {name}: {format_issue(issue) if issue else '-'}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--config", type=Path,
+        default=Path(os.environ.get("MUYAN_PILOT_CONFIG", "muyan-pilot.toml")),
+    )
+    parser = argparse.ArgumentParser(description=__doc__, parents=[common])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_parser = subparsers.add_parser(
+        "add", parents=[common],
+        help="create an Issue in a source repo and add ai-ready",
+    )
+    add_parser.add_argument("title")
+    add_parser.add_argument("--body", default="")
+    add_parser.add_argument(
+        "--repo", default=None,
+        help="source repo (default: first configured source)",
+    )
+    subparsers.add_parser(
+        "status", parents=[common],
+        help="show current Issue, ready queue and recent result",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    config = load_config(args.config)
+    validate_config(config)
+    if args.command == "add":
+        repo = args.repo or config["source_repos"][0]
+        if repo not in config["source_repos"]:
+            parser.error(
+                f"--repo must be one of: {', '.join(config['source_repos'])}"
+            )
+        LOGGER.info("dispatch repo=%s title=%s", repo, args.title)
+        url = dispatch_issue(repo, args.title, args.body)
+        print(f"created: {url}")
+        print(f"label: {READY_LABEL}")
+    else:
+        print(status_report(config))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,0 +1,286 @@
+import json
+
+import pytest
+
+import bootstrap_runner as runner
+import muyan_pilot
+
+
+def test_issue_number_extracts_number_from_github_url():
+    assert muyan_pilot.issue_number(
+        "https://github.com/xqliu/muyan-pilot/issues/3"
+    ) == 3
+
+
+def test_issue_number_rejects_url_without_issue_number():
+    with pytest.raises(ValueError, match="no issue number"):
+        muyan_pilot.issue_number("https://github.com/xqliu/muyan-pilot")
+
+
+def test_create_issue_runs_gh_issue_create_and_returns_url(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    url = muyan_pilot.create_issue(
+        "xqliu/muyan-pilot", "New task", "Do it",
+    )
+    assert url == "https://github.com/xqliu/muyan-pilot/issues/13"
+    assert calls == [[
+        "gh", "issue", "create", "--repo", "xqliu/muyan-pilot",
+        "--title", "New task", "--body", "Do it",
+    ]]
+
+
+def test_dispatch_issue_creates_issue_and_adds_ai_ready(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    url = muyan_pilot.dispatch_issue("xqliu/muyan-pilot", "New task", "Do it")
+    assert url == "https://github.com/xqliu/muyan-pilot/issues/13"
+    assert calls == [
+        [
+            "gh", "issue", "create", "--repo", "xqliu/muyan-pilot",
+            "--title", "New task", "--body", "Do it",
+        ],
+        [
+            "gh", "issue", "edit", "13", "--repo", "xqliu/muyan-pilot",
+            "--add-label", "ai-ready",
+        ],
+    ]
+
+
+def test_dispatch_issue_propagates_create_failure(monkeypatch):
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            runner.subprocess.CalledProcessError(1, command, stderr="nope"),
+        ),
+    )
+    with pytest.raises(runner.subprocess.CalledProcessError):
+        muyan_pilot.dispatch_issue("xqliu/muyan-pilot", "t", "b")
+
+
+def test_list_labeled_issues_queries_github_with_label_and_state(monkeypatch):
+    issue = {"number": 3, "title": "task", "url": "u"}
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or json.dumps([issue]),
+    )
+    issues = muyan_pilot.list_labeled_issues(
+        "xqliu/muyan-pilot", "ai-in-progress", state="open",
+    )
+    assert issues == [issue]
+    assert calls == [[
+        "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
+        "--state", "open", "--search", "label:ai-in-progress",
+        "--json", "number,title,url,state", "--limit", "1",
+    ]]
+
+
+def test_list_labeled_issues_returns_empty_list_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: "[]")
+    assert muyan_pilot.list_labeled_issues("xqliu/muyan-pilot", "ai-ready") == []
+
+
+def test_current_issue_returns_first_in_progress_issue(monkeypatch):
+    issue = {"number": 3, "title": "task", "url": "u"}
+    monkeypatch.setattr(
+        muyan_pilot, "list_labeled_issues",
+        lambda repo, label, state="open": [issue] if label == "ai-in-progress" else [],
+    )
+    assert muyan_pilot.current_issue("xqliu/muyan-pilot") == issue
+
+
+def test_current_issue_returns_none_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.current_issue("xqliu/muyan-pilot") is None
+
+
+def test_ready_issue_returns_first_ready_issue(monkeypatch):
+    issue = {"number": 11, "title": "task", "url": "u"}
+    calls = []
+
+    def fake_list(repo, label, state="open", search=None):
+        calls.append((label, search))
+        return [issue] if label == "ai-ready" else []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == issue
+    assert calls == [("ai-ready", "label:ai-ready -label:ai-in-progress")]
+
+
+def test_ready_issue_excludes_in_progress_issues(monkeypatch):
+    ready = {"number": 12, "title": "next", "url": "u12"}
+    in_progress = {"number": 3, "title": "now", "url": "u3"}
+    calls = []
+
+    def fake_list(repo, label, state="open", search=None):
+        calls.append(search)
+        if search == "label:ai-ready -label:ai-in-progress":
+            return [ready]
+        if search == "label:ai-in-progress":
+            return [in_progress]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == ready
+    assert calls == ["label:ai-ready -label:ai-in-progress"]
+
+
+def test_ready_issue_returns_none_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") is None
+
+
+def test_recent_result_returns_newest_pr_opened_or_blocked_issue(monkeypatch):
+    pr_opened = {"number": 2, "title": "done", "url": "u2", "state": "CLOSED"}
+    blocked = {"number": 5, "title": "stuck", "url": "u5", "state": "OPEN"}
+    calls = []
+
+    def fake_list(repo, label, state="open"):
+        calls.append((label, state))
+        if label == "ai-pr-opened":
+            return [pr_opened]
+        if label == "ai-blocked":
+            return [blocked]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") == blocked
+    assert calls == [("ai-pr-opened", "all"), ("ai-blocked", "all")]
+
+
+def test_recent_result_prefers_pr_opened_when_newer(monkeypatch):
+    pr_opened = {"number": 9, "title": "done", "url": "u9", "state": "OPEN"}
+    blocked = {"number": 5, "title": "stuck", "url": "u5", "state": "OPEN"}
+
+    def fake_list(repo, label, state="open"):
+        if label == "ai-pr-opened":
+            return [pr_opened]
+        if label == "ai-blocked":
+            return [blocked]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") == pr_opened
+
+
+def test_recent_result_returns_none_when_no_result(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") is None
+
+
+def test_format_issue_shows_number_title_and_url():
+    issue = {"number": 3, "title": "task", "url": "https://x/3"}
+    assert muyan_pilot.format_issue(issue) == "#3 task https://x/3"
+
+
+def test_status_report_lists_sources_current_ready_and_result(monkeypatch):
+    current = {"number": 3, "title": "now", "url": "u3"}
+    ready = {"number": 11, "title": "next", "url": "u11"}
+    result = {"number": 2, "title": "done", "url": "u2"}
+
+    def fake_lookup(repo, name):
+        assert repo == "xqliu/muyan-pilot"
+        return {"current": current, "ready": ready, "result": result}[name]
+
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: fake_lookup(repo, "current"))
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: fake_lookup(repo, "ready"))
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: fake_lookup(repo, "result"))
+    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    assert "source: xqliu/muyan-pilot" in report
+    assert "current: #3 now u3" in report
+    assert "ready: #11 next u11" in report
+    assert "result: #2 done u2" in report
+
+
+def test_status_report_marks_empty_lookups(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    assert "current: -" in report
+    assert "ready: -" in report
+    assert "result: -" in report
+
+
+def test_main_add_dispatches_to_selected_source_repo(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        "source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "dispatch_issue",
+        lambda repo, title, body: calls.append((repo, title, body))
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    assert muyan_pilot.main([
+        "add", "New task", "--body", "Do it", "--config", str(config),
+    ]) == 0
+    assert calls == [("xqliu/muyan-pilot", "New task", "Do it")]
+    out = capsys.readouterr().out
+    assert "created: https://github.com/xqliu/muyan-pilot/issues/13" in out
+    assert "label: ai-ready" in out
+
+
+def test_main_add_uses_explicit_repo_override(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        "source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "dispatch_issue",
+        lambda repo, title, body: calls.append(repo) or "https://github.com/x/y/issues/1",
+    )
+    assert muyan_pilot.main([
+        "add", "T", "--repo", "xqliu/muyan-ceo", "--config", str(config),
+    ]) == 0
+    assert calls == ["xqliu/muyan-ceo"]
+
+
+def test_main_add_rejects_repo_not_in_config(monkeypatch, tmp_path):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n", encoding="utf-8")
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        muyan_pilot.main([
+            "add", "T", "--repo", "other/repo", "--config", str(config),
+        ])
+
+
+def test_main_status_prints_report(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n", encoding="utf-8")
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(
+        muyan_pilot, "status_report",
+        lambda config: "source: xqliu/muyan-pilot\ncurrent: -",
+    )
+    assert muyan_pilot.main(["status", "--config", str(config)]) == 0
+    out = capsys.readouterr().out
+    assert "source: xqliu/muyan-pilot" in out
+    assert "current: -" in out
+
+
+def test_main_rejects_unknown_command(tmp_path):
+    with pytest.raises(SystemExit):
+        muyan_pilot.main(["deploy", "--config", str(tmp_path / "c.toml")])
+
+
+def test_main_requires_config_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        muyan_pilot.main(["status", "--config", str(tmp_path / "missing.toml")])


### PR DESCRIPTION
Closes #3

## Goal

Smallest useful CLI for creating/dispatching an Issue and inspecting the current queue/run result. No database or web UI — GitHub Issues and labels are the only state store.

## Changes

- `muyan_pilot.py add TITLE [--body TEXT] [--repo OWNER/REPO] [--config PATH]`
  - Creates an Issue in the selected source repo (default: first configured source) and adds the `ai-ready` label.
  - `--repo` must be one of the configured `source_repos` (no repository discovery).
  - Prints `created: <url>` and `label: ai-ready`; any gh failure is logged and raised (fail fast).
- `muyan_pilot.py status [--config PATH]` — read-only, per source repo:
  - `current`: newest open `ai-in-progress` Issue
  - `ready`: newest open `ai-ready` Issue, excluding in-progress (same semantics as the runner queue)
  - `result`: most recent `ai-pr-opened` / `ai-blocked` Issue (any state)
- `bootstrap_runner.py`: extracted `parse_issue_array` (shared by `parse_issue_list` and the CLI); behavior unchanged.
- `.gitignore`: ignore `.pi-session/` runtime artifacts.
- `README.md`: document the new commands.

## Verification

- `python3 -m pytest tests/ -q` → 65 passed
- `python3 -m pytest tests/ --cov=bootstrap_runner --cov=muyan_pilot --cov-branch` → 100% line + branch for both files
- Live smoke (this machine's config):
  - `status` → current #3 (this task), ready #15, result #1
  - `add "Smoke: verify muyan-pilot add dispatch (Issue #3)"` → created Issue #13 with `ai-ready` (verified via `gh issue view`, then closed with a comment)
  - `add ... --repo other/repo` → `error: --repo must be one of: xqliu/muyan-pilot`
- Review-fix loop: full R1–R9 review, 0 Blocker / 0 Major (1 Minor fixed: ready pool now excludes in-progress Issues, matching runner queue semantics)
