### PR TITLE
Run the Pilot scheduler 24 hours a day

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，每 15 分钟自动执行一次：
+正常运行使用 systemd user timer，全天 24 小时运行，每 15 分钟自动执行一次（触发点覆盖 00:00–23:45）：
 
 ```bash
 mkdir -p ~/.config/systemd/user

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* 01..06:00/15:00
+OnCalendar=*-*-* *:00/15
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -1,10 +1,13 @@
-"""Regression tests for the systemd scheduling files (Issue #21).
+"""Regression tests for the systemd scheduling files (Issues #21, #33).
 
-The idle polling interval is 15 minutes inside the 01:00-06:55 night window.
-The timer must not add a task duration limit, must not queue catch-up ticks,
-and the README must document the same schedule as the unit files.
+The scheduler runs 24 hours a day: the idle polling interval is 15 minutes
+across the full day (00:00, 00:15, ..., 23:45). The timer must not add a
+task duration limit, must not queue catch-up ticks, and the README must
+document the same schedule as the unit files.
 """
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -33,10 +36,37 @@ def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
     return sections
 
 
-def test_timer_polls_ready_issues_every_15_minutes_in_night_window():
+def test_timer_polls_ready_issues_every_15_minutes_all_day():
     timer = parse_unit(TIMER_FILE)
-    assert timer["Timer"]["OnCalendar"] == ["*-*-* 01..06:00/15:00"]
-    # Triggers: 01:00, 01:15, ..., 06:45 — every tick inside 01:00-06:55.
+    on_calendar = timer["Timer"]["OnCalendar"]
+    # Triggers: 00:00, 00:15, ..., 23:45 — every tick across the full day.
+    assert on_calendar == ["*-*-* *:00/15"]
+    # Semantic guard: the hour field must be open (no night-window range such
+    # as 01..06) and the minute field must step by 15 minutes.
+    date_part, time_part = on_calendar[0].split(" ")
+    assert date_part == "*-*-*"
+    hour_field, minute_field = time_part.split(":")
+    assert hour_field == "*"
+    assert minute_field == "00/15"
+
+
+def test_timer_calendar_expression_parses_with_systemd_analyze():
+    # Acceptance: the systemd calendar must be parseable by systemd-analyze.
+    analyze = shutil.which("systemd-analyze")
+    if analyze is None:
+        pytest.skip("systemd-analyze not available on this machine")
+    on_calendar = parse_unit(TIMER_FILE)["Timer"]["OnCalendar"][0]
+    result = subprocess.run(
+        [analyze, "calendar", on_calendar],
+        capture_output=True, text=True, check=True,
+    )
+    assert "Normalized form" in result.stdout
+
+
+def test_timer_calendar_test_skips_without_systemd_analyze(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(pytest.skip.Exception):
+        test_timer_calendar_expression_parses_with_systemd_analyze()
 
 
 def test_timer_does_not_queue_catch_up_ticks_or_second_service():
@@ -66,7 +96,7 @@ def test_service_keeps_running_task_without_duration_limit():
 def test_readme_documents_same_schedule_as_timer():
     timer = parse_unit(TIMER_FILE)
     on_calendar = timer["Timer"]["OnCalendar"][0]
-    match = re.match(r"\*-\*-\* \d+\.\.\d+:\d+/(?P<minutes>\d+):\d+$", on_calendar)
+    match = re.match(r"\*-\*-\* \*:\d+/(?P<minutes>\d+)", on_calendar)
     assert match is not None, f"unexpected OnCalendar format: {on_calendar}"
     readme = README_FILE.read_text(encoding="utf-8")
     assert f"每 {match['minutes']} 分钟自动执行一次" in readme


### PR DESCRIPTION
Fixes #33

## Change

- `systemd/muyan-pilot.timer`: `OnCalendar=*-*-* 01..06:00/15:00` → `OnCalendar=*-*-* *:00/15` — full-day operation, 15-minute idle polling (00:00, 00:15, …, 23:45; 96 ticks/day).
- `tests/test_systemd_timer.py`: no longer assumes the night window; asserts the full-day expression, its open hour field and 15-minute step, and that `systemd-analyze calendar` parses the expression (skips cleanly where unavailable).
- `README.md`: documents the same 24h / 15-minute schedule.

Unchanged by design: `Persistent=false` (no catch-up ticks), `AccuracySec=30s`, `Unit=muyan-pilot.service`, `WantedBy=timers.target`, and the service unit (systemd does not start a second instance while one is active; no business-task timeout added; `%h` specifiers keep the units free of hardcoded local directories).

## Verification

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → 76 passed
- `/usr/bin/python3 -m coverage report --show-missing` → 100% line/branch coverage (all files)
- `systemd-analyze calendar "*-*-* *:00/15"` → parses, normalized `*-*-* *:00/15:00`
- `systemd-analyze calendar --iterations=200` → constant 15-minute gaps; a full day contains exactly 96 triggers covering 00:00–23:45
- Note: `*-*-* 00:00/15` was rejected — it fires only 00:00–00:45 (4×/day) because the step applies within the fixed hour 00.

No merge; only the feature branch was pushed.