### PR TITLE
feat: one-command status and stage comments for active runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 .coverage
 htmlcov/
 .muyan-pilot/
+.pi-session/
 muyan-pilot.toml

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ systemctl --user list-timers muyan-pilot.timer
 
 手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
 
+## 任务派发与状态
+
+`muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
+
+```bash
+# 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
+python3 muyan_pilot.py add "任务标题" --body "任务描述" --config muyan-pilot.toml
+
+# 派发到指定 source repo（必须在配置 source_repos 中）
+python3 muyan_pilot.py add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
+
+# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和最近结果（ai-pr-opened / ai-blocked）
+python3 muyan_pilot.py status --config muyan-pilot.toml
+```
+
+`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
+
 前置条件：
 
 - `gh auth status` 成功；

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ systemctl --user list-timers muyan-pilot.timer
 
 ## 任务派发与状态
 
-`muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
+`muyan_pilot.py` 是最小 CLI，用于手工派活和日常查看。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
 
 ```bash
 # 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
@@ -31,11 +31,30 @@ python3 muyan_pilot.py add "任务标题" --body "任务描述" --config muyan-p
 # 派发到指定 source repo（必须在配置 source_repos 中）
 python3 muyan_pilot.py add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
 
-# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和最近结果（ai-pr-opened / ai-blocked）
+# 一条命令完成日常查看（systemd、当前任务、ready 队列、最近结果、排查入口）
 python3 muyan_pilot.py status --config muyan-pilot.toml
 ```
 
-`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
+`status` 只读，不修改任何标签，显示：
+
+- 每个 source repo：`current`（ai-in-progress）、`ready` 队列（ai-ready，最多 10 条）、`result`（最近一条 ai-pr-opened / ai-blocked）；
+- `systemd`：`muyan-pilot.timer` / `muyan-pilot.service` 状态和下一次触发时间（systemd 不可用时标记 unavailable）；
+- `current run`：磁盘上的 pilot worktree、branch、stage（由 `plan.md` / `test.log` / `verify.md` 推导）、Pi session 目录和最新 session 文件；
+- `troubleshooting`：journalctl 排查命令和最新 Pi session 文件路径。
+
+Runner 在关键节点回写简短结构化 comment，Issue 历史可以还原任务阶段链：
+
+```text
+Muyan Pilot started
+Muyan Pilot plan ready
+Muyan Pilot tests/verify
+Muyan Pilot pr_opened
+Muyan Pilot opened PR: <url>
+```
+
+失败时回写 `Muyan Pilot failed: <原因>` 并添加 `ai-blocked`。完整 Pi session 和日志保存在本地（worktree 的 `.pi-session/`、journal），不把 token 或完整原始 prompt 贴到 GitHub。
+
+`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签。命令失败立即报错，不做回退。
 
 前置条件：
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -19,6 +19,20 @@ from pathlib import Path
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
 
+# Worktree artifacts written by Pi; they define the task stage chain.
+PLAN_FILE = "plan.md"
+TEST_LOG_FILE = "test.log"
+VERIFY_FILE = "verify.md"
+
+# Fixed short bodies so Issue comments reconstruct the stage chain without
+# leaking tokens or raw prompts to GitHub.
+STAGE_COMMENTS = {
+    "started": "Muyan Pilot started",
+    "plan_ready": "Muyan Pilot plan ready",
+    "tests/verify": "Muyan Pilot tests/verify",
+    "pr_opened": "Muyan Pilot pr_opened",
+}
+
 
 def _config_path(value: str, base: Path) -> Path:
     path = Path(os.path.expandvars(os.path.expanduser(value)))
@@ -151,6 +165,21 @@ def comment_issue(number: int, *, repo: str, body: str) -> None:
                  "--body", body])
 
 
+def stage_comment(stage: str, repo: str, number: int) -> None:
+    """Post one short structured stage comment on the Issue."""
+    try:
+        body = STAGE_COMMENTS[stage]
+    except KeyError:
+        raise ValueError(f"unknown stage: {stage}") from None
+    comment_issue(number, repo=repo, body=body)
+
+
+def latest_session_file(session_dir: Path) -> str:
+    """Return the newest Pi session file in the dir, or '-' when none."""
+    files = sorted(session_dir.glob("*.jsonl")) if session_dir.is_dir() else []
+    return str(files[-1]) if files else "-"
+
+
 def task_branch(source_repo: str, number: int) -> str:
     return f"muyan-pilot/{source_repo.replace('/', '-')}-issue-{number}"
 
@@ -193,24 +222,27 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         "Complete the delivery process in the system prompt."
     )
     skill_args = [item for skill in config["skills"] for item in ("--skill", str(skill))]
+    session_dir = worktree / ".pi-session"
     command = [
         "pi", *skill_args, "--print", "--session-dir",
-        str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
+        str(session_dir), "--system-prompt", system_prompt, context,
     ]
     LOGGER.info(
         "pi_session=%s issue=%s source_repo=%s",
-        worktree / ".pi-session", issue["number"], source_repo,
+        session_dir, issue["number"], source_repo,
     )
-    return run_command(
+    output = run_command(
         command,
         cwd=worktree,
         timeout=timeout,
         log_stdout=True,
         log_command=[
-            "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
+            "pi", "--print", "--session-dir", str(session_dir),
             "--system-prompt", "<redacted>", "<issue-context-redacted>",
         ],
     )
+    LOGGER.info("pi_session_file=%s", latest_session_file(session_dir))
+    return output
 
 
 def verify_pr(worktree: Path, branch: str) -> str:
@@ -238,10 +270,16 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     branch = task_branch(source_repo, number)
     edit_issue(number, repo=source_repo, add="ai-in-progress")
+    stage_comment("started", source_repo, number)
     try:
         worktree = create_worktree(config["repo_dir"], source_repo, number)
         run_pi(issue, worktree, config, source_repo)
+        if (worktree / PLAN_FILE).is_file():
+            stage_comment("plan_ready", source_repo, number)
+        if (worktree / TEST_LOG_FILE).is_file() or (worktree / VERIFY_FILE).is_file():
+            stage_comment("tests/verify", source_repo, number)
         pr_url = verify_pr(worktree, branch)
+        stage_comment("pr_opened", source_repo, number)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
             remove="ai-in-progress",

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -103,11 +103,17 @@ def run_command(command: list[str], *, cwd: Path | None = None,
     return result.stdout.strip()
 
 
-def parse_issue_list(raw: str) -> dict | None:
-    """Return the first issue from gh's JSON array, or None when idle."""
+def parse_issue_array(raw: str) -> list[dict]:
+    """Return the issue array from gh's JSON output."""
     issues = json.loads(raw)
     if not isinstance(issues, list):
         raise ValueError("issue list must be a JSON array")
+    return issues
+
+
+def parse_issue_list(raw: str) -> dict | None:
+    """Return the first issue from gh's JSON array, or None when idle."""
+    issues = parse_issue_array(raw)
     return issues[0] if issues else None
 
 

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -2,8 +2,10 @@
 """Muyan Pilot task dispatch and status CLI.
 
 `add` creates an Issue in a configured source repo and labels it `ai-ready`.
-`status` reports the current in-progress Issue, the next ready Issue, and the
-most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
+`status` is the one-command daily check: systemd timer/service state and next
+trigger, the current in-progress Issue, the ready queue, the most recent
+result (`ai-pr-opened` / `ai-blocked`), the active worktree/stage/Pi session,
+and journal/session troubleshooting entry points.
 
 GitHub Issues and labels are the only state store. There is no database,
 queue, or web UI. Command failures are logged and raised by the reused
@@ -12,12 +14,18 @@ bootstrap_runner.run_command; there is no fallback.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import re
+import subprocess
 from pathlib import Path
 
 from bootstrap_runner import (
+    PLAN_FILE,
+    TEST_LOG_FILE,
+    VERIFY_FILE,
+    latest_session_file,
     load_config,
     parse_issue_array,
     run_command,
@@ -59,12 +67,12 @@ def dispatch_issue(repo: str, title: str, body: str) -> str:
 
 
 def list_labeled_issues(repo: str, label: str, state: str = "open",
-                        search: str | None = None) -> list[dict]:
+                        search: str | None = None, limit: int = 1) -> list[dict]:
     """Return the newest Issues matching a label search (gh lists newest first)."""
     raw = run_command([
         "gh", "issue", "list", "--repo", repo, "--state", state,
         "--search", search or f"label:{label}",
-        "--json", "number,title,url,state", "--limit", "1",
+        "--json", "number,title,url,state", "--limit", str(limit),
     ])
     return parse_issue_array(raw)
 
@@ -74,11 +82,12 @@ def current_issue(repo: str) -> dict | None:
     return issues[0] if issues else None
 
 
-def ready_issue(repo: str) -> dict | None:
-    issues = list_labeled_issues(
+def ready_issues(repo: str) -> list[dict]:
+    """Return the ready queue (newest first), excluding in-progress Issues."""
+    return list_labeled_issues(
         repo, READY_LABEL, search=f"label:{READY_LABEL} -label:{IN_PROGRESS_LABEL}",
+        limit=10,
     )
-    return issues[0] if issues else None
 
 
 def recent_result(repo: str) -> dict | None:
@@ -95,17 +104,146 @@ def format_issue(issue: dict) -> str:
     return f"#{issue['number']} {issue['title']} {issue['url']}"
 
 
+def systemd_status() -> list[str]:
+    """Report the pilot timer/service state and the next timer trigger."""
+    try:
+        timer_state = run_command([
+            "systemctl", "--user", "show", "muyan-pilot.timer",
+            "--property=ActiveState", "--value",
+        ])
+        service_state = run_command([
+            "systemctl", "--user", "show", "muyan-pilot.service",
+            "--property=ActiveState", "--value",
+        ])
+        raw_next = run_command([
+            "systemctl", "--user", "list-timers", "muyan-pilot.timer",
+            "--no-legend", "--plain",
+        ])
+    except (subprocess.CalledProcessError, OSError) as exc:
+        return [f"  systemd: unavailable ({exc})"]
+    if service_state == "active":
+        # A timer does not schedule the next elapse while its service runs.
+        next_trigger = "waiting for service to finish"
+    else:
+        parts = raw_next.split()
+        next_trigger = " ".join(parts[:4]) if len(parts) >= 4 else "-"
+    return [
+        f"  timer: {timer_state or '-'}",
+        f"  service: {service_state or '-'}",
+        f"  next trigger: {next_trigger}",
+    ]
+
+
+def worktree_list(config: dict) -> str:
+    """Return `git worktree list --porcelain` for the configured repo."""
+    return run_command(
+        ["git", "worktree", "list", "--porcelain"], cwd=config["repo_dir"],
+    )
+
+
+def _worktree_entries(raw: str) -> list[dict]:
+    """Parse `git worktree list --porcelain` into path/branch entries."""
+    entries = []
+    current = None
+    for line in raw.splitlines():
+        if line.startswith("worktree "):
+            current = {"path": Path(line.split(" ", 1)[1]), "branch": ""}
+            entries.append(current)
+        elif line.startswith("branch ") and current is not None:
+            current["branch"] = line.split(" ", 1)[1]
+    return entries
+
+
+def session_info(session_file: str) -> dict[str, str]:
+    """Read the first Pi session record; '-' when missing or unreadable."""
+    if session_file == "-":
+        return {"id": "-", "cwd": "-"}
+    try:
+        first_line = Path(session_file).read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, IndexError):
+        return {"id": "-", "cwd": "-"}
+    try:
+        record = json.loads(first_line)
+    except json.JSONDecodeError:
+        return {"id": "-", "cwd": "-"}
+    return {"id": record.get("id", "-"), "cwd": record.get("cwd", "-")}
+
+
+def stage_for(worktree: Path) -> str:
+    """Derive the current stage from worktree artifacts (newest wins)."""
+    if (worktree / VERIFY_FILE).is_file():
+        return "verify"
+    if (worktree / TEST_LOG_FILE).is_file():
+        return "testing"
+    if (worktree / PLAN_FILE).is_file():
+        return "planning"
+    return "started"
+
+
+def current_run(config: dict) -> list[str]:
+    """Describe pilot worktrees on disk: branch, stage and Pi session."""
+    entries = _worktree_entries(worktree_list(config))
+    lines = []
+    for entry in entries:
+        if not entry["path"].name.startswith("muyan-pilot-"):
+            continue
+        lines.append(f"  worktree: {entry['path']}")
+        lines.append(f"  branch: {entry['branch'] or '-'}")
+        lines.append(f"  stage: {stage_for(entry['path'])}")
+        session_dir = entry["path"] / ".pi-session"
+        session_file = latest_session_file(session_dir)
+        info = session_info(session_file)
+        lines.append(f"  pi_session: {session_dir}")
+        lines.append(f"  pi_session_file: {session_file}")
+        lines.append(f"  session id: {info['id']}")
+        lines.append(f"  session cwd: {info['cwd']}")
+    return lines or ["  worktree: -"]
+
+
+def newest_session_file(config: dict) -> str:
+    """Return the newest Pi session file across pilot worktrees, '-' if none."""
+    entries = _worktree_entries(worktree_list(config))
+    files = [
+        latest_session_file(entry["path"] / ".pi-session")
+        for entry in entries
+        if entry["path"].name.startswith("muyan-pilot-")
+    ]
+    files = [item for item in files if item != "-"]
+    if not files:
+        return "-"
+    # Session file names start with an ISO timestamp, so the newest file has
+    # the largest name (worktree paths differ and must not decide the order).
+    return max(files, key=lambda item: Path(item).name)
+
+
+def troubleshooting(config: dict) -> list[str]:
+    """Point at the journal and the newest Pi session for debugging."""
+    return [
+        "  journal: journalctl --user -u muyan-pilot.service --since today",
+        f"  session: {newest_session_file(config)}",
+    ]
+
+
 def status_report(config: dict) -> str:
     lines = []
     for repo in config["source_repos"]:
         lines.append(f"source: {repo}")
-        for name, lookup in (
-            ("current", current_issue),
-            ("ready", ready_issue),
-            ("result", recent_result),
-        ):
-            issue = lookup(repo)
-            lines.append(f"  {name}: {format_issue(issue) if issue else '-'}")
+        current = current_issue(repo)
+        lines.append(f"  current: {format_issue(current) if current else '-'}")
+        queue = ready_issues(repo)
+        if queue:
+            for issue in queue:
+                lines.append(f"  ready: {format_issue(issue)}")
+        else:
+            lines.append("  ready: -")
+        result = recent_result(repo)
+        lines.append(f"  result: {format_issue(result) if result else '-'}")
+    lines.append("systemd:")
+    lines.extend(systemd_status())
+    lines.append("current run:")
+    lines.extend(current_run(config))
+    lines.append("troubleshooting:")
+    lines.extend(troubleshooting(config))
     return "\n".join(lines)
 
 
@@ -129,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     subparsers.add_parser(
         "status", parents=[common],
-        help="show current Issue, ready queue and recent result",
+        help="one-command check: systemd, current run, ready queue, recent result, troubleshooting",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Muyan Pilot task dispatch and status CLI.
+
+`add` creates an Issue in a configured source repo and labels it `ai-ready`.
+`status` reports the current in-progress Issue, the next ready Issue, and the
+most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
+
+GitHub Issues and labels are the only state store. There is no database,
+queue, or web UI. Command failures are logged and raised by the reused
+bootstrap_runner.run_command; there is no fallback.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+
+from bootstrap_runner import (
+    load_config,
+    parse_issue_array,
+    run_command,
+    validate_config,
+)
+
+LOGGER = logging.getLogger("muyan_pilot.cli")
+
+ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
+READY_LABEL = "ai-ready"
+IN_PROGRESS_LABEL = "ai-in-progress"
+RESULT_LABELS = ("ai-pr-opened", "ai-blocked")
+
+
+def issue_number(url: str) -> int:
+    """Extract the Issue number from a GitHub Issue URL."""
+    match = ISSUE_URL_PATTERN.search(url)
+    if not match:
+        raise ValueError(f"no issue number in URL: {url}")
+    return int(match.group(1))
+
+
+def create_issue(repo: str, title: str, body: str) -> str:
+    """Create an Issue via gh and return its URL."""
+    return run_command([
+        "gh", "issue", "create", "--repo", repo,
+        "--title", title, "--body", body,
+    ])
+
+
+def dispatch_issue(repo: str, title: str, body: str) -> str:
+    """Create an Issue and mark it `ai-ready`; return the Issue URL."""
+    url = create_issue(repo, title, body)
+    run_command([
+        "gh", "issue", "edit", str(issue_number(url)), "--repo", repo,
+        "--add-label", READY_LABEL,
+    ])
+    return url
+
+
+def list_labeled_issues(repo: str, label: str, state: str = "open",
+                        search: str | None = None) -> list[dict]:
+    """Return the newest Issues matching a label search (gh lists newest first)."""
+    raw = run_command([
+        "gh", "issue", "list", "--repo", repo, "--state", state,
+        "--search", search or f"label:{label}",
+        "--json", "number,title,url,state", "--limit", "1",
+    ])
+    return parse_issue_array(raw)
+
+
+def current_issue(repo: str) -> dict | None:
+    issues = list_labeled_issues(repo, IN_PROGRESS_LABEL)
+    return issues[0] if issues else None
+
+
+def ready_issue(repo: str) -> dict | None:
+    issues = list_labeled_issues(
+        repo, READY_LABEL, search=f"label:{READY_LABEL} -label:{IN_PROGRESS_LABEL}",
+    )
+    return issues[0] if issues else None
+
+
+def recent_result(repo: str) -> dict | None:
+    """Return the newest `ai-pr-opened` or `ai-blocked` Issue, any state."""
+    newest = None
+    for label in RESULT_LABELS:
+        for issue in list_labeled_issues(repo, label, state="all"):
+            if newest is None or int(issue["number"]) > int(newest["number"]):
+                newest = issue
+    return newest
+
+
+def format_issue(issue: dict) -> str:
+    return f"#{issue['number']} {issue['title']} {issue['url']}"
+
+
+def status_report(config: dict) -> str:
+    lines = []
+    for repo in config["source_repos"]:
+        lines.append(f"source: {repo}")
+        for name, lookup in (
+            ("current", current_issue),
+            ("ready", ready_issue),
+            ("result", recent_result),
+        ):
+            issue = lookup(repo)
+            lines.append(f"  {name}: {format_issue(issue) if issue else '-'}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--config", type=Path,
+        default=Path(os.environ.get("MUYAN_PILOT_CONFIG", "muyan-pilot.toml")),
+    )
+    parser = argparse.ArgumentParser(description=__doc__, parents=[common])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_parser = subparsers.add_parser(
+        "add", parents=[common],
+        help="create an Issue in a source repo and add ai-ready",
+    )
+    add_parser.add_argument("title")
+    add_parser.add_argument("--body", default="")
+    add_parser.add_argument(
+        "--repo", default=None,
+        help="source repo (default: first configured source)",
+    )
+    subparsers.add_parser(
+        "status", parents=[common],
+        help="show current Issue, ready queue and recent result",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    config = load_config(args.config)
+    validate_config(config)
+    if args.command == "add":
+        repo = args.repo or config["source_repos"][0]
+        if repo not in config["source_repos"]:
+            parser.error(
+                f"--repo must be one of: {', '.join(config['source_repos'])}"
+            )
+        LOGGER.info("dispatch repo=%s title=%s", repo, args.title)
+        url = dispatch_issue(repo, args.title, args.body)
+        print(f"created: {url}")
+        print(f"label: {READY_LABEL}")
+    else:
+        print(status_report(config))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -350,31 +350,73 @@ def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
         runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
 
 
-def test_process_issue_success(monkeypatch, tmp_path):
+def test_process_issue_success_posts_stage_chain(monkeypatch, tmp_path):
     calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / "plan.md").write_text("plan", encoding="utf-8")
+    (worktree / "test.log").write_text("log", encoding="utf-8")
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "stage_comment", lambda stage, repo, number: calls.append(("stage", stage, repo, number)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     issue = {"number": 4, "title": "Fix", "body": "Body"}
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}
-    assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
-    assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
-    assert calls[1][0] == "edit"
-    assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
-    assert calls[2][0] == "comment"
+    assert runner.process_issue(issue, config, "xqliu/muyan-pilot") == "https://github.com/muyantech/muyan-pilot/pull/4"
+    assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-pilot", "add": "ai-in-progress"})
+    assert calls[1] == ("stage", "started", "xqliu/muyan-pilot", 4)
+    assert calls[2] == ("stage", "plan_ready", "xqliu/muyan-pilot", 4)
+    assert calls[3] == ("stage", "tests/verify", "xqliu/muyan-pilot", 4)
+    assert calls[4] == ("stage", "pr_opened", "xqliu/muyan-pilot", 4)
+    assert calls[5] == ("edit", (4,), {"repo": "xqliu/muyan-pilot", "add": "ai-pr-opened", "remove": "ai-in-progress"})
+    assert calls[6] == ("comment", (4,), {"repo": "xqliu/muyan-pilot", "body": "Muyan Pilot opened PR: https://github.com/muyantech/muyan-pilot/pull/4"})
+
+
+def test_process_issue_posts_tests_verify_from_verify_md_only(monkeypatch, tmp_path):
+    calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / "plan.md").write_text("plan", encoding="utf-8")
+    (worktree / "verify.md").write_text("verify", encoding="utf-8")
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "stage_comment", lambda stage, repo, number: calls.append(("stage", stage, repo, number)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    runner.process_issue({"number": 4, "title": "Fix", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-pilot")
+    stages = [call[1] for call in calls if call[0] == "stage"]
+    assert stages == ["started", "plan_ready", "tests/verify", "pr_opened"]
+
+
+def test_process_issue_skips_stage_comments_without_artifacts(monkeypatch, tmp_path):
+    calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "stage_comment", lambda stage, repo, number: calls.append(("stage", stage, repo, number)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    runner.process_issue({"number": 4, "title": "Fix", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-pilot")
+    stages = [call[1] for call in calls if call[0] == "stage"]
+    assert stages == ["started", "pr_opened"]
 
 
 def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "stage_comment", lambda stage, repo, number: calls.append(("stage", stage, repo, number)))
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     with pytest.raises(RuntimeError, match="git failed"):
-        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
-    assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
-    assert calls[2][0] == "comment"
+        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-pilot")
+    assert calls[1] == ("stage", "started", "xqliu/muyan-pilot", 8)
+    assert calls[2] == ("edit", (8,), {"repo": "xqliu/muyan-pilot", "add": "ai-blocked", "remove": "ai-in-progress"})
+    assert calls[3] == ("comment", (8,), {"repo": "xqliu/muyan-pilot", "body": "Muyan Pilot failed: git failed"})
 
 
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
@@ -386,9 +428,10 @@ def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypat
             raise RuntimeError("github report failed")
 
     monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(runner, "stage_comment", lambda stage, repo, number: None)
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
-        runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
+        runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-pilot")
     assert "failure reporting failed" in caplog.text
 
 
@@ -432,3 +475,69 @@ def test_main_requires_prompt_file(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     with pytest.raises(FileNotFoundError):
         runner.main(["--config", str(config)])
+
+
+def test_stage_comment_posts_fixed_short_body(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    runner.stage_comment("plan_ready", "xqliu/muyan-pilot", 18)
+    assert calls == [
+        ((18,), {"repo": "xqliu/muyan-pilot", "body": "Muyan Pilot plan ready"}),
+    ]
+
+
+def test_stage_comment_rejects_unknown_stage():
+    with pytest.raises(ValueError, match="unknown stage"):
+        runner.stage_comment("nope", "xqliu/muyan-pilot", 1)
+
+
+def test_latest_session_file_returns_newest_jsonl(tmp_path):
+    (tmp_path / "2026-08-25T01-23-26-000Z_a.jsonl").write_text("", encoding="utf-8")
+    (tmp_path / "2026-08-25T01-24-00-000Z_b.jsonl").write_text("", encoding="utf-8")
+    assert runner.latest_session_file(tmp_path) == str(
+        tmp_path / "2026-08-25T01-24-00-000Z_b.jsonl",
+    )
+
+
+def test_latest_session_file_marks_empty_dir(tmp_path):
+    assert runner.latest_session_file(tmp_path) == "-"
+
+
+def test_latest_session_file_marks_missing_dir(tmp_path):
+    assert runner.latest_session_file(tmp_path / "nope") == "-"
+
+
+def test_run_pi_logs_session_file_after_success(monkeypatch, tmp_path, caplog):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("SYSTEM", encoding="utf-8")
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    (session_dir / "2026-08-25T01-23-26-000Z_a.jsonl").write_text("{}", encoding="utf-8")
+    (session_dir / "2026-08-25T01-24-00-000Z_b.jsonl").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: "done")
+    config = {
+        "prompt": prompt, "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path, "context_files": [], "skills": [],
+    }
+    with caplog.at_level("INFO"):
+        runner.run_pi({"number": 4, "title": "t", "body": "b"}, tmp_path, config, "owner/repo")
+    assert (
+        "pi_session_file=" + str(session_dir / "2026-08-25T01-24-00-000Z_b.jsonl")
+        in caplog.text
+    )
+
+
+def test_run_pi_marks_missing_session_dir(monkeypatch, tmp_path, caplog):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("SYSTEM", encoding="utf-8")
+    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: "done")
+    config = {
+        "prompt": prompt, "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path, "context_files": [], "skills": [],
+    }
+    with caplog.at_level("INFO"):
+        runner.run_pi({"number": 4, "title": "t", "body": "b"}, tmp_path, config, "owner/repo")
+    assert "pi_session_file=-" in caplog.text

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -104,40 +105,296 @@ def test_current_issue_returns_none_when_idle(monkeypatch):
     assert muyan_pilot.current_issue("xqliu/muyan-pilot") is None
 
 
-def test_ready_issue_returns_first_ready_issue(monkeypatch):
-    issue = {"number": 11, "title": "task", "url": "u"}
+def test_ready_issues_returns_queue_in_github_order(monkeypatch):
+    issues = [
+        {"number": 15, "title": "t15", "url": "u15"},
+        {"number": 14, "title": "t14", "url": "u14"},
+    ]
     calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command) or json.dumps(issues),
+    )
+    assert muyan_pilot.ready_issues("xqliu/muyan-pilot") == issues
+    assert calls == [[
+        "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
+        "--state", "open", "--search", "label:ai-ready -label:ai-in-progress",
+        "--json", "number,title,url,state", "--limit", "10",
+    ]]
 
-    def fake_list(repo, label, state="open", search=None):
-        calls.append((label, search))
-        return [issue] if label == "ai-ready" else []
 
-    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
-    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == issue
-    assert calls == [("ai-ready", "label:ai-ready -label:ai-in-progress")]
+def test_ready_issues_returns_empty_list_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: "[]")
+    assert muyan_pilot.ready_issues("xqliu/muyan-pilot") == []
 
 
-def test_ready_issue_excludes_in_progress_issues(monkeypatch):
-    ready = {"number": 12, "title": "next", "url": "u12"}
-    in_progress = {"number": 3, "title": "now", "url": "u3"}
+def test_list_labeled_issues_uses_custom_limit(monkeypatch):
     calls = []
-
-    def fake_list(repo, label, state="open", search=None):
-        calls.append(search)
-        if search == "label:ai-ready -label:ai-in-progress":
-            return [ready]
-        if search == "label:ai-in-progress":
-            return [in_progress]
-        return []
-
-    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
-    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == ready
-    assert calls == ["label:ai-ready -label:ai-in-progress"]
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command) or "[]",
+    )
+    muyan_pilot.list_labeled_issues("owner/repo", "ai-ready", limit=3)
+    assert calls[0][-2:] == ["--limit", "3"]
 
 
-def test_ready_issue_returns_none_when_idle(monkeypatch):
-    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
-    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") is None
+def test_systemd_status_reports_waiting_while_service_active(monkeypatch):
+    outputs = iter([
+        "active",
+        "active",
+        "- - Tue 2026-08-25 01:23:24 +08 15min ago muyan-pilot.timer muyan-pilot.service",
+    ])
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: next(outputs))
+    assert muyan_pilot.systemd_status() == [
+        "  timer: active",
+        "  service: active",
+        "  next trigger: waiting for service to finish",
+    ]
+
+
+def test_systemd_status_reports_next_trigger_when_service_idle(monkeypatch):
+    outputs = iter([
+        "active",
+        "inactive",
+        "Tue 2026-08-25 01:30:00 +08  5min  Tue 2026-08-25 01:25:00 +08  5min  muyan-pilot.timer  muyan-pilot.service",
+    ])
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: next(outputs))
+    assert muyan_pilot.systemd_status() == [
+        "  timer: active",
+        "  service: inactive",
+        "  next trigger: Tue 2026-08-25 01:30:00 +08",
+    ]
+
+
+def test_systemd_status_marks_empty_states_and_missing_next_trigger(monkeypatch):
+    outputs = iter(["", "", ""])
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: next(outputs))
+    assert muyan_pilot.systemd_status() == [
+        "  timer: -",
+        "  service: -",
+        "  next trigger: -",
+    ]
+
+
+def test_systemd_status_marks_unavailable_when_systemctl_missing(monkeypatch):
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(FileNotFoundError("systemctl")),
+    )
+    assert muyan_pilot.systemd_status() == ["  systemd: unavailable (systemctl)"]
+
+
+def test_systemd_status_marks_unavailable_when_systemctl_fails(monkeypatch):
+    error = runner.subprocess.CalledProcessError(3, ["systemctl"], stderr="no")
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(error),
+    )
+    assert muyan_pilot.systemd_status() == [
+        f"  systemd: unavailable ({error})",
+    ]
+
+
+def test_worktree_list_runs_git_in_configured_repo(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "raw",
+    )
+    assert muyan_pilot.worktree_list({"repo_dir": Path("/repo")}) == "raw"
+    assert calls == [(
+        ["git", "worktree", "list", "--porcelain"], {"cwd": Path("/repo")},
+    )]
+
+
+def test_worktree_entries_parses_porcelain_output():
+    raw = (
+        "worktree /home/x/muyan-pilot\n"
+        "HEAD fb8ead2\n"
+        "branch refs/heads/main\n"
+        "\n"
+        "worktree /tmp/muyan-pilot-xqliu-muyan-pilot-issue-18\n"
+        "HEAD d0bbc08\n"
+        "branch refs/heads/muyan-pilot/xqliu-muyan-pilot-issue-18\n"
+    )
+    assert muyan_pilot._worktree_entries(raw) == [
+        {"path": Path("/home/x/muyan-pilot"), "branch": "refs/heads/main"},
+        {
+            "path": Path("/tmp/muyan-pilot-xqliu-muyan-pilot-issue-18"),
+            "branch": "refs/heads/muyan-pilot/xqliu-muyan-pilot-issue-18",
+        },
+    ]
+
+
+def test_worktree_entries_keeps_detached_head_without_branch():
+    raw = "worktree /tmp/wt\nHEAD abc\n"
+    assert muyan_pilot._worktree_entries(raw) == [
+        {"path": Path("/tmp/wt"), "branch": ""},
+    ]
+
+
+def test_worktree_entries_ignores_branch_line_without_worktree():
+    assert muyan_pilot._worktree_entries("branch refs/heads/main\n") == []
+
+
+def test_session_info_reads_first_record(tmp_path):
+    session = tmp_path / "s.jsonl"
+    session.write_text(
+        '{"type":"session","id":"abc","cwd":"/tmp/wt"}\n'
+        '{"type":"message"}\n',
+        encoding="utf-8",
+    )
+    assert muyan_pilot.session_info(str(session)) == {"id": "abc", "cwd": "/tmp/wt"}
+
+
+def test_session_info_defaults_missing_fields(tmp_path):
+    session = tmp_path / "s.jsonl"
+    session.write_text('{"type":"session"}\n', encoding="utf-8")
+    assert muyan_pilot.session_info(str(session)) == {"id": "-", "cwd": "-"}
+
+
+def test_session_info_marks_dash_placeholder():
+    assert muyan_pilot.session_info("-") == {"id": "-", "cwd": "-"}
+
+
+def test_session_info_marks_missing_file(tmp_path):
+    assert muyan_pilot.session_info(str(tmp_path / "nope.jsonl")) == {"id": "-", "cwd": "-"}
+
+
+def test_session_info_marks_empty_file(tmp_path):
+    session = tmp_path / "s.jsonl"
+    session.write_text("", encoding="utf-8")
+    assert muyan_pilot.session_info(str(session)) == {"id": "-", "cwd": "-"}
+
+
+def test_session_info_marks_invalid_json(tmp_path):
+    session = tmp_path / "s.jsonl"
+    session.write_text("not json\n", encoding="utf-8")
+    assert muyan_pilot.session_info(str(session)) == {"id": "-", "cwd": "-"}
+
+
+def test_stage_for_reports_verify_when_verify_md_exists(tmp_path):
+    (tmp_path / "verify.md").write_text("v", encoding="utf-8")
+    (tmp_path / "plan.md").write_text("p", encoding="utf-8")
+    assert muyan_pilot.stage_for(tmp_path) == "verify"
+
+
+def test_stage_for_reports_testing_when_test_log_exists(tmp_path):
+    (tmp_path / "test.log").write_text("t", encoding="utf-8")
+    (tmp_path / "plan.md").write_text("p", encoding="utf-8")
+    assert muyan_pilot.stage_for(tmp_path) == "testing"
+
+
+def test_stage_for_reports_planning_when_plan_md_exists(tmp_path):
+    (tmp_path / "plan.md").write_text("p", encoding="utf-8")
+    assert muyan_pilot.stage_for(tmp_path) == "planning"
+
+
+def test_stage_for_reports_started_when_no_artifacts(tmp_path):
+    assert muyan_pilot.stage_for(tmp_path) == "started"
+
+
+def test_current_run_describes_pilot_worktree(monkeypatch, tmp_path):
+    worktree = tmp_path / "muyan-pilot-xqliu-muyan-pilot-issue-18"
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True)
+    session = session_dir / "2026-08-25T01-23-26-000Z_abc.jsonl"
+    session.write_text(
+        '{"type":"session","id":"abc","cwd":"' + str(worktree) + '"}\n',
+        encoding="utf-8",
+    )
+    (worktree / "plan.md").write_text("p", encoding="utf-8")
+    other = tmp_path / "other-worktree"
+    other.mkdir()
+    raw = (
+        f"worktree {other}\nHEAD a\nbranch refs/heads/main\n\n"
+        f"worktree {worktree}\nHEAD b\n"
+        "branch refs/heads/muyan-pilot/xqliu-muyan-pilot-issue-18\n"
+    )
+    monkeypatch.setattr(muyan_pilot, "worktree_list", lambda config: raw)
+    assert muyan_pilot.current_run({"repo_dir": tmp_path}) == [
+        f"  worktree: {worktree}",
+        "  branch: refs/heads/muyan-pilot/xqliu-muyan-pilot-issue-18",
+        "  stage: planning",
+        f"  pi_session: {session_dir}",
+        f"  pi_session_file: {session}",
+        "  session id: abc",
+        f"  session cwd: {worktree}",
+    ]
+
+
+def test_current_run_marks_missing_pilot_worktree(monkeypatch):
+    monkeypatch.setattr(
+        muyan_pilot, "worktree_list",
+        lambda config: "worktree /home/x/muyan-pilot\nHEAD a\nbranch refs/heads/main\n",
+    )
+    assert muyan_pilot.current_run({"repo_dir": Path("/home/x/muyan-pilot")}) == [
+        "  worktree: -",
+    ]
+
+
+def test_current_run_marks_detached_branch_and_missing_session(monkeypatch, tmp_path):
+    worktree = tmp_path / "muyan-pilot-owner-repo-issue-3"
+    worktree.mkdir()
+    monkeypatch.setattr(
+        muyan_pilot, "worktree_list",
+        lambda config: f"worktree {worktree}\nHEAD a\n",
+    )
+    lines = muyan_pilot.current_run({"repo_dir": tmp_path})
+    assert "  branch: -" in lines
+    assert "  pi_session_file: -" in lines
+    assert "  session id: -" in lines
+
+
+def test_newest_session_file_orders_by_file_name_not_path(monkeypatch, tmp_path):
+    newer = tmp_path / "muyan-pilot-owner-repo-issue-1"
+    (newer / ".pi-session").mkdir(parents=True)
+    (newer / ".pi-session" / "2026-08-25T01-23-26-000Z_a.jsonl").write_text(
+        "{}", encoding="utf-8",
+    )
+    older = tmp_path / "muyan-pilot-owner-repo-issue-9"
+    (older / ".pi-session").mkdir(parents=True)
+    (older / ".pi-session" / "2026-08-25T01-10-16-000Z_b.jsonl").write_text(
+        "{}", encoding="utf-8",
+    )
+    without_session = tmp_path / "muyan-pilot-owner-repo-issue-2"
+    without_session.mkdir()
+    raw = (
+        f"worktree {older}\nHEAD a\nbranch refs/heads/b1\n"
+        f"worktree {newer}\nHEAD b\nbranch refs/heads/b2\n"
+        f"worktree {without_session}\nHEAD c\nbranch refs/heads/b3\n"
+    )
+    monkeypatch.setattr(muyan_pilot, "worktree_list", lambda config: raw)
+    assert muyan_pilot.newest_session_file({"repo_dir": tmp_path}) == str(
+        newer / ".pi-session" / "2026-08-25T01-23-26-000Z_a.jsonl",
+    )
+
+
+def test_newest_session_file_marks_missing_session(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "worktree_list", lambda config: "")
+    assert muyan_pilot.newest_session_file({"repo_dir": Path("/repo")}) == "-"
+
+
+def test_troubleshooting_points_at_journal_and_newest_session(monkeypatch, tmp_path):
+    worktree = tmp_path / "muyan-pilot-owner-repo-issue-3"
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "2026-08-25T01-23-26-000Z_a.jsonl").write_text("{}", encoding="utf-8")
+    (session_dir / "2026-08-25T01-24-00-000Z_b.jsonl").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        muyan_pilot, "worktree_list",
+        lambda config: f"worktree {worktree}\nHEAD a\nbranch refs/heads/b\n",
+    )
+    assert muyan_pilot.troubleshooting({"repo_dir": tmp_path}) == [
+        "  journal: journalctl --user -u muyan-pilot.service --since today",
+        "  session: " + str(session_dir / "2026-08-25T01-24-00-000Z_b.jsonl"),
+    ]
+
+
+def test_troubleshooting_marks_missing_session(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "worktree_list", lambda config: "")
+    lines = muyan_pilot.troubleshooting({"repo_dir": Path("/repo")})
+    assert lines[1] == "  session: -"
 
 
 def test_recent_result_returns_newest_pr_opened_or_blocked_issue(monkeypatch):
@@ -185,27 +442,43 @@ def test_format_issue_shows_number_title_and_url():
 
 def test_status_report_lists_sources_current_ready_and_result(monkeypatch):
     current = {"number": 3, "title": "now", "url": "u3"}
-    ready = {"number": 11, "title": "next", "url": "u11"}
+    ready = [
+        {"number": 11, "title": "next", "url": "u11"},
+        {"number": 12, "title": "next2", "url": "u12"},
+    ]
     result = {"number": 2, "title": "done", "url": "u2"}
-
-    def fake_lookup(repo, name):
-        assert repo == "xqliu/muyan-pilot"
-        return {"current": current, "ready": ready, "result": result}[name]
-
-    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: fake_lookup(repo, "current"))
-    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: fake_lookup(repo, "ready"))
-    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: fake_lookup(repo, "result"))
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: current)
+    monkeypatch.setattr(muyan_pilot, "ready_issues", lambda repo: ready)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: result)
+    monkeypatch.setattr(
+        muyan_pilot, "systemd_status", lambda: ["  timer: active (running)"],
+    )
+    monkeypatch.setattr(muyan_pilot, "current_run", lambda config: ["  worktree: /tmp/wt"])
+    monkeypatch.setattr(
+        muyan_pilot, "troubleshooting",
+        lambda config: ["  journal: journalctl --user -u muyan-pilot.service --since today"],
+    )
     report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
     assert "source: xqliu/muyan-pilot" in report
     assert "current: #3 now u3" in report
     assert "ready: #11 next u11" in report
+    assert "ready: #12 next2 u12" in report
     assert "result: #2 done u2" in report
+    assert "systemd:" in report
+    assert "  timer: active (running)" in report
+    assert "current run:" in report
+    assert "  worktree: /tmp/wt" in report
+    assert "troubleshooting:" in report
+    assert "  journal: journalctl --user -u muyan-pilot.service --since today" in report
 
 
 def test_status_report_marks_empty_lookups(monkeypatch):
     monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
-    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "ready_issues", lambda repo: [])
     monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "systemd_status", lambda: ["  timer: -"])
+    monkeypatch.setattr(muyan_pilot, "current_run", lambda config: ["  worktree: -"])
+    monkeypatch.setattr(muyan_pilot, "troubleshooting", lambda config: ["  session: -"])
     report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
     assert "current: -" in report
     assert "ready: -" in report

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,0 +1,286 @@
+import json
+
+import pytest
+
+import bootstrap_runner as runner
+import muyan_pilot
+
+
+def test_issue_number_extracts_number_from_github_url():
+    assert muyan_pilot.issue_number(
+        "https://github.com/xqliu/muyan-pilot/issues/3"
+    ) == 3
+
+
+def test_issue_number_rejects_url_without_issue_number():
+    with pytest.raises(ValueError, match="no issue number"):
+        muyan_pilot.issue_number("https://github.com/xqliu/muyan-pilot")
+
+
+def test_create_issue_runs_gh_issue_create_and_returns_url(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    url = muyan_pilot.create_issue(
+        "xqliu/muyan-pilot", "New task", "Do it",
+    )
+    assert url == "https://github.com/xqliu/muyan-pilot/issues/13"
+    assert calls == [[
+        "gh", "issue", "create", "--repo", "xqliu/muyan-pilot",
+        "--title", "New task", "--body", "Do it",
+    ]]
+
+
+def test_dispatch_issue_creates_issue_and_adds_ai_ready(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    url = muyan_pilot.dispatch_issue("xqliu/muyan-pilot", "New task", "Do it")
+    assert url == "https://github.com/xqliu/muyan-pilot/issues/13"
+    assert calls == [
+        [
+            "gh", "issue", "create", "--repo", "xqliu/muyan-pilot",
+            "--title", "New task", "--body", "Do it",
+        ],
+        [
+            "gh", "issue", "edit", "13", "--repo", "xqliu/muyan-pilot",
+            "--add-label", "ai-ready",
+        ],
+    ]
+
+
+def test_dispatch_issue_propagates_create_failure(monkeypatch):
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            runner.subprocess.CalledProcessError(1, command, stderr="nope"),
+        ),
+    )
+    with pytest.raises(runner.subprocess.CalledProcessError):
+        muyan_pilot.dispatch_issue("xqliu/muyan-pilot", "t", "b")
+
+
+def test_list_labeled_issues_queries_github_with_label_and_state(monkeypatch):
+    issue = {"number": 3, "title": "task", "url": "u"}
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: calls.append(command)
+        or json.dumps([issue]),
+    )
+    issues = muyan_pilot.list_labeled_issues(
+        "xqliu/muyan-pilot", "ai-in-progress", state="open",
+    )
+    assert issues == [issue]
+    assert calls == [[
+        "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
+        "--state", "open", "--search", "label:ai-in-progress",
+        "--json", "number,title,url,state", "--limit", "1",
+    ]]
+
+
+def test_list_labeled_issues_returns_empty_list_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "run_command", lambda command, **kwargs: "[]")
+    assert muyan_pilot.list_labeled_issues("xqliu/muyan-pilot", "ai-ready") == []
+
+
+def test_current_issue_returns_first_in_progress_issue(monkeypatch):
+    issue = {"number": 3, "title": "task", "url": "u"}
+    monkeypatch.setattr(
+        muyan_pilot, "list_labeled_issues",
+        lambda repo, label, state="open": [issue] if label == "ai-in-progress" else [],
+    )
+    assert muyan_pilot.current_issue("xqliu/muyan-pilot") == issue
+
+
+def test_current_issue_returns_none_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.current_issue("xqliu/muyan-pilot") is None
+
+
+def test_ready_issue_returns_first_ready_issue(monkeypatch):
+    issue = {"number": 11, "title": "task", "url": "u"}
+    calls = []
+
+    def fake_list(repo, label, state="open", search=None):
+        calls.append((label, search))
+        return [issue] if label == "ai-ready" else []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == issue
+    assert calls == [("ai-ready", "label:ai-ready -label:ai-in-progress")]
+
+
+def test_ready_issue_excludes_in_progress_issues(monkeypatch):
+    ready = {"number": 12, "title": "next", "url": "u12"}
+    in_progress = {"number": 3, "title": "now", "url": "u3"}
+    calls = []
+
+    def fake_list(repo, label, state="open", search=None):
+        calls.append(search)
+        if search == "label:ai-ready -label:ai-in-progress":
+            return [ready]
+        if search == "label:ai-in-progress":
+            return [in_progress]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") == ready
+    assert calls == ["label:ai-ready -label:ai-in-progress"]
+
+
+def test_ready_issue_returns_none_when_idle(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.ready_issue("xqliu/muyan-pilot") is None
+
+
+def test_recent_result_returns_newest_pr_opened_or_blocked_issue(monkeypatch):
+    pr_opened = {"number": 2, "title": "done", "url": "u2", "state": "CLOSED"}
+    blocked = {"number": 5, "title": "stuck", "url": "u5", "state": "OPEN"}
+    calls = []
+
+    def fake_list(repo, label, state="open"):
+        calls.append((label, state))
+        if label == "ai-pr-opened":
+            return [pr_opened]
+        if label == "ai-blocked":
+            return [blocked]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") == blocked
+    assert calls == [("ai-pr-opened", "all"), ("ai-blocked", "all")]
+
+
+def test_recent_result_prefers_pr_opened_when_newer(monkeypatch):
+    pr_opened = {"number": 9, "title": "done", "url": "u9", "state": "OPEN"}
+    blocked = {"number": 5, "title": "stuck", "url": "u5", "state": "OPEN"}
+
+    def fake_list(repo, label, state="open"):
+        if label == "ai-pr-opened":
+            return [pr_opened]
+        if label == "ai-blocked":
+            return [blocked]
+        return []
+
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", fake_list)
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") == pr_opened
+
+
+def test_recent_result_returns_none_when_no_result(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "list_labeled_issues", lambda *a, **k: [])
+    assert muyan_pilot.recent_result("xqliu/muyan-pilot") is None
+
+
+def test_format_issue_shows_number_title_and_url():
+    issue = {"number": 3, "title": "task", "url": "https://x/3"}
+    assert muyan_pilot.format_issue(issue) == "#3 task https://x/3"
+
+
+def test_status_report_lists_sources_current_ready_and_result(monkeypatch):
+    current = {"number": 3, "title": "now", "url": "u3"}
+    ready = {"number": 11, "title": "next", "url": "u11"}
+    result = {"number": 2, "title": "done", "url": "u2"}
+
+    def fake_lookup(repo, name):
+        assert repo == "xqliu/muyan-pilot"
+        return {"current": current, "ready": ready, "result": result}[name]
+
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: fake_lookup(repo, "current"))
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: fake_lookup(repo, "ready"))
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: fake_lookup(repo, "result"))
+    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    assert "source: xqliu/muyan-pilot" in report
+    assert "current: #3 now u3" in report
+    assert "ready: #11 next u11" in report
+    assert "result: #2 done u2" in report
+
+
+def test_status_report_marks_empty_lookups(monkeypatch):
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    assert "current: -" in report
+    assert "ready: -" in report
+    assert "result: -" in report
+
+
+def test_main_add_dispatches_to_selected_source_repo(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        "source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "dispatch_issue",
+        lambda repo, title, body: calls.append((repo, title, body))
+        or "https://github.com/xqliu/muyan-pilot/issues/13",
+    )
+    assert muyan_pilot.main([
+        "add", "New task", "--body", "Do it", "--config", str(config),
+    ]) == 0
+    assert calls == [("xqliu/muyan-pilot", "New task", "Do it")]
+    out = capsys.readouterr().out
+    assert "created: https://github.com/xqliu/muyan-pilot/issues/13" in out
+    assert "label: ai-ready" in out
+
+
+def test_main_add_uses_explicit_repo_override(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        "source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "dispatch_issue",
+        lambda repo, title, body: calls.append(repo) or "https://github.com/x/y/issues/1",
+    )
+    assert muyan_pilot.main([
+        "add", "T", "--repo", "xqliu/muyan-ceo", "--config", str(config),
+    ]) == 0
+    assert calls == ["xqliu/muyan-ceo"]
+
+
+def test_main_add_rejects_repo_not_in_config(monkeypatch, tmp_path):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n", encoding="utf-8")
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        muyan_pilot.main([
+            "add", "T", "--repo", "other/repo", "--config", str(config),
+        ])
+
+
+def test_main_status_prints_report(monkeypatch, tmp_path, capsys):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n", encoding="utf-8")
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(
+        muyan_pilot, "status_report",
+        lambda config: "source: xqliu/muyan-pilot\ncurrent: -",
+    )
+    assert muyan_pilot.main(["status", "--config", str(config)]) == 0
+    out = capsys.readouterr().out
+    assert "source: xqliu/muyan-pilot" in out
+    assert "current: -" in out
+
+
+def test_main_rejects_unknown_command(tmp_path):
+    with pytest.raises(SystemExit):
+        muyan_pilot.main(["deploy", "--config", str(tmp_path / "c.toml")])
+
+
+def test_main_requires_config_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        muyan_pilot.main(["status", "--config", str(tmp_path / "missing.toml")])


### PR DESCRIPTION
Closes #18

Builds on PR #17 (issue #3, already merged into main), which introduced `muyan_pilot.py`.

## Goal

One-command observability: no more manual ps / worktree / journal / Pi session digging.

## Changes

- `muyan_pilot.py status` (read-only) now shows:
  - per source repo: `current` (ai-in-progress), `ready` queue (up to 10), `result` (newest ai-pr-opened / ai-blocked);
  - `systemd`: timer/service state and next trigger — while the service runs, the timer schedules no next elapse (verified empirically), so it reports `waiting for service to finish`; otherwise the next elapse time;
  - `current run`: pilot worktrees on disk with branch, stage (derived from `plan.md` / `test.log` / `verify.md`), Pi session dir and newest session file (id + cwd from the session's first record);
  - `troubleshooting`: journalctl entry point and the newest Pi session file path.
- Runner posts short structured stage comments so the Issue history reconstructs the task stage chain:
  `Muyan Pilot started` → `Muyan Pilot plan ready` → `Muyan Pilot tests/verify` → `Muyan Pilot pr_opened` → `Muyan Pilot opened PR: <url>`; failures keep `Muyan Pilot failed: <reason>` + `ai-blocked`. No tokens or raw prompts go to GitHub.
- `run_pi` logs the session file path after pi; the existing `run_command` failure logging keeps command, return code, stdout/stderr, and the session dir is logged before pi starts.
- `ready_issue` (single) replaced by `ready_issues` (queue); `list_labeled_issues` gains a `limit` param (default 1, old behavior).

No database, web dashboard, or queue system introduced.

## Verification

- `python3 -m pytest tests/ -q` → 100 passed
- `python3 -m pytest tests/ --cov=bootstrap_runner --cov=muyan_pilot --cov-branch` → 100% line + branch for both files
- Live `status` on this machine's config: shows current #18, 5-item ready queue, result #3, systemd states, both pilot worktrees with sessions, and correct newest-session troubleshooting entry
- Live stage-comment smoke on throwaway issue #22: all four stage comments posted in order, chain reconstructs the stages, issue closed
- Timer behavior verified with a throwaway user timer: no next elapse while the triggered service is active, resumes after it stops
