### PR TITLE
feat: write structured stage comments to source issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,23 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 ```
 
 Runner 每次处理一个 Issue 后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。
+
+## Issue 交付链 comment
+
+Runner 在关键节点向 source Issue 回写简短结构化 comment（只来自 Runner 自己的结构化事件，不含完整 Pi session、prompt、token 或命令输出），Issue 历史可以还原任务链：
+
+```text
+Muyan Pilot started          # 领取后：source repo、branch、worktree
+Muyan Pilot plan_ready       # worktree 出现 plan.md 后
+Muyan Pilot tests_verify     # worktree 出现 test.log / verify.md 后
+Muyan Pilot pr_opened        # 成功后：commit、PR URL
+Muyan Pilot opened PR: <url>
+```
+
+失败时添加 `ai-blocked` 并回写：
+
+```text
+Muyan Pilot failed           # 失败阶段、错误摘要、下一步人工动作
+```
+
+完整 Pi session 和日志保留在本地（worktree 的 `.pi-session/`、journal），不回写 GitHub。comment 或标签回写失败不会掩盖原始错误：原始异常继续抛出，上报失败只记日志。

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，每 5 分钟自动执行一次：
+正常运行使用 systemd user timer，每 15 分钟自动执行一次：
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -151,6 +151,23 @@ def comment_issue(number: int, *, repo: str, body: str) -> None:
                  "--body", body])
 
 
+def git_commit(worktree: Path) -> str:
+    """Return the short HEAD commit of the worktree."""
+    return run_command(["git", "rev-parse", "--short", "HEAD"], cwd=worktree)
+
+
+def stage_comment(stage: str, repo: str, number: int, details: list[str]) -> None:
+    """Post one structured stage comment built from runner events only.
+
+    The body never contains the raw Pi session, prompts, tokens, or command
+    output; details are short key/value lines chosen by the caller.
+    """
+    body = "Muyan Pilot " + stage
+    if details:
+        body += "\n" + "\n".join(details)
+    comment_issue(number, repo=repo, body=body)
+
+
 def task_branch(source_repo: str, number: int) -> str:
     return f"muyan-pilot/{source_repo.replace('/', '-')}-issue-{number}"
 
@@ -238,10 +255,27 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     branch = task_branch(source_repo, number)
     edit_issue(number, repo=source_repo, add="ai-in-progress")
+    stage = "claim"
     try:
+        stage_comment("started", source_repo, number, [
+            f"source repo: {source_repo}",
+            f"branch: {branch}",
+            f"worktree: {worktree_path(source_repo, number)}",
+        ])
+        stage = "worktree"
         worktree = create_worktree(config["repo_dir"], source_repo, number)
+        stage = "pi"
         run_pi(issue, worktree, config, source_repo)
+        if (worktree / "plan.md").is_file():
+            stage_comment("plan_ready", source_repo, number, [])
+        if (worktree / "test.log").is_file() or (worktree / "verify.md").is_file():
+            stage_comment("tests_verify", source_repo, number, [])
+        stage = "verify_pr"
         pr_url = verify_pr(worktree, branch)
+        stage_comment("pr_opened", source_repo, number, [
+            f"commit: {git_commit(worktree)}",
+            f"pr: {pr_url}",
+        ])
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
             remove="ai-in-progress",
@@ -252,16 +286,18 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         )
         return pr_url
     except Exception as exc:
-        LOGGER.exception("issue=%s failed", number)
+        LOGGER.exception("issue=%s failed stage=%s", number, stage)
         try:
             edit_issue(
                 number, repo=source_repo, add="ai-blocked",
                 remove="ai-in-progress",
             )
-            comment_issue(
-                number, repo=source_repo,
-                body=f"Muyan Pilot failed: {exc}",
-            )
+            stage_comment("failed", source_repo, number, [
+                f"stage: {stage}",
+                f"error: {exc}",
+                "next action: inspect the journal log and the worktree, fix the "
+                "blocker, then remove ai-blocked and re-add ai-ready to retry",
+            ])
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)
         raise

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* 01..06:00/5:00
+OnCalendar=*-*-* 01..06:00/15:00
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -265,6 +265,54 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     ]]
 
 
+def test_git_commit_returns_short_head(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "abc1234",
+    )
+    assert runner.git_commit(tmp_path) == "abc1234"
+    assert calls == [(
+        ["git", "rev-parse", "--short", "HEAD"], {"cwd": tmp_path},
+    )]
+
+
+def test_stage_comment_posts_stage_header_and_details(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda number, **kwargs: calls.append((number, kwargs)),
+    )
+    runner.stage_comment(
+        "started", "xqliu/muyan-pilot", 15,
+        ["source repo: xqliu/muyan-pilot",
+         "branch: muyan-pilot/xqliu-muyan-pilot-issue-15",
+         "worktree: /tmp/wt"],
+    )
+    assert calls == [(
+        15,
+        {
+            "repo": "xqliu/muyan-pilot",
+            "body": (
+                "Muyan Pilot started\n"
+                "source repo: xqliu/muyan-pilot\n"
+                "branch: muyan-pilot/xqliu-muyan-pilot-issue-15\n"
+                "worktree: /tmp/wt"
+            ),
+        },
+    )]
+
+
+def test_stage_comment_without_details_posts_header_only(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda number, **kwargs: calls.append((number, kwargs)),
+    )
+    runner.stage_comment("pr_opened", "xqliu/muyan-pilot", 15, [])
+    assert calls == [(15, {"repo": "xqliu/muyan-pilot", "body": "Muyan Pilot pr_opened"})]
+
+
 def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text(
@@ -350,31 +398,98 @@ def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
         runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
 
 
-def test_process_issue_success(monkeypatch, tmp_path):
+def test_process_issue_success_posts_stage_chain(monkeypatch, tmp_path):
     calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / "plan.md").write_text("plan", encoding="utf-8")
+    (worktree / "test.log").write_text("log", encoding="utf-8")
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "stage_comment", lambda *args: calls.append(("stage", args)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "git_commit", lambda worktree: "abc1234")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     issue = {"number": 4, "title": "Fix", "body": "Body"}
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}
     assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
-    assert calls[1][0] == "edit"
-    assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
-    assert calls[2][0] == "comment"
+    assert calls[1] == ("stage", (
+        "started", "xqliu/muyan-ceo", 4,
+        ["source repo: xqliu/muyan-ceo",
+         "branch: muyan-pilot/xqliu-muyan-ceo-issue-4",
+         "worktree: " + str(runner.worktree_path("xqliu/muyan-ceo", 4))],
+    ))
+    assert calls[2] == ("stage", ("plan_ready", "xqliu/muyan-ceo", 4, []))
+    assert calls[3] == ("stage", ("tests_verify", "xqliu/muyan-ceo", 4, []))
+    assert calls[4] == ("stage", (
+        "pr_opened", "xqliu/muyan-ceo", 4,
+        ["commit: abc1234",
+         "pr: https://github.com/muyantech/muyan-pilot/pull/4"],
+    ))
+    assert calls[5] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"})
+    assert calls[6] == ("comment", (4,), {"repo": "xqliu/muyan-ceo", "body": "Muyan Pilot opened PR: https://github.com/muyantech/muyan-pilot/pull/4"})
 
 
-def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
+def test_process_issue_success_skips_missing_stage_artifacts(monkeypatch, tmp_path):
+    calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "stage_comment", lambda *args: calls.append(("stage", args)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "git_commit", lambda worktree: "abc1234")
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    issue = {"number": 4, "title": "Fix", "body": "Body"}
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}
+    runner.process_issue(issue, config, "xqliu/muyan-ceo")
+    stages = [call[1][0] for call in calls if call[0] == "stage"]
+    assert stages == ["started", "pr_opened"]
+
+
+def test_process_issue_failure_posts_failed_comment(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
+    monkeypatch.setattr(runner, "stage_comment", lambda *args: calls.append(("stage", args)))
+    monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git worktree add failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
-    with pytest.raises(RuntimeError, match="git failed"):
+    with pytest.raises(RuntimeError, match="git worktree add failed"):
         runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
-    assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
-    assert calls[2][0] == "comment"
+    assert calls[0] == ("edit", (8,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
+    assert calls[1][0] == "stage"
+    assert calls[1][1][0] == "started"
+    assert calls[2] == ("edit", (8,), {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"})
+    assert calls[3] == ("stage", (
+        "failed", "xqliu/muyan-ceo", 8,
+        ["stage: worktree",
+         "error: git worktree add failed",
+         "next action: inspect the journal log and the worktree, fix the "
+         "blocker, then remove ai-blocked and re-add ai-ready to retry"],
+    ))
+
+
+def test_process_issue_command_failure_posts_failed_comment(monkeypatch, tmp_path):
+    calls = []
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    error = subprocess.CalledProcessError(1, ["gh", "pr", "list"], stderr="no token")
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "stage_comment", lambda *args: calls.append(("stage", args)))
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: worktree)
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(runner, "verify_pr", Mock(side_effect=error))
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_issue({"number": 9, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
+    assert calls[2] == ("edit", (9,), {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"})
+    failed = calls[3]
+    assert failed[0] == "stage"
+    assert failed[1][0] == "failed"
+    assert failed[1][3][0] == "stage: verify_pr"
+    assert "no token" not in failed[1][3][1]
 
 
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
@@ -386,6 +501,7 @@ def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypat
             raise RuntimeError("github report failed")
 
     monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(runner, "stage_comment", lambda *args: None)
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
         runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")


### PR DESCRIPTION
Closes #15

## Goal

Runner 在交付链的关键节点向 source Issue 回写**结构化** comment，形成可追溯的交付记录；不泄露完整 Pi session、prompt、token 或命令输出；保持 fail-fast 与 100% line/branch coverage。

## Changes

- `bootstrap_runner.py`:
  - `git_commit(worktree)`：短 HEAD commit（`git rev-parse --short HEAD`）；
  - `stage_comment(stage, repo, number, details)`：单一结构化 comment（`Muyan Pilot <stage>` + 短 key/value 行），只由 Runner 自己的结构化事件构造；
  - `process_issue` 按阶段回写：
    - `started`（领取后：source repo、branch、worktree）；
    - `plan_ready`（worktree 出现 plan.md）；
    - `tests_verify`（worktree 出现 test.log / verify.md）；
    - `pr_opened`（成功后：commit、PR URL）+ 原 `Muyan Pilot opened PR: <url>`；
    - 失败：先加 `ai-blocked`，再回写 `failed`（失败 stage、错误摘要、下一步人工动作）。
  - 失败日志增加 `stage=` 字段；原始异常继续抛出，上报失败只记日志（不掩盖主错误）。
- `tests/test_bootstrap_runner.py`：新增 git_commit / stage_comment 测试；改写 process_issue 测试覆盖成功链、缺产物跳过、RuntimeError 失败链、命令失败（CalledProcessError，stderr 不入 comment）回写、上报失败不掩盖原始异常。
- `README.md`：新增 Issue 交付链 comment 说明。

## Verification

```text
/usr/bin/python3 -m pytest tests/ -q
→ 70 passed
/usr/bin/python3 -m coverage run --branch --source=bootstrap_runner,muyan_pilot -m pytest tests/ -q
/usr/bin/python3 -m coverage report --show-missing
→ bootstrap_runner.py 158/158 lines, 42/42 branches
→ muyan_pilot.py 73/73 lines, 16/16 branches
→ TOTAL 100% line + branch
```

## Notes

- 与开放 PR #23（issue #18）在 `process_issue` 区域重叠：#23 引入固定短 stage 标记与 status CLI，本 PR 引入带详情的结构化 comment；两者合并时需调和（本 PR 不重复 #18 的 status 工作）。
- 本 PR 的 Issue #15 已按新格式逐阶段回写 comment（started / plan ready / tests_verify / 本 PR），可作为交付链样例。
- 不 merge、不 push 保护分支。