### PR TITLE
Create tasks from latest remote base and make retries conflict-safe

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -7,6 +7,9 @@ source_repos = [
 repo_dir = "."
 workspace_root = ".."
 prompt = "prompt.md"
+# Delivery base branch: every task worktree is created from the latest
+# origin/<base_branch> (fetched and frozen at claim time). Default: "main".
+base_branch = "main"
 # Optional Pi skills. Paths may be absolute, use ~, or be relative to this file.
 skills = []
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,19 @@ follow it before changing code.
 - Command errors fail fast: log the command, return code, stdout and stderr,
   then raise. Never swallow an error or add a fallback path.
 
+## Base freshness
+
+- Every task worktree is created from the frozen `origin/<base_branch>` SHA
+  (default `main`), never from the main worktree's current HEAD.
+- Branch and worktree names carry the unique run id, so a retried Issue gets
+  a new independent run and the old scene is preserved.
+- Before creating the PR, re-fetch `origin/<base_branch>`; if the base
+  advanced, merge it into the task branch, resolve conflicts manually, rerun
+  the full tests and the complete review-fix loop, then push the task branch.
+- The runner rejects a delivery whose HEAD does not contain the latest remote
+  base. No auto conflict resolution, no force push, no merge or push of the
+  protected branch.
+
 ## Git
 
 - Work on the task feature branch.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 
 Runner 每次处理一个 Issue 后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。
 
-## 任务 worktree
+## 任务 base 与 worktree
 
-每个任务的现场放在配置 repo 的 `.worktrees/` 目录下，目录名包含 source repo 与 Issue 编号（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14`），任务完成后随项目保留，便于回看现场。`.worktrees/` 已加入 `.gitignore`，不会进入版本库。
+每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。
+
+Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需合入最新 base、手工解决冲突、重跑完整测试与 review 后再推送。Runner 在验收时用 `git merge-base --is-ancestor origin/<base_branch> HEAD` 验证最新远端 base 是交付 HEAD 的祖先；不满足则 fail fast，不接受 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
+
+`.worktrees/` 已加入 `.gitignore`，不会进入版本库。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -271,9 +271,12 @@ def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
             f"origin/{base_branch}; merge the latest base, rerun full tests "
             "and review, then retry"
         ) from None
+    local_head = run_command(
+        ["git", "rev-parse", "HEAD"], cwd=worktree,
+    )
     raw = run_command([
         "gh", "pr", "list", "--state", "open", "--head", branch,
-        "--json", "url", "--limit", "2",
+        "--json", "url,baseRefName,headRefOid", "--limit", "2",
     ], cwd=worktree)
     prs = json.loads(raw)
     if not isinstance(prs, list) or len(prs) != 1:
@@ -281,6 +284,26 @@ def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
     url = prs[0].get("url")
     if not url:
         raise RuntimeError("open PR has no URL")
+    base_ref = prs[0].get("baseRefName")
+    if base_ref != base_branch:
+        LOGGER.error(
+            "pr_base_mismatch expected=%s actual=%s branch=%s",
+            base_branch, base_ref, branch,
+        )
+        raise RuntimeError(
+            f"PR base is {base_ref}, expected {base_branch}; recreate the "
+            "PR against the configured base branch"
+        )
+    head_oid = prs[0].get("headRefOid")
+    if head_oid != local_head:
+        LOGGER.error(
+            "pr_head_mismatch pr_head=%s local_head=%s branch=%s",
+            head_oid, local_head, branch,
+        )
+        raise RuntimeError(
+            f"PR head {head_oid} is not local HEAD {local_head}; the "
+            "verified commit was not pushed, push the reviewed commit and retry"
+        )
     return url
 
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -13,6 +13,7 @@ import logging
 import os
 import subprocess
 import tomllib
+import uuid
 from pathlib import Path
 
 
@@ -33,6 +34,9 @@ def load_config(path: Path) -> dict:
         raise ValueError("source_repos must be a non-empty list")
     if not all(isinstance(repo, str) and repo for repo in source_repos):
         raise ValueError("source_repos must contain non-empty strings")
+    base_branch = data.get("base_branch", "main")
+    if not isinstance(base_branch, str) or not base_branch:
+        raise ValueError("base_branch must be a non-empty string")
     return {
         "source_repos": source_repos,
         "repo_dir": _config_path(data.get("repo_dir", "."), base),
@@ -42,6 +46,7 @@ def load_config(path: Path) -> dict:
         "context_files": [
             _config_path(item, base) for item in data.get("context_files", [])
         ],
+        "base_branch": base_branch,
     }
 
 
@@ -150,23 +155,44 @@ def comment_issue(number: int, *, repo: str, body: str) -> None:
                  "--body", body])
 
 
-def task_branch(source_repo: str, number: int) -> str:
-    return f"muyan-pilot/{source_repo.replace('/', '-')}-issue-{number}"
+def new_run_id() -> str:
+    """Return a unique short run identifier for one task attempt."""
+    return uuid.uuid4().hex[:8]
 
 
-def worktree_path(repo_dir: Path, source_repo: str, number: int) -> Path:
+def freeze_base(repo_dir: Path, base_branch: str) -> str:
+    """Fetch the remote and freeze the exact SHA of origin/<base_branch>."""
+    run_command(["git", "fetch", "origin", base_branch], cwd=repo_dir)
+    return run_command(
+        ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,
+    )
+
+
+def task_branch(source_repo: str, number: int, run_id: str) -> str:
+    return (
+        f"muyan-pilot/{source_repo.replace('/', '-')}-issue-{number}-{run_id}"
+    )
+
+
+def worktree_path(repo_dir: Path, source_repo: str, number: int,
+                  run_id: str) -> Path:
     """Task worktrees live in the configured repo's .worktrees/ directory."""
     slug = source_repo.replace("/", "-")
-    return repo_dir / ".worktrees" / f"muyan-pilot-{slug}-issue-{number}"
+    return (
+        repo_dir / ".worktrees"
+        / f"muyan-pilot-{slug}-issue-{number}-{run_id}"
+    )
 
 
-def create_worktree(repo_dir: Path, source_repo: str, number: int) -> Path:
-    path = worktree_path(repo_dir, source_repo, number)
+def create_worktree(repo_dir: Path, source_repo: str, number: int,
+                    run_id: str, base_sha: str) -> Path:
+    """Create the task worktree from the frozen base SHA, never HEAD."""
+    path = worktree_path(repo_dir, source_repo, number, run_id)
     if path.exists():
         raise RuntimeError(f"worktree path already exists: {path}")
-    branch = task_branch(source_repo, number)
+    branch = task_branch(source_repo, number, run_id)
     run_command([
-        "git", "worktree", "add", "-b", branch, str(path), "HEAD",
+        "git", "worktree", "add", "-b", branch, str(path), base_sha,
     ], cwd=repo_dir)
     return path
 
@@ -184,6 +210,9 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "WORKSPACE_ROOT": str(config["workspace_root"]),
             "CONTEXT_FILES": "\n".join(str(path) for path in config["context_files"]),
             "SKILLS": "\n".join(str(path) for path in config["skills"]),
+            "BASE_BRANCH": config["base_branch"],
+            "BASE_SHA": config["base_sha"],
+            "RUN_ID": config["run_id"],
         },
     )
     context = (
@@ -213,7 +242,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     )
 
 
-def verify_pr(worktree: Path, branch: str) -> str:
+def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
     current_branch = run_command(
         ["git", "branch", "--show-current"], cwd=worktree,
     )
@@ -221,6 +250,27 @@ def verify_pr(worktree: Path, branch: str) -> str:
         raise RuntimeError(
             f"Pi changed branch: expected={branch} actual={current_branch}"
         )
+    # Re-fetch before judging: the delivery must contain the latest remote
+    # base, otherwise it is behind and the PR is rejected (fail fast).
+    run_command(
+        ["git", "fetch", "origin", base_branch], cwd=worktree,
+    )
+    try:
+        run_command(
+            ["git", "merge-base", "--is-ancestor",
+             f"origin/{base_branch}", "HEAD"],
+            cwd=worktree,
+        )
+    except subprocess.CalledProcessError:
+        LOGGER.error(
+            "delivery_behind_base base_branch=%s branch=%s",
+            base_branch, branch,
+        )
+        raise RuntimeError(
+            f"delivery HEAD is behind latest remote base "
+            f"origin/{base_branch}; merge the latest base, rerun full tests "
+            "and review, then retry"
+        ) from None
     raw = run_command([
         "gh", "pr", "list", "--state", "open", "--head", branch,
         "--json", "url", "--limit", "2",
@@ -236,19 +286,31 @@ def verify_pr(worktree: Path, branch: str) -> str:
 
 def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
-    branch = task_branch(source_repo, number)
+    base_branch = config["base_branch"]
+    base_sha = freeze_base(config["repo_dir"], base_branch)
+    run_id = new_run_id()
+    branch = task_branch(source_repo, number, run_id)
+    run_info = (
+        f"base_branch={base_branch} base_sha={base_sha} run_id={run_id}"
+    )
+    LOGGER.info(
+        "issue=%s %s", number, run_info,
+    )
     edit_issue(number, repo=source_repo, add="ai-in-progress")
     try:
-        worktree = create_worktree(config["repo_dir"], source_repo, number)
+        worktree = create_worktree(
+            config["repo_dir"], source_repo, number, run_id, base_sha,
+        )
+        config = {**config, "base_sha": base_sha, "run_id": run_id}
         run_pi(issue, worktree, config, source_repo)
-        pr_url = verify_pr(worktree, branch)
+        pr_url = verify_pr(worktree, branch, base_branch)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
             remove="ai-in-progress",
         )
         comment_issue(
             number, repo=source_repo,
-            body=f"Muyan Pilot opened PR: {pr_url}",
+            body=f"Muyan Pilot opened PR: {pr_url} ({run_info})",
         )
         return pr_url
     except Exception as exc:
@@ -260,7 +322,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             )
             comment_issue(
                 number, repo=source_repo,
-                body=f"Muyan Pilot failed: {exc}",
+                body=f"Muyan Pilot failed: {exc} ({run_info})",
             )
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 
 from bootstrap_runner import (
+    freeze_base,
     load_config,
     parse_issue_array,
     run_command,
@@ -99,6 +100,8 @@ def status_report(config: dict) -> str:
     lines = []
     for repo in config["source_repos"]:
         lines.append(f"source: {repo}")
+        base_sha = freeze_base(config["repo_dir"], config["base_branch"])
+        lines.append(f"  base: {config['base_branch']} {base_sha}")
         for name, lookup in (
             ("current", current_issue),
             ("ready", ready_issue),

--- a/prompt.md
+++ b/prompt.md
@@ -11,6 +11,9 @@ Runtime context supplied by the runner:
   `{{CONTEXT_FILES}}`
 - Skills configured for this run:
   `{{SKILLS}}`
+- Delivery base branch: `{{BASE_BRANCH}}`
+- Delivery base SHA (frozen `origin/{{BASE_BRANCH}}` at claim time): `{{BASE_SHA}}`
+- Run id: `{{RUN_ID}}`
 
 Read every configured context file, the target repository's `AGENTS.md`,
 README, build files, tests, and relevant history before changing code.
@@ -32,10 +35,24 @@ Work through this exact loop:
 6. Verify the result yourself.
 7. Commit the change, push only the current feature branch, and open exactly one draft or normal PR for this Issue.
 
+Base freshness before creating the PR:
+
+Your worktree was created from `{{BASE_SHA}}` (the frozen
+`origin/{{BASE_BRANCH}}` at claim time). Before creating the PR:
+
+1. Run `git fetch origin {{BASE_BRANCH}}` in the worktree.
+2. If `git merge-base --is-ancestor origin/{{BASE_BRANCH}} HEAD` fails, the
+   base advanced while you worked: merge `origin/{{BASE_BRANCH}}` into your
+   task branch, resolve conflicts manually, rerun the full test suite and the
+   complete review-fix loop, then push the updated task branch.
+3. The runner rejects a delivery whose HEAD does not contain the latest
+   remote base, so do not create the PR until the check passes.
+
 Rules:
 
 - Do not merge.
 - Do not push `main` or `master`.
+- Do not force push or auto-resolve conflicts.
 - Do not claim success without a real commit, successful verification, and a PR.
 - If the request is unclear or the environment cannot be verified, stop and explain the blocker.
 - The final response must summarize changed files, tests, UI screenshots when applicable, commit, and PR URL.

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -33,6 +33,17 @@ REQUIRED_ITEMS = (
     ("no-protected-push", "main"),
     ("no-protected-push-master", "master"),
     ("pr-only", "PR"),
+    # 6b. Base freshness: worktrees start from the frozen origin/<base> SHA,
+    #     runs carry a unique run id, the base is re-fetched before the PR,
+    #     behind deliveries are rejected, no auto conflict resolution or
+    #     force push.
+    ("base-freshness", "base freshness"),
+    ("base-frozen-sha", "frozen"),
+    ("base-run-id", "run id"),
+    ("base-refetch", "re-fetch"),
+    ("base-reject-behind", "rejects"),
+    ("base-no-auto-resolve", "auto conflict resolution"),
+    ("base-no-force-push", "force push"),
     # 7. No database, queue, daemon loop, risk engine, or fallback.
     ("no-database", "database"),
     ("no-queue", "queue"),

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -407,6 +407,9 @@ def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
         runner.verify_pr(tmp_path, "muyan-pilot/issue-4", "main")
 
 
+FAKE_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
 def fake_verify_run(command, **kwargs):
     """Complete fake for verify_pr: git commands answered, gh returns a PR."""
     if command[:3] == ["git", "branch", "--show-current"]:
@@ -415,8 +418,14 @@ def fake_verify_run(command, **kwargs):
         return ""
     if command[:3] == ["git", "merge-base", "--is-ancestor"]:
         return ""
+    if command[:3] == ["git", "rev-parse", "HEAD"]:
+        return FAKE_HEAD_SHA
     if command[:2] == ["gh", "pr"]:
-        return '[{"url":"https://github.com/muyantech/muyan-pilot/pull/4"}]'
+        return json.dumps([{
+            "url": "https://github.com/muyantech/muyan-pilot/pull/4",
+            "baseRefName": "main",
+            "headRefOid": FAKE_HEAD_SHA,
+        }])
     raise AssertionError(f"unexpected command: {command}")
 
 
@@ -441,7 +450,7 @@ def test_fake_verify_run_rejects_unexpected_command():
 
 def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", "[]",
+        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "[]",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
@@ -450,7 +459,7 @@ def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
 
 def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", "{}",
+        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "{}",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
@@ -474,11 +483,66 @@ def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, t
 
 def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", "[{}]",
+        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "[{}]",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="open PR has no URL"):
         runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+
+
+def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/muyantech/muyan-pilot/pull/4",
+                "baseRefName": "develop",
+                "headRefOid": FAKE_HEAD_SHA,
+            }])
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(
+        RuntimeError, match="PR base is develop, expected main",
+    ):
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+
+
+def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/muyantech/muyan-pilot/pull/4",
+                "baseRefName": "main",
+                "headRefOid": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            }])
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(
+        RuntimeError, match="PR head deadbeef.* is not local HEAD 01234567",
+    ):
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+
+
+def test_verify_pr_queries_base_and_head_and_accepts_matching_pr(
+    monkeypatch, tmp_path,
+):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main") == (
+        "https://github.com/muyantech/muyan-pilot/pull/4"
+    )
+    assert ["git", "rev-parse", "HEAD"] in calls
+    assert [
+        "gh", "pr", "list", "--state", "open", "--head",
+        "muyan-pilot/issue-4-run1", "--json", "url,baseRefName,headRefOid",
+        "--limit", "2",
+    ] in calls
 
 
 def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_path):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -49,6 +50,32 @@ def test_load_config_rejects_empty_source_repo_name(tmp_path):
     config_path = tmp_path / "muyan-pilot.toml"
     config_path.write_text('source_repos = ["owner/repo", ""]\n', encoding="utf-8")
     with pytest.raises(ValueError, match="source_repos must contain non-empty strings"):
+        runner.load_config(config_path)
+
+
+def test_load_config_defaults_base_branch_to_main(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    config = runner.load_config(config_path)
+    assert config["base_branch"] == "main"
+
+
+def test_load_config_reads_explicit_base_branch(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nbase_branch = "develop"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["base_branch"] == "develop"
+
+
+def test_load_config_rejects_empty_base_branch(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nbase_branch = ""\n', encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="base_branch must be a non-empty string"):
         runner.load_config(config_path)
 
 
@@ -226,43 +253,88 @@ def test_edit_issue_allows_no_label_change(monkeypatch):
     assert calls == [["gh", "issue", "edit", "3", "--repo", "xqliu/muyan-ceo"]]
 
 
+def test_new_run_id_is_unique_short_hex():
+    first = runner.new_run_id()
+    second = runner.new_run_id()
+    assert re.fullmatch(r"[0-9a-f]{8}", first)
+    assert first != second
+
+
+def test_freeze_base_fetches_remote_and_returns_exact_sha(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return "abc123def456"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.freeze_base(tmp_path, "main") == "abc123def456"
+    assert calls == [(
+        ["git", "fetch", "origin", "main"], {"cwd": tmp_path},
+    ), (
+        ["git", "rev-parse", "origin/main"], {"cwd": tmp_path},
+    )]
+
+
+def test_freeze_base_fails_fast_when_remote_base_is_missing(monkeypatch, tmp_path):
+    error = subprocess.CalledProcessError(
+        128, ["git", "rev-parse", "origin/main"],
+        stderr="fatal: ambiguous argument",
+    )
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(error),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.freeze_base(tmp_path, "main")
+
+
 def test_create_worktree_rejects_existing_path(tmp_path):
-    existing = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3"
+    existing = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-run1"
     existing.mkdir(parents=True)
     with pytest.raises(RuntimeError, match="worktree path already exists"):
-        runner.create_worktree(tmp_path, "owner/repo", 3)
+        runner.create_worktree(tmp_path, "owner/repo", 3, "run1", "abc123def456")
 
 
-def test_create_worktree_runs_git_add(monkeypatch, tmp_path):
-    path = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3"
+def test_create_worktree_adds_branch_from_frozen_base_sha(monkeypatch, tmp_path):
+    path = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-run1"
     calls = []
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)))
-    assert runner.create_worktree(tmp_path, "owner/repo", 3) == path
+    assert runner.create_worktree(tmp_path, "owner/repo", 3, "run1", "abc123def456") == path
     assert calls == [(
-        ["git", "worktree", "add", "-b", "muyan-pilot/owner-repo-issue-3", str(path), "HEAD"],
+        ["git", "worktree", "add", "-b", "muyan-pilot/owner-repo-issue-3-run1", str(path), "abc123def456"],
         {"cwd": tmp_path},
     )]
 
 
-def test_worktree_path_lives_inside_repo_worktrees():
+def test_worktree_path_lives_inside_repo_worktrees_and_includes_run_id():
     repo_dir = Path("/srv/muyan/muyan-pilot")
-    path = runner.worktree_path(repo_dir, "owner/repo", 3)
-    assert path == repo_dir / ".worktrees" / "muyan-pilot-owner-repo-issue-3"
+    path = runner.worktree_path(repo_dir, "owner/repo", 3, "run1")
+    assert path == repo_dir / ".worktrees" / "muyan-pilot-owner-repo-issue-3-run1"
     assert Path(tempfile.gettempdir()) not in path.parents
 
 
 def test_worktree_path_keeps_source_repo_in_name_to_avoid_same_number_collision():
     repo_dir = Path("/srv/muyan/muyan-pilot")
-    pilot = runner.worktree_path(repo_dir, "xqliu/muyan-pilot", 14)
-    ceo = runner.worktree_path(repo_dir, "xqliu/muyan-ceo", 14)
-    assert pilot == repo_dir / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-14"
-    assert ceo == repo_dir / ".worktrees" / "muyan-pilot-xqliu-muyan-ceo-issue-14"
+    pilot = runner.worktree_path(repo_dir, "xqliu/muyan-pilot", 14, "run1")
+    ceo = runner.worktree_path(repo_dir, "xqliu/muyan-ceo", 14, "run1")
+    assert pilot == repo_dir / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-14-run1"
+    assert ceo == repo_dir / ".worktrees" / "muyan-pilot-xqliu-muyan-ceo-issue-14-run1"
     assert pilot != ceo
 
 
+def test_worktree_path_and_task_branch_differ_per_run_for_same_issue():
+    repo_dir = Path("/srv/muyan/muyan-pilot")
+    first_path = runner.worktree_path(repo_dir, "owner/repo", 3, "run1")
+    retry_path = runner.worktree_path(repo_dir, "owner/repo", 3, "run2")
+    assert first_path != retry_path
+    assert runner.task_branch("owner/repo", 3, "run1") != runner.task_branch("owner/repo", 3, "run2")
+    assert runner.task_branch("owner/repo", 3, "run1") == "muyan-pilot/owner-repo-issue-3-run1"
+
+
 def test_task_branch_includes_source_repo_to_avoid_same_number_collision():
-    assert runner.task_branch("owner/pilot", 1) == "muyan-pilot/owner-pilot-issue-1"
-    assert runner.task_branch("owner/pilot", 1) != runner.task_branch("owner/ceo", 1)
+    assert runner.task_branch("owner/pilot", 1, "run1") == "muyan-pilot/owner-pilot-issue-1-run1"
+    assert runner.task_branch("owner/pilot", 1, "run1") != runner.task_branch("owner/ceo", 1, "run1")
 
 
 def test_comment_issue_runs_gh_comment(monkeypatch):
@@ -275,11 +347,12 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     ]]
 
 
-def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
+def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text(
         "SYSTEM {{SOURCE_REPO}} {{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{ISSUE_BODY}} "
-        "{{WORKSPACE_ROOT}} {{CONTEXT_FILES}} {{SKILLS}}",
+        "{{WORKSPACE_ROOT}} {{CONTEXT_FILES}} {{SKILLS}} {{BASE_BRANCH}} "
+        "{{BASE_SHA}} {{RUN_ID}}",
         encoding="utf-8",
     )
     calls = []
@@ -291,6 +364,9 @@ def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
         "workspace_root": tmp_path,
         "context_files": [tmp_path / "context.md"],
         "skills": [tmp_path / "skill.md"],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "run1",
     }
     assert runner.run_pi(issue, tmp_path, config, "owner/repo") == "done"
     command, kwargs = calls[0]
@@ -301,6 +377,7 @@ def test_run_pi_loads_configured_prompt_and_invokes_pi(monkeypatch, tmp_path):
     assert "Fix body" in command[7]
     assert str(tmp_path / "context.md") in command[7]
     assert str(tmp_path / "skill.md") in command[7]
+    assert command[7].endswith("main abc123def456 run1")
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
     assert kwargs["timeout"] is None
@@ -315,7 +392,7 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
-        {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": []},
+        {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
         "owner/repo",
     )
     command, kwargs = calls[0]
@@ -327,64 +404,123 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "other-branch")
     with pytest.raises(RuntimeError, match="Pi changed branch"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4", "main")
+
+
+def fake_verify_run(command, **kwargs):
+    """Complete fake for verify_pr: git commands answered, gh returns a PR."""
+    if command[:3] == ["git", "branch", "--show-current"]:
+        return "muyan-pilot/issue-4-run1"
+    if command[:3] == ["git", "fetch", "origin"]:
+        return ""
+    if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+        return ""
+    if command[:2] == ["gh", "pr"]:
+        return '[{"url":"https://github.com/muyantech/muyan-pilot/pull/4"}]'
+    raise AssertionError(f"unexpected command: {command}")
+
+
+def test_verify_pr_rejects_delivery_behind_latest_remote_base(monkeypatch, tmp_path, caplog):
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            raise subprocess.CalledProcessError(1, command, stderr="not an ancestor")
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match="behind latest remote base",
+    ):
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+    assert "base_branch=main" in caplog.text
+
+
+def test_fake_verify_run_rejects_unexpected_command():
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_verify_run(["gh", "release", "list"])
 
 
 def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
-    outputs = iter(["muyan-pilot/issue-4", "[]"])
+    outputs = iter([
+        "muyan-pilot/issue-4-run1", "", "", "[]",
+    ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
 
 
 def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
-    outputs = iter(["muyan-pilot/issue-4", "{}"])
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
-    with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
-
-
-def test_verify_pr_returns_url(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4",
-        '[{"url":"https://github.com/muyantech/muyan-pilot/pull/4"}]',
+        "muyan-pilot/issue-4-run1", "", "", "{}",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
-    assert runner.verify_pr(tmp_path, "muyan-pilot/issue-4") == "https://github.com/muyantech/muyan-pilot/pull/4"
+    with pytest.raises(RuntimeError, match="exactly one open PR"):
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+
+
+def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main") == (
+        "https://github.com/muyantech/muyan-pilot/pull/4"
+    )
+    assert ["git", "fetch", "origin", "main"] in calls
+    assert ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"] in calls
 
 
 def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
-    outputs = iter(["muyan-pilot/issue-4", "[{}]"])
+    outputs = iter([
+        "muyan-pilot/issue-4-run1", "", "", "[{}]",
+    ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="open PR has no URL"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4")
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
 
 
-def test_process_issue_success(monkeypatch, tmp_path):
+def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
     monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
-    monkeypatch.setattr(runner, "verify_pr", lambda *args: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "verify_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     issue = {"number": 4, "title": "Fix", "body": "Body"}
-    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}
     assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
     assert calls[1][0] == "edit"
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
-    assert calls[2][0] == "comment"
+    comment = calls[2]
+    assert comment[0] == "comment"
+    body = comment[2]["body"]
+    assert "Muyan Pilot opened PR: https://github.com/muyantech/muyan-pilot/pull/4" in body
+    assert "base_branch=main" in body
+    assert "base_sha=abc123def456" in body
+    assert "run_id=run1" in body
 
 
 def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     with pytest.raises(RuntimeError, match="git failed"):
-        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
+        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
     assert calls[2][0] == "comment"
+    failure_body = calls[2][2]["body"]
+    assert "Muyan Pilot failed: git failed" in failure_body
+    assert "base_branch=main" in failure_body
+    assert "base_sha=abc123def456" in failure_body
+    assert "run_id=run1" in failure_body
 
 
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
@@ -396,9 +532,11 @@ def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypat
             raise RuntimeError("github report failed")
 
     monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
-        runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md"}, "xqliu/muyan-ceo")
+        runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
     assert "failure reporting failed" in caplog.text
 
 

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -1,0 +1,140 @@
+"""Real git smoke tests for Issue #31 base-freeze behavior.
+
+These tests execute actual git commands inside a temporary local repository
+(no network, no remote push, no protected branch) and prove the acceptance
+criteria:
+
+- a task worktree is created from the latest ``origin/<base>`` even when the
+  main worktree is checked out on a side branch;
+- a retry of the same Issue gets a new independent branch/worktree instead of
+  "worktree path already exists";
+- ``verify_pr`` rejects a delivery that does not contain the latest remote
+  base and accepts one that does.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import bootstrap_runner as runner
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def clone(tmp_path: Path) -> Path:
+    """Local bare origin plus a clone with two commits on main."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    (clone / "a.txt").write_text("a", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "first")
+    (clone / "b.txt").write_text("b", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "second")
+    git(clone, "push", "origin", "main")
+    return clone
+
+
+def commit_file(clone: Path, name: str, message: str) -> str:
+    (clone / name).write_text(message, encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", message)
+    return git(clone, "rev-parse", "HEAD")
+
+
+def install_fake_gh(monkeypatch, pr_json: str) -> None:
+    """Run real git commands; answer `gh` with a fixed JSON payload."""
+    real_run = runner.run_command
+
+    def fake_run(command, **kwargs):
+        if command[:1] == ["gh"]:
+            return pr_json
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+
+
+def test_task_created_from_latest_origin_base_when_main_worktree_on_side_branch(clone):
+    # Main worktree drifts to a side branch that is not pushed anywhere.
+    git(clone, "checkout", "-b", "side-branch")
+    commit_file(clone, "side.txt", "side work")
+    side_sha = git(clone, "rev-parse", "HEAD")
+    origin_main = git(clone, "rev-parse", "origin/main")
+    assert side_sha != origin_main
+
+    base_sha = runner.freeze_base(clone, "main")
+    assert base_sha == origin_main
+
+    path = runner.create_worktree(clone, "owner/repo", 3, "run1", base_sha)
+    assert path.exists()
+    # The worktree HEAD is the frozen origin/main, not the side-branch HEAD.
+    assert git(path, "rev-parse", "HEAD") == origin_main
+    assert git(path, "branch", "--show-current") == "muyan-pilot/owner-repo-issue-3-run1"
+
+
+def test_retry_of_same_issue_gets_new_independent_run(clone):
+    base_sha = runner.freeze_base(clone, "main")
+    first = runner.create_worktree(clone, "owner/repo", 3, "run1", base_sha)
+    commit_file(first, "first-run.txt", "first run work")
+    second = runner.create_worktree(clone, "owner/repo", 3, "run2", base_sha)
+    assert second != first
+    assert git(second, "rev-parse", "HEAD") == base_sha
+    # The old scene is preserved untouched.
+    assert git(first, "rev-parse", "HEAD") != base_sha
+    assert (first / "first-run.txt").is_file()
+
+
+def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
+    # Delivery branch is based on the first commit only.
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1",
+        git(clone, "rev-parse", "origin/main~1"))
+    commit_file(clone, "delivery.txt", "delivery")
+    # Remote main advances after the delivery was created.
+    git(clone, "checkout", "main")
+    commit_file(clone, "advance.txt", "main advanced")
+    git(clone, "push", "origin", "main")
+    # The delivery worktree stays on the task branch.
+    git(clone, "checkout", "muyan-pilot/owner-repo-issue-3-run1")
+
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match="behind latest remote base",
+    ):
+        runner.verify_pr(clone, "muyan-pilot/owner-repo-issue-3-run1", "main")
+    assert "base_branch=main" in caplog.text
+
+
+def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monkeypatch):
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1")
+    commit_file(clone, "delivery.txt", "delivery")
+    # Remote main is unchanged, so the delivery contains it.
+    install_fake_gh(
+        monkeypatch,
+        '[{"url":"https://github.com/owner/repo/pull/3"}]',
+    )
+    assert runner.verify_pr(
+        clone, "muyan-pilot/owner-repo-issue-3-run1", "main",
+    ) == "https://github.com/owner/repo/pull/3"
+
+
+def test_git_helper_fails_fast_on_nonzero_exit(clone):
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git(clone, "rev-parse", "no-such-ref")

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -11,6 +11,7 @@ criteria:
 - ``verify_pr`` rejects a delivery that does not contain the latest remote
   base and accepts one that does.
 """
+import json
 import subprocess
 from pathlib import Path
 
@@ -126,13 +127,38 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
     git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1")
     commit_file(clone, "delivery.txt", "delivery")
     # Remote main is unchanged, so the delivery contains it.
+    local_head = git(clone, "rev-parse", "HEAD")
     install_fake_gh(
         monkeypatch,
-        '[{"url":"https://github.com/owner/repo/pull/3"}]',
+        json.dumps([{
+            "url": "https://github.com/owner/repo/pull/3",
+            "baseRefName": "main",
+            "headRefOid": local_head,
+        }]),
     )
     assert runner.verify_pr(
         clone, "muyan-pilot/owner-repo-issue-3-run1", "main",
     ) == "https://github.com/owner/repo/pull/3"
+
+
+def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
+    # Commit A is pushed (the PR points at it); commit B is local only.
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1")
+    commit_file(clone, "delivery-a.txt", "commit A")
+    pushed_head = git(clone, "rev-parse", "HEAD")
+    commit_file(clone, "delivery-b.txt", "commit B")
+    install_fake_gh(
+        monkeypatch,
+        json.dumps([{
+            "url": "https://github.com/owner/repo/pull/3",
+            "baseRefName": "main",
+            "headRefOid": pushed_head,
+        }]),
+    )
+    with pytest.raises(RuntimeError, match="is not local HEAD"):
+        runner.verify_pr(
+            clone, "muyan-pilot/owner-repo-issue-3-run1", "main",
+        )
 
 
 def test_git_helper_fails_fast_on_nonzero_exit(clone):

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -182,18 +183,47 @@ def test_status_report_lists_sources_current_ready_and_result(monkeypatch):
     monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: fake_lookup(repo, "current"))
     monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: fake_lookup(repo, "ready"))
     monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: fake_lookup(repo, "result"))
-    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    monkeypatch.setattr(muyan_pilot, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    report = muyan_pilot.status_report({
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": Path("/srv/muyan/muyan-pilot"),
+        "base_branch": "main",
+    })
     assert "source: xqliu/muyan-pilot" in report
+    assert "base: main abc123def456" in report
     assert "current: #3 now u3" in report
     assert "ready: #11 next u11" in report
     assert "result: #2 done u2" in report
+
+
+def test_status_report_freezes_base_from_configured_repo_dir(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot, "freeze_base",
+        lambda repo_dir, base_branch: calls.append((repo_dir, base_branch)) or "abc123def456",
+    )
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    muyan_pilot.status_report({
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": Path("/srv/muyan/muyan-pilot"),
+        "base_branch": "develop",
+    })
+    assert calls == [(Path("/srv/muyan/muyan-pilot"), "develop")]
 
 
 def test_status_report_marks_empty_lookups(monkeypatch):
     monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
     monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
     monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
-    report = muyan_pilot.status_report({"source_repos": ["xqliu/muyan-pilot"]})
+    monkeypatch.setattr(muyan_pilot, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    report = muyan_pilot.status_report({
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": Path("/srv/muyan/muyan-pilot"),
+        "base_branch": "main",
+    })
+    assert "base: main abc123def456" in report
     assert "current: -" in report
     assert "ready: -" in report
     assert "result: -" in report


### PR DESCRIPTION
Closes #31

## What changed

- **TOML base config**: `base_branch` (default `main`) in `muyan-pilot.toml`; no hardcoded personal directories.
- **Frozen base at claim time**: every claim runs `git fetch origin <base>` in the configured repo and freezes the exact `origin/<base>` SHA (`freeze_base`).
- **Worktree from the frozen SHA**: `git worktree add` now uses the frozen SHA, never the main worktree's current HEAD — a main worktree parked on a side branch can no longer poison task deliveries.
- **Unique run id**: branch and worktree names carry a uuid4 run id (`muyan-pilot/owner-repo-issue-3-a1b2c3d4`), so a retried Issue gets a new independent run and the old scene is preserved (no more "worktree path already exists" on re-claim).
- **Recorded everywhere**: base branch, base SHA and run id appear in the Pi prompt, the Issue comment (success and failure) and `muyan_pilot.py status` output.
- **Runner gate**: `verify_pr` re-fetches before judging and runs `git merge-base --is-ancestor origin/<base> HEAD`; a delivery that does not contain the latest remote base is rejected fail-fast (no PR accepted).
- **Prompt/contract**: Pi must re-fetch before creating the PR; if the base advanced, merge it manually, rerun the full tests and the complete review-fix loop, then push. No auto conflict resolution, no force push, no merge/push of the protected branch (AGENTS.md + README updated).

## Verification

- 91 tests pass; 100% line and branch coverage (`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`).
- New real-git smoke tests (`tests/test_git_base_smoke.py`) prove, with actual git commands in a temp repo: task created from latest origin/main while the main worktree sits on a side branch; retry of the same Issue gets a new independent run with the old scene preserved; behind delivery rejected; up-to-date delivery accepted.
- Live smoke on the real repo: main worktree temporarily on a side branch → new run created from frozen `origin/main` (9530c7c); main restored afterwards.
- Review-fix loop: full R1–R9 review, 0 Blocker / 0 Major.