### PR TITLE
chore: pin 15-minute idle poll schedule (review of PR #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，每 5 分钟自动执行一次：
+正常运行使用 systemd user timer，每 15 分钟自动执行一次：
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* 01..06:00/5:00
+OnCalendar=*-*-* 01..06:00/15:00
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -1,0 +1,86 @@
+"""Regression tests for the systemd scheduling files (Issue #21).
+
+The idle polling interval is 15 minutes inside the 01:00-06:55 night window.
+The timer must not add a task duration limit, must not queue catch-up ticks,
+and the README must document the same schedule as the unit files.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TIMER_FILE = REPO_ROOT / "systemd" / "muyan-pilot.timer"
+SERVICE_FILE = REPO_ROOT / "systemd" / "muyan-pilot.service"
+README_FILE = REPO_ROOT / "README.md"
+
+
+def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
+    """Parse a systemd unit file into section -> key -> [values]."""
+    sections: dict[str, dict[str, list[str]]] = {}
+    current: dict[str, list[str]] | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current = sections.setdefault(line[1:-1], {})
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or current is None:
+            raise ValueError(f"unparseable unit line: {raw_line!r}")
+        current.setdefault(key.strip(), []).append(value.strip())
+    return sections
+
+
+def test_timer_polls_ready_issues_every_15_minutes_in_night_window():
+    timer = parse_unit(TIMER_FILE)
+    assert timer["Timer"]["OnCalendar"] == ["*-*-* 01..06:00/15:00"]
+    # Triggers: 01:00, 01:15, ..., 06:45 — every tick inside 01:00-06:55.
+
+
+def test_timer_does_not_queue_catch_up_ticks_or_second_service():
+    timer = parse_unit(TIMER_FILE)
+    # While muyan-pilot.service is active systemd does not start a second
+    # instance of the same unit; Persistent=false additionally means a
+    # missed tick is dropped instead of queued for a second task.
+    assert timer["Timer"]["Persistent"] == ["false"]
+    assert timer["Timer"]["AccuracySec"] == ["30s"]
+    assert timer["Timer"]["Unit"] == ["muyan-pilot.service"]
+    assert timer["Install"]["WantedBy"] == ["timers.target"]
+
+
+def test_service_keeps_running_task_without_duration_limit():
+    service = parse_unit(SERVICE_FILE)
+    section = service["Service"]
+    assert section["Type"] == ["simple"]
+    # Deployment adapter only (systemd startup kill limit), not a task timeout.
+    assert section["TimeoutStartSec"] == ["infinity"]
+    assert "RuntimeMaxSec" not in section
+    assert "TimeoutStopSec" not in section
+    assert section["ExecStart"] == [
+        "/usr/bin/python3 %h/Documents/muyan/muyan-pilot/bootstrap_runner.py",
+    ]
+
+
+def test_readme_documents_same_schedule_as_timer():
+    timer = parse_unit(TIMER_FILE)
+    on_calendar = timer["Timer"]["OnCalendar"][0]
+    match = re.match(r"\*-\*-\* \d+\.\.\d+:\d+/(?P<minutes>\d+):\d+$", on_calendar)
+    assert match is not None, f"unexpected OnCalendar format: {on_calendar}"
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert f"每 {match['minutes']} 分钟自动执行一次" in readme
+
+
+def test_parse_unit_rejects_unparseable_line(tmp_path):
+    bad = tmp_path / "bad.service"
+    bad.write_text("[Service]\nnot a key value\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unparseable unit line"):
+        parse_unit(bad)
+
+
+def test_parse_unit_rejects_key_before_any_section(tmp_path):
+    bad = tmp_path / "bad.service"
+    bad.write_text("Description=orphan\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unparseable unit line"):
+        parse_unit(bad)


### PR DESCRIPTION
Closes #21.

Issue #21 要求把空闲任务池轮询间隔从 5 分钟调整为 15 分钟，并由 Pilot 复核 PR #19 的人工临时调整。

## 变更

- 保留 PR #19 的调整（`da28396`）：`systemd/muyan-pilot.timer` → `OnCalendar=*-*-* 01..06:00/15:00`，README → 每 15 分钟自动执行一次。
- 新增 `tests/test_systemd_timer.py`：解析 systemd unit 文件并固化验收条件——
  - 15 分钟间隔、夜间窗口 01:00–06:55（触发点 01:00…06:45）；
  - `Persistent=false`（不排队补跑；service 运行中 systemd 不会启动第二个实例）；
  - service 无任务时长上限（无 `RuntimeMaxSec`/`TimeoutStopSec`，`TimeoutStartSec=infinity` 仅为部署适配）；
  - README 文案从 timer 文件推导分钟数并断言一致，防止文档与 timer 再次漂移。

## 验证

- RED：对 `origin/main` 的 5 分钟版本运行新测试 → `test_timer_polls_ready_issues_every_15_minutes_in_night_window` FAIL（`01..06:00/5:00` ≠ `01..06:00/15:00`）。
- GREEN + 全量回归：`/usr/bin/python3 -m pytest --cov --cov-branch` → 71 passed；`bootstrap_runner.py`、`muyan_pilot.py` 100% line + branch。
- 本机部署同步：`~/.config/systemd/user/muyan-pilot.timer` 由 5 分钟更新为 15 分钟（daemon-reload + restart）；同规格临时 timer 实测 `NextElapseUSecRealtime=02:45:00`（15 分钟边界），验证后已清理。
- 未增加业务任务 timeout；未 merge、未 push 保护分支。