### PR TITLE
feat: stream live Pi activity during active runs (Issue #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ python3 muyan_pilot.py status --config muyan-pilot.toml
 
 `add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
 
+## 实时进展
+
+Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把最近活动写入 journal（systemd 日志）：
+
+- `pi_activity issue=... source_repo=... branch=... worktree=... session=... session_file=... events=... phase=... last_activity=... last=...`——有新事件时记录当前阶段（test / pr / push / commit / base / worktree / ui / bash 或工具名）、最近活动时间和脱敏后的工具/命令摘要；
+- `pi_idle ... stale_seconds=...`——超过 5 分钟没有新事件时告警，带完整现场（找不到 session 文件时同样告警）；
+- `pi_failed returncode=... ...`——进程异常退出时先记录现场再抛出错误；session JSONL 完整保留在 worktree 中，作为本地完整记录。
+
+`muyan_pilot.py status` 同时展示当前（`ai-in-progress`）任务的实时状态：
+
+```bash
+python3 muyan_pilot.py status --config muyan-pilot.toml
+# source: xqliu/muyan-pilot
+#   base: main abc123def456
+#   current: #24 Stream live Pi activity ... https://github.com/xqliu/muyan-pilot/issues/24
+#     live: phase=test last_activity=2026-08-25T02:30:00Z last=bash pytest tests/
+#     session: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>/.pi-session/<session>.jsonl
+#     worktree: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>
+#   ready: -
+#   result: -
+```
+
+journal 和 `status` 只暴露脱敏摘要：完整 prompt、Issue body 和 token 不会写入日志（命令日志固定为 `<redacted>`，工具摘要截断到 200 字符并屏蔽常见 token 形状）。关键阶段继续回写 GitHub Issue 评论：Pi 启动（含 branch 和 worktree）、PR 创建、失败现场。
+
 前置条件：
 
 - `gh auth status` 成功；

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -11,13 +11,27 @@ import argparse
 import json
 import logging
 import os
+import select
 import subprocess
+import time
 import tomllib
 import uuid
 from pathlib import Path
 
+from pi_activity import (
+    SessionWatcher,
+    activity_snapshot,
+    format_activity_scene,
+)
+
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
+
+# Live activity polling while Pi runs (Issue #24). The journal gets one
+# activity line per poll with new events, and an idle warning when the
+# session stays silent for this long.
+PI_POLL_INTERVAL = 15.0
+PI_IDLE_WARN_SECONDS = 300.0
 
 
 def _config_path(value: str, base: Path) -> Path:
@@ -197,8 +211,122 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
     return path
 
 
+def _drain_stream(stream, chunks: list[bytes]) -> None:
+    """Read a pipe to EOF, appending chunks (process must be finished)."""
+    while True:
+        data = os.read(stream.fileno(), 65536)
+        if not data:
+            return
+        chunks.append(data)
+
+
+def _decode_chunks(chunks: list[bytes]) -> str:
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+def _log_pi_activity(activity: dict, context: str,
+                     idle_warn_seconds: float) -> None:
+    """Log new session activity, or an idle warning with the full scene."""
+    scene = format_activity_scene(activity)
+    if activity["changed"]:
+        LOGGER.info("pi_activity %s %s", context, scene)
+        return
+    if activity["stale_seconds"] >= idle_warn_seconds:
+        LOGGER.warning(
+            "pi_idle %s %s stale_seconds=%.0f",
+            context, scene, activity["stale_seconds"],
+        )
+
+
+def stream_pi(
+    command: list[str],
+    *,
+    cwd: Path,
+    timeout: int | None = None,
+    poll_interval: float = PI_POLL_INTERVAL,
+    idle_warn_seconds: float = PI_IDLE_WARN_SECONDS,
+    log_command: list[str] | None = None,
+    issue: int | None = None,
+    source_repo: str | None = None,
+    branch: str | None = None,
+) -> str:
+    """Run Pi and stream its live session activity into the journal.
+
+    Every poll, the newest Pi session JSONL activity is logged with the task
+    context (issue, source repo, branch, worktree): phase, last activity
+    time and a sanitized tool summary. When no new event arrives for
+    `idle_warn_seconds`, a warning with the full scene is logged. On a
+    non-zero exit the scene is logged before the error is raised. The
+    session JSONL stays in the worktree as the complete local record; the
+    full prompt and Issue body are never logged.
+    """
+    # The raw pi command embeds the full prompt and Issue body; only the
+    # redacted form may ever reach the journal or an exception message.
+    safe_command = log_command or ["<redacted>"]
+    LOGGER.info("command=%s cwd=%s", " ".join(safe_command), cwd)
+    watcher = SessionWatcher(cwd / ".pi-session")
+    context = (
+        f"issue={issue} source_repo={source_repo} branch={branch} "
+        f"worktree={cwd}"
+    )
+    process = subprocess.Popen(
+        command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    deadline = None if timeout is None else time.monotonic() + timeout
+    activity = watcher.poll()
+    timed_out = False
+    try:
+        while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                process.kill()
+                timed_out = True
+                break
+            ready, _, _ = select.select(
+                [process.stdout, process.stderr], [], [], poll_interval,
+            )
+            for stream in ready:
+                data = os.read(stream.fileno(), 65536)
+                if data:
+                    if stream is process.stdout:
+                        stdout_chunks.append(data)
+                    else:
+                        stderr_chunks.append(data)
+            activity = watcher.poll()
+            _log_pi_activity(activity, context, idle_warn_seconds)
+            if process.poll() is not None:
+                break
+    finally:
+        _drain_stream(process.stdout, stdout_chunks)
+        _drain_stream(process.stderr, stderr_chunks)
+    stdout = _decode_chunks(stdout_chunks)
+    stderr = _decode_chunks(stderr_chunks)
+    if timed_out:
+        LOGGER.error(
+            "pi_timeout timeout=%s %s %s",
+            timeout, context, format_activity_scene(activity),
+        )
+        raise subprocess.TimeoutExpired(
+            safe_command, timeout, output=stdout, stderr=stderr,
+        )
+    if process.returncode != 0:
+        LOGGER.error(
+            "pi_failed returncode=%s %s %s",
+            process.returncode, context, format_activity_scene(activity),
+        )
+        raise subprocess.CalledProcessError(
+            process.returncode, safe_command, output=stdout, stderr=stderr,
+        )
+    if stderr:
+        LOGGER.info("stderr=%s", stderr.rstrip())
+    LOGGER.info("stdout=%s", stdout.rstrip())
+    return stdout.strip()
+
+
 def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
-           timeout: int | None = None) -> str:
+           timeout: int | None = None,
+           branch: str | None = None) -> str:
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -230,15 +358,17 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         "pi_session=%s issue=%s source_repo=%s",
         worktree / ".pi-session", issue["number"], source_repo,
     )
-    return run_command(
+    return stream_pi(
         command,
         cwd=worktree,
         timeout=timeout,
-        log_stdout=True,
         log_command=[
             "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
             "--system-prompt", "<redacted>", "<issue-context-redacted>",
         ],
+        issue=int(issue["number"]),
+        source_repo=source_repo,
+        branch=branch,
     )
 
 
@@ -320,12 +450,20 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         "issue=%s %s", number, run_info,
     )
     edit_issue(number, repo=source_repo, add="ai-in-progress")
+    worktree: Path | None = None
     try:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, base_sha,
         )
         config = {**config, "base_sha": base_sha, "run_id": run_id}
-        run_pi(issue, worktree, config, source_repo)
+        comment_issue(
+            number, repo=source_repo,
+            body=(
+                f"Muyan Pilot started Pi: {run_info} branch={branch} "
+                f"worktree={worktree}"
+            ),
+        )
+        run_pi(issue, worktree, config, source_repo, branch=branch)
         pr_url = verify_pr(worktree, branch, base_branch)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
@@ -338,15 +476,23 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         return pr_url
     except Exception as exc:
         LOGGER.exception("issue=%s failed", number)
+        scene = ""
+        if worktree is not None:
+            try:
+                scene = format_activity_scene(
+                    activity_snapshot(worktree / ".pi-session"),
+                )
+            except Exception:
+                LOGGER.exception("issue=%s activity scene failed", number)
         try:
             edit_issue(
                 number, repo=source_repo, add="ai-blocked",
                 remove="ai-in-progress",
             )
-            comment_issue(
-                number, repo=source_repo,
-                body=f"Muyan Pilot failed: {exc} ({run_info})",
-            )
+            body = f"Muyan Pilot failed: {exc} ({run_info})"
+            if scene:
+                body += f" {scene}"
+            comment_issue(number, repo=source_repo, body=body)
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)
         raise

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -2,8 +2,10 @@
 """Muyan Pilot task dispatch and status CLI.
 
 `add` creates an Issue in a configured source repo and labels it `ai-ready`.
-`status` reports the current in-progress Issue, the next ready Issue, and the
-most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
+`status` reports the current in-progress Issue (with its live Pi activity:
+phase, last activity time, sanitized last tool summary, session file and
+worktree), the next ready Issue, and the most recent result
+(`ai-pr-opened` / `ai-blocked`) per source repo.
 
 GitHub Issues and labels are the only state store. There is no database,
 queue, or web UI. Command failures are logged and raised by the reused
@@ -24,6 +26,7 @@ from bootstrap_runner import (
     run_command,
     validate_config,
 )
+from pi_activity import activity_snapshot
 
 LOGGER = logging.getLogger("muyan_pilot.cli")
 
@@ -96,14 +99,55 @@ def format_issue(issue: dict) -> str:
     return f"#{issue['number']} {issue['title']} {issue['url']}"
 
 
+def latest_task_worktree(repo_dir: Path, source_repo: str,
+                         number: int) -> Path | None:
+    """Return the newest task worktree for an Issue, or None."""
+    slug = source_repo.replace("/", "-")
+    pattern = f".worktrees/muyan-pilot-{slug}-issue-{number}-*"
+    candidates = [
+        path for path in repo_dir.glob(pattern) if path.is_dir()
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def live_activity_lines(repo_dir: Path, source_repo: str,
+                        issue: dict) -> list[str]:
+    """Return the live Pi activity lines for an in-progress Issue."""
+    worktree = latest_task_worktree(repo_dir, source_repo, int(issue["number"]))
+    if worktree is None:
+        return ["    live: no task worktree found"]
+    snapshot = activity_snapshot(worktree / ".pi-session")
+    if snapshot is None:
+        return [
+            "    live: no pi session yet",
+            f"    worktree: {worktree}",
+        ]
+    return [
+        (
+            f"    live: phase={snapshot['phase']} "
+            f"last_activity={snapshot['last_activity'] or '-'} "
+            f"last={snapshot['last'] or '-'}"
+        ),
+        f"    session: {snapshot['session_file']}",
+        f"    worktree: {worktree}",
+    ]
+
+
 def status_report(config: dict) -> str:
     lines = []
     for repo in config["source_repos"]:
         lines.append(f"source: {repo}")
         base_sha = freeze_base(config["repo_dir"], config["base_branch"])
         lines.append(f"  base: {config['base_branch']} {base_sha}")
+        current = current_issue(repo)
+        lines.append(f"  current: {format_issue(current) if current else '-'}")
+        if current is not None:
+            lines.extend(
+                live_activity_lines(config["repo_dir"], repo, current),
+            )
         for name, lookup in (
-            ("current", current_issue),
             ("ready", ready_issue),
             ("result", recent_result),
         ):
@@ -132,7 +176,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     subparsers.add_parser(
         "status", parents=[common],
-        help="show current Issue, ready queue and recent result",
+        help="show current Issue (with live Pi activity), ready queue and recent result",
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/pi_activity.py
+++ b/pi_activity.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Live Pi session activity tracking (Issue #24).
+
+Pi writes its session as an append-only JSONL file under the task worktree
+(`.pi-session/*.jsonl`) while it runs. This module follows that file and
+reduces it to a small, redacted activity snapshot: session id, event count,
+current phase, last activity time, and a sanitized summary of the newest
+tool call or result.
+
+Only assistant and toolResult messages are agent activity. User messages
+carry the full prompt and Issue body and are never summarized. The module
+never writes anything; the runner and the status command decide what to log
+or print. No database, queue, or daemon — just reading a local file.
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+MAX_SUMMARY_LENGTH = 200
+
+# Ordered: the first matching rule wins for a bash command.
+PHASE_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b(pytest|coverage)\b"), "test"),
+    (re.compile(r"\bgh\s+pr\b"), "pr"),
+    (re.compile(r"\bgit\s+push\b"), "push"),
+    (re.compile(r"\bgit\s+commit\b"), "commit"),
+    (re.compile(r"\bgit\s+(fetch|merge)\b"), "base"),
+    (re.compile(r"\bgit\s+worktree\b"), "worktree"),
+    (re.compile(r"\bplaywright\b"), "ui"),
+)
+
+# Obvious token shapes that must never reach the journal or a status output.
+TOKEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"Bearer\s+[A-Za-z0-9._\-]+"), "Bearer <redacted>"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}"), "ghp_<redacted>"),
+    (re.compile(r"\bsk-[A-Za-z0-9]{16,}"), "sk-<redacted>"),
+)
+
+
+def latest_session_file(session_dir: Path) -> Path | None:
+    """Return the newest `*.jsonl` in the session dir, or None."""
+    if not session_dir.is_dir():
+        return None
+    files = [path for path in session_dir.glob("*.jsonl") if path.is_file()]
+    if not files:
+        return None
+    return max(files, key=lambda path: path.stat().st_mtime)
+
+
+def read_new_events(path: Path, offset: int) -> tuple[list[dict], int]:
+    """Read complete JSONL records from `offset`.
+
+    Returns `(records, new_offset)`. A trailing partial line (Pi is still
+    writing it) is left for the next read. Unparseable or non-object lines
+    are skipped. A file that shrank below `offset` is re-read from the
+    start.
+    """
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return [], offset
+    if size < offset:
+        offset = 0
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        data = handle.read()
+    end = data.rfind(b"\n")
+    if end < 0:
+        return [], offset
+    complete = data[: end + 1]
+    records: list[dict] = []
+    for line in complete.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records, offset + len(complete)
+
+
+def parse_iso_utc(value: str) -> float | None:
+    """Parse an ISO-8601 timestamp (UTC assumed when naive); None if bad."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def sanitize(text: str) -> str:
+    """Single-line, truncated, token-redacted summary safe for logs."""
+    text = " ".join(text.split())
+    for pattern, replacement in TOKEN_PATTERNS:
+        text = pattern.sub(replacement, text)
+    if len(text) > MAX_SUMMARY_LENGTH:
+        text = text[:MAX_SUMMARY_LENGTH].rstrip() + "..."
+    return text
+
+
+def tool_args_summary(name: str, arguments: dict) -> str:
+    """Return the most informative single argument of a tool call."""
+    if name == "bash":
+        command = arguments.get("command")
+        return command if isinstance(command, str) else ""
+    for key in ("path", "file_path", "tool", "query"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def phase_for(name: str, arguments: dict) -> str:
+    """Map a tool call to a human-readable work phase."""
+    if name == "bash":
+        command = arguments.get("command")
+        command = command if isinstance(command, str) else ""
+        for pattern, phase in PHASE_RULES:
+            if pattern.search(command):
+                return phase
+        return "bash"
+    return name
+
+
+class SessionWatcher:
+    """Follow the newest Pi session JSONL and track the latest activity."""
+
+    def __init__(self, session_dir: Path,
+                 now: Callable[[], float] = time.time) -> None:
+        self.session_dir = session_dir
+        self._now = now
+        self.session_file: Path | None = None
+        self.session_id: str | None = None
+        self.phase: str | None = None
+        self.last_activity: str | None = None
+        self.last: str | None = None
+        self.events = 0
+        self.start_time = now()
+        self._offset = 0
+        self._last_activity_epoch: float | None = None
+
+    def poll(self) -> dict:
+        """Read new session records; return the current activity state."""
+        if self.session_file is None:
+            self.session_file = latest_session_file(self.session_dir)
+        changed = False
+        if self.session_file is not None:
+            records, self._offset = read_new_events(
+                self.session_file, self._offset,
+            )
+            for record in records:
+                self._apply(record)
+            changed = bool(records)
+        return self.state(changed=changed)
+
+    def state(self, changed: bool = False) -> dict:
+        """Return the activity state as a plain dict (no file access)."""
+        now = self._now()
+        if self._last_activity_epoch is not None:
+            stale = now - self._last_activity_epoch
+        else:
+            stale = now - self.start_time
+        return {
+            "session_id": self.session_id,
+            "session_file": str(self.session_file) if self.session_file
+            else None,
+            "events": self.events,
+            "phase": self.phase or "starting",
+            "last_activity": self.last_activity,
+            "last": self.last,
+            "changed": changed,
+            "stale_seconds": max(0.0, stale),
+        }
+
+    def _apply(self, record: dict) -> None:
+        self.events += 1
+        record_type = record.get("type")
+        if record_type == "session":
+            session_id = record.get("id")
+            if isinstance(session_id, str) and session_id:
+                self.session_id = session_id
+            return
+        if record_type != "message":
+            return
+        message = record.get("message")
+        if not isinstance(message, dict):
+            return
+        role = message.get("role")
+        if role == "assistant":
+            self._apply_assistant(message)
+        elif role == "toolResult":
+            self._apply_tool_result(message)
+        timestamp = record.get("timestamp")
+        if isinstance(timestamp, str) and timestamp:
+            epoch = parse_iso_utc(timestamp)
+            if epoch is not None:
+                self.last_activity = timestamp
+                self._last_activity_epoch = epoch
+
+    def _apply_assistant(self, message: dict) -> None:
+        content = message.get("content")
+        if not isinstance(content, list):
+            return
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            kind = item.get("type")
+            if kind == "toolCall":
+                name = item.get("name")
+                name = name if isinstance(name, str) and name else "tool"
+                arguments = item.get("arguments")
+                arguments = arguments if isinstance(arguments, dict) else {}
+                self.phase = phase_for(name, arguments)
+                self.last = sanitize(f"{name} {tool_args_summary(name, arguments)}").strip()
+            elif kind == "text":
+                self.last = "assistant text"
+            elif kind == "thinking":
+                self.last = "thinking"
+
+    def _apply_tool_result(self, message: dict) -> None:
+        name = message.get("toolName")
+        name = name if isinstance(name, str) and name else "tool"
+        suffix = " (error)" if message.get("isError") else ""
+        self.last = f"tool_result {name}{suffix}"
+        if name != "bash":
+            self.phase = name
+
+
+def activity_snapshot(session_dir: Path) -> dict | None:
+    """Full-scan the newest session file; None when no session exists yet."""
+    watcher = SessionWatcher(session_dir)
+    watcher.poll()
+    if watcher.session_file is None:
+        return None
+    return watcher.state()
+
+
+def format_activity_scene(snapshot: dict | None) -> str:
+    """Format an activity snapshot as a `key=value` scene string."""
+    if snapshot is None:
+        return ""
+    return (
+        f"session={snapshot['session_id'] or '-'} "
+        f"session_file={snapshot['session_file'] or '-'} "
+        f"phase={snapshot['phase']} "
+        f"last_activity={snapshot['last_activity'] or '-'} "
+        f"last={snapshot['last'] or '-'}"
+    )

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,7 +1,11 @@
 import json
+import os
 import re
 import subprocess
+import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -356,40 +360,66 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
         encoding="utf-8",
     )
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
     issue = {"number": 4, "title": "Fix title", "body": "Fix body"}
     config = {
         "prompt": prompt_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
-        "context_files": [tmp_path / "context.md"],
-        "skills": [tmp_path / "skill.md"],
+        "context_files": ["context.md"],
+        "skills": ["skill.md"],
         "base_branch": "main",
         "base_sha": "abc123def456",
         "run_id": "run1",
     }
     assert runner.run_pi(issue, tmp_path, config, "owner/repo") == "done"
     command, kwargs = calls[0]
-    assert command[:4] == ["pi", "--skill", str(tmp_path / "skill.md"), "--print"]
+    assert command[:4] == ["pi", "--skill", "skill.md", "--print"]
     assert "owner/repo" in command[7]
     assert " 4 " in command[7]
     assert "Fix title" in command[7]
     assert "Fix body" in command[7]
-    assert str(tmp_path / "context.md") in command[7]
-    assert str(tmp_path / "skill.md") in command[7]
+    assert "context.md" in command[7]
+    assert "skill.md" in command[7]
     assert command[7].endswith("main abc123def456 run1")
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
     assert kwargs["timeout"] is None
-    assert kwargs["log_stdout"] is True
+    assert kwargs["issue"] == 4
+    assert kwargs["source_repo"] == "owner/repo"
+    assert kwargs["branch"] is None
     assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+
+
+def test_run_pi_passes_task_branch_to_stream_pi(monkeypatch, tmp_path):
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append(kwargs) or "done")
+    issue = {"number": 5, "title": "t", "body": "b"}
+    config = {
+        "prompt": prompt_path,
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "run1",
+    }
+    runner.run_pi(
+        issue, tmp_path, config, "owner/repo",
+        timeout=7, branch="muyan-pilot/owner-repo-issue-5-run1",
+    )
+    assert calls[0]["branch"] == "muyan-pilot/owner-repo-issue-5-run1"
+    assert calls[0]["timeout"] == 7
 
 
 def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text("PRIVATE SYSTEM {{ISSUE_BODY}}", encoding="utf-8")
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
         {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
@@ -398,7 +428,11 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
     command, kwargs = calls[0]
     assert "PRIVATE SYSTEM" in command[5]
     assert "token" in command[5]
-    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+    assert kwargs["log_command"] == [
+        "pi", "--print", "--session-dir",
+        str(tmp_path / ".pi-session"),
+        "--system-prompt", "<redacted>", "<issue-context-redacted>",
+    ]
 
 
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
@@ -558,15 +592,23 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}
     assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
-    assert calls[1][0] == "edit"
-    assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
-    comment = calls[2]
+    start = calls[1]
+    assert start[0] == "comment"
+    assert "Muyan Pilot started Pi:" in start[2]["body"]
+    assert "base_branch=main" in start[2]["body"]
+    assert "base_sha=abc123def456" in start[2]["body"]
+    assert "run_id=run1" in start[2]["body"]
+    assert "branch=muyan-pilot/xqliu-muyan-ceo-issue-4-run1" in start[2]["body"]
+    assert "worktree=" + str(tmp_path / "wt") in start[2]["body"]
+    assert calls[2][0] == "edit"
+    assert calls[2][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
+    comment = calls[3]
     assert comment[0] == "comment"
     body = comment[2]["body"]
     assert "Muyan Pilot opened PR: https://github.com/muyantech/muyan-pilot/pull/4" in body
     assert "base_branch=main" in body
     assert "base_sha=abc123def456" in body
-    assert "run_id=run1" in body
+    assert "run_id=run1" in body in body
 
 
 def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
@@ -644,3 +686,242 @@ def test_main_requires_prompt_file(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     with pytest.raises(FileNotFoundError):
         runner.main(["--config", str(config)])
+
+
+def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, ["pi"], stderr="boom"),
+        ),
+    )
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: {
+        "session_id": "sess-9",
+        "session_file": str(tmp_path / "wt" / ".pi-session" / "s.jsonl"),
+        "phase": "test",
+        "last_activity": "2026-08-25T02:30:00Z",
+        "last": "bash pytest tests/",
+    })
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
+    failure_body = calls[-1][2]["body"]
+    assert "Muyan Pilot failed:" in failure_body
+    assert "session=sess-9" in failure_body
+    assert "phase=test" in failure_body
+    assert "last_activity=2026-08-25T02:30:00Z" in failure_body
+    assert "last=bash pytest tests/" in failure_body
+
+
+def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, caplog):
+    calls = []
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("git failed")),
+    )
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    monkeypatch.setattr(
+        runner, "activity_snapshot",
+        lambda session_dir: (_ for _ in ()).throw(OSError("disk error")),
+    )
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
+        runner.process_issue({"number": 9, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
+    assert "activity scene failed" in caplog.text
+    failure_body = calls[-1][2]["body"]
+    assert "Muyan Pilot failed: git failed" in failure_body
+    assert "session=" not in failure_body
+
+
+def make_fake_pi(tmp_path: Path, *, session_records: list[tuple[float, dict]],
+                 stdout: str = "", stderr: str = "", exit_code: int = 0,
+                 sleep: float = 0.0) -> list[str]:
+    """Build a command that mimics pi: appends session records over time."""
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    records_literal = repr(session_records)
+    script = (
+        "import json, sys, time\n"
+        f"session = {str(session_dir / 'sess.jsonl')!r}\n"
+        f"records = {records_literal}\n"
+        "for delay, record in records:\n"
+        "    time.sleep(delay)\n"
+        "    with open(session, 'a') as handle:\n"
+        "        handle.write(json.dumps(record) + '\\n')\n"
+        f"time.sleep({sleep!r})\n"
+        f"sys.stdout.write({stdout!r})\n"
+        f"sys.stderr.write({stderr!r})\n"
+        f"sys.exit({exit_code!r})\n"
+    )
+    return [sys.executable, "-c", script]
+
+
+def fake_session_records():
+    return [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": "2026-08-25T02:00:00Z", "cwd": "/w"}),
+        (0.1, {"type": "message", "id": "u1",
+               "timestamp": "2026-08-25T02:00:00Z",
+               "message": {"role": "user", "content": [
+                   {"type": "text", "text": "SECRET ISSUE BODY"}]}}),
+        (0.2, {"type": "message", "id": "a1",
+               "timestamp": "2026-08-25T02:00:01Z",
+               "message": {"role": "assistant", "content": [
+                   {"type": "toolCall", "id": "t1", "name": "bash",
+                    "arguments": {"command": "pytest tests/"}}]}}),
+    ]
+
+
+def test_stream_pi_logs_live_activity_and_returns_stdout(tmp_path, caplog):
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stdout="final answer",
+    )
+    with caplog.at_level("INFO"):
+        result = runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
+            issue=24, source_repo="xqliu/muyan-pilot",
+            branch="muyan-pilot/xqliu-muyan-pilot-issue-24-run1",
+        )
+    assert result == "final answer"
+    # Without an explicit log_command the raw command is never logged.
+    assert "command=<redacted>" in caplog.text
+    assert "pi_activity issue=24 source_repo=xqliu/muyan-pilot" in caplog.text
+    assert "branch=muyan-pilot/xqliu-muyan-pilot-issue-24-run1" in caplog.text
+    assert f"worktree={tmp_path}" in caplog.text
+    assert "session=sess-1" in caplog.text
+    assert "phase=test" in caplog.text
+    assert "last=bash pytest tests/" in caplog.text
+    assert "stdout=final answer" in caplog.text
+    # The user message (full prompt / Issue body) never reaches the journal.
+    assert "SECRET ISSUE BODY" not in caplog.text
+
+
+def test_stream_pi_logs_command_redacted_and_stderr(tmp_path, caplog):
+    command = make_fake_pi(
+        tmp_path, session_records=[],
+        stdout="ok", stderr="warning line",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
+            log_command=["pi", "--print", "<redacted>"],
+        )
+    assert "command=pi --print <redacted>" in caplog.text
+    assert "stderr=warning line" in caplog.text
+
+
+def test_stream_pi_logs_failure_scene_and_reraises(tmp_path, caplog):
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stderr="pi exploded", exit_code=3,
+    )
+    with caplog.at_level("ERROR"), pytest.raises(
+        subprocess.CalledProcessError,
+    ) as excinfo:
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
+            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+        )
+    assert excinfo.value.returncode == 3
+    assert "pi exploded" in (excinfo.value.stderr or "")
+    # The exception must not carry the raw command (prompt / Issue body).
+    assert "SECRET ISSUE BODY" not in str(excinfo.value)
+    assert "pi_failed returncode=3" in caplog.text
+    assert "session=sess-1" in caplog.text
+    assert "phase=test" in caplog.text
+    # The session JSONL stays in the worktree as the local record.
+    session_files = list((tmp_path / ".pi-session").glob("*.jsonl"))
+    assert len(session_files) == 1
+    assert len(session_files[0].read_text(encoding="utf-8").splitlines()) == 3
+
+
+def test_stream_pi_warns_when_session_is_idle(tmp_path, caplog):
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        sleep=1.0,
+    )
+    with caplog.at_level("WARNING"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=0.5,
+            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+        )
+    assert "pi_idle" in caplog.text
+    assert "stale_seconds=" in caplog.text
+    assert "session=sess-1" in caplog.text
+
+
+def test_stream_pi_warns_when_no_session_file_appears(tmp_path, caplog):
+    command = make_fake_pi(tmp_path, session_records=[], sleep=1.0)
+    with caplog.at_level("WARNING"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=0.5,
+            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+        )
+    assert "pi_idle" in caplog.text
+    assert "session=-" in caplog.text
+    assert "session_file=-" in caplog.text
+
+
+def test_stream_pi_drains_pipe_data_written_after_exit(
+    monkeypatch, tmp_path, caplog,
+):
+    """Data left in the pipes after the process exits is drained and kept."""
+
+    class FakeProcess:
+        def __init__(self, command, **kwargs):
+            self._out_r, self._out_w = os.pipe()
+            self._err_r, self._err_w = os.pipe()
+            self.stdout = os.fdopen(self._out_r, "rb")
+            self.stderr = os.fdopen(self._err_r, "rb")
+            self._out_writer = os.fdopen(self._out_w, "wb")
+            self._err_writer = os.fdopen(self._err_w, "wb")
+            self.returncode = 0
+
+        def poll(self):
+            return self.returncode
+
+    def fake_popen(command, **kwargs):
+        process = FakeProcess(command, **kwargs)
+
+        def writer():
+            time.sleep(0.3)
+            process._out_writer.write(b"late stdout data")
+            process._err_writer.write(b"late stderr data")
+            process._out_writer.close()
+            process._err_writer.close()
+
+        threading.Thread(target=writer, daemon=True).start()
+        return process
+
+    monkeypatch.setattr(runner.subprocess, "Popen", fake_popen)
+    with caplog.at_level("INFO"):
+        result = runner.stream_pi(
+            ["fake"], cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
+        )
+    assert result == "late stdout data"
+    assert "stderr=late stderr data" in caplog.text
+
+
+def test_stream_pi_times_out_and_kills_process(tmp_path, caplog):
+    command = make_fake_pi(tmp_path, session_records=[], sleep=10.0)
+    with caplog.at_level("ERROR"), pytest.raises(
+        subprocess.TimeoutExpired,
+    ) as excinfo:
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1, timeout=0.5,
+            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+        )
+    assert excinfo.value.timeout == 0.5
+    # The exception must not carry the raw command (prompt / Issue body).
+    assert "sleep" not in str(excinfo.value)
+    assert "pi_timeout timeout=0.5" in caplog.text
+    assert "issue=24" in caplog.text

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -301,3 +302,121 @@ def test_main_rejects_unknown_command(tmp_path):
 def test_main_requires_config_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         muyan_pilot.main(["status", "--config", str(tmp_path / "missing.toml")])
+
+
+def test_latest_task_worktree_returns_none_when_missing(tmp_path):
+    assert muyan_pilot.latest_task_worktree(
+        tmp_path, "xqliu/muyan-pilot", 3,
+    ) is None
+
+
+def test_latest_task_worktree_returns_newest_by_mtime(tmp_path):
+    old = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-3-run1"
+    new = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-3-run2"
+    old.mkdir(parents=True)
+    new.mkdir(parents=True)
+    old_time = old.stat().st_mtime
+    os.utime(old, (old_time - 100, old_time - 100))
+    assert muyan_pilot.latest_task_worktree(
+        tmp_path, "xqliu/muyan-pilot", 3,
+    ) == new
+
+
+def test_latest_task_worktree_ignores_other_issues_and_repos(tmp_path):
+    other_issue = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-4-run1"
+    other_repo = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-ceo-issue-3-run1"
+    other_issue.mkdir(parents=True)
+    other_repo.mkdir(parents=True)
+    assert muyan_pilot.latest_task_worktree(
+        tmp_path, "xqliu/muyan-pilot", 3,
+    ) is None
+
+
+def test_live_activity_lines_without_worktree(tmp_path):
+    lines = muyan_pilot.live_activity_lines(
+        tmp_path, "xqliu/muyan-pilot",
+        {"number": 3, "title": "task", "url": "u3"},
+    )
+    assert lines == ["    live: no task worktree found"]
+
+
+def test_live_activity_lines_with_worktree_but_no_session(tmp_path):
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-3-run1"
+    worktree.mkdir(parents=True)
+    lines = muyan_pilot.live_activity_lines(
+        tmp_path, "xqliu/muyan-pilot",
+        {"number": 3, "title": "task", "url": "u3"},
+    )
+    assert lines == [
+        "    live: no pi session yet",
+        f"    worktree: {worktree}",
+    ]
+
+
+def test_live_activity_lines_with_session(tmp_path):
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-3-run1"
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True)
+    with (session_dir / "s.jsonl").open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps({
+            "type": "session", "id": "sess-1",
+            "timestamp": "2026-08-25T02:00:00Z", "cwd": str(worktree),
+        }) + "\n")
+        handle.write(json.dumps({
+            "type": "message", "id": "a1",
+            "timestamp": "2026-08-25T02:00:01Z",
+            "message": {"role": "assistant", "content": [
+                {"type": "toolCall", "id": "t1", "name": "bash",
+                 "arguments": {"command": "pytest tests/"}}]},
+        }) + "\n")
+    lines = muyan_pilot.live_activity_lines(
+        tmp_path, "xqliu/muyan-pilot",
+        {"number": 3, "title": "task", "url": "u3"},
+    )
+    assert lines == [
+        "    live: phase=test last_activity=2026-08-25T02:00:01Z "
+        "last=bash pytest tests/",
+        f"    session: {session_dir / 's.jsonl'}",
+        f"    worktree: {worktree}",
+    ]
+
+
+def test_status_report_includes_live_lines_for_current_issue(monkeypatch, tmp_path):
+    current = {"number": 3, "title": "now", "url": "u3"}
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-xqliu-muyan-pilot-issue-3-run1"
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "s.jsonl").write_text(
+        json.dumps({"type": "session", "id": "sess-1",
+                    "timestamp": "2026-08-25T02:00:00Z",
+                    "cwd": str(worktree)}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: current)
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    report = muyan_pilot.status_report({
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": tmp_path,
+        "base_branch": "main",
+    })
+    assert "current: #3 now u3" in report
+    assert "    live: phase=starting last_activity=- last=-" in report
+    assert f"    session: {session_dir / 's.jsonl'}" in report
+    assert f"    worktree: {worktree}" in report
+    assert "ready: -" in report
+
+
+def test_status_report_has_no_live_lines_without_current_issue(monkeypatch, tmp_path):
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "ready_issue", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "recent_result", lambda repo: None)
+    monkeypatch.setattr(muyan_pilot, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    report = muyan_pilot.status_report({
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": tmp_path,
+        "base_branch": "main",
+    })
+    assert "live:" not in report
+    assert "current: -" in report

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -1,0 +1,531 @@
+"""Unit tests for pi_activity: live Pi session JSONL tracking (Issue #24).
+
+The session JSONL is append-only: `session` / `model_change` /
+`thinking_level_change` / `message` records. Only assistant and toolResult
+messages are agent activity; user messages carry the full prompt and Issue
+body and must never be summarized.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import pi_activity
+
+
+def write_records(path: Path, records: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+
+
+SESSION_RECORD = {
+    "type": "session", "id": "sess-1",
+    "timestamp": "2026-01-01T00:00:00Z", "cwd": "/work",
+}
+MODEL_RECORD = {
+    "type": "model_change", "id": "m1",
+    "timestamp": "2026-01-01T00:00:00Z",
+}
+USER_RECORD = {
+    "type": "message", "id": "u1",
+    "timestamp": "2026-01-01T00:00:01Z",
+    "message": {
+        "role": "user",
+        "content": [{"type": "text", "text": "SECRET ISSUE BODY"}],
+    },
+}
+ASSISTANT_TOOL_CALL = {
+    "type": "message", "id": "a1",
+    "timestamp": "2026-01-01T00:00:02Z",
+    "message": {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "let me test"},
+            {"type": "toolCall", "id": "t1", "name": "bash",
+             "arguments": {"command": "pytest tests/"}},
+        ],
+    },
+}
+ASSISTANT_TEXT = {
+    "type": "message", "id": "a2",
+    "timestamp": "2026-01-01T00:00:04Z",
+    "message": {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "done"}],
+    },
+}
+TOOL_RESULT = {
+    "type": "message", "id": "r1",
+    "timestamp": "2026-01-01T00:00:03Z",
+    "message": {
+        "role": "toolResult", "toolCallId": "t1", "toolName": "bash",
+        "content": [{"type": "text", "text": "ok"}],
+    },
+}
+TOOL_RESULT_ERROR = {
+    "type": "message", "id": "r2",
+    "timestamp": "2026-01-01T00:00:05Z",
+    "message": {
+        "role": "toolResult", "toolCallId": "t2", "toolName": "bash",
+        "content": [{"type": "text", "text": "boom"}], "isError": True,
+    },
+}
+
+
+def test_latest_session_file_returns_none_when_directory_missing(tmp_path):
+    assert pi_activity.latest_session_file(tmp_path / "nope") is None
+
+
+def test_latest_session_file_returns_none_when_directory_empty(tmp_path):
+    assert pi_activity.latest_session_file(tmp_path) is None
+
+
+def test_latest_session_file_ignores_non_jsonl_files(tmp_path):
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+    assert pi_activity.latest_session_file(tmp_path) is None
+
+
+def test_latest_session_file_returns_newest_by_mtime(tmp_path):
+    old = tmp_path / "old.jsonl"
+    new = tmp_path / "new.jsonl"
+    old.write_text("{}", encoding="utf-8")
+    new.write_text("{}", encoding="utf-8")
+    old_time = os.stat(old).st_mtime
+    os.utime(old, (old_time - 100, old_time - 100))
+    assert pi_activity.latest_session_file(tmp_path) == new
+
+
+def test_read_new_events_returns_empty_when_file_missing(tmp_path):
+    records, offset = pi_activity.read_new_events(
+        tmp_path / "missing.jsonl", 0,
+    )
+    assert records == []
+    assert offset == 0
+
+
+def test_read_new_events_keeps_partial_last_line_for_next_read(tmp_path):
+    path = tmp_path / "s.jsonl"
+    path.write_text('{"type": "session", "id": "a"}\n{"type": "sess',
+                    encoding="utf-8")
+    records, offset = pi_activity.read_new_events(path, 0)
+    assert records == [{"type": "session", "id": "a"}]
+    # The partial line is not consumed: the next read starts where it began.
+    records2, offset2 = pi_activity.read_new_events(path, offset)
+    assert records2 == []
+    assert offset2 == offset
+
+
+def test_read_new_events_consumes_complete_lines(tmp_path):
+    path = tmp_path / "s.jsonl"
+    first = '{"type": "session", "id": "a"}\n'
+    path.write_text(first, encoding="utf-8")
+    records, offset = pi_activity.read_new_events(path, 0)
+    assert records == [{"type": "session", "id": "a"}]
+    assert offset == len(first.encode("utf-8"))
+    # No new data: nothing to read.
+    records2, offset2 = pi_activity.read_new_events(path, offset)
+    assert records2 == []
+    assert offset2 == offset
+
+
+def test_read_new_events_skips_unparseable_and_non_object_lines(tmp_path):
+    path = tmp_path / "s.jsonl"
+    path.write_text(
+        'not json\n[1, 2]\n{"type": "session", "id": "a"}\n\n',
+        encoding="utf-8",
+    )
+    records, _ = pi_activity.read_new_events(path, 0)
+    assert records == [{"type": "session", "id": "a"}]
+
+
+def test_read_new_events_rereads_from_start_when_file_shrank(tmp_path):
+    path = tmp_path / "s.jsonl"
+    path.write_text('{"type": "session", "id": "a"}\n' * 3, encoding="utf-8")
+    _, offset = pi_activity.read_new_events(path, 0)
+    path.write_text('{"type": "session", "id": "b"}\n', encoding="utf-8")
+    records, new_offset = pi_activity.read_new_events(path, offset)
+    assert records == [{"type": "session", "id": "b"}]
+    assert new_offset == len('{"type": "session", "id": "b"}\n'.encode("utf-8"))
+
+
+def test_sanitize_collapses_whitespace_and_truncates_long_text():
+    text = "git commit -m 'line one\nline two\ttabbed' " + "x" * 300
+    sanitized = pi_activity.sanitize(text)
+    assert "\n" not in sanitized and "\t" not in sanitized
+    assert len(sanitized) <= pi_activity.MAX_SUMMARY_LENGTH + 3
+    assert sanitized.endswith("...")
+
+
+def test_sanitize_keeps_short_text_unchanged():
+    assert pi_activity.sanitize("bash: pytest tests/") == "bash: pytest tests/"
+
+
+@pytest.mark.parametrize("raw,needle", [
+    ("curl -H 'Authorization: Bearer abcDEF123._-'", "Bearer <redacted>"),
+    ("gh api -H 'Authorization: token ghp_AbCdEf1234567890xyz'",
+     "ghp_<redacted>"),
+    ("export OPENAI_KEY=sk-AbCdEf1234567890xyz", "sk-<redacted>"),
+])
+def test_sanitize_redacts_token_shapes(raw, needle):
+    assert needle in pi_activity.sanitize(raw)
+
+
+def test_tool_args_summary_returns_bash_command():
+    assert pi_activity.tool_args_summary(
+        "bash", {"command": "pytest tests/"},
+    ) == "pytest tests/"
+
+
+def test_tool_args_summary_returns_first_known_path_key():
+    assert pi_activity.tool_args_summary(
+        "read", {"path": "/tmp/a.md", "offset": 3},
+    ) == "/tmp/a.md"
+    assert pi_activity.tool_args_summary(
+        "mcp", {"tool": "sentry_tool", "args": {}},
+    ) == "sentry_tool"
+
+
+def test_tool_args_summary_returns_empty_without_known_keys():
+    assert pi_activity.tool_args_summary("bash", {}) == ""
+
+
+def test_phase_for_maps_bash_commands_to_key_phases():
+    assert pi_activity.phase_for(
+        "bash", {"command": "/usr/bin/python3 -m pytest tests/ -q"},
+    ) == "test"
+    assert pi_activity.phase_for(
+        "bash", {"command": "python3 -m coverage run -m pytest"},
+    ) == "test"
+    assert pi_activity.phase_for(
+        "bash", {"command": "gh pr create --fill"},
+    ) == "pr"
+    assert pi_activity.phase_for(
+        "bash", {"command": "git push origin HEAD"},
+    ) == "push"
+    assert pi_activity.phase_for(
+        "bash", {"command": "git commit -m feat"},
+    ) == "commit"
+    assert pi_activity.phase_for(
+        "bash", {"command": "git fetch origin main"},
+    ) == "base"
+    assert pi_activity.phase_for(
+        "bash", {"command": "git merge origin/main"},
+    ) == "base"
+    assert pi_activity.phase_for(
+        "bash", {"command": "git worktree add .worktrees/w"},
+    ) == "worktree"
+    assert pi_activity.phase_for(
+        "bash", {"command": "npx playwright test"},
+    ) == "ui"
+
+
+def test_phase_for_falls_back_to_bash_for_plain_commands():
+    assert pi_activity.phase_for("bash", {"command": "ls -la"}) == "bash"
+
+
+def test_phase_for_uses_tool_name_for_non_bash_tools():
+    assert pi_activity.phase_for("read", {"path": "/a"}) == "read"
+    assert pi_activity.phase_for("write", {"path": "/a"}) == "write"
+
+
+def test_parse_iso_utc_returns_epoch_for_zulu_timestamp():
+    assert pi_activity.parse_iso_utc("2026-01-01T00:00:00Z") == (
+        pi_activity.datetime(2026, 1, 1, tzinfo=pi_activity.timezone.utc)
+        .timestamp()
+    )
+
+
+def test_parse_iso_utc_assumes_utc_for_naive_timestamp():
+    assert pi_activity.parse_iso_utc("2026-01-01T00:00:00") == (
+        pi_activity.datetime(2026, 1, 1, tzinfo=pi_activity.timezone.utc)
+        .timestamp()
+    )
+
+
+def test_parse_iso_utc_returns_none_for_invalid_timestamp():
+    assert pi_activity.parse_iso_utc("not a timestamp") is None
+
+
+def test_watcher_tracks_session_activity_and_phase(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD, MODEL_RECORD, USER_RECORD,
+        ASSISTANT_TOOL_CALL, TOOL_RESULT,
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["session_id"] == "sess-1"
+    assert state["session_file"] == str(session)
+    assert state["events"] == 5
+    assert state["phase"] == "test"
+    assert state["last_activity"] == "2026-01-01T00:00:03Z"
+    assert state["last"] == "tool_result bash"
+    assert state["changed"] is True
+    # The user message (full prompt / Issue body) is never summarized.
+    assert "SECRET ISSUE BODY" not in state["last"]
+    # Second poll: no new records, not changed.
+    again = watcher.poll()
+    assert again["changed"] is False
+    assert again["events"] == 5
+
+
+def test_watcher_phase_follows_latest_tool_call(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        ASSISTANT_TOOL_CALL,
+        TOOL_RESULT,
+        {
+            "type": "message", "id": "a3",
+            "timestamp": "2026-01-01T00:00:06Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "t3", "name": "bash",
+                     "arguments": {"command": "gh pr create --fill"}},
+                ],
+            },
+        },
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["phase"] == "pr"
+    assert state["last"] == "bash gh pr create --fill"
+
+
+def test_watcher_marks_tool_result_errors(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, TOOL_RESULT_ERROR])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["last"] == "tool_result bash (error)"
+
+
+def test_watcher_keeps_phase_for_non_bash_tool_results(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {
+            "type": "message", "id": "a4",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "t4", "name": "read",
+                     "arguments": {"path": "/a.md"}},
+                ],
+            },
+        },
+        {
+            "type": "message", "id": "r4",
+            "timestamp": "2026-01-01T00:00:03Z",
+            "message": {
+                "role": "toolResult", "toolCallId": "t4", "toolName": "read",
+                "content": [],
+            },
+        },
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["phase"] == "read"
+    assert state["last"] == "tool_result read"
+
+
+def test_watcher_reports_assistant_text_as_activity(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TEXT])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["last"] == "assistant text"
+    assert state["phase"] == "starting"
+
+
+def test_watcher_reads_new_records_incrementally(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    assert watcher.poll()["events"] == 1
+    with session.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(ASSISTANT_TOOL_CALL) + "\n")
+    state = watcher.poll()
+    assert state["events"] == 2
+    assert state["phase"] == "test"
+    assert state["changed"] is True
+
+
+def test_watcher_starts_following_session_file_when_it_appears(tmp_path):
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    assert watcher.poll()["session_file"] is None
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD])
+    state = watcher.poll()
+    assert state["session_file"] == str(session)
+    assert state["session_id"] == "sess-1"
+
+
+def test_watcher_stale_seconds_from_last_activity(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL])
+    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:02Z")
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: last_epoch + 42.0,
+    )
+    state = watcher.poll()
+    assert state["stale_seconds"] == pytest.approx(42.0)
+
+
+def test_watcher_stale_seconds_from_start_without_activity(tmp_path):
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: 1_000_050.0,
+    )
+    watcher.start_time = 1_000_000.0
+    state = watcher.poll()
+    assert state["stale_seconds"] == pytest.approx(50.0)
+    assert state["phase"] == "starting"
+    assert state["last"] is None
+
+
+def test_watcher_clamps_negative_stale_to_zero(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL])
+    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:02Z")
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: last_epoch - 10.0,
+    )
+    assert watcher.poll()["stale_seconds"] == 0.0
+
+
+def test_watcher_ignores_empty_session_id(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        {"type": "session", "id": "", "timestamp": "2026-01-01T00:00:00Z"},
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["session_id"] is None
+
+
+def test_watcher_ignores_assistant_content_that_is_not_a_list(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {"type": "message", "id": "a8",
+         "timestamp": "2026-01-01T00:00:02Z",
+         "message": {"role": "assistant", "content": "plain string"}},
+        {"type": "message", "id": "a9",
+         "timestamp": "2026-01-01T00:00:03Z",
+         "message": {"role": "assistant"}},
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["last"] is None
+    assert state["phase"] == "starting"
+
+
+def test_watcher_ignores_records_without_message_object(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {"type": "message", "id": "x1", "timestamp": "2026-01-01T00:00:02Z"},
+        {"type": "message", "id": "x2", "timestamp": "2026-01-01T00:00:03Z",
+         "message": "not a dict"},
+        {"type": "message", "id": "x3", "timestamp": "2026-01-01T00:00:04Z",
+         "message": {"role": "user", "content": "plain string"}},
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["events"] == 4
+    assert state["last"] is None
+    assert state["phase"] == "starting"
+
+
+def test_watcher_handles_malformed_tool_call_items(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {
+            "type": "message", "id": "a5",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    "not a dict",
+                    {"type": "toolCall"},
+                    {"type": "toolCall", "name": 7,
+                     "arguments": "not a dict"},
+                    {"type": "unknown-kind"},
+                ],
+            },
+        },
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["last"] == "tool"
+    assert state["phase"] == "tool"
+
+
+def test_watcher_handles_missing_or_invalid_timestamps(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {"type": "message", "id": "a6", "timestamp": "bad",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "x"}]}},
+        {"type": "message", "id": "a7",
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "y"}]}},
+    ])
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: 1_000_000.0,
+    )
+    watcher.start_time = 999_900.0
+    state = watcher.poll()
+    assert state["last_activity"] is None
+    # No usable activity epoch: stale falls back to the start time.
+    assert state["stale_seconds"] == pytest.approx(100.0)
+
+
+def test_activity_snapshot_returns_none_without_session(tmp_path):
+    assert pi_activity.activity_snapshot(tmp_path) is None
+
+
+def test_activity_snapshot_scans_newest_session_file(tmp_path):
+    write_records(tmp_path / "s.jsonl", [SESSION_RECORD, ASSISTANT_TOOL_CALL])
+    snapshot = pi_activity.activity_snapshot(tmp_path)
+    assert snapshot["session_id"] == "sess-1"
+    assert snapshot["phase"] == "test"
+    assert snapshot["last"] == "bash pytest tests/"
+    assert snapshot["changed"] is False
+
+
+def test_format_activity_scene_returns_empty_string_for_none():
+    assert pi_activity.format_activity_scene(None) == ""
+
+
+def test_format_activity_scene_formats_key_value_fields():
+    snapshot = {
+        "session_id": "sess-1",
+        "session_file": "/w/.pi-session/s.jsonl",
+        "phase": "test",
+        "last_activity": "2026-01-01T00:00:02Z",
+        "last": "bash pytest tests/",
+    }
+    assert pi_activity.format_activity_scene(snapshot) == (
+        "session=sess-1 session_file=/w/.pi-session/s.jsonl phase=test "
+        "last_activity=2026-01-01T00:00:02Z last=bash pytest tests/"
+    )
+
+
+def test_format_activity_scene_marks_missing_fields():
+    assert pi_activity.format_activity_scene({
+        "session_id": None,
+        "session_file": None,
+        "phase": "starting",
+        "last_activity": None,
+        "last": None,
+    }) == (
+        "session=- session_file=- phase=starting "
+        "last_activity=- last=-"
+    )


### PR DESCRIPTION
## What

While Pi runs, the Runner now streams its live activity from the task
worktree's Pi session JSONL (`.pi-session/*.jsonl`) into the journal and
the `status` command, instead of only logging the start command and the
final result.

## Changes

- **`pi_activity.py` (new)**: follows the newest session JSONL and reduces
  it to a redacted activity snapshot — session id, event count, phase
  (test / pr / push / commit / base / worktree / ui / bash or tool name),
  last activity time, and a sanitized summary of the newest tool call or
  result. User messages (full prompt / Issue body) are never summarized;
  summaries are single-line, truncated to 200 chars, and `Bearer` /
  `ghp_…` / `sk-…` token shapes are redacted.
- **`bootstrap_runner.py`**: new `stream_pi` runs Pi with `Popen` and a
  select-based poll loop (15 s):
  - `pi_activity issue=… source_repo=… branch=… worktree=… session=…
    session_file=… events=… phase=… last_activity=… last=…` on new events;
  - `pi_idle … stale_seconds=…` warning when no new event for 5 minutes
    (including when no session file appears);
  - `pi_failed returncode=… …` / `pi_timeout …` scene logged before the
    error is raised; the session JSONL stays in the worktree as the
    complete local record.
  - The raw pi command (full prompt + Issue context) is never logged and
    never embedded in exception messages (`<redacted>`).
  - `run_pi` gains an optional `branch`; `process_issue` posts a start
    comment (run info + branch + worktree) and appends the session scene
    to the failure comment.
- **`muyan_pilot.py`**: `status` shows the live activity of the current
  `ai-in-progress` issue (phase, last activity, last summary, session
  file, worktree). Read-only.
- **`README.md`**: documents the journal lines and the new status output.

## Verification

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` →
  **156 passed** (was 95).
- `/usr/bin/python3 -m coverage report --show-missing` → **100% line and
  branch** for `bootstrap_runner.py`, `muyan_pilot.py`, `pi_activity.py`
  and all test files.
- Real smoke: `stream_pi` against a real `pi --print` run — redacted
  command log, live `pi_activity` lines with session id/file/phase/last
  activity, `pi_idle` warnings during a silent model call, final
  `stderr=`/`stdout=`, correct return value.
- Review-fix loop: 2 full R1–R9 rounds, 0 Blocker / 0 Major (round 1
  caught and fixed a secret leak via `str(CalledProcessError)`).

No UI work in this task, so no Playwright run is required. No database,
queue, or new dependency introduced; fail-fast preserved.

Closes #24