### PR TITLE
chore: poll ready tasks every fifteen minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，每 5 分钟自动执行一次：
+正常运行使用 systemd user timer，每 15 分钟自动执行一次：
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* 01..06:00/5:00
+OnCalendar=*-*-* 01..06:00/15:00
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service


### PR DESCRIPTION
Closes #21.

当前 15 分钟 timer 调整先由人工完成，Issue #21 用于补齐任务池记录并让后续 Pilot 自己复核/维护。

Observed first self-development task #3 took about 13 minutes; 15 minutes is an initial idle-polling hypothesis, not a task timeout.