### PR TITLE
feat: stream live Pi activity during active runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，每 5 分钟自动执行一次：
+正常运行使用 systemd user timer，每 15 分钟自动执行一次：
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ python3 muyan_pilot.py status --config muyan-pilot.toml
 
 `add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
 
+## 运行中的实时活动
+
+Runner 启动 Pi 后不再缓冲 stdout，而是每秒轮询 worktree 里的 Pi session JSONL（`<worktree>/.pi-session/*.jsonl`），把每个新事件写入 journal（systemd 日志）：
+
+```text
+pi_activity issue=24 source_repo=xqliu/muyan-pilot branch=muyan-pilot/xqliu-muyan-pilot-issue-24 worktree=/tmp/... session=2026-....jsonl phase=test at=2026-08-24T17:56:01.728Z summary=pytest tests/ -q
+```
+
+- `phase` 是关键阶段：`test`、`verify`、`commit`、`push`、`pr`、`issue_comment`、`worktree`、`branch`、`setup`、`ui_test`、`read`、`edit`、`search`、`command`、`reply`、`thinking`、`tool_result`、`session_start`、`session_end`；
+- `summary` 是脱敏后的工具调用摘要（bash 命令首行、文件路径或搜索模式），不记录完整 prompt、Issue body、工具输出、推理内容或 token；
+- 超过 300 秒没有新事件时写 `pi_stalled` 警告（含最后活动阶段、时间和 session 文件）；
+- Pi 进程退出时写 `pi_finished` 现场行（returncode、最后活动、session 文件）；非零退出仍按原样抛出 `CalledProcessError`，fail-fast 不变；
+- 首次进入 `pr` 阶段时向 Issue 回写一条关键阶段 comment（失败不影响主流程）。
+
+`status` 对 `ai-in-progress` 的 Issue 额外显示一行实时现场（来自该 worktree 的 session 文件）：
+
+```text
+source: xqliu/muyan-pilot
+  current: #24 Stream live Pi activity ... https://github.com/xqliu/muyan-pilot/issues/24
+  live: phase=test at=2026-08-24T17:56:01.728Z summary=pytest tests/ -q session=2026-....jsonl
+  ready: -
+  result: -
+```
+
+完整 session 保存在本地 `<worktree>/.pi-session/`，不上传、不打印。
+
 前置条件：
 
 - `gh auth status` 成功；

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -13,11 +13,22 @@ import logging
 import os
 import subprocess
 import tempfile
+import time
 import tomllib
 from pathlib import Path
 
+from pi_session import (
+    PHASE_PR,
+    parse_session_events,
+    session_file_for,
+)
+
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
+
+# Live activity polling defaults (seconds).
+POLL_INTERVAL = 1.0
+STALL_TIMEOUT = 300.0
 
 
 def _config_path(value: str, base: Path) -> Path:
@@ -171,8 +182,89 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int) -> Path:
     return path
 
 
+def watch_pi_session(process, *, worktree: Path, issue: dict, source_repo: str,
+                     branch: str, started: float, command: list[str],
+                     poll_interval: float = POLL_INTERVAL,
+                     stall_timeout: float = STALL_TIMEOUT,
+                     timeout: int | None = None,
+                     on_phase=None) -> int:
+    """Poll the Pi session JSONL and log live activity until Pi exits.
+
+    Every poll re-reads the session file and logs each new event once
+    (phase, timestamp, sanitized summary). Warns when no new event arrives
+    within `stall_timeout` seconds and always logs a final scene line
+    (return code, last activity, session file) so a failed or stalled run
+    can be located from the journal alone. Returns the process return code.
+    """
+    number = issue["number"]
+    seen = 0
+    last_activity_at = started
+    last_activity = None
+
+    def log_new_events(session_file: Path | None) -> None:
+        nonlocal seen, last_activity_at, last_activity
+        if session_file is None:
+            return
+        for event in parse_session_events(session_file)[seen:]:
+            seen += 1
+            last_activity_at = time.time()
+            last_activity = (event["phase"], event["summary"], event["timestamp"])
+            LOGGER.info(
+                "pi_activity issue=%s source_repo=%s branch=%s worktree=%s "
+                "session=%s phase=%s at=%s summary=%s",
+                number, source_repo, branch, worktree, session_file.name,
+                event["phase"], event["timestamp"], event["summary"],
+            )
+            if on_phase is not None:
+                on_phase(event)
+
+    while True:
+        now = time.time()
+        if timeout is not None and now - started >= timeout:
+            process.kill()
+            process.wait()
+            LOGGER.error("pi_timeout issue=%s timeout=%s", number, timeout)
+            raise subprocess.TimeoutExpired(command, timeout)
+        session_file = session_file_for(worktree, started)
+        log_new_events(session_file)
+        idle_for = now - last_activity_at
+        if idle_for >= stall_timeout:
+            LOGGER.warning(
+                "pi_stalled issue=%s idle_seconds=%s last_activity=%s "
+                "last_summary=%s last_at=%s session=%s",
+                number, int(idle_for),
+                last_activity[0] if last_activity else "none",
+                last_activity[1] if last_activity else "-",
+                last_activity[2] if last_activity else "-",
+                session_file.name if session_file else "-",
+            )
+            last_activity_at = now
+        returncode = process.poll()
+        if returncode is not None:
+            session_file = session_file_for(worktree, started)
+            log_new_events(session_file)
+            LOGGER.info(
+                "pi_finished issue=%s source_repo=%s branch=%s worktree=%s "
+                "session=%s returncode=%s last_activity=%s last_summary=%s last_at=%s",
+                number, source_repo, branch, worktree,
+                session_file.name if session_file else "-",
+                returncode,
+                last_activity[0] if last_activity else "none",
+                last_activity[1] if last_activity else "-",
+                last_activity[2] if last_activity else "-",
+            )
+            return returncode
+        time.sleep(poll_interval)
+
+
 def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
-           timeout: int | None = None) -> str:
+           timeout: int | None = None, on_phase=None) -> str:
+    """Run one Pi session in the worktree, streaming live activity to the log.
+
+    Pi stdout is not captured into the journal until the process exits; the
+    live view comes from the session JSONL via watch_pi_session. A nonzero
+    exit still raises CalledProcessError, exactly like run_command did.
+    """
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -197,20 +289,34 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         "pi", *skill_args, "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
+    branch = task_branch(source_repo, issue["number"])
     LOGGER.info(
-        "pi_session=%s issue=%s source_repo=%s",
-        worktree / ".pi-session", issue["number"], source_repo,
+        "pi_session=%s issue=%s source_repo=%s branch=%s worktree=%s",
+        worktree / ".pi-session", issue["number"], source_repo, branch, worktree,
     )
-    return run_command(
-        command,
-        cwd=worktree,
-        timeout=timeout,
-        log_stdout=True,
-        log_command=[
-            "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
-            "--system-prompt", "<redacted>", "<issue-context-redacted>",
-        ],
+    started = time.time()
+    process = subprocess.Popen(
+        command, cwd=worktree,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
     )
+    try:
+        returncode = watch_pi_session(
+            process, worktree=worktree, issue=issue, source_repo=source_repo,
+            branch=branch, started=started, command=command, timeout=timeout,
+            on_phase=on_phase,
+        )
+    except BaseException:
+        process.kill()
+        process.wait()
+        raise
+    output = process.stdout.read() if process.stdout else ""
+    if returncode != 0:
+        LOGGER.error(
+            "pi_failed issue=%s returncode=%s stdout=%s",
+            issue["number"], returncode, (output or "").strip()[-2000:],
+        )
+        raise subprocess.CalledProcessError(returncode, command, output=output)
+    return (output or "").strip()
 
 
 def verify_pr(worktree: Path, branch: str) -> str:
@@ -238,9 +344,27 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     branch = task_branch(source_repo, number)
     edit_issue(number, repo=source_repo, add="ai-in-progress")
+    milestone_commented = False
+
+    def on_milestone(event: dict) -> None:
+        nonlocal milestone_commented
+        if milestone_commented or event["phase"] != PHASE_PR:
+            return
+        milestone_commented = True
+        try:
+            comment_issue(
+                number, repo=source_repo,
+                body=(
+                    f"Muyan Pilot: key phase `{event['phase']}` reached "
+                    f"({event['summary']}) at {event['timestamp']}."
+                ),
+            )
+        except Exception:
+            LOGGER.exception("issue=%s milestone comment failed", number)
+
     try:
         worktree = create_worktree(config["repo_dir"], source_repo, number)
-        run_pi(issue, worktree, config, source_repo)
+        run_pi(issue, worktree, config, source_repo, on_phase=on_milestone)
         pr_url = verify_pr(worktree, branch)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -2,8 +2,10 @@
 """Muyan Pilot task dispatch and status CLI.
 
 `add` creates an Issue in a configured source repo and labels it `ai-ready`.
-`status` reports the current in-progress Issue, the next ready Issue, and the
-most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
+`status` reports the current in-progress Issue (including its live Pi session
+activity: phase, last activity time and a sanitized summary), the next ready
+Issue, and the most recent result (`ai-pr-opened` / `ai-blocked`) per source
+repo.
 
 GitHub Issues and labels are the only state store. There is no database,
 queue, or web UI. Command failures are logged and raised by the reused
@@ -22,7 +24,9 @@ from bootstrap_runner import (
     parse_issue_array,
     run_command,
     validate_config,
+    worktree_path,
 )
+from pi_session import newest_session_file, summarize_session_file
 
 LOGGER = logging.getLogger("muyan_pilot.cli")
 
@@ -95,17 +99,37 @@ def format_issue(issue: dict) -> str:
     return f"#{issue['number']} {issue['title']} {issue['url']}"
 
 
+def live_status(repo: str, issue: dict) -> str:
+    """One-line live scene for an in-progress Issue from its Pi session."""
+    worktree = worktree_path(repo, int(issue["number"]))
+    if not worktree.is_dir():
+        return "live: worktree missing"
+    session_file = newest_session_file(worktree)
+    if session_file is None:
+        return "live: no session file yet"
+    _, activity = summarize_session_file(session_file)
+    if activity is None:
+        return f"live: session={session_file.name} (no events yet)"
+    phase, summary, at = activity
+    return (
+        f"live: phase={phase} at={at} summary={summary} "
+        f"session={session_file.name}"
+    )
+
+
 def status_report(config: dict) -> str:
     lines = []
     for repo in config["source_repos"]:
         lines.append(f"source: {repo}")
-        for name, lookup in (
-            ("current", current_issue),
-            ("ready", ready_issue),
-            ("result", recent_result),
+        current = current_issue(repo)
+        for name, issue in (
+            ("current", current),
+            ("ready", ready_issue(repo)),
+            ("result", recent_result(repo)),
         ):
-            issue = lookup(repo)
             lines.append(f"  {name}: {format_issue(issue) if issue else '-'}")
+        if current is not None:
+            lines.append(f"  {live_status(repo, current)}")
     return "\n".join(lines)
 
 
@@ -129,7 +153,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     subparsers.add_parser(
         "status", parents=[common],
-        help="show current Issue, ready queue and recent result",
+        help="show current Issue (with live Pi activity), ready queue and recent result",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/pi_session.py
+++ b/pi_session.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Parse Pi session JSONL files into sanitized live activity events.
+
+Pi writes one JSON object per line to `<worktree>/.pi-session/*.jsonl` while a
+session runs. This module turns those lines into short, redacted summaries that
+the runner can log live to the journal and that `muyan_pilot.py status` can
+display. Full prompts, issue bodies, tool outputs and reasoning are never
+captured in the events.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+SUMMARY_LIMIT = 160
+REDACTED = "<redacted>"
+
+# Key phases surfaced to the user (journal + status + Issue comments).
+PHASE_TEST = "test"
+PHASE_VERIFY = "verify"
+PHASE_COMMIT = "commit"
+PHASE_PUSH = "push"
+PHASE_PR = "pr"
+PHASE_ISSUE_COMMENT = "issue_comment"
+PHASE_WORKTREE = "worktree"
+PHASE_BRANCH = "branch"
+PHASE_SETUP = "setup"
+PHASE_UI_TEST = "ui_test"
+PHASE_READ = "read"
+PHASE_EDIT = "edit"
+PHASE_SEARCH = "search"
+PHASE_COMMAND = "command"
+PHASE_THINKING = "thinking"
+PHASE_REPLY = "reply"
+PHASE_TOOL_RESULT = "tool_result"
+PHASE_SESSION_START = "session_start"
+PHASE_SESSION_END = "session_end"
+
+_GITHUB_TOKEN = re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}")
+_BEARER = re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_TOKEN_FLAG = re.compile(r"(--token[= ])\S+")
+_API_KEY = re.compile(
+    r"([\"']?[A-Za-z0-9_.-]*api[_-]?key[A-Za-z0-9_.-]*[\"']?\s*[=:]\s*)"
+    r"([\"']?)[A-Za-z0-9._~+/=-]+\2",
+    re.IGNORECASE,
+)
+
+_BASH_PHASES = (
+    (("pip install", "npm install", "apt install"), PHASE_SETUP),
+    (("pytest", "coverage", "npm test", "unittest"), PHASE_TEST),
+    (("muyan_pilot.py status",), PHASE_VERIFY),
+    (("git commit",), PHASE_COMMIT),
+    (("git push",), PHASE_PUSH),
+    (("gh pr",), PHASE_PR),
+    (("gh issue comment",), PHASE_ISSUE_COMMENT),
+    (("git worktree",), PHASE_WORKTREE),
+    (("git branch",), PHASE_BRANCH),
+    (("playwright",), PHASE_UI_TEST),
+)
+
+_TOOL_PHASES = {
+    "read": PHASE_READ,
+    "write": PHASE_EDIT,
+    "edit": PHASE_EDIT,
+    "grep": PHASE_SEARCH,
+    "glob": PHASE_SEARCH,
+    "search": PHASE_SEARCH,
+    "playwright": PHASE_UI_TEST,
+    "mcp": "mcp",
+}
+
+_SUMMARY_KEYS = ("command", "path", "file", "pattern", "query", "glob")
+
+
+def redact(text: str) -> str:
+    """Replace credentials in a string before it is logged or shown."""
+    text = _GITHUB_TOKEN.sub(REDACTED, text)
+    text = _BEARER.sub("Bearer " + REDACTED, text)
+    text = _TOKEN_FLAG.sub(r"\1" + REDACTED, text)
+    text = _API_KEY.sub(r"\1\2" + REDACTED + r"\2", text)
+    return text
+
+
+def _truncate(text: str) -> str:
+    text = " ".join(text.split())
+    if len(text) <= SUMMARY_LIMIT:
+        return text
+    return text[: SUMMARY_LIMIT - 1] + "…"
+
+
+def classify_phase(name: str, arguments: object) -> str:
+    """Map a tool call to a key phase (test, commit, push, pr, ...)."""
+    if name == "bash":
+        if isinstance(arguments, dict):
+            command = arguments.get("command")
+            if isinstance(command, str):
+                for needles, phase in _BASH_PHASES:
+                    if any(needle in command for needle in needles):
+                        return phase
+        return PHASE_COMMAND
+    return _TOOL_PHASES.get(name, name)
+
+
+def summarize_tool(name: str, arguments: object) -> str:
+    """Build a short sanitized summary for one tool call."""
+    if isinstance(arguments, dict):
+        for key in _SUMMARY_KEYS:
+            value = arguments.get(key)
+            if isinstance(value, str) and value:
+                if name == "bash" and key == "command":
+                    value = value.splitlines()[0].strip()
+                return _truncate(redact(value))
+        return _truncate(redact(json.dumps(arguments, ensure_ascii=False)))
+    return name
+
+
+def _event(kind: str, phase: str, timestamp: str, summary: str) -> dict:
+    return {
+        "kind": kind,
+        "phase": phase,
+        "timestamp": timestamp,
+        "summary": _truncate(redact(summary)),
+    }
+
+
+def _assistant_events(message: dict, timestamp: str) -> list[dict]:
+    """Summarize an assistant message: each tool call, then its text."""
+    events = []
+    for part in message.get("content", []):
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "toolCall":
+            name = part.get("name")
+            if not isinstance(name, str):
+                continue
+            events.append(_event(
+                "assistant", classify_phase(name, part.get("arguments")),
+                timestamp, summarize_tool(name, part.get("arguments")),
+            ))
+    for part in message.get("content", []):
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str) and text.strip():
+                events.append(_event("assistant", PHASE_REPLY, timestamp, text))
+                break
+    if not events:
+        events.append(_event("assistant", PHASE_THINKING, timestamp, "thinking"))
+    return events
+
+
+def _tool_result_event(message: dict, timestamp: str) -> dict:
+    name = message.get("toolName")
+    if not isinstance(name, str) or not name:
+        name = "tool"
+    status = "failed" if message.get("isError") else "ok"
+    return _event("toolResult", PHASE_TOOL_RESULT, timestamp, f"{name} {status}")
+
+
+def parse_session_events(path: Path) -> list[dict]:
+    """Read a session JSONL file and return sanitized activity events.
+
+    Malformed lines are skipped: Pi may still be writing the last line when
+    the file is read, and a crashed session may end mid-line.
+    """
+    if not path.is_file():
+        return []
+    events = []
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        kind = data.get("type")
+        if kind == "session":
+            timestamp = data.get("timestamp")
+            if not isinstance(timestamp, str) or not timestamp:
+                continue
+            event = _event(
+                "session_start", PHASE_SESSION_START, timestamp, "session started",
+            )
+            session_id = data.get("id")
+            if isinstance(session_id, str) and session_id:
+                event["session_id"] = session_id
+            events.append(event)
+        elif kind in ("model_change", "thinking_level_change"):
+            if kind == "model_change":
+                provider = data.get("provider")
+                model = data.get("modelId")
+                summary = "model " + "/".join(
+                    value for value in (provider, model)
+                    if isinstance(value, str) and value
+                )
+            else:
+                level = data.get("thinkingLevel")
+                summary = "thinking level " + (
+                    level if isinstance(level, str) else "unknown"
+                )
+            events.append(_event(kind, kind, str(data.get("timestamp")), summary))
+        elif kind == "session_end":
+            timestamp = data.get("timestamp")
+            if isinstance(timestamp, str) and timestamp:
+                events.append(_event(
+                    "session_end", PHASE_SESSION_END, timestamp, "session ended",
+                ))
+        elif kind == "message":
+            message = data.get("message")
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            timestamp = data.get("timestamp")
+            if not isinstance(timestamp, str) or not timestamp:
+                continue
+            if role == "assistant":
+                events.extend(_assistant_events(message, timestamp))
+            elif role == "toolResult":
+                events.append(_tool_result_event(message, timestamp))
+    return events
+
+
+def latest_activity(events: list[dict]) -> tuple[str, str, str] | None:
+    """Return (phase, summary, timestamp) of the newest event, or None."""
+    if not events:
+        return None
+    newest = max(events, key=lambda event: event["timestamp"])
+    return newest["phase"], newest["summary"], newest["timestamp"]
+
+
+def newest_session_file(worktree: Path) -> Path | None:
+    """Return the newest session JSONL in the worktree, or None."""
+    session_dir = worktree / ".pi-session"
+    if not session_dir.is_dir():
+        return None
+    candidates = list(session_dir.glob("*.jsonl"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def session_file_for(worktree: Path, started: float) -> Path | None:
+    """Return the newest session JSONL created at or after `started`."""
+    newest = newest_session_file(worktree)
+    if newest is None or newest.stat().st_mtime < started:
+        return None
+    return newest
+
+
+def summarize_session_file(path: Path) -> tuple[str | None, tuple[str, str, str] | None]:
+    """Return (session id, latest activity) for one session file."""
+    events = parse_session_events(path)
+    session_id = None
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and data.get("type") == "session":
+            value = data.get("id")
+            if isinstance(value, str):
+                session_id = value
+            break
+    return session_id, latest_activity(events)

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* 01..06:00/5:00
+OnCalendar=*-*-* 01..06:00/15:00
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -265,15 +265,94 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     ]]
 
 
-def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
+class FakePiProcess:
+    """Stand-in for subprocess.Popen with scripted poll() results."""
+
+    def __init__(self, command, cwd, **kwargs):
+        self.command = command
+        self.cwd = cwd
+        self.kwargs = kwargs
+        self.polls = list(getattr(type(self), "polls", [0]))
+        self.stdout = FakeStdout(getattr(type(self), "output", ""))
+        self.killed = False
+        self.waited = False
+        self._final = None
+
+    def poll(self):
+        if len(self.polls) > 1:
+            self.polls.pop(0)
+            return None
+        self._final = self.polls.pop(0)
+        return self._final
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self):
+        self.waited = True
+        if self._final is None:
+            self.poll()
+        return self._final
+
+
+class FakeStdout:
+    def __init__(self, text):
+        self._text = text
+
+    def read(self):
+        return self._text
+
+
+def _write_session_file(worktree, *lines):
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / "session.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _session_line(**overrides):
+    data = {
+        "type": "session", "version": 3, "id": "sess-1",
+        "timestamp": "2026-08-24T17:55:32.139Z",
+        "cwd": str(Path("/tmp")),
+    }
+    data.update(overrides)
+    return json.dumps(data)
+
+
+def _assistant_line(command, timestamp="2026-08-24T17:56:01.728Z"):
+    return json.dumps({
+        "type": "message", "id": "m1", "parentId": None, "timestamp": timestamp,
+        "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "id": "c1", "name": "bash",
+             "arguments": {"command": command}},
+        ]},
+    })
+
+
+def test_run_pi_spawns_pi_and_streams_live_activity(monkeypatch, tmp_path, caplog):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text(
         "SYSTEM {{SOURCE_REPO}} {{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{ISSUE_BODY}} "
         "{{WORKSPACE_ROOT}} {{CONTEXT_FILES}} {{SKILLS}}",
         encoding="utf-8",
     )
-    calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
+    created = {}
+
+    class PopenSpy(FakePiProcess):
+        def __init__(self, command, cwd, **kwargs):
+            super().__init__(command, cwd, **kwargs)
+            created["process"] = self
+            _write_session_file(
+                cwd,
+                _session_line(),
+                _assistant_line("pytest tests/ -q"),
+            )
+
+    PopenSpy.polls = [None, 0]
+    PopenSpy.output = "final output\n"
+    monkeypatch.setattr(runner.subprocess, "Popen", PopenSpy)
     issue = {"number": 4, "title": "Fix title", "body": "Fix body"}
     config = {
         "prompt": prompt_path,
@@ -282,36 +361,275 @@ def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
         "context_files": [tmp_path / "context.md"],
         "skills": [tmp_path / "skill.md"],
     }
-    assert runner.run_pi(issue, tmp_path, config, "owner/repo") == "done"
-    command, kwargs = calls[0]
-    assert command[:4] == ["pi", "--skill", str(tmp_path / "skill.md"), "--print"]
-    assert "owner/repo" in command[7]
-    assert " 4 " in command[7]
-    assert "Fix title" in command[7]
-    assert "Fix body" in command[7]
-    assert str(tmp_path / "context.md") in command[7]
-    assert str(tmp_path / "skill.md") in command[7]
-    assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
-    assert kwargs["cwd"] == tmp_path
-    assert kwargs["timeout"] is None
-    assert kwargs["log_stdout"] is True
-    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+    with caplog.at_level("INFO"):
+        assert runner.run_pi(issue, tmp_path, config, "owner/repo") == "final output"
+    process = created["process"]
+    assert process.command[:4] == ["pi", "--skill", str(tmp_path / "skill.md"), "--print"]
+    assert "owner/repo" in process.command[7]
+    assert " 4 " in process.command[7]
+    assert "Fix title" in process.command[7]
+    assert "Fix body" in process.command[7]
+    assert str(tmp_path / "context.md") in process.command[7]
+    assert str(tmp_path / "skill.md") in process.command[7]
+    assert process.command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
+    assert process.cwd == tmp_path
+    assert process.kwargs == {
+        "stdout": runner.subprocess.PIPE, "stderr": runner.subprocess.STDOUT,
+        "text": True,
+    }
+    activity = [line for line in caplog.text.splitlines() if "pi_activity" in line]
+    assert len(activity) == 2
+    assert "phase=session_start" in activity[0]
+    assert "phase=test" in activity[1]
+    assert "summary=pytest tests/ -q" in activity[1]
+    assert "issue=4" in activity[1]
+    assert "source_repo=owner/repo" in activity[1]
+    assert "branch=muyan-pilot/owner-repo-issue-4" in activity[1]
+    assert "worktree=" + str(tmp_path) in activity[1]
+    assert "session=session.jsonl" in activity[1]
+    finished = [line for line in caplog.text.splitlines() if "pi_finished" in line]
+    assert len(finished) == 1
+    assert "returncode=0" in finished[0]
+    assert "last_activity=test" in finished[0]
+    assert "last_at=2026-08-24T17:56:01.728Z" in finished[0]
 
 
-def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path):
+def test_run_pi_invokes_pi_with_rendered_prompt_and_issue_context(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text("PRIVATE SYSTEM {{ISSUE_BODY}}", encoding="utf-8")
-    calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
+
+    class PopenSpy(FakePiProcess):
+        pass
+
+    PopenSpy.polls = [0]
+    PopenSpy.output = ""
+    monkeypatch.setattr(runner.subprocess, "Popen", PopenSpy)
+    created = {}
+    original_init = PopenSpy.__init__
+
+    def spy_init(self, command, cwd, **kwargs):
+        original_init(self, command, cwd, **kwargs)
+        created["command"] = command
+
+    PopenSpy.__init__ = spy_init
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
         {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
         "owner/repo",
     )
-    command, kwargs = calls[0]
+    command = created["command"]
     assert "PRIVATE SYSTEM" in command[5]
     assert "token" in command[5]
-    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+
+
+def test_run_pi_raises_called_process_error_on_nonzero_exit(monkeypatch, tmp_path, caplog):
+    class PopenSpy(FakePiProcess):
+        pass
+
+    PopenSpy.polls = [None, 3]
+    PopenSpy.output = "boom\n"
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(runner.subprocess, "Popen", PopenSpy)
+    with caplog.at_level("INFO"), pytest.raises(
+        subprocess.CalledProcessError,
+    ) as excinfo:
+        runner.run_pi(
+            {"number": 6, "title": "Fail", "body": ""}, tmp_path,
+            {"prompt": tmp_path / "prompt.md", "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
+            "owner/repo",
+        )
+    assert excinfo.value.returncode == 3
+    assert "boom" in (excinfo.value.output or "")
+    assert "pi_finished" in caplog.text
+    assert "returncode=3" in caplog.text
+    assert "pi_failed" in caplog.text
+
+
+def test_run_pi_kills_process_when_watcher_fails(monkeypatch, tmp_path):
+    class PopenSpy(FakePiProcess):
+        pass
+
+    PopenSpy.polls = [None, 0]
+    PopenSpy.output = ""
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(runner.subprocess, "Popen", PopenSpy)
+    created = {}
+    original_init = PopenSpy.__init__
+
+    def spy_init(self, command, cwd, **kwargs):
+        original_init(self, command, cwd, **kwargs)
+        created["process"] = self
+
+    PopenSpy.__init__ = spy_init
+    monkeypatch.setattr(
+        runner, "session_file_for",
+        lambda worktree, started: (_ for _ in ()).throw(RuntimeError("watch failed")),
+    )
+    with pytest.raises(RuntimeError, match="watch failed"):
+        runner.run_pi(
+            {"number": 7, "title": "Fail", "body": ""}, tmp_path,
+            {"prompt": tmp_path / "prompt.md", "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
+            "owner/repo",
+        )
+    process = created["process"]
+    assert process.killed is True
+    assert process.waited is True
+
+
+def test_run_pi_raises_timeout_when_pi_runs_too_long(monkeypatch, tmp_path, caplog):
+    class PopenSpy(FakePiProcess):
+        pass
+
+    PopenSpy.polls = [None, None, 0]
+    PopenSpy.output = ""
+    (tmp_path / "prompt.md").write_text("prompt", encoding="utf-8")
+    monkeypatch.setattr(runner.subprocess, "Popen", PopenSpy)
+    created = {}
+    original_init = PopenSpy.__init__
+
+    def spy_init(self, command, cwd, **kwargs):
+        original_init(self, command, cwd, **kwargs)
+        created["process"] = self
+
+    PopenSpy.__init__ = spy_init
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    monkeypatch.setattr(runner.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        runner.time, "sleep",
+        lambda seconds: clock.update(now=clock["now"] + seconds + 30.0),
+    )
+    with caplog.at_level("ERROR"), pytest.raises(subprocess.TimeoutExpired):
+        runner.run_pi(
+            {"number": 8, "title": "Slow", "body": ""}, tmp_path,
+            {"prompt": tmp_path / "prompt.md", "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
+            "owner/repo",
+            timeout=50,
+        )
+    clock["now"] = clock["now"]  # no-op to keep linters quiet
+    assert created["process"].killed is True
+    assert "pi_timeout" in caplog.text
+
+
+def test_watch_pi_session_logs_each_new_event_once(monkeypatch, tmp_path, caplog):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    session_file = session_dir / "session.jsonl"
+    session_file.write_text(_session_line() + "\n", encoding="utf-8")
+    process = FakePiProcess([], None)
+    process.polls = [None, 0]
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+
+    def fake_sleep(seconds):
+        # A new event appears between polls and must be picked up next poll.
+        session_file.write_text(
+            session_file.read_text(encoding="utf-8")
+            + _assistant_line("pytest tests/ -q") + "\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(runner.time, "sleep", fake_sleep)
+    phases = []
+    with caplog.at_level("INFO"):
+        assert runner.watch_pi_session(
+            process, worktree=tmp_path, issue={"number": 9, "title": "t", "body": ""},
+            source_repo="owner/repo", branch="b", started=900.0,
+            command=["pi"], poll_interval=1.0, stall_timeout=300.0,
+            on_phase=lambda event: phases.append(event["phase"]),
+        ) == 0
+    activities = [line for line in caplog.text.splitlines() if "pi_activity" in line]
+    assert len(activities) == 2
+    assert "phase=session_start" in activities[0]
+    assert "phase=test" in activities[1]
+    assert phases == ["session_start", "test"]
+
+
+def test_watch_pi_session_invokes_on_phase_for_every_new_event(monkeypatch, tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    session_file = session_dir / "session.jsonl"
+    session_file.write_text(
+        _session_line() + "\n"
+        + _assistant_line("pytest tests/ -q") + "\n"
+        + _assistant_line("gh pr create --title x", timestamp="2026-08-24T17:57:00.000Z") + "\n",
+        encoding="utf-8",
+    )
+    process = FakePiProcess([], None)
+    process.polls = [0]
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    seen = []
+    assert runner.watch_pi_session(
+        process, worktree=tmp_path, issue={"number": 10, "title": "t", "body": ""},
+        source_repo="owner/repo", branch="b", started=900.0,
+        command=["pi"], poll_interval=1.0, stall_timeout=300.0,
+        on_phase=seen.append,
+    ) == 0
+    assert [event["phase"] for event in seen] == ["session_start", "test", "pr"]
+    assert seen[2]["summary"] == "gh pr create --title x"
+
+
+def test_watch_pi_session_warns_when_no_new_activity(monkeypatch, tmp_path, caplog):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    session_file = session_dir / "session.jsonl"
+    session_file.write_text(_session_line() + "\n", encoding="utf-8")
+    process = FakePiProcess([], None)
+    process.polls = [None, 0]
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    monkeypatch.setattr(
+        runner.time, "sleep",
+        lambda seconds: clock.update(now=clock["now"] + seconds + 300.0),
+    )
+    with caplog.at_level("WARNING"):
+        assert runner.watch_pi_session(
+            process, worktree=tmp_path, issue={"number": 11, "title": "t", "body": ""},
+            source_repo="owner/repo", branch="b", started=900.0,
+            command=["pi"], poll_interval=1.0, stall_timeout=300.0,
+        ) == 0
+    stalled = [line for line in caplog.text.splitlines() if "pi_stalled" in line]
+    assert len(stalled) == 1
+    assert "idle_seconds=301" in stalled[0]
+    assert "last_activity=session_start" in stalled[0]
+    assert "session=session.jsonl" in stalled[0]
+
+
+def test_watch_pi_session_reports_scene_when_no_session_file(monkeypatch, tmp_path, caplog):
+    process = FakePiProcess([], None)
+    process.polls = [0]
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    with caplog.at_level("INFO"):
+        assert runner.watch_pi_session(
+            process, worktree=tmp_path, issue={"number": 12, "title": "t", "body": ""},
+            source_repo="owner/repo", branch="b", started=900.0,
+            command=["pi"], poll_interval=1.0, stall_timeout=300.0,
+        ) == 0
+    finished = [line for line in caplog.text.splitlines() if "pi_finished" in line]
+    assert len(finished) == 1
+    assert "session=-" in finished[0]
+    assert "last_activity=none" in finished[0]
+
+
+def test_watch_pi_session_raises_timeout_and_kills_process(monkeypatch, tmp_path, caplog):
+    process = FakePiProcess([], None)
+    process.polls = [None, None, None, None]
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(runner.time, "time", lambda: clock["now"])
+    monkeypatch.setattr(
+        runner.time, "sleep",
+        lambda seconds: clock.update(now=clock["now"] + seconds + 30.0),
+    )
+    with caplog.at_level("ERROR"), pytest.raises(subprocess.TimeoutExpired):
+        runner.watch_pi_session(
+            process, worktree=tmp_path, issue={"number": 13, "title": "t", "body": ""},
+            source_repo="owner/repo", branch="b", started=900.0,
+            command=["pi"], poll_interval=1.0, stall_timeout=300.0, timeout=50,
+        )
+    assert process.killed is True
+    assert "pi_timeout" in caplog.text
 
 
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
@@ -375,6 +693,63 @@ def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path)
         runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
     assert calls[2][0] == "comment"
+
+
+def test_process_issue_comments_once_when_pr_phase_reached(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run_pi(issue, worktree, config, source_repo, timeout=None, on_phase=None):
+        calls.append(("run_pi", on_phase))
+        if on_phase is not None:
+            on_phase({"phase": "test", "summary": "pytest", "timestamp": "t1"})
+            on_phase({"phase": "pr", "summary": "gh pr create --title x",
+                      "timestamp": "2026-08-24T17:57:00.000Z"})
+            on_phase({"phase": "pr", "summary": "gh pr list",
+                      "timestamp": "2026-08-24T17:57:01.000Z"})
+        return "done"
+
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", kwargs)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "run_pi", fake_run_pi)
+    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/x/y/pull/4")
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", kwargs)))
+    issue = {"number": 4, "title": "Fix", "body": "Body"}
+    assert runner.process_issue(issue, {"repo_dir": tmp_path}, "xqliu/muyan-ceo") == "https://github.com/x/y/pull/4"
+    comments = [call for call in calls if call[0] == "comment"]
+    assert len(comments) == 2
+    milestone = comments[0][1]["body"]
+    assert "pr" in milestone
+    assert "gh pr create --title x" in milestone
+    assert "2026-08-24T17:57:00.000Z" in milestone
+    assert comments[1][1]["body"] == "Muyan Pilot opened PR: https://github.com/x/y/pull/4"
+
+
+def test_process_issue_milestone_comment_failure_does_not_block_success(monkeypatch, tmp_path, caplog):
+    calls = []
+
+    def fake_run_pi(issue, worktree, config, source_repo, timeout=None, on_phase=None):
+        if on_phase is not None:
+            on_phase({"phase": "pr", "summary": "gh pr create --title x",
+                      "timestamp": "t"})
+        return "done"
+
+    def fake_comment(number, *, repo, body):
+        calls.append(body)
+        if "key phase" in body:
+            raise RuntimeError("github down")
+
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "run_pi", fake_run_pi)
+    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/x/y/pull/4")
+    monkeypatch.setattr(runner, "comment_issue", fake_comment)
+    with caplog.at_level("ERROR"):
+        assert runner.process_issue(
+            {"number": 4, "title": "Fix", "body": "Body"},
+            {"repo_dir": tmp_path}, "xqliu/muyan-ceo",
+        ) == "https://github.com/x/y/pull/4"
+    assert "milestone comment failed" in caplog.text
+    assert calls[-1] == "Muyan Pilot opened PR: https://github.com/x/y/pull/4"
 
 
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -195,11 +196,16 @@ def test_status_report_lists_sources_current_ready_and_result(monkeypatch):
     monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: fake_lookup(repo, "current"))
     monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: fake_lookup(repo, "ready"))
     monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: fake_lookup(repo, "result"))
+    monkeypatch.setattr(
+        muyan_pilot, "live_status",
+        lambda repo, issue: "live: phase=test at=t summary=pytest session=s.jsonl",
+    )
     report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
     assert "source: xqliu/muyan-pilot" in report
     assert "current: #3 now u3" in report
     assert "ready: #11 next u11" in report
     assert "result: #2 done u2" in report
+    assert "live: phase=test at=t summary=pytest session=s.jsonl" in report
 
 
 def test_status_report_marks_empty_lookups(monkeypatch):
@@ -210,6 +216,54 @@ def test_status_report_marks_empty_lookups(monkeypatch):
     assert "current: -" in report
     assert "ready: -" in report
     assert "result: -" in report
+    assert "live:" not in report
+
+
+def test_live_status_reports_missing_worktree(monkeypatch):
+    monkeypatch.setattr(
+        muyan_pilot, "worktree_path",
+        lambda repo, number: Path("/tmp/does-not-exist-wt"),
+    )
+    assert muyan_pilot.live_status("owner/repo", {"number": 3}) == "live: worktree missing"
+
+
+def test_live_status_reports_no_session_file_yet(monkeypatch, tmp_path):
+    monkeypatch.setattr(muyan_pilot, "worktree_path", lambda repo, number: tmp_path)
+    assert muyan_pilot.live_status("owner/repo", {"number": 3}) == "live: no session file yet"
+
+
+def test_live_status_shows_phase_summary_and_session(monkeypatch, tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    session_file = session_dir / "2026-08-24T17-55-32-139Z_sess.jsonl"
+    session_file.write_text(
+        json.dumps({"type": "session", "version": 3, "id": "sess-1",
+                    "timestamp": "2026-08-24T17:55:32.139Z", "cwd": str(tmp_path)})
+        + "\n"
+        + json.dumps({"type": "message", "id": "m1", "parentId": None,
+                      "timestamp": "2026-08-24T17:56:01.728Z",
+                      "message": {"role": "assistant", "content": [
+                          {"type": "toolCall", "id": "c1", "name": "bash",
+                           "arguments": {"command": "pytest tests/ -q"}},
+                      ]}}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(muyan_pilot, "worktree_path", lambda repo, number: tmp_path)
+    line = muyan_pilot.live_status("owner/repo", {"number": 3})
+    assert line == (
+        "live: phase=test at=2026-08-24T17:56:01.728Z "
+        "summary=pytest tests/ -q session=2026-08-24T17-55-32-139Z_sess.jsonl"
+    )
+
+
+def test_live_status_reports_session_without_events(monkeypatch, tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    (session_dir / "broken.jsonl").write_text("not json\n", encoding="utf-8")
+    monkeypatch.setattr(muyan_pilot, "worktree_path", lambda repo, number: tmp_path)
+    assert muyan_pilot.live_status("owner/repo", {"number": 3}) == (
+        "live: session=broken.jsonl (no events yet)"
+    )
 
 
 def test_main_add_dispatches_to_selected_source_repo(monkeypatch, tmp_path, capsys):

--- a/tests/test_pi_session.py
+++ b/tests/test_pi_session.py
@@ -1,0 +1,478 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import pi_session
+
+
+def _session_line(**overrides):
+    data = {
+        "type": "session", "version": 3,
+        "id": "01a034e9-caab-7921-8228-5b2b584065be",
+        "timestamp": "2026-08-24T17:55:32.139Z",
+        "cwd": "/tmp/muyan-pilot-xqliu-muyan-pilot-issue-24",
+    }
+    data.update(overrides)
+    return json.dumps(data)
+
+
+def _message_line(role, content, timestamp="2026-08-24T17:55:40.223Z", **extra):
+    data = {
+        "type": "message", "id": "15bea09c", "parentId": "2f5bc939",
+        "timestamp": timestamp,
+        "message": {"role": role, "content": content, **extra},
+    }
+    return json.dumps(data)
+
+
+def _write_session(tmp_path, *lines):
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def test_parse_session_events_reads_session_header():
+    path = _write_session(Path("/tmp"), _session_line())
+    events = pi_session.parse_session_events(path)
+    assert events == [{
+        "kind": "session_start",
+        "phase": "session_start",
+        "timestamp": "2026-08-24T17:55:32.139Z",
+        "session_id": "01a034e9-caab-7921-8228-5b2b584065be",
+        "summary": "session started",
+    }]
+
+
+def test_parse_session_events_reads_model_and_thinking_changes():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        json.dumps({"type": "model_change", "id": "a", "timestamp": "t1",
+                    "provider": "local-qwen", "modelId": "qwen3.8:27b"}),
+        json.dumps({"type": "thinking_level_change", "id": "b", "timestamp": "t2",
+                    "thinkingLevel": "high"}),
+    )
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == [
+        "session_start", "model_change", "thinking_level_change",
+    ]
+    assert events[1]["summary"] == "model local-qwen/qwen3.8:27b"
+    assert events[2]["summary"] == "thinking level high"
+
+
+def test_parse_session_events_summarizes_assistant_tool_calls():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [
+            {"type": "thinking", "thinking": "secret reasoning"},
+            {"type": "toolCall", "id": "c1", "name": "bash",
+             "arguments": {"command": "pytest tests/ -q"}},
+            {"type": "toolCall", "id": "c2", "name": "read",
+             "arguments": {"path": "/tmp/repo/README.md"}},
+        ]),
+    )
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == [
+        "session_start", "assistant", "assistant",
+    ]
+    assert events[1]["phase"] == "test"
+    assert events[1]["summary"] == "pytest tests/ -q"
+    assert events[2]["phase"] == "read"
+    assert events[2]["summary"] == "/tmp/repo/README.md"
+    assert "secret reasoning" not in json.dumps(events)
+
+
+def test_parse_session_events_summarizes_assistant_text_as_reply():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [
+            {"type": "thinking", "thinking": "hmm"},
+            {"type": "text", "text": "Now I will open the pull request."},
+        ]),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1] == {
+        "kind": "assistant", "phase": "reply",
+        "timestamp": "2026-08-24T17:55:40.223Z",
+        "summary": "Now I will open the pull request.",
+    }
+
+
+def test_parse_session_events_ignores_non_string_or_blank_text():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [
+            {"type": "text", "text": 123},
+            {"type": "text", "text": "   "},
+        ]),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1]["phase"] == "thinking"
+
+
+def test_parse_session_events_marks_thinking_only_assistant_message():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [{"type": "thinking", "thinking": "hmm"}]),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1] == {
+        "kind": "assistant", "phase": "thinking",
+        "timestamp": "2026-08-24T17:55:40.223Z",
+        "summary": "thinking",
+    }
+
+
+def test_parse_session_events_summarizes_tool_results():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("toolResult", [
+            {"type": "text", "text": "full output should not be logged"},
+        ], toolCallId="c1", toolName="bash", isError=False),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1] == {
+        "kind": "toolResult", "phase": "tool_result",
+        "timestamp": "2026-08-24T17:55:40.223Z",
+        "summary": "bash ok",
+    }
+    assert "full output" not in json.dumps(events)
+
+
+def test_parse_session_events_marks_failed_tool_result():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("toolResult", [], toolCallId="c1", toolName="bash",
+                      isError=True),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1]["phase"] == "tool_result"
+    assert events[1]["summary"] == "bash failed"
+
+
+def test_parse_session_events_skips_non_dict_content_parts_and_bad_tool_names():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [
+            "not-a-dict",
+            {"type": "toolCall", "id": "c1"},
+            {"type": "toolCall", "id": "c2", "name": 5,
+             "arguments": {"command": "pytest"}},
+        ]),
+    )
+    events = pi_session.parse_session_events(path)
+    # No valid tool call or text -> falls back to a single thinking event.
+    assert events[1] == {
+        "kind": "assistant", "phase": "thinking",
+        "timestamp": "2026-08-24T17:55:40.223Z", "summary": "thinking",
+    }
+
+
+def test_parse_session_events_tool_result_without_name_uses_tool():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("toolResult", [], toolCallId="c1", isError=False),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[1]["summary"] == "tool ok"
+
+
+def test_parse_session_events_session_without_id_has_no_session_id_field():
+    path = _write_session(
+        Path("/tmp"),
+        json.dumps({"type": "session", "timestamp": "2026-08-24T17:55:32.139Z"}),
+    )
+    events = pi_session.parse_session_events(path)
+    assert "session_id" not in events[0]
+
+
+def test_parse_session_events_skips_session_and_message_without_timestamp():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        json.dumps({"type": "session", "id": "no-ts"}),
+        json.dumps({"type": "message", "id": "m1"}),
+        json.dumps({"type": "message", "id": "m2",
+                    "message": {"role": "assistant", "content": []}}),
+    )
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == ["session_start"]
+
+
+def test_parse_session_events_skips_user_messages_and_unknown_types():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("user", [{"type": "text", "text": "issue body secret"}]),
+        json.dumps({"type": "compaction", "timestamp": "t9"}),
+    )
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == ["session_start"]
+    assert "issue body secret" not in json.dumps(events)
+
+
+def test_parse_session_events_skips_malformed_and_partial_lines():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        '{"type": "message", "message": {"role": "assistant", "cont',
+        "not json at all",
+        "",
+        _message_line("assistant", [{"type": "text", "text": "ok"}]),
+    )
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == ["session_start", "assistant"]
+
+
+def test_parse_session_events_skips_non_object_lines():
+    path = _write_session(Path("/tmp"), "42", "null", _session_line())
+    events = pi_session.parse_session_events(path)
+    assert [event["kind"] for event in events] == ["session_start"]
+
+
+def test_parse_session_events_returns_empty_for_missing_file():
+    assert pi_session.parse_session_events(Path("/tmp/does-not-exist.jsonl")) == []
+
+
+def test_parse_session_events_appends_session_end_when_file_closed():
+    path = _write_session(
+        Path("/tmp"),
+        _session_line(),
+        _message_line("assistant", [{"type": "text", "text": "done"}]),
+        json.dumps({"type": "session_end", "timestamp": "2026-08-24T18:00:00.000Z"}),
+    )
+    events = pi_session.parse_session_events(path)
+    assert events[-1] == {
+        "kind": "session_end", "phase": "session_end",
+        "timestamp": "2026-08-24T18:00:00.000Z", "summary": "session ended",
+    }
+
+
+def test_parse_session_events_ignores_session_end_without_timestamp():
+    path = _write_session(Path("/tmp"), _session_line(),
+                          json.dumps({"type": "session_end"}))
+    assert [event["kind"] for event in pi_session.parse_session_events(path)] == [
+        "session_start",
+    ]
+
+
+def test_classify_phase_maps_bash_commands_to_key_phases():
+    cases = {
+        "pytest tests/ -q": "test",
+        "python3 -m pytest tests/": "test",
+        "coverage run -m pytest": "test",
+        "python3 -m coverage report": "test",
+        "npm test": "test",
+        "python3 muyan_pilot.py status": "verify",
+        "git commit -m 'feat: x'": "commit",
+        "git push origin branch": "push",
+        "gh pr create --title x": "pr",
+        "gh pr list --state open": "pr",
+        "gh issue comment 3 --body x": "issue_comment",
+        "git worktree add -b x /tmp/wt HEAD": "worktree",
+        "git branch --show-current": "branch",
+        "pip install pytest": "setup",
+        "npx playwright test": "ui_test",
+        "ls -la": "command",
+    }
+    for command, phase in cases.items():
+        assert pi_session.classify_phase("bash", {"command": command}) == phase, command
+
+
+def test_classify_phase_maps_tool_names():
+    assert pi_session.classify_phase("read", {}) == "read"
+    assert pi_session.classify_phase("write", {"path": "a"}) == "edit"
+    assert pi_session.classify_phase("edit", {"path": "a"}) == "edit"
+    assert pi_session.classify_phase("grep", {"pattern": "x"}) == "search"
+    assert pi_session.classify_phase("glob", {"pattern": "x"}) == "search"
+    assert pi_session.classify_phase("search", {"query": "x"}) == "search"
+    assert pi_session.classify_phase("playwright", {}) == "ui_test"
+    assert pi_session.classify_phase("mcp", {}) == "mcp"
+    assert pi_session.classify_phase("unknown_tool", {}) == "unknown_tool"
+
+
+def test_classify_phase_ignores_non_dict_arguments():
+    assert pi_session.classify_phase("bash", None) == "command"
+    assert pi_session.classify_phase("bash", "pytest") == "command"
+
+
+def test_classify_phase_ignores_non_string_bash_command():
+    assert pi_session.classify_phase("bash", {"command": 5}) == "command"
+    assert pi_session.classify_phase("bash", {}) == "command"
+
+
+def test_summarize_tool_uses_first_line_of_bash_command():
+    summary = pi_session.summarize_tool(
+        "bash", {"command": "cd /tmp/repo && pytest\n\n# comment"},
+    )
+    assert summary == "cd /tmp/repo && pytest"
+
+
+def test_summarize_tool_truncates_long_summaries():
+    command = "echo " + "a" * 500
+    summary = pi_session.summarize_tool("bash", {"command": command})
+    assert len(summary) <= pi_session.SUMMARY_LIMIT
+    assert summary.endswith("…")
+
+
+def test_summarize_tool_uses_path_or_pattern_for_other_tools():
+    assert pi_session.summarize_tool("read", {"path": "/tmp/a.md"}) == "/tmp/a.md"
+    assert pi_session.summarize_tool("write", {"file": "/tmp/a.md"}) == "/tmp/a.md"
+    assert pi_session.summarize_tool("grep", {"pattern": "def main"}) == "def main"
+    assert pi_session.summarize_tool("glob", {"glob": "**/*.py"}) == "**/*.py"
+    assert pi_session.summarize_tool("search", {"query": "status"}) == "status"
+
+
+def test_summarize_tool_falls_back_to_redacted_arguments_json():
+    summary = pi_session.summarize_tool("mcp", {"key": "value"})
+    assert summary == '{"key": "value"}'
+    summary = pi_session.summarize_tool("mcp", None)
+    assert summary == "mcp"
+
+
+def test_summarize_tool_redacts_credentials():
+    summary = pi_session.summarize_tool(
+        "bash", {"command": "curl -H 'Authorization: Bearer gho_abcdefghijklmnop' x"},
+    )
+    assert "gho_abcdefghijklmnop" not in summary
+    assert "<redacted>" in summary
+
+
+def test_redact_replaces_github_tokens():
+    text = "token ghp_abcdefghijklmnopqrstuvwxyz123456 end"
+    assert pi_session.redact(text) == "token <redacted> end"
+
+
+def test_redact_replaces_bearer_headers():
+    text = "Authorization: Bearer abc12345.def-ghi"
+    assert pi_session.redact(text) == "Authorization: Bearer <redacted>"
+
+
+def test_redact_replaces_token_flags_and_api_keys():
+    assert pi_session.redact("gh api --token abc123456789") == "gh api --token <redacted>"
+    assert pi_session.redact("export API_KEY=sk-1234567890") == "export API_KEY=<redacted>"
+    assert pi_session.redact("api_key = 'sk-1234567890'") == "api_key = '<redacted>'"
+
+
+def test_redact_leaves_normal_text_unchanged():
+    text = "pytest tests/ -q passed 65 tests"
+    assert pi_session.redact(text) == text
+
+
+def test_latest_activity_returns_newest_event():
+    events = [
+        {"kind": "session_start", "phase": "session_start",
+         "timestamp": "2026-08-24T17:55:32.139Z", "summary": "session started"},
+        {"kind": "assistant", "phase": "test",
+         "timestamp": "2026-08-24T17:56:01.728Z", "summary": "pytest tests/ -q"},
+    ]
+    assert pi_session.latest_activity(events) == (
+        "test", "pytest tests/ -q", "2026-08-24T17:56:01.728Z",
+    )
+
+
+def test_latest_activity_returns_none_for_empty_events():
+    assert pi_session.latest_activity([]) is None
+
+
+def test_session_file_for_picks_newest_file_created_after_start(tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    old = session_dir / "old.jsonl"
+    old.write_text("{}", encoding="utf-8")
+    new = session_dir / "new.jsonl"
+    new.write_text("{}", encoding="utf-8")
+    import os
+    old_time = 1000.0
+    os.utime(old, (old_time, old_time))
+    assert pi_session.session_file_for(tmp_path, 2000.0) == new
+
+
+def test_session_file_for_returns_none_when_no_file_or_dir_missing(tmp_path):
+    assert pi_session.session_file_for(tmp_path, 0.0) is None
+    assert pi_session.session_file_for(tmp_path / "missing", 0.0) is None
+
+
+def test_session_file_for_returns_none_when_no_file_created_after_start(tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    old = session_dir / "old.jsonl"
+    old.write_text("{}", encoding="utf-8")
+    import os
+    os.utime(old, (1000.0, 1000.0))
+    assert pi_session.session_file_for(tmp_path, 2000.0) is None
+
+
+def test_newest_session_file_returns_none_for_empty_session_dir(tmp_path):
+    (tmp_path / ".pi-session").mkdir()
+    assert pi_session.newest_session_file(tmp_path) is None
+
+
+def test_newest_session_file_picks_most_recent_file(tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    first = session_dir / "first.jsonl"
+    second = session_dir / "second.jsonl"
+    first.write_text("{}", encoding="utf-8")
+    second.write_text("{}", encoding="utf-8")
+    import os
+    os.utime(first, (1000.0, 1000.0))
+    assert pi_session.newest_session_file(tmp_path) == second
+
+
+def test_summarize_session_file_returns_session_id_and_latest_activity(tmp_path):
+    path = _write_session(
+        tmp_path,
+        _session_line(),
+        _message_line("assistant", [
+            {"type": "toolCall", "id": "c1", "name": "bash",
+             "arguments": {"command": "pytest tests/ -q"}},
+        ]),
+    )
+    assert pi_session.summarize_session_file(path) == (
+        "01a034e9-caab-7921-8228-5b2b584065be",
+        ("test", "pytest tests/ -q", "2026-08-24T17:55:40.223Z"),
+    )
+
+
+def test_summarize_session_file_handles_header_only_session(tmp_path):
+    path = _write_session(tmp_path, _session_line())
+    assert pi_session.summarize_session_file(path) == (
+        "01a034e9-caab-7921-8228-5b2b584065be",
+        ("session_start", "session started", "2026-08-24T17:55:32.139Z"),
+    )
+
+
+def test_summarize_session_file_handles_unparseable_file(tmp_path):
+    path = tmp_path / "broken.jsonl"
+    path.write_text("not json\n", encoding="utf-8")
+    assert pi_session.summarize_session_file(path) == (None, None)
+
+
+def test_summarize_session_file_finds_session_line_after_other_lines(tmp_path):
+    path = _write_session(
+        tmp_path,
+        json.dumps({"type": "message", "id": "m0"}),
+        _session_line(),
+    )
+    assert pi_session.summarize_session_file(path)[0] == "01a034e9-caab-7921-8228-5b2b584065be"
+
+
+def test_summarize_session_file_ignores_non_string_session_id(tmp_path):
+    path = _write_session(
+        tmp_path,
+        json.dumps({"type": "session", "id": 5, "timestamp": "t"}),
+    )
+    assert pi_session.summarize_session_file(path) == (
+        None, ("session_start", "session started", "t"),
+    )


### PR DESCRIPTION
Closes #24

## What

Pi 长时间运行期间不再是黑盒：Runner 在 Pi 运行期间每秒轮询 worktree 里的 Pi session JSONL，把每个新事件写入 journal（systemd 日志）：

- `pi_activity issue=... source_repo=... branch=... worktree=... session=... phase=... at=... summary=...`
- 超过 300 秒没有新事件：`pi_stalled` 警告（含最后活动阶段、时间、session 文件）
- Pi 退出：`pi_finished` 现场行（returncode、最后活动、session 文件）；非零退出仍按原样抛 `CalledProcessError`，fail-fast 不变
- 首次进入 `pr` 阶段：向 Issue 回写一条关键阶段 comment（best effort，失败不影响主流程）

`muyan_pilot.py status` 对 `ai-in-progress` 的 Issue 额外显示一行实时现场：

```text
  current: #24 Stream live Pi activity ...
  live: phase=test at=2026-08-24T17:56:01.728Z summary=pytest tests/ -q session=2026-....jsonl
```

## Sanitization

Events 只包含脱敏摘要（bash 命令首行 / 文件路径 / 搜索模式，160 字符截断，token/Bearer/api_key 模式替换为 `<redacted>`）。完整 prompt、Issue body、工具输出、推理内容不进入事件；完整 session 保存在本地 `<worktree>/.pi-session/`。

## Changed files

- `pi_session.py`（新）：session JSONL 解析、阶段分类、脱敏、最新活动
- `bootstrap_runner.py`：`run_pi` 改为 Popen + `watch_pi_session` 实时轮询；`process_issue` 增加 pr 关键阶段 comment
- `muyan_pilot.py`：`status` 增加 live 行
- `README.md`：文档
- `tests/`：122 个测试，100% line/branch coverage（bootstrap_runner / muyan_pilot / pi_session）

## Verification

- `/usr/bin/python3 -m pytest tests/ -q` → 122 passed
- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q && coverage report` → 100%
- 真实 session JSONL 冒烟：watcher 正确流式输出 pi_activity/pi_finished；`live_status` 对真实 worktree 输出正确现场
- 无 UI 交付，无需 Playwright