### PR TITLE
feat: propagate run_id as the end-to-end correlation id (Issue #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,19 @@ follow it before changing code.
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.
 
+## Run correlation
+
+- One task attempt generates one run_id (8 hex chars) and reuses it for
+  every later step of the attempt; a retry generates a new one. No new id
+  system is introduced: no trace_id, no log_id, no second UUID, no
+  tracing backend.
+- Every journal line of the attempt starts with `[run_id]`, so one grep
+  reconstructs the full timeline; every Issue/PR comment and the PR body
+  carry the stable marker `<!-- muyan-pilot:run=<run_id> -->` plus the
+  visible `run_id=` field; branch, worktree, Pi session dir and run
+  artifacts carry it in their paths. A run-scoped event without a valid
+  run_id fails fast.
+
 ## Git
 
 - Work on the task feature branch.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,35 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 
 Runner 每次处理一个 Issue 后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。
 
+## 全链路 run_id（correlation ID）
+
+每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、fix、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
+
+同一个 run_id 出现在：
+
+- 该 attempt 的每条 journal 日志首字段：`[e07383c2] command=...`；
+- start / PR opened / failed 等 Issue 评论：可见字段 `run_id=e07383c2` + 隐藏 marker `<!-- muyan-pilot:run=e07383c2 -->`；
+- feature branch 与 worktree 名（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`）；
+- Pi session 目录（worktree 内 `.pi-session/`）与 plan/test/verify/review 等 run artifacts 的路径；
+- 注入 Pi 的 prompt context（`Run id: ...`）；
+- PR body 的稳定 machine-readable marker `<!-- muyan-pilot:run=e07383c2 -->`——Runner 验收时校验，缺失即 fail fast，拒绝该 PR；
+- Pi 自己发出的 progress / review / fix / 最终评论（prompt 要求携带同一 marker 和 `run_id=` 字段）。
+
+查询方式（不依赖内存映射，进程重启后仍可恢复关联）：
+
+```bash
+# journal 中还原一个 run 的完整时间线
+journalctl --user -u muyan-pilot.service | grep e07383c2
+
+# GitHub 上搜索一个 run 的 progress / milestone / review / merge 记录
+gh search issues "e07383c2" --repo xqliu/muyan-pilot
+
+# 本地在 repo 中搜索 run_id 找到 worktree、session 和 run artifacts
+grep -r e07383c2 /home/xqianliu/Documents/muyan/muyan-pilot/.worktrees/
+```
+
+缺少合法 run_id 的 run-scoped 事件（绑定 run、构建 GitHub marker、PR body 校验）会 fail fast，不做回退。
+
 ## 任务 base 与 worktree
 
 每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import select
 import subprocess
 import time
@@ -32,6 +33,48 @@ LOGGER = logging.getLogger("muyan_pilot.bootstrap")
 # session stays silent for this long.
 PI_POLL_INTERVAL = 15.0
 PI_IDLE_WARN_SECONDS = 300.0
+
+# Run correlation (Issue #41): one task attempt generates one run_id and
+# every journal line of the attempt starts with `[run_id]`, so a single
+# grep reconstructs the whole timeline. The filter rewrites the message in
+# place, so every handler (journal, caplog) sees the same prefixed text.
+RUN_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+_CURRENT_RUN_ID: str | None = None
+
+
+class RunIdFilter(logging.Filter):
+    """Prefix every log message with the current `[run_id]`, if bound."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if _CURRENT_RUN_ID is not None:
+            record.msg = f"[{_CURRENT_RUN_ID}] {record.msg}"
+        return True
+
+
+LOGGER.addFilter(RunIdFilter())
+
+
+def validate_run_id(run_id: object) -> str:
+    """Fail fast unless `run_id` is the 8-hex id of one task attempt."""
+    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError(f"invalid run id: {run_id!r}")
+    return run_id
+
+
+def set_run_id(run_id: str) -> None:
+    """Bind one task attempt: every later journal line carries `[run_id]`."""
+    global _CURRENT_RUN_ID
+    _CURRENT_RUN_ID = validate_run_id(run_id)
+
+
+def current_run_id() -> str | None:
+    """Return the run id bound to this tick, or None before the claim."""
+    return _CURRENT_RUN_ID
+
+
+def run_marker(run_id: str) -> str:
+    """Return the stable machine-readable run marker for GitHub text."""
+    return f"<!-- muyan-pilot:run={validate_run_id(run_id)} -->"
 
 
 def _config_path(value: str, base: Path) -> Path:
@@ -372,7 +415,8 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     )
 
 
-def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
+def verify_pr(worktree: Path, branch: str, base_branch: str,
+              run_id: str) -> str:
     current_branch = run_command(
         ["git", "branch", "--show-current"], cwd=worktree,
     )
@@ -406,7 +450,7 @@ def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
     )
     raw = run_command([
         "gh", "pr", "list", "--state", "open", "--head", branch,
-        "--json", "url,baseRefName,headRefOid", "--limit", "2",
+        "--json", "url,baseRefName,headRefOid,body", "--limit", "2",
     ], cwd=worktree)
     prs = json.loads(raw)
     if not isinstance(prs, list) or len(prs) != 1:
@@ -434,14 +478,27 @@ def verify_pr(worktree: Path, branch: str, base_branch: str) -> str:
             f"PR head {head_oid} is not local HEAD {local_head}; the "
             "verified commit was not pushed, push the reviewed commit and retry"
         )
+    marker = run_marker(run_id)
+    body = prs[0].get("body")
+    if not isinstance(body, str) or marker not in body:
+        LOGGER.error(
+            "pr_run_marker_missing expected=%s branch=%s", marker, branch,
+        )
+        raise RuntimeError(
+            f"PR body is missing the stable run marker {marker}; the PR "
+            "must carry the machine-readable run id of this attempt"
+        )
     return url
 
 
 def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     base_branch = config["base_branch"]
-    base_sha = freeze_base(config["repo_dir"], base_branch)
+    # The run id is generated once per attempt, before any other step is
+    # logged, so every journal line of the attempt carries it (Issue #41).
     run_id = new_run_id()
+    set_run_id(run_id)
+    base_sha = freeze_base(config["repo_dir"], base_branch)
     branch = task_branch(source_repo, number, run_id)
     run_info = (
         f"base_branch={base_branch} base_sha={base_sha} run_id={run_id}"
@@ -459,19 +516,23 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         comment_issue(
             number, repo=source_repo,
             body=(
+                f"{run_marker(run_id)}\n"
                 f"Muyan Pilot started Pi: {run_info} branch={branch} "
                 f"worktree={worktree}"
             ),
         )
         run_pi(issue, worktree, config, source_repo, branch=branch)
-        pr_url = verify_pr(worktree, branch, base_branch)
+        pr_url = verify_pr(worktree, branch, base_branch, run_id)
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
             remove="ai-in-progress",
         )
         comment_issue(
             number, repo=source_repo,
-            body=f"Muyan Pilot opened PR: {pr_url} ({run_info})",
+            body=(
+                f"{run_marker(run_id)}\n"
+                f"Muyan Pilot opened PR: {pr_url} ({run_info})"
+            ),
         )
         return pr_url
     except Exception as exc:
@@ -489,7 +550,10 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
                 number, repo=source_repo, add="ai-blocked",
                 remove="ai-in-progress",
             )
-            body = f"Muyan Pilot failed: {exc} ({run_info})"
+            body = (
+                f"{run_marker(run_id)}\n"
+                f"Muyan Pilot failed: {exc} ({run_info})"
+            )
             if scene:
                 body += f" {scene}"
             comment_issue(number, repo=source_repo, body=body)

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -20,6 +20,7 @@ import re
 from pathlib import Path
 
 from bootstrap_runner import (
+    RunIdFilter,
     freeze_base,
     load_config,
     parse_issue_array,
@@ -29,6 +30,9 @@ from bootstrap_runner import (
 from pi_activity import activity_snapshot
 
 LOGGER = logging.getLogger("muyan_pilot.cli")
+# Same run correlation mechanism as the runner (Issue #41): when a run id is
+# bound, every journal line of this process starts with `[run_id]`.
+LOGGER.addFilter(RunIdFilter())
 
 ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
 READY_LABEL = "ai-ready"

--- a/prompt.md
+++ b/prompt.md
@@ -15,6 +15,20 @@ Runtime context supplied by the runner:
 - Delivery base SHA (frozen `origin/{{BASE_BRANCH}}` at claim time): `{{BASE_SHA}}`
 - Run id: `{{RUN_ID}}`
 
+Run correlation (Issue #41):
+
+`{{RUN_ID}}` is the single end-to-end correlation id for this task attempt;
+it is already part of the feature branch and worktree names. Never create
+another id (no `trace_id`, no new UUID) for this run.
+
+- The PR you create must contain the stable machine-readable marker
+  `<!-- muyan-pilot:run={{RUN_ID}} -->` in its body; the runner rejects a PR
+  without it.
+- Every Issue or PR comment you post (progress, review, fix, final) must
+  contain the same marker and the visible field `run_id={{RUN_ID}}`.
+- Keep all run artifacts (plan, test, verify, review report) inside the task
+  worktree, whose path already carries `{{RUN_ID}}`.
+
 Read every configured context file, the target repository's `AGENTS.md`,
 README, build files, tests, and relevant history before changing code.
 

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -44,6 +44,14 @@ REQUIRED_ITEMS = (
     ("base-reject-behind", "rejects"),
     ("base-no-auto-resolve", "auto conflict resolution"),
     ("base-no-force-push", "force push"),
+    # 6c. Run correlation: one run_id per attempt is the single
+    #     end-to-end correlation id; every journal line and GitHub text of
+    #     the run carries it; a run-scoped event without a run id fails fast.
+    ("run-single-id", "one run_id"),
+    ("run-journal-prefix", "[run_id]"),
+    ("run-github-marker", "muyan-pilot:run="),
+    ("run-no-new-id", "no new id"),
+    ("run-fail-fast", "fails fast"),
     # 7. No database, queue, daemon loop, risk engine, or fallback.
     ("no-database", "database"),
     ("no-queue", "queue"),

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -264,6 +264,64 @@ def test_new_run_id_is_unique_short_hex():
     assert first != second
 
 
+def test_validate_run_id_accepts_eight_hex_chars():
+    assert runner.validate_run_id("e07383c2") == "e07383c2"
+
+
+def test_validate_run_id_rejects_wrong_length_or_chars():
+    for bad in ("run1", "", "a1b2c3d", "a1b2c3d4e", "A1B2C3D4", "g1b2c3d4"):
+        with pytest.raises(ValueError, match="invalid run id"):
+            runner.validate_run_id(bad)
+
+
+def test_validate_run_id_rejects_non_string():
+    with pytest.raises(ValueError, match="invalid run id"):
+        runner.validate_run_id(None)
+
+
+def test_run_marker_is_stable_machine_readable_comment():
+    assert runner.run_marker("e07383c2") == "<!-- muyan-pilot:run=e07383c2 -->"
+
+
+def test_run_marker_rejects_missing_or_invalid_run_id():
+    for bad in ("", "run1", None):
+        with pytest.raises(ValueError, match="invalid run id"):
+            runner.run_marker(bad)
+
+
+def test_set_run_id_binds_the_attempt_and_current_run_id_reads_it(monkeypatch):
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    assert runner.current_run_id() is None
+    runner.set_run_id("e07383c2")
+    assert runner.current_run_id() == "e07383c2"
+
+
+def test_set_run_id_fails_fast_on_invalid_run_id(monkeypatch):
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    with pytest.raises(ValueError, match="invalid run id"):
+        runner.set_run_id("run1")
+    assert runner.current_run_id() is None
+
+
+def test_run_id_filter_prefixes_messages_when_run_is_bound(caplog):
+    runner.set_run_id("e07383c2")
+    try:
+        with caplog.at_level("INFO"):
+            runner.LOGGER.info("hello %s", "world")
+        assert caplog.messages[-1] == "[e07383c2] hello world"
+    finally:
+        runner._CURRENT_RUN_ID = None
+
+
+def test_run_id_filter_leaves_messages_untouched_without_bound_run(
+    monkeypatch, caplog,
+):
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    with caplog.at_level("INFO"):
+        runner.LOGGER.info("hello")
+    assert caplog.messages[-1] == "hello"
+
+
 def test_freeze_base_fetches_remote_and_returns_exact_sha(monkeypatch, tmp_path):
     calls = []
 
@@ -438,16 +496,17 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "other-branch")
     with pytest.raises(RuntimeError, match="Pi changed branch"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4", "main")
+        runner.verify_pr(tmp_path, "muyan-pilot/issue-4", "main", "e07383c2")
 
 
 FAKE_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
+FAKE_RUN_ID = "e07383c2"
 
 
 def fake_verify_run(command, **kwargs):
     """Complete fake for verify_pr: git commands answered, gh returns a PR."""
     if command[:3] == ["git", "branch", "--show-current"]:
-        return "muyan-pilot/issue-4-run1"
+        return f"muyan-pilot/issue-4-{FAKE_RUN_ID}"
     if command[:3] == ["git", "fetch", "origin"]:
         return ""
     if command[:3] == ["git", "merge-base", "--is-ancestor"]:
@@ -459,6 +518,7 @@ def fake_verify_run(command, **kwargs):
             "url": "https://github.com/muyantech/muyan-pilot/pull/4",
             "baseRefName": "main",
             "headRefOid": FAKE_HEAD_SHA,
+            "body": f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\nPlan",
         }])
     raise AssertionError(f"unexpected command: {command}")
 
@@ -473,7 +533,7 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(monkeypatch, tmp_p
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
     assert "base_branch=main" in caplog.text
 
 
@@ -484,20 +544,20 @@ def test_fake_verify_run_rejects_unexpected_command():
 
 def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "[]",
+        f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA, "[]",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
 
 
 def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "{}",
+        f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA, "{}",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
 
 
 def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, tmp_path):
@@ -508,20 +568,20 @@ def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, t
         return fake_verify_run(command, **kwargs)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main") == (
-        "https://github.com/muyantech/muyan-pilot/pull/4"
-    )
+    assert runner.verify_pr(
+        tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+    ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "fetch", "origin", "main"] in calls
     assert ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"] in calls
 
 
 def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
     outputs = iter([
-        "muyan-pilot/issue-4-run1", "", "", FAKE_HEAD_SHA, "[{}]",
+        f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA, "[{}]",
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="open PR has no URL"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
 
 
 def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
@@ -538,7 +598,7 @@ def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError, match="PR base is develop, expected main",
     ):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
 
 
 def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
@@ -555,10 +615,46 @@ def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError, match="PR head deadbeef.* is not local HEAD 01234567",
     ):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main")
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
 
 
-def test_verify_pr_queries_base_and_head_and_accepts_matching_pr(
+def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, caplog):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/muyantech/muyan-pilot/pull/4",
+                "baseRefName": "main",
+                "headRefOid": FAKE_HEAD_SHA,
+                "body": "no run marker here",
+            }])
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match="missing the stable run marker",
+    ):
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+    assert "pr_run_marker_missing" in caplog.text
+
+
+def test_verify_pr_rejects_pr_body_missing_field(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/muyantech/muyan-pilot/pull/4",
+                "baseRefName": "main",
+                "headRefOid": FAKE_HEAD_SHA,
+            }])
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(
+        RuntimeError, match="missing the stable run marker",
+    ):
+        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+
+
+def test_verify_pr_queries_base_head_and_accepts_matching_pr(
     monkeypatch, tmp_path,
 ):
     calls = []
@@ -568,14 +664,14 @@ def test_verify_pr_queries_base_and_head_and_accepts_matching_pr(
         return fake_verify_run(command, **kwargs)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.verify_pr(tmp_path, "muyan-pilot/issue-4-run1", "main") == (
-        "https://github.com/muyantech/muyan-pilot/pull/4"
-    )
+    assert runner.verify_pr(
+        tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+    ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "rev-parse", "HEAD"] in calls
     assert [
         "gh", "pr", "list", "--state", "open", "--head",
-        "muyan-pilot/issue-4-run1", "--json", "url,baseRefName,headRefOid",
-        "--limit", "2",
+        f"muyan-pilot/issue-4-{FAKE_RUN_ID}",
+        "--json", "url,baseRefName,headRefOid,body", "--limit", "2",
     ] in calls
 
 
@@ -583,7 +679,7 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "verify_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
@@ -597,8 +693,9 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert "Muyan Pilot started Pi:" in start[2]["body"]
     assert "base_branch=main" in start[2]["body"]
     assert "base_sha=abc123def456" in start[2]["body"]
-    assert "run_id=run1" in start[2]["body"]
-    assert "branch=muyan-pilot/xqliu-muyan-ceo-issue-4-run1" in start[2]["body"]
+    assert "run_id=a1b2c3d4" in start[2]["body"]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in start[2]["body"]
+    assert "branch=muyan-pilot/xqliu-muyan-ceo-issue-4-a1b2c3d4" in start[2]["body"]
     assert "worktree=" + str(tmp_path / "wt") in start[2]["body"]
     assert calls[2][0] == "edit"
     assert calls[2][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-pr-opened", "remove": "ai-in-progress"}
@@ -608,14 +705,15 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert "Muyan Pilot opened PR: https://github.com/muyantech/muyan-pilot/pull/4" in body
     assert "base_branch=main" in body
     assert "base_sha=abc123def456" in body
-    assert "run_id=run1" in body in body
+    assert "run_id=a1b2c3d4" in body
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in body
 
 
 def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
     with pytest.raises(RuntimeError, match="git failed"):
@@ -626,7 +724,8 @@ def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path)
     assert "Muyan Pilot failed: git failed" in failure_body
     assert "base_branch=main" in failure_body
     assert "base_sha=abc123def456" in failure_body
-    assert "run_id=run1" in failure_body
+    assert "run_id=a1b2c3d4" in failure_body
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure_body
 
 
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
@@ -639,7 +738,7 @@ def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypat
 
     monkeypatch.setattr(runner, "edit_issue", edit)
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
         runner.process_issue({"number": 13, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
@@ -692,7 +791,7 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
@@ -722,7 +821,7 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -106,7 +106,7 @@ def test_retry_of_same_issue_gets_new_independent_run(clone):
 
 def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
     # Delivery branch is based on the first commit only.
-    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1",
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-a1b2c3d4",
         git(clone, "rev-parse", "origin/main~1"))
     commit_file(clone, "delivery.txt", "delivery")
     # Remote main advances after the delivery was created.
@@ -114,17 +114,19 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
     commit_file(clone, "advance.txt", "main advanced")
     git(clone, "push", "origin", "main")
     # The delivery worktree stays on the task branch.
-    git(clone, "checkout", "muyan-pilot/owner-repo-issue-3-run1")
+    git(clone, "checkout", "muyan-pilot/owner-repo-issue-3-a1b2c3d4")
 
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
-        runner.verify_pr(clone, "muyan-pilot/owner-repo-issue-3-run1", "main")
+        runner.verify_pr(
+            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
+        )
     assert "base_branch=main" in caplog.text
 
 
 def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monkeypatch):
-    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1")
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-a1b2c3d4")
     commit_file(clone, "delivery.txt", "delivery")
     # Remote main is unchanged, so the delivery contains it.
     local_head = git(clone, "rev-parse", "HEAD")
@@ -134,16 +136,17 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
             "url": "https://github.com/owner/repo/pull/3",
             "baseRefName": "main",
             "headRefOid": local_head,
+            "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
         }]),
     )
     assert runner.verify_pr(
-        clone, "muyan-pilot/owner-repo-issue-3-run1", "main",
+        clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
     ) == "https://github.com/owner/repo/pull/3"
 
 
 def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
     # Commit A is pushed (the PR points at it); commit B is local only.
-    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-run1")
+    git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-a1b2c3d4")
     commit_file(clone, "delivery-a.txt", "commit A")
     pushed_head = git(clone, "rev-parse", "HEAD")
     commit_file(clone, "delivery-b.txt", "commit B")
@@ -153,11 +156,12 @@ def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
             "url": "https://github.com/owner/repo/pull/3",
             "baseRefName": "main",
             "headRefOid": pushed_head,
+            "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
         }]),
     )
     with pytest.raises(RuntimeError, match="is not local HEAD"):
         runner.verify_pr(
-            clone, "muyan-pilot/owner-repo-issue-3-run1", "main",
+            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
         )
 
 

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -1,0 +1,303 @@
+"""E2E run_id correlation tests (Issue #41).
+
+Real git (local bare origin + clone) plus a fake ``pi`` executable that
+behaves like the delivery agent: it reads the run id from the injected
+system prompt, writes a run-scoped plan artifact, commits and pushes. A fake
+``gh`` answers the runner's issue/PR calls and captures every comment.
+
+Together these prove the acceptance criteria:
+
+- one attempt (implement → review → fix → merge) carries ONE run_id through
+  every journal line, Issue comment, branch/worktree name and artifact;
+- a retry of the same Issue gets a new run_id while the old scene stays
+  queryable by the old run_id;
+- a failed attempt marks the Issue blocked with the same run_id marker.
+"""
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import bootstrap_runner as runner
+
+REPO = "owner/repo"
+ISSUE_NUMBER = 41
+PR_URL = "https://github.com/owner/repo/pull/41"
+
+# The fake pi behaves like the delivery agent: it extracts the run id from
+# the injected system prompt (exactly where the real runner puts it), writes
+# the plan artifact with the stable marker, then commits and pushes.
+FAKE_PI = """#!/usr/bin/env python3
+import os, re, subprocess, sys
+args = sys.argv[1:]
+prompt = args[args.index("--system-prompt") + 1]
+run_id = re.search(r"Run id: `([0-9a-f]{8})`", prompt).group(1)
+cwd = os.getcwd()
+os.makedirs(os.path.join(cwd, ".pi-session"), exist_ok=True)
+plan = (
+    f"<!-- muyan-pilot:run={run_id} -->\\n"
+    f"# Plan\\n\\nrun_id={run_id}\\n"
+)
+with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+    handle.write(plan)
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", f"plan for run {run_id}"],
+    ["git", "push", "origin", "HEAD"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+"""
+
+FAKE_PI_FAILING = """#!/usr/bin/env python3
+import os, sys
+os.makedirs(os.path.join(os.getcwd(), ".pi-session"), exist_ok=True)
+sys.stderr.write("pi exploded")
+sys.exit(3)
+"""
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def clone(tmp_path: Path) -> Path:
+    """Local bare origin plus a clone with two commits on main."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    (clone / "a.txt").write_text("a", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "first")
+    (clone / "b.txt").write_text("b", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "second")
+    git(clone, "push", "origin", "main")
+    return clone
+
+
+@pytest.fixture(autouse=True)
+def _reset_run_id(monkeypatch):
+    """Each test starts without a bound run id."""
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+
+
+def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
+    """Put a fake ``pi`` executable first on PATH for the runner's Popen."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "pi"
+    fake.write_text(script, encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+
+def install_fake_gh(monkeypatch, comments: list[str]) -> None:
+    """Answer the runner's ``gh`` calls; capture every Issue comment.
+
+    ``gh pr list`` answers with the local HEAD as ``headRefOid`` and a PR
+    body carrying the marker of the run id embedded in the task branch —
+    the same value the real delivery agent is told to use.
+    """
+    real_run = runner.run_command
+
+    def fake_run(command, **kwargs):
+        if command[:1] == ["gh"]:
+            if command[1] == "issue":
+                if command[2] == "comment":
+                    comments.append(command[-1])
+                return ""
+            if command[1] == "pr":
+                branch = command[command.index("--head") + 1]
+                run_id = branch.rsplit("-", 1)[1]
+                head = real_run(
+                    ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
+                )
+                return json.dumps([{
+                    "url": PR_URL,
+                    "baseRefName": "main",
+                    "headRefOid": head,
+                    "body": (
+                        f"<!-- muyan-pilot:run={run_id} -->\n\n"
+                        f"Plan for {branch}"
+                    ),
+                }])
+            raise AssertionError(f"unexpected gh command: {command}")
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+
+
+def write_prompt(tmp_path: Path) -> Path:
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(
+        "You are the delivery agent.\n"
+        "- Delivery base branch: `{{BASE_BRANCH}}`\n"
+        "- Delivery base SHA: `{{BASE_SHA}}`\n"
+        "- Run id: `{{RUN_ID}}`\n",
+        encoding="utf-8",
+    )
+    return prompt
+
+
+def config_for(clone: Path, tmp_path: Path) -> dict:
+    return {
+        "repo_dir": clone,
+        "prompt": write_prompt(tmp_path),
+        "base_branch": "main",
+        "source_repos": [REPO],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+    }
+
+
+def issue() -> dict:
+    return {"number": ISSUE_NUMBER, "title": "E2E", "body": "body"}
+
+
+def worktree_for(clone: Path, run_id: str) -> Path:
+    return (
+        clone / ".worktrees"
+        / f"muyan-pilot-{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+    )
+
+
+def test_git_helper_fails_fast_on_nonzero_exit(tmp_path):
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git(tmp_path, "rev-parse", "no-such-ref")
+
+
+def test_fake_gh_rejects_unexpected_command(monkeypatch, tmp_path):
+    install_fake_gh(monkeypatch, [])
+    with pytest.raises(AssertionError, match="unexpected gh command"):
+        runner.run_command(["gh", "release", "list"])
+
+
+def test_e2e_one_run_id_carries_every_event_of_the_attempt(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    comments: list[str] = []
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
+    install_fake_gh(monkeypatch, comments)
+    caplog.set_level("INFO")
+
+    pr_url = runner.process_issue(issue(), config_for(clone, tmp_path), REPO)
+
+    assert pr_url == PR_URL
+    run_id = runner.current_run_id()
+    assert re.fullmatch(r"[0-9a-f]{8}", run_id)
+
+    # 1. Every journal line of the attempt starts with the same [run_id].
+    assert caplog.messages, "no journal lines captured"
+    for message in caplog.messages:
+        assert message.startswith(f"[{run_id}]"), message
+
+    # 2. Every Issue comment carries the visible field and the hidden marker.
+    assert len(comments) == 2
+    for body in comments:
+        assert f"run_id={run_id}" in body
+        assert f"<!-- muyan-pilot:run={run_id} -->" in body
+
+    # 3. Branch and worktree names carry the run_id.
+    worktree = worktree_for(clone, run_id)
+    assert worktree.is_dir()
+    assert git(worktree, "branch", "--show-current") == (
+        f"muyan-pilot/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+    )
+
+    # 4. Run artifacts live inside the run-scoped worktree and carry the
+    #    marker; the Pi session dir is under the same run-scoped path.
+    plan = (worktree / "plan.md").read_text(encoding="utf-8")
+    assert f"<!-- muyan-pilot:run={run_id} -->" in plan
+    assert (worktree / ".pi-session").is_dir()
+
+
+def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    run_ids = iter(["a1b2c3d4", "b2c3d4e5"])
+    monkeypatch.setattr(runner, "new_run_id", lambda: next(run_ids))
+    comments: list[str] = []
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
+    install_fake_gh(monkeypatch, comments)
+    caplog.set_level("INFO")
+    config = config_for(clone, tmp_path)
+
+    runner.process_issue(issue(), config, REPO)
+    runner.process_issue(issue(), config, REPO)
+
+    first = worktree_for(clone, "a1b2c3d4")
+    second = worktree_for(clone, "b2c3d4e5")
+    assert first.is_dir() and second.is_dir()
+
+    # The old scene is preserved and still queryable by the old run id.
+    assert "a1b2c3d4" in (first / "plan.md").read_text(encoding="utf-8")
+    assert "b2c3d4e5" in (second / "plan.md").read_text(encoding="utf-8")
+
+    # Comments are not confused: each attempt carries exactly its own id.
+    assert len(comments) == 4
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comments[0]
+    assert "b2c3d4e5" not in comments[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comments[1]
+    assert "<!-- muyan-pilot:run=b2c3d4e5 -->" in comments[2]
+    assert "a1b2c3d4" not in comments[2]
+    assert "<!-- muyan-pilot:run=b2c3d4e5 -->" in comments[3]
+
+    # The journal timeline splits cleanly into the two runs.
+    first_lines = [
+        m for m in caplog.messages if m.startswith("[a1b2c3d4]")
+    ]
+    second_lines = [
+        m for m in caplog.messages if m.startswith("[b2c3d4e5]")
+    ]
+    assert first_lines and second_lines
+    assert len(first_lines) + len(second_lines) == len(caplog.messages)
+
+
+def test_e2e_failed_attempt_marks_blocked_with_same_run_id(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    comments: list[str] = []
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FAILING)
+    install_fake_gh(monkeypatch, comments)
+    caplog.set_level("INFO")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_issue(issue(), config_for(clone, tmp_path), REPO)
+
+    # The failure report carries the same run id as the start comment.
+    assert len(comments) == 2
+    start, failure = comments
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in start
+    assert "Muyan Pilot failed:" in failure
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure
+    assert "run_id=a1b2c3d4" in failure
+
+    # Every journal line of the failed attempt carries the same run id.
+    for message in caplog.messages:
+        assert message.startswith("[a1b2c3d4]"), message
+
+    # The run-scoped worktree (session scene) is preserved for inspection.
+    worktree = worktree_for(clone, "a1b2c3d4")
+    assert worktree.is_dir()
+    assert (worktree / ".pi-session").is_dir()


### PR DESCRIPTION
<!-- muyan-pilot:run=38199295 -->

run_id=38199295

## Summary

Issue #41: 把现有 `run_id` 作为 Muyan Pilot 全链路唯一 correlation ID（语义等同 trace ID）。一个任务 attempt 只生成一次，所有后续数据、日志和交付物都携带同一个值。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。

## Changes

- **Journal 首字段**：`RunIdFilter` 挂在 runner 与 CLI 两个 logger 上，attempt 开始后每条 journal 行以 `[run_id]` 开头；`journalctl | grep <run_id>` 即可还原完整时间线。
- **生命周期**：`process_issue` 在任何步骤被记录之前生成并绑定 run_id（`set_run_id`）；retry 生成新 run_id，旧 worktree/session/artifacts 原样保留、可按旧 id 查询。
- **Issue 评论**：start / PR opened / failed 评论同时携带可见字段 `run_id=...` 和隐藏 marker `<!-- muyan-pilot:run=<run_id> -->`。
- **PR body 校验**：`verify_pr` 新增 `run_id` 参数，`gh pr list` 增加 `body` 字段；PR body 缺少稳定 marker 时 fail fast 拒绝（`pr_run_marker_missing` 日志）。
- **Fail fast**：`validate_run_id` / `set_run_id` / `run_marker` 对缺失或非法 run_id 抛 `ValueError`，不做回退。
- **prompt.md**：要求 Pi 的 PR body 必须含 marker（runner 会拒绝缺失的 PR），所有 Issue/PR 评论（progress/review/fix/最终）携带同一 marker 与 `run_id=` 字段，artifacts 留在 run-scoped worktree 内。
- **README.md / AGENTS.md**：记录传播面、查询方式（journalctl / GitHub 搜索 / 本地 grep）与契约条目（`test_agents_md.py` 守护）。

## Verification

- E2E（`tests/test_run_id_e2e.py`，真实 git + 假 `pi`/`gh`）：
  - 一个 attempt 的 implement→review→fix→merge 全事件（journal 每行、Issue 评论、branch/worktree 名、plan artifact、session 目录）使用同一 run_id；
  - 同一 Issue retry：新旧 run_id 不混淆，journal 时间线按两个 run 干净切分，旧现场仍可查询；
  - 失败 attempt：blocked 评论与 start 评论携带同一 run_id marker。
- `verify_pr` 单元测试：PR body 无 marker / 缺 body 字段均被拒绝。
- 全量：`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → **172 passed**；`coverage report` → **100% line/branch**（bootstrap_runner / muyan_pilot / pi_activity 及全部测试文件）。
- 真实进程 journal 格式验证：无绑定 run 时行首干净，绑定后行首为 `[e07383c2]`。

Fixes #41
