### PR TITLE
feat: concise run-scoped journal lines for live Pi activity (Issue #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,24 @@ python3 muyan_pilot.py status --config muyan-pilot.toml
 
 ## 实时进展
 
-Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把最近活动写入 journal（systemd 日志）：
+Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把简短活动写入 journal（systemd 日志）。完整不变现场（branch / worktree / session 文件）只在 run 开始和失败时各记录一次，运行中只输出短的变化字段，避免每 15–30 秒重复整段上下文：
 
-- `pi_activity issue=... source_repo=... branch=... worktree=... session=... session_file=... events=... phase=... last_activity=... last=...`——有新事件时记录当前阶段（test / pr / push / commit / base / worktree / ui / bash 或工具名）、最近活动时间和脱敏后的工具/命令摘要；
-- `pi_idle ... stale_seconds=...`——超过 5 分钟没有新事件时告警，带完整现场（找不到 session 文件时同样告警）；
-- `pi_failed returncode=... ...`——进程异常退出时先记录现场再抛出错误；session JSONL 完整保留在 worktree 中，作为本地完整记录。
+- `run_start run=... issue=owner/repo#n role=implement branch=... worktree=... session=... session_file=... phase=... last_activity=... action=... result=...`——run 开始时记录一次完整现场；
+- `activity run=... issue=... role=... phase=... action="..." result=... idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
+- `heartbeat run=... issue=... role=... phase=... elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
+- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s`——进程异常退出或超时时先记录完整现场再抛出错误；
+- `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
+
+所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析），可用短 `run` id 串起整个 run；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。默认 tail 示例（仅用于查看，不是产品步骤）：
+
+```bash
+journalctl --user -u muyan-pilot.service -f
+# Aug 25 14:30:01 host muyan-pilot[123]: INFO run_start run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement branch=muyan-pilot/... worktree=/home/.../.worktrees/... session=sess-1 session_file=/home/.../.pi-session/sess-1.jsonl phase=starting last_activity=- action=- result=-
+# Aug 25 14:30:16 host muyan-pilot[123]: INFO activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=- idle=6s
+# Aug 25 14:30:31 host muyan-pilot[123]: INFO heartbeat run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test elapsed=30s idle=15s
+# Aug 25 14:30:32 host muyan-pilot[123]: INFO activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=ok idle=0s
+# Aug 25 15:12:40 host muyan-pilot[123]: INFO run_end run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/xqliu/muyan-pilot/pull/19 commit=0123456789abcdef0123456789abcdef01234567
+```
 
 `muyan_pilot.py status` 同时展示当前（`ai-in-progress`）任务的实时状态：
 
@@ -54,14 +67,14 @@ python3 muyan_pilot.py status --config muyan-pilot.toml
 # source: xqliu/muyan-pilot
 #   base: main abc123def456
 #   current: #24 Stream live Pi activity ... https://github.com/xqliu/muyan-pilot/issues/24
-#     live: phase=test last_activity=2026-08-25T02:30:00Z last=bash pytest tests/
+#     live: phase=test last_activity=2026-08-25T02:30:00Z action=bash pytest tests/ result=ok
 #     session: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>/.pi-session/<session>.jsonl
 #     worktree: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>
 #   ready: -
 #   result: -
 ```
 
-journal 和 `status` 只暴露脱敏摘要：完整 prompt、Issue body 和 token 不会写入日志（命令日志固定为 `<redacted>`，工具摘要截断到 200 字符并屏蔽常见 token 形状）。关键阶段继续回写 GitHub Issue 评论：Pi 启动（含 branch 和 worktree）、PR 创建、失败现场。
+journal 和 `status` 只暴露脱敏摘要：完整 prompt、Issue body 和 token 不会写入日志（命令日志固定为 `<redacted>`，工具摘要截断到 200 字符并屏蔽常见 token 形状）。关键阶段继续回写 GitHub Issue 评论：Pi 启动（含 branch 和 worktree）、PR 创建、失败现场（含完整 run 现场）。session JSONL 完整保留在 worktree 中，作为本地完整记录。
 
 前置条件：
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -21,17 +21,24 @@ from pathlib import Path
 from pi_activity import (
     SessionWatcher,
     activity_snapshot,
-    format_activity_scene,
+    format_duration,
+    format_end_scene,
+    format_run_scene,
+    quote_value,
 )
 
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
 
-# Live activity polling while Pi runs (Issue #24). The journal gets one
-# activity line per poll with new events, and an idle warning when the
-# session stays silent for this long.
+# Live activity polling while Pi runs (Issue #24): every poll the journal
+# gets either an `activity` line (something changed) or a `heartbeat` line
+# (nothing changed; the idle time is carried on the line itself).
 PI_POLL_INTERVAL = 15.0
-PI_IDLE_WARN_SECONDS = 300.0
+
+# The bootstrap runner drives a single implementation session per run
+# (Issue #40: implement/review/fix/merge share the same line format and
+# carry their role; the MVP runs one role).
+ROLE_IMPLEMENT = "implement"
 
 
 def _config_path(value: str, base: Path) -> Path:
@@ -174,6 +181,20 @@ def new_run_id() -> str:
     return uuid.uuid4().hex[:8]
 
 
+def issue_context(source_repo: str, number: int) -> str:
+    """Issue reference used on every journal line: `owner/repo#number`."""
+    return f"{source_repo}#{number}"
+
+
+def log_format() -> str:
+    """Journal log format without a Python timestamp (Issue #40).
+
+    systemd journal already provides time, host and process on every
+    line; printing `%(asctime)s` again only duplicates information.
+    """
+    return "%(levelname)s %(message)s"
+
+
 def freeze_base(repo_dir: Path, base_branch: str) -> str:
     """Fetch the remote and freeze the exact SHA of origin/<base_branch>."""
     run_command(["git", "fetch", "origin", base_branch], cwd=repo_dir)
@@ -224,18 +245,27 @@ def _decode_chunks(chunks: list[bytes]) -> str:
     return b"".join(chunks).decode("utf-8", "replace")
 
 
-def _log_pi_activity(activity: dict, context: str,
-                     idle_warn_seconds: float) -> None:
-    """Log new session activity, or an idle warning with the full scene."""
-    scene = format_activity_scene(activity)
-    if activity["changed"]:
-        LOGGER.info("pi_activity %s %s", context, scene)
-        return
-    if activity["stale_seconds"] >= idle_warn_seconds:
-        LOGGER.warning(
-            "pi_idle %s %s stale_seconds=%.0f",
-            context, scene, activity["stale_seconds"],
-        )
+def _log_activity(activity: dict, *, run_id: str, issue_ref: str,
+                  role: str) -> None:
+    """Log one short activity line with the changed fields only."""
+    LOGGER.info(
+        "activity run=%s issue=%s role=%s phase=%s action=%s result=%s "
+        "idle=%s",
+        run_id, issue_ref, role, activity["phase"],
+        quote_value(activity["action"] or "-"),
+        activity["result"] or "-",
+        format_duration(activity["stale_seconds"]),
+    )
+
+
+def _log_heartbeat(activity: dict, *, run_id: str, issue_ref: str,
+                   role: str, elapsed: float) -> None:
+    """Log one heartbeat line when nothing changed since the last poll."""
+    LOGGER.info(
+        "heartbeat run=%s issue=%s role=%s phase=%s elapsed=%s idle=%s",
+        run_id, issue_ref, role, activity["phase"],
+        format_duration(elapsed), format_duration(activity["stale_seconds"]),
+    )
 
 
 def stream_pi(
@@ -244,33 +274,44 @@ def stream_pi(
     cwd: Path,
     timeout: int | None = None,
     poll_interval: float = PI_POLL_INTERVAL,
-    idle_warn_seconds: float = PI_IDLE_WARN_SECONDS,
+    run_id: str,
+    issue: int,
+    source_repo: str,
+    branch: str,
     log_command: list[str] | None = None,
-    issue: int | None = None,
-    source_repo: str | None = None,
-    branch: str | None = None,
 ) -> str:
-    """Run Pi and stream its live session activity into the journal.
+    """Run Pi and stream concise live activity into the journal (Issue #40).
 
-    Every poll, the newest Pi session JSONL activity is logged with the task
-    context (issue, source repo, branch, worktree): phase, last activity
-    time and a sanitized tool summary. When no new event arrives for
-    `idle_warn_seconds`, a warning with the full scene is logged. On a
-    non-zero exit the scene is logged before the error is raised. The
-    session JSONL stays in the worktree as the complete local record; the
-    full prompt and Issue body are never logged.
+    The full invariant scene (branch, worktree, session file) is logged
+    once as `run_start`. While Pi runs, only short changed fields are
+    logged: `activity` when phase/action/result change, `heartbeat` at
+    the poll interval otherwise (the idle time rides on the line). On a
+    non-zero exit or timeout a `run_failed` line carries the full scene
+    again as the debug entry. The caller logs `run_end` once the PR and
+    commit are known. The session JSONL stays in the worktree as the
+    complete local record; the full prompt and Issue body are never
+    logged.
     """
     # The raw pi command embeds the full prompt and Issue body; only the
     # redacted form may ever reach the journal or an exception message.
     safe_command = log_command or ["<redacted>"]
     LOGGER.info("command=%s cwd=%s", " ".join(safe_command), cwd)
+    issue_ref = issue_context(source_repo, issue)
     watcher = SessionWatcher(cwd / ".pi-session")
-    context = (
-        f"issue={issue} source_repo={source_repo} branch={branch} "
-        f"worktree={cwd}"
-    )
+    start = time.monotonic()
+    # The initial state is what run_start already reported; activity lines
+    # are only emitted when the visible fields actually change.
+    initial = watcher.poll()
+    last_visible = (initial["phase"], initial["action"], initial["result"])
     process = subprocess.Popen(
         command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    LOGGER.info(
+        "run_start %s",
+        format_run_scene(
+            initial, run_id=run_id, issue=issue_ref,
+            role=ROLE_IMPLEMENT, branch=branch, worktree=str(cwd),
+        ),
     )
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
@@ -294,7 +335,22 @@ def stream_pi(
                     else:
                         stderr_chunks.append(data)
             activity = watcher.poll()
-            _log_pi_activity(activity, context, idle_warn_seconds)
+            visible = (
+                activity["phase"], activity["action"], activity["result"],
+            )
+            if visible != last_visible:
+                # Only changed fields are repeated; an unchanged poll is a
+                # heartbeat (Issue #40).
+                _log_activity(
+                    activity, run_id=run_id, issue_ref=issue_ref,
+                    role=ROLE_IMPLEMENT,
+                )
+                last_visible = visible
+            else:
+                _log_heartbeat(
+                    activity, run_id=run_id, issue_ref=issue_ref,
+                    role=ROLE_IMPLEMENT, elapsed=time.monotonic() - start,
+                )
             if process.poll() is not None:
                 break
     finally:
@@ -303,17 +359,27 @@ def stream_pi(
     stdout = _decode_chunks(stdout_chunks)
     stderr = _decode_chunks(stderr_chunks)
     if timed_out:
+        reason = f"timeout_{format_duration(timeout)}"
         LOGGER.error(
-            "pi_timeout timeout=%s %s %s",
-            timeout, context, format_activity_scene(activity),
+            "run_failed %s reason=%s",
+            format_run_scene(
+                activity, run_id=run_id, issue=issue_ref,
+                role=ROLE_IMPLEMENT, branch=branch, worktree=str(cwd),
+            ),
+            reason,
         )
         raise subprocess.TimeoutExpired(
             safe_command, timeout, output=stdout, stderr=stderr,
         )
     if process.returncode != 0:
+        reason = f"pi_exit_{process.returncode}"
         LOGGER.error(
-            "pi_failed returncode=%s %s %s",
-            process.returncode, context, format_activity_scene(activity),
+            "run_failed %s reason=%s",
+            format_run_scene(
+                activity, run_id=run_id, issue=issue_ref,
+                role=ROLE_IMPLEMENT, branch=branch, worktree=str(cwd),
+            ),
+            reason,
         )
         raise subprocess.CalledProcessError(
             process.returncode, safe_command, output=stdout, stderr=stderr,
@@ -325,8 +391,7 @@ def stream_pi(
 
 
 def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
-           timeout: int | None = None,
-           branch: str | None = None) -> str:
+           branch: str, timeout: int | None = None) -> str:
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -354,10 +419,6 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         "pi", *skill_args, "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
-    LOGGER.info(
-        "pi_session=%s issue=%s source_repo=%s",
-        worktree / ".pi-session", issue["number"], source_repo,
-    )
     return stream_pi(
         command,
         cwd=worktree,
@@ -366,6 +427,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
             "--system-prompt", "<redacted>", "<issue-context-redacted>",
         ],
+        run_id=config["run_id"],
         issue=int(issue["number"]),
         source_repo=source_repo,
         branch=branch,
@@ -451,6 +513,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     )
     edit_issue(number, repo=source_repo, add="ai-in-progress")
     worktree: Path | None = None
+    started = time.monotonic()
     try:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, base_sha,
@@ -465,6 +528,9 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         )
         run_pi(issue, worktree, config, source_repo, branch=branch)
         pr_url = verify_pr(worktree, branch, base_branch)
+        commit = run_command(
+            ["git", "rev-parse", "HEAD"], cwd=worktree,
+        )
         edit_issue(
             number, repo=source_repo, add="ai-pr-opened",
             remove="ai-in-progress",
@@ -473,14 +539,34 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             number, repo=source_repo,
             body=f"Muyan Pilot opened PR: {pr_url} ({run_info})",
         )
+        LOGGER.info(
+            "run_end %s",
+            format_end_scene(
+                run_id=run_id, issue=issue_context(source_repo, number),
+                role=ROLE_IMPLEMENT, result="pr_opened",
+                elapsed=time.monotonic() - started,
+                pr=pr_url, commit=commit,
+            ),
+        )
         return pr_url
     except Exception as exc:
         LOGGER.exception("issue=%s failed", number)
         scene = ""
         if worktree is not None:
             try:
-                scene = format_activity_scene(
-                    activity_snapshot(worktree / ".pi-session"),
+                snapshot = activity_snapshot(worktree / ".pi-session")
+                if snapshot is None:
+                    # No session file yet: the scene still carries the full
+                    # debug entry (worktree, branch) with '-' session fields.
+                    snapshot = {
+                        "session_id": None, "session_file": None,
+                        "phase": "starting", "last_activity": None,
+                        "action": None, "result": None,
+                    }
+                scene = format_run_scene(
+                    snapshot,
+                    run_id=run_id, issue=issue_context(source_repo, number),
+                    role=ROLE_IMPLEMENT, branch=branch, worktree=str(worktree),
                 )
             except Exception:
                 LOGGER.exception("issue=%s activity scene failed", number)
@@ -505,7 +591,7 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(os.environ.get("MUYAN_PILOT_CONFIG", "muyan-pilot.toml")),
     )
     args = parser.parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(level=logging.INFO, format=log_format())
 
     config = load_config(args.config)
     validate_config(config)

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -3,9 +3,9 @@
 
 `add` creates an Issue in a configured source repo and labels it `ai-ready`.
 `status` reports the current in-progress Issue (with its live Pi activity:
-phase, last activity time, sanitized last tool summary, session file and
-worktree), the next ready Issue, and the most recent result
-(`ai-pr-opened` / `ai-blocked`) per source repo.
+phase, last activity time, the last meaningful action, the newest tool
+call result, session file and worktree), the next ready Issue, and the
+most recent result (`ai-pr-opened` / `ai-blocked`) per source repo.
 
 GitHub Issues and labels are the only state store. There is no database,
 queue, or web UI. Command failures are logged and raised by the reused
@@ -22,6 +22,7 @@ from pathlib import Path
 from bootstrap_runner import (
     freeze_base,
     load_config,
+    log_format,
     parse_issue_array,
     run_command,
     validate_config,
@@ -128,7 +129,8 @@ def live_activity_lines(repo_dir: Path, source_repo: str,
         (
             f"    live: phase={snapshot['phase']} "
             f"last_activity={snapshot['last_activity'] or '-'} "
-            f"last={snapshot['last'] or '-'}"
+            f"action={snapshot['action'] or '-'} "
+            f"result={snapshot['result'] or '-'}"
         ),
         f"    session: {snapshot['session_file']}",
         f"    worktree: {worktree}",
@@ -179,7 +181,7 @@ def main(argv: list[str] | None = None) -> int:
         help="show current Issue (with live Pi activity), ready queue and recent result",
     )
     args = parser.parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(level=logging.INFO, format=log_format())
 
     config = load_config(args.config)
     validate_config(config)

--- a/pi_activity.py
+++ b/pi_activity.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
-"""Live Pi session activity tracking (Issue #24).
+"""Live Pi session activity tracking (Issues #24, #40).
 
 Pi writes its session as an append-only JSONL file under the task worktree
 (`.pi-session/*.jsonl`) while it runs. This module follows that file and
 reduces it to a small, redacted activity snapshot: session id, event count,
-current phase, last activity time, and a sanitized summary of the newest
-tool call or result.
+current phase, last activity time, the last meaningful action (the newest
+tool call or assistant statement), and the result of the newest tool call
+(`ok` / `error`). A tool result reports the outcome without overwriting the
+action that produced it.
+
+The module also formats the journal lines (Issue #40): the full invariant
+scene (branch, worktree, session file) is only ever built for the
+run_start / run_failed / run_end lines; activity and heartbeat lines carry
+short changed fields only. All lines are stable `key=value` pairs (values
+with spaces are double-quoted) so an agent can parse them without a log
+framework.
 
 Only assistant and toolResult messages are agent activity. User messages
 carry the full prompt and Issue body and are never summarized. The module
@@ -143,7 +152,8 @@ class SessionWatcher:
         self.session_id: str | None = None
         self.phase: str | None = None
         self.last_activity: str | None = None
-        self.last: str | None = None
+        self.action: str | None = None
+        self.result: str | None = None
         self.events = 0
         self.start_time = now()
         self._offset = 0
@@ -177,7 +187,8 @@ class SessionWatcher:
             "events": self.events,
             "phase": self.phase or "starting",
             "last_activity": self.last_activity,
-            "last": self.last,
+            "action": self.action,
+            "result": self.result,
             "changed": changed,
             "stale_seconds": max(0.0, stale),
         }
@@ -221,17 +232,24 @@ class SessionWatcher:
                 arguments = item.get("arguments")
                 arguments = arguments if isinstance(arguments, dict) else {}
                 self.phase = phase_for(name, arguments)
-                self.last = sanitize(f"{name} {tool_args_summary(name, arguments)}").strip()
+                self.action = sanitize(
+                    f"{name} {tool_args_summary(name, arguments)}",
+                ).strip()
+                # The previous tool's result no longer describes this call.
+                self.result = None
             elif kind == "text":
-                self.last = "assistant text"
+                self.action = "assistant text"
+                self.result = None
             elif kind == "thinking":
-                self.last = "thinking"
+                self.action = "thinking"
+                self.result = None
 
     def _apply_tool_result(self, message: dict) -> None:
         name = message.get("toolName")
         name = name if isinstance(name, str) and name else "tool"
-        suffix = " (error)" if message.get("isError") else ""
-        self.last = f"tool_result {name}{suffix}"
+        # The result reports the outcome only; the action that produced it
+        # stays visible (Issue #40).
+        self.result = "error" if message.get("isError") else "ok"
         if name != "bash":
             self.phase = name
 
@@ -245,14 +263,108 @@ def activity_snapshot(session_dir: Path) -> dict | None:
     return watcher.state()
 
 
-def format_activity_scene(snapshot: dict | None) -> str:
-    """Format an activity snapshot as a `key=value` scene string."""
-    if snapshot is None:
-        return ""
+def format_duration(seconds: float) -> str:
+    """Compact human duration: `0.5s`, `6s`, `14m`, `1h5m`."""
+    if seconds <= 0:
+        return "0s"
+    if seconds < 1:
+        return f"{seconds:.1f}s"
+    total = int(seconds)
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h{minutes}m"
+    if minutes:
+        return f"{minutes}m"
+    return f"{secs}s"
+
+
+def quote_value(value: str) -> str:
+    """Double-quote a key=value field when it needs quoting.
+
+    Values containing spaces or double quotes are quoted; embedded double
+    quotes are escaped as `\\"` so the field stays parseable by
+    `parse_scene`.
+    """
+    if " " in value or '"' in value:
+        return '"' + value.replace('"', '\\"') + '"'
+    return value
+
+
+def format_run_scene(snapshot: dict, *, run_id: str, issue: str, role: str,
+                     branch: str, worktree: str) -> str:
+    """Full invariant scene for run_start / run_failed lines.
+
+    This is the only place the full branch, worktree and session file are
+    emitted; activity/heartbeat lines must not repeat them (Issue #40).
+    """
     return (
+        f"run={run_id} issue={issue} role={role} "
+        f"branch={branch} worktree={worktree} "
         f"session={snapshot['session_id'] or '-'} "
         f"session_file={snapshot['session_file'] or '-'} "
         f"phase={snapshot['phase']} "
         f"last_activity={snapshot['last_activity'] or '-'} "
-        f"last={snapshot['last'] or '-'}"
+        f"action={quote_value(snapshot['action'] or '-')} "
+        f"result={snapshot['result'] or '-'}"
     )
+
+
+def format_end_scene(*, run_id: str, issue: str, role: str, result: str,
+                     elapsed: float, pr: str, commit: str) -> str:
+    """run_end line: the result plus the full debug entry (PR, commit)."""
+    return (
+        f"run={run_id} issue={issue} role={role} "
+        f"result={result} elapsed={format_duration(elapsed)} "
+        f"pr={pr} commit={commit}"
+    )
+
+
+def parse_scene(line: str) -> dict[str, str | None]:
+    """Parse a `key=value` scene line into a dict.
+
+    Values may be double-quoted (when they contain spaces) and may contain
+    `=`. Bare words without `=` (such as the line-kind prefix `activity`,
+    `heartbeat`, `run_start`, ...) are skipped. `key=` without a value
+    parses to None.
+    """
+    fields: dict[str, str | None] = {}
+    index = 0
+    length = len(line)
+    while index < length:
+        while index < length and line[index] == " ":
+            index += 1
+        if index >= length:
+            break
+        # Read the key up to '=' or the next space.
+        key_start = index
+        while index < length and line[index] != "=" and line[index] != " ":
+            index += 1
+        key = line[key_start:index]
+        if not key or index >= length or line[index] != "=":
+            continue  # bare word (line-kind prefix or garbage): skip it
+        index += 1  # skip '='
+        if index < length and line[index] == '"':
+            index += 1
+            start = index
+            while index < length:
+                if (line[index] == "\\"
+                        and index + 1 < length
+                        and line[index + 1] == '"'):
+                    index += 2  # escaped quote: part of the value
+                    continue
+                if line[index] == '"':
+                    break
+                index += 1
+            raw = line[start:index]
+            if index < length:  # closing quote found
+                index += 1
+            else:  # unterminated quote: keep the rest of the line
+                index = length
+            fields[key] = raw.replace('\\"', '"')
+        else:
+            start = index
+            while index < length and line[index] != " ":
+                index += 1
+            fields[key] = line[start:index] or None
+    return fields

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import subprocess
@@ -351,6 +352,12 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     ]]
 
 
+def test_issue_context_uses_owner_repo_number_form():
+    assert runner.issue_context("xqliu/muyan-pilot", 40) == (
+        "xqliu/muyan-pilot#40"
+    )
+
+
 def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text(
@@ -372,7 +379,10 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
         "base_sha": "abc123def456",
         "run_id": "run1",
     }
-    assert runner.run_pi(issue, tmp_path, config, "owner/repo") == "done"
+    assert runner.run_pi(
+        issue, tmp_path, config, "owner/repo",
+        branch="muyan-pilot/owner-repo-issue-4-run1",
+    ) == "done"
     command, kwargs = calls[0]
     assert command[:4] == ["pi", "--skill", "skill.md", "--print"]
     assert "owner/repo" in command[7]
@@ -385,9 +395,10 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
     assert kwargs["timeout"] is None
+    assert kwargs["run_id"] == "run1"
     assert kwargs["issue"] == 4
     assert kwargs["source_repo"] == "owner/repo"
-    assert kwargs["branch"] is None
+    assert kwargs["branch"] == "muyan-pilot/owner-repo-issue-4-run1"
     assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
 
 
@@ -423,7 +434,7 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
         {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
-        "owner/repo",
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-5-run1",
     )
     command, kwargs = calls[0]
     assert "PRIVATE SYSTEM" in command[5]
@@ -588,6 +599,7 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "verify_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "0123456789abcdef0123456789abcdef01234567")
     issue = {"number": 4, "title": "Fix", "body": "Body"}
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}
     assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/muyan-pilot/pull/4"
@@ -611,6 +623,33 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert "run_id=run1" in body in body
 
 
+def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(runner, "verify_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: "0123456789abcdef0123456789abcdef01234567",
+    )
+    with caplog.at_level("INFO"):
+        runner.process_issue(
+            {"number": 4, "title": "Fix", "body": "Body"},
+            {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"},
+            "xqliu/muyan-ceo",
+        )
+    ends = [line for line in caplog.text.splitlines() if " run_end " in line]
+    assert len(ends) == 1
+    assert "run=run1" in ends[0]
+    assert "issue=xqliu/muyan-ceo#4" in ends[0]
+    assert "result=pr_opened" in ends[0]
+    assert "pr=https://github.com/muyantech/muyan-pilot/pull/4" in ends[0]
+    assert "commit=0123456789abcdef0123456789abcdef01234567" in ends[0]
+
+
 def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
@@ -618,6 +657,7 @@ def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
     monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
     with pytest.raises(RuntimeError, match="git failed"):
         runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
     assert calls[1][2] == {"repo": "xqliu/muyan-ceo", "add": "ai-blocked", "remove": "ai-in-progress"}
@@ -688,6 +728,31 @@ def test_main_requires_prompt_file(monkeypatch, tmp_path):
         runner.main(["--config", str(config)])
 
 
+def test_process_issue_failure_without_session_still_carries_scene(
+    monkeypatch, tmp_path,
+):
+    calls = []
+    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(runner, "new_run_id", lambda: "run1")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("pi died")),
+    )
+    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
+    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
+    with pytest.raises(RuntimeError, match="pi died"):
+        runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
+    failure_body = calls[-1][2]["body"]
+    # No session file yet: the scene still carries the full debug entry
+    # (worktree, branch) with '-' session fields.
+    assert f"worktree={tmp_path / 'wt'}" in failure_body
+    assert "branch=muyan-pilot/xqliu-muyan-ceo-issue-8-run1" in failure_body
+    assert "session=-" in failure_body
+    assert "session_file=-" in failure_body
+
+
 def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
@@ -706,7 +771,8 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
         "session_file": str(tmp_path / "wt" / ".pi-session" / "s.jsonl"),
         "phase": "test",
         "last_activity": "2026-08-25T02:30:00Z",
-        "last": "bash pytest tests/",
+        "action": "bash pytest tests/",
+        "result": "ok",
     })
     with pytest.raises(subprocess.CalledProcessError):
         runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
@@ -715,7 +781,11 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     assert "session=sess-9" in failure_body
     assert "phase=test" in failure_body
     assert "last_activity=2026-08-25T02:30:00Z" in failure_body
-    assert "last=bash pytest tests/" in failure_body
+    assert 'action="bash pytest tests/"' in failure_body
+    assert "result=ok" in failure_body
+    # The full scene on the failure comment carries the debug entry.
+    assert f"worktree={tmp_path / 'wt'}" in failure_body
+    assert "branch=muyan-pilot/xqliu-muyan-ceo-issue-8-run1" in failure_body
 
 
 def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, caplog):
@@ -746,7 +816,7 @@ def make_fake_pi(tmp_path: Path, *, session_records: list[tuple[float, dict]],
                  sleep: float = 0.0) -> list[str]:
     """Build a command that mimics pi: appends session records over time."""
     session_dir = tmp_path / ".pi-session"
-    session_dir.mkdir()
+    session_dir.mkdir(exist_ok=True)
     records_literal = repr(session_records)
     script = (
         "import json, sys, time\n"
@@ -780,29 +850,181 @@ def fake_session_records():
     ]
 
 
-def test_stream_pi_logs_live_activity_and_returns_stdout(tmp_path, caplog):
+def test_log_format_has_no_python_timestamp():
+    # journald already provides time, host and process (Issue #40): the
+    # Python logger must not print a second timestamp.
+    formatter = logging.Formatter(runner.log_format())
+    record = logging.LogRecord(
+        "muyan_pilot.bootstrap", logging.INFO, "file", 1, "message", None, None,
+    )
+    assert formatter.format(record) == "INFO message"
+
+
+def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
     command = make_fake_pi(
         tmp_path, session_records=fake_session_records(),
         stdout="final answer",
     )
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
-            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
-            issue=24, source_repo="xqliu/muyan-pilot",
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
             branch="muyan-pilot/xqliu-muyan-pilot-issue-24-run1",
         )
     assert result == "final answer"
     # Without an explicit log_command the raw command is never logged.
     assert "command=<redacted>" in caplog.text
-    assert "pi_activity issue=24 source_repo=xqliu/muyan-pilot" in caplog.text
-    assert "branch=muyan-pilot/xqliu-muyan-pilot-issue-24-run1" in caplog.text
-    assert f"worktree={tmp_path}" in caplog.text
-    assert "session=sess-1" in caplog.text
-    assert "phase=test" in caplog.text
-    assert "last=bash pytest tests/" in caplog.text
-    assert "stdout=final answer" in caplog.text
+    starts = [line for line in caplog.text.splitlines()
+              if " run_start " in line]
+    assert len(starts) == 1
+    start = starts[0]
+    assert "run=run1" in start
+    assert "issue=xqliu/muyan-pilot#24" in start
+    assert "role=implement" in start
+    assert "branch=muyan-pilot/xqliu-muyan-pilot-issue-24-run1" in start
+    assert f"worktree={tmp_path}" in start
+    # The session fields are part of the scene; before Pi writes its first
+    # record they are '-' (the full entry reappears on run_failed).
+    assert "session=-" in start
+    assert "session_file=-" in start
+    assert "phase=starting" in start
     # The user message (full prompt / Issue body) never reaches the journal.
     assert "SECRET ISSUE BODY" not in caplog.text
+
+
+def test_stream_pi_run_start_carries_existing_session_file(tmp_path, caplog):
+    # When the session file already exists, run_start carries its path.
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    (session_dir / "sess.jsonl").write_text(
+        json.dumps({"type": "session", "id": "sess-1"}) + "\n",
+        encoding="utf-8",
+    )
+    command = make_fake_pi(tmp_path, session_records=[], stdout="ok")
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    starts = [line for line in caplog.text.splitlines()
+              if " run_start " in line]
+    assert len(starts) == 1
+    assert "session=sess-1" in starts[0]
+    assert f"session_file={session_dir / 'sess.jsonl'}" in starts[0]
+
+
+def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stdout="final answer", sleep=0.3,
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    activities = [line for line in lines if " activity " in line]
+    heartbeats = [line for line in lines if " heartbeat " in line]
+    # The visible fields change once (starting -> test): exactly one
+    # activity line; unchanged polls must not repeat it (Issue #40).
+    assert len(activities) == 1
+    line = activities[0]
+    assert "run=run1" in line
+    assert "issue=xqliu/muyan-pilot#24" in line
+    assert "role=implement" in line
+    assert "phase=test" in line
+    assert 'action="bash pytest tests/"' in line
+    assert "result=-" in line  # no tool result in this fake session
+    assert "idle=" in line
+    # No full scene on activity lines (Issue #40).
+    assert "branch=" not in line
+    assert f"worktree={tmp_path}" not in line
+    assert "session_file=" not in line
+    assert "source_repo=" not in line
+    # The idle tail produced heartbeats at the poll interval.
+    assert len(heartbeats) >= 1
+    for line in heartbeats:
+        assert "run=run1" in line
+        assert "role=implement" in line
+        assert "phase=starting" in line or "phase=test" in line
+        assert "elapsed=" in line
+        assert "idle=" in line
+        assert "branch=" not in line
+        assert f"worktree={tmp_path}" not in line
+    # The legacy verbose line is gone.
+    assert "pi_activity" not in caplog.text
+    assert "pi_idle" not in caplog.text
+
+
+def test_stream_pi_activity_keeps_action_after_tool_result(tmp_path, caplog):
+    """A tool result updates result only; the action line is not repeated."""
+    records = fake_session_records() + [
+        (0.5, {"type": "message", "id": "r1",
+               "timestamp": "2026-08-25T02:00:02Z",
+               "message": {"role": "toolResult", "toolCallId": "t1",
+                           "toolName": "bash",
+                           "content": [{"type": "text", "text": "ok"}]}}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stdout="final answer",
+        sleep=0.3,
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    activities = [line for line in lines if " activity " in line]
+    # One activity line for the tool call, one for the result=ok update;
+    # the action (the real command) is preserved on both.
+    assert len(activities) == 2
+    assert all('action="bash pytest tests/"' in line for line in activities)
+    assert "result=-" in activities[0]
+    assert "result=ok" in activities[1]
+    assert "tool_result" not in caplog.text
+
+
+def test_stream_pi_heartbeat_interval_is_stable(tmp_path, caplog):
+    """A silent session emits one heartbeat per poll interval, no activity."""
+    command = make_fake_pi(
+        tmp_path, session_records=[], sleep=1.0,
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    heartbeats = [line for line in lines if " heartbeat " in line]
+    activities = [line for line in lines if " activity " in line]
+    assert activities == []
+    # ~1s of idleness at a 0.1s interval: several heartbeats, one per poll.
+    assert len(heartbeats) >= 4
+    for line in heartbeats:
+        assert "phase=starting" in line
+        assert "session=-" not in line  # session fields are not repeated
+
+
+def test_stream_pi_success_logs_no_run_end(tmp_path, caplog):
+    # run_end is logged by process_issue once the PR and commit are known;
+    # stream_pi must not emit it (it cannot know them).
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stdout="final answer",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    assert " run_end " not in caplog.text
 
 
 def test_stream_pi_logs_command_redacted_and_stderr(tmp_path, caplog):
@@ -812,14 +1034,17 @@ def test_stream_pi_logs_command_redacted_and_stderr(tmp_path, caplog):
     )
     with caplog.at_level("INFO"):
         runner.stream_pi(
-            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
-            log_command=["pi", "--print", "<redacted>"],
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b", log_command=["pi", "--print", "<redacted>"],
         )
     assert "command=pi --print <redacted>" in caplog.text
     assert "stderr=warning line" in caplog.text
 
 
-def test_stream_pi_logs_failure_scene_and_reraises(tmp_path, caplog):
+def test_stream_pi_logs_run_failed_with_full_scene_and_reraises(
+    tmp_path, caplog,
+):
     command = make_fake_pi(
         tmp_path, session_records=fake_session_records(),
         stderr="pi exploded", exit_code=3,
@@ -828,47 +1053,63 @@ def test_stream_pi_logs_failure_scene_and_reraises(tmp_path, caplog):
         subprocess.CalledProcessError,
     ) as excinfo:
         runner.stream_pi(
-            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
-            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
         )
     assert excinfo.value.returncode == 3
     assert "pi exploded" in (excinfo.value.stderr or "")
     # The exception must not carry the raw command (prompt / Issue body).
     assert "SECRET ISSUE BODY" not in str(excinfo.value)
-    assert "pi_failed returncode=3" in caplog.text
-    assert "session=sess-1" in caplog.text
-    assert "phase=test" in caplog.text
+    failures = [line for line in caplog.text.splitlines()
+                if " run_failed " in line]
+    assert len(failures) == 1
+    failure = failures[0]
+    assert "run=run1" in failure
+    assert "issue=xqliu/muyan-pilot#24" in failure
+    assert "role=implement" in failure
+    assert "phase=test" in failure
+    assert "reason=pi_exit_3" in failure
+    # The full scene is the debug entry again: worktree and session file.
+    assert f"worktree={tmp_path}" in failure
+    assert f"session_file={tmp_path / '.pi-session' / 'sess.jsonl'}" in failure
+    assert "session=sess-1" in failure
     # The session JSONL stays in the worktree as the local record.
     session_files = list((tmp_path / ".pi-session").glob("*.jsonl"))
     assert len(session_files) == 1
     assert len(session_files[0].read_text(encoding="utf-8").splitlines()) == 3
 
 
-def test_stream_pi_warns_when_session_is_idle(tmp_path, caplog):
+def test_stream_pi_heartbeats_when_session_is_idle(tmp_path, caplog):
     command = make_fake_pi(
         tmp_path, session_records=fake_session_records(),
         sleep=1.0,
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("INFO"):
         runner.stream_pi(
-            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=0.5,
-            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
         )
-    assert "pi_idle" in caplog.text
-    assert "stale_seconds=" in caplog.text
-    assert "session=sess-1" in caplog.text
+    heartbeats = [line for line in caplog.text.splitlines()
+                  if " heartbeat " in line]
+    assert len(heartbeats) >= 1
+    # Idle duration is visible on the heartbeat line itself.
+    assert any("idle=" in line for line in heartbeats)
 
 
-def test_stream_pi_warns_when_no_session_file_appears(tmp_path, caplog):
+def test_stream_pi_heartbeats_when_no_session_file_appears(tmp_path, caplog):
     command = make_fake_pi(tmp_path, session_records=[], sleep=1.0)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("INFO"):
         runner.stream_pi(
-            command, cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=0.5,
-            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
         )
-    assert "pi_idle" in caplog.text
-    assert "session=-" in caplog.text
-    assert "session_file=-" in caplog.text
+    heartbeats = [line for line in caplog.text.splitlines()
+                  if " heartbeat " in line]
+    assert len(heartbeats) >= 1
+    assert all("phase=starting" in line for line in heartbeats)
 
 
 def test_stream_pi_drains_pipe_data_written_after_exit(
@@ -905,7 +1146,9 @@ def test_stream_pi_drains_pipe_data_written_after_exit(
     monkeypatch.setattr(runner.subprocess, "Popen", fake_popen)
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
-            ["fake"], cwd=tmp_path, poll_interval=0.1, idle_warn_seconds=3600,
+            ["fake"], cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
         )
     assert result == "late stdout data"
     assert "stderr=late stderr data" in caplog.text
@@ -918,10 +1161,14 @@ def test_stream_pi_times_out_and_kills_process(tmp_path, caplog):
     ) as excinfo:
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1, timeout=0.5,
-            issue=24, source_repo="xqliu/muyan-pilot", branch="b",
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
         )
     assert excinfo.value.timeout == 0.5
     # The exception must not carry the raw command (prompt / Issue body).
     assert "sleep" not in str(excinfo.value)
-    assert "pi_timeout timeout=0.5" in caplog.text
-    assert "issue=24" in caplog.text
+    failures = [line for line in caplog.text.splitlines()
+                if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=timeout_0.5s" in failures[0]
+    assert "issue=xqliu/muyan-pilot#24" in failures[0]

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -375,7 +375,7 @@ def test_live_activity_lines_with_session(tmp_path):
     )
     assert lines == [
         "    live: phase=test last_activity=2026-08-25T02:00:01Z "
-        "last=bash pytest tests/",
+        "action=bash pytest tests/ result=-",
         f"    session: {session_dir / 's.jsonl'}",
         f"    worktree: {worktree}",
     ]
@@ -402,7 +402,7 @@ def test_status_report_includes_live_lines_for_current_issue(monkeypatch, tmp_pa
         "base_branch": "main",
     })
     assert "current: #3 now u3" in report
-    assert "    live: phase=starting last_activity=- last=-" in report
+    assert "    live: phase=starting last_activity=- action=- result=-" in report
     assert f"    session: {session_dir / 's.jsonl'}" in report
     assert f"    worktree: {worktree}" in report
     assert "ready: -" in report

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -261,10 +261,12 @@ def test_watcher_tracks_session_activity_and_phase(tmp_path):
     assert state["events"] == 5
     assert state["phase"] == "test"
     assert state["last_activity"] == "2026-01-01T00:00:03Z"
-    assert state["last"] == "tool_result bash"
+    # The tool result reports the outcome without hiding the real action.
+    assert state["action"] == "bash pytest tests/"
+    assert state["result"] == "ok"
     assert state["changed"] is True
     # The user message (full prompt / Issue body) is never summarized.
-    assert "SECRET ISSUE BODY" not in state["last"]
+    assert "SECRET ISSUE BODY" not in (state["action"] or "")
     # Second poll: no new records, not changed.
     again = watcher.poll()
     assert again["changed"] is False
@@ -292,15 +294,77 @@ def test_watcher_phase_follows_latest_tool_call(tmp_path):
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
     assert state["phase"] == "pr"
-    assert state["last"] == "bash gh pr create --fill"
+    assert state["action"] == "bash gh pr create --fill"
 
 
-def test_watcher_marks_tool_result_errors(tmp_path):
+def test_watcher_tool_result_error_keeps_action_and_sets_result(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {
+            "type": "message", "id": "a0",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "t0", "name": "bash",
+                     "arguments": {"command": "gh pr create --fill"}},
+                ],
+            },
+        },
+        TOOL_RESULT_ERROR,
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    # The error is visible via result; the real action is not overwritten.
+    assert state["action"] == "bash gh pr create --fill"
+    assert state["result"] == "error"
+
+
+def test_watcher_new_tool_call_clears_stale_result(tmp_path):
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {
+            "type": "message", "id": "a0",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "t0", "name": "bash",
+                     "arguments": {"command": "pytest tests/"}},
+                ],
+            },
+        },
+        TOOL_RESULT,
+        {
+            "type": "message", "id": "a1",
+            "timestamp": "2026-01-01T00:00:04Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "t1", "name": "edit",
+                     "arguments": {"path": "progress.py"}},
+                ],
+            },
+        },
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    # The new call is pending: the previous result must not be shown as if
+    # it described the new action.
+    assert state["action"] == "edit progress.py"
+    assert state["result"] is None
+    assert state["phase"] == "edit"
+
+
+def test_watcher_tool_result_without_call_keeps_action_none(tmp_path):
     session = tmp_path / "s.jsonl"
     write_records(session, [SESSION_RECORD, TOOL_RESULT_ERROR])
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
-    assert state["last"] == "tool_result bash (error)"
+    assert state["action"] is None
+    assert state["result"] == "error"
 
 
 def test_watcher_keeps_phase_for_non_bash_tool_results(tmp_path):
@@ -330,7 +394,8 @@ def test_watcher_keeps_phase_for_non_bash_tool_results(tmp_path):
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
     assert state["phase"] == "read"
-    assert state["last"] == "tool_result read"
+    assert state["action"] == "read /a.md"
+    assert state["result"] == "ok"
 
 
 def test_watcher_reports_assistant_text_as_activity(tmp_path):
@@ -338,7 +403,8 @@ def test_watcher_reports_assistant_text_as_activity(tmp_path):
     write_records(session, [SESSION_RECORD, ASSISTANT_TEXT])
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
-    assert state["last"] == "assistant text"
+    assert state["action"] == "assistant text"
+    assert state["result"] is None
     assert state["phase"] == "starting"
 
 
@@ -384,7 +450,8 @@ def test_watcher_stale_seconds_from_start_without_activity(tmp_path):
     state = watcher.poll()
     assert state["stale_seconds"] == pytest.approx(50.0)
     assert state["phase"] == "starting"
-    assert state["last"] is None
+    assert state["action"] is None
+    assert state["result"] is None
 
 
 def test_watcher_clamps_negative_stale_to_zero(tmp_path):
@@ -420,7 +487,8 @@ def test_watcher_ignores_assistant_content_that_is_not_a_list(tmp_path):
     ])
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
-    assert state["last"] is None
+    assert state["action"] is None
+    assert state["result"] is None
     assert state["phase"] == "starting"
 
 
@@ -437,7 +505,8 @@ def test_watcher_ignores_records_without_message_object(tmp_path):
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
     assert state["events"] == 4
-    assert state["last"] is None
+    assert state["action"] is None
+    assert state["result"] is None
     assert state["phase"] == "starting"
 
 
@@ -462,7 +531,7 @@ def test_watcher_handles_malformed_tool_call_items(tmp_path):
     ])
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
-    assert state["last"] == "tool"
+    assert state["action"] == "tool"
     assert state["phase"] == "tool"
 
 
@@ -483,6 +552,7 @@ def test_watcher_handles_missing_or_invalid_timestamps(tmp_path):
     watcher.start_time = 999_900.0
     state = watcher.poll()
     assert state["last_activity"] is None
+    assert state["action"] == "assistant text"
     # No usable activity epoch: stale falls back to the start time.
     assert state["stale_seconds"] == pytest.approx(100.0)
 
@@ -496,36 +566,173 @@ def test_activity_snapshot_scans_newest_session_file(tmp_path):
     snapshot = pi_activity.activity_snapshot(tmp_path)
     assert snapshot["session_id"] == "sess-1"
     assert snapshot["phase"] == "test"
-    assert snapshot["last"] == "bash pytest tests/"
+    assert snapshot["action"] == "bash pytest tests/"
+    assert snapshot["result"] is None
     assert snapshot["changed"] is False
 
 
-def test_format_activity_scene_returns_empty_string_for_none():
-    assert pi_activity.format_activity_scene(None) == ""
+def test_format_duration_uses_seconds_minutes_and_hours():
+    assert pi_activity.format_duration(0) == "0s"
+    assert pi_activity.format_duration(0.5) == "0.5s"
+    assert pi_activity.format_duration(59) == "59s"
+    assert pi_activity.format_duration(60) == "1m"
+    assert pi_activity.format_duration(840) == "14m"
+    assert pi_activity.format_duration(3600) == "1h0m"
+    assert pi_activity.format_duration(15300) == "4h15m"
 
 
-def test_format_activity_scene_formats_key_value_fields():
+def test_quote_value_quotes_only_values_with_spaces():
+    assert pi_activity.quote_value("test") == "test"
+    assert pi_activity.quote_value("bash pytest tests/") == (
+        '"bash pytest tests/"'
+    )
+
+
+def test_quote_value_escapes_embedded_quotes():
+    assert pi_activity.quote_value('git commit -m "feat: x"') == (
+        '"git commit -m \\"feat: x\\""'
+    )
+    assert pi_activity.quote_value('a"b') == '"a\\"b"'
+
+
+def test_format_run_scene_is_the_full_scene_logged_once():
     snapshot = {
         "session_id": "sess-1",
-        "session_file": "/w/.pi-session/s.jsonl",
+        "session_file": "/w/.pi-session/sess-1.jsonl",
         "phase": "test",
         "last_activity": "2026-01-01T00:00:02Z",
-        "last": "bash pytest tests/",
+        "action": "bash pytest tests/",
+        "result": "ok",
     }
-    assert pi_activity.format_activity_scene(snapshot) == (
-        "session=sess-1 session_file=/w/.pi-session/s.jsonl phase=test "
-        "last_activity=2026-01-01T00:00:02Z last=bash pytest tests/"
+    scene = pi_activity.format_run_scene(
+        snapshot, run_id="e07383c2",
+        issue="xqliu/muyan-pilot#18", role="implement",
+        branch="muyan-pilot/xqliu-muyan-pilot-issue-18-e07383c2",
+        worktree="/w",
+    )
+    assert scene == (
+        "run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement "
+        "branch=muyan-pilot/xqliu-muyan-pilot-issue-18-e07383c2 worktree=/w "
+        "session=sess-1 session_file=/w/.pi-session/sess-1.jsonl phase=test "
+        "last_activity=2026-01-01T00:00:02Z action=\"bash pytest tests/\" "
+        "result=ok"
     )
 
 
-def test_format_activity_scene_marks_missing_fields():
-    assert pi_activity.format_activity_scene({
-        "session_id": None,
-        "session_file": None,
-        "phase": "starting",
-        "last_activity": None,
-        "last": None,
-    }) == (
-        "session=- session_file=- phase=starting "
-        "last_activity=- last=-"
+def test_format_run_scene_marks_missing_fields():
+    scene = pi_activity.format_run_scene(
+        {
+            "session_id": None,
+            "session_file": None,
+            "phase": "starting",
+            "last_activity": None,
+            "action": None,
+            "result": None,
+        },
+        run_id="run1", issue="owner/repo#1", role="implement",
+        branch="b", worktree="/w",
     )
+    assert scene == (
+        "run=run1 issue=owner/repo#1 role=implement branch=b worktree=/w "
+        "session=- session_file=- phase=starting last_activity=- "
+        "action=- result=-"
+    )
+
+
+def test_format_end_scene_carries_result_and_pr_entry():
+    scene = pi_activity.format_end_scene(
+        run_id="e07383c2", issue="xqliu/muyan-pilot#18", role="implement",
+        result="pr_opened", elapsed=2520,
+        pr="https://github.com/xqliu/muyan-pilot/pull/40",
+        commit="0123456789abcdef0123456789abcdef01234567",
+    )
+    assert scene == (
+        "run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement "
+        "result=pr_opened elapsed=42m "
+        "pr=https://github.com/xqliu/muyan-pilot/pull/40 "
+        "commit=0123456789abcdef0123456789abcdef01234567"
+    )
+
+
+def test_parse_scene_handles_quoted_values_and_equals_inside_values():
+    scene = (
+        'run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test '
+        'action="git commit -m \'a=b c\'" result=ok idle=6s'
+    )
+    fields = pi_activity.parse_scene(scene)
+    assert fields["run"] == "e07383c2"
+    assert fields["issue"] == "xqliu/muyan-pilot#18"
+    assert fields["action"] == "git commit -m 'a=b c'"
+    assert fields["result"] == "ok"
+    assert fields["idle"] == "6s"
+
+
+def test_parse_scene_skips_line_kind_prefix():
+    # Journal lines start with the line kind (activity / heartbeat /
+    # run_start / run_failed / run_end) before the key=value fields.
+    fields = pi_activity.parse_scene(
+        'activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement '
+        'phase=test action="bash pytest tests/" result=ok idle=6s'
+    )
+    assert fields["run"] == "e07383c2"
+    assert fields["action"] == "bash pytest tests/"
+    assert fields["idle"] == "6s"
+
+
+def test_parse_scene_marks_missing_values_and_ignores_garbage():
+    fields = pi_activity.parse_scene("run=a-1 phase= idle= x=1")
+    assert fields["run"] == "a-1"
+    assert fields["phase"] is None
+    assert fields["idle"] is None
+    assert fields["x"] == "1"
+    assert pi_activity.parse_scene("no key here at all") == {}
+
+
+def test_parse_scene_stops_at_trailing_whitespace():
+    assert pi_activity.parse_scene("run=a-1 ") == {"run": "a-1"}
+
+
+def test_parse_scene_keeps_rest_of_line_for_unterminated_quote():
+    fields = pi_activity.parse_scene('run=a-1 action="unclosed value')
+    assert fields["run"] == "a-1"
+    assert fields["action"] == "unclosed value"
+
+
+def test_parse_scene_unescapes_embedded_quotes():
+    fields = pi_activity.parse_scene(
+        'action="git commit -m \\"feat: x\\"" phase=commit'
+    )
+    assert fields["action"] == 'git commit -m "feat: x"'
+    assert fields["phase"] == "commit"
+
+
+def test_parse_scene_round_trips_escaped_quotes():
+    value = 'git commit -m "feat: a=b" && push'
+    field = f"action={pi_activity.quote_value(value)}"
+    assert pi_activity.parse_scene(field)["action"] == value
+
+
+def test_parse_scene_round_trips_run_scene():
+    snapshot = {
+        "session_id": "sess-1",
+        "session_file": "/w/.pi-session/sess-1.jsonl",
+        "phase": "test",
+        "last_activity": "2026-01-01T00:00:02Z",
+        "action": "bash pytest tests/",
+        "result": "ok",
+    }
+    scene = pi_activity.format_run_scene(
+        snapshot, run_id="e07383c2",
+        issue="xqliu/muyan-pilot#18", role="implement",
+        branch="muyan-pilot/xqliu-muyan-pilot-issue-18-e07383c2",
+        worktree="/w",
+    )
+    fields = pi_activity.parse_scene(scene)
+    assert fields["run"] == "e07383c2"
+    assert fields["issue"] == "xqliu/muyan-pilot#18"
+    assert fields["branch"] == (
+        "muyan-pilot/xqliu-muyan-pilot-issue-18-e07383c2"
+    )
+    assert fields["session_file"] == "/w/.pi-session/sess-1.jsonl"
+    assert fields["action"] == "bash pytest tests/"
+    assert fields["result"] == "ok"


### PR DESCRIPTION
<!-- muyan-pilot:run=e9d57da8 -->

run_id=e9d57da8

Closes xqliu/muyan-pilot#40

## What changed

Live Pi activity journal lines are now concise and run-scoped:

- `run_start` logs the full invariant scene (branch / worktree / session file) **once** at run start; `activity` and `heartbeat` lines carry short changed fields only (`run=`, `issue=owner/repo#n`, `role=`, `phase=`, `action=`, `result=`, `idle=` / `elapsed=`) — no more repeating the full context every 15–30 s.
- `activity` is emitted only when phase/action/result actually change; unchanged polls emit a `heartbeat` with `elapsed` and `idle` on the line (the old `pi_idle` warning is gone — idle time is always visible).
- `tool_result` updates `result` (`ok`/`error`) without overwriting the real `action`; a new tool call clears the stale result.
- `run_failed` carries the full scene again as the debug entry with `reason=pi_exit_N` / `reason=timeout_Xs`; `run_end` carries `result=pr_opened`, `elapsed`, PR URL and commit.
- The Python logger no longer prints its own timestamp (`log_format()` shared by runner and CLI) — journald already provides time/host/process.
- All lines stay stable `key=value` (values with spaces/quotes are double-quoted, embedded quotes escaped) and are parseable via the new `pi_activity.parse_scene`; the `[run_id]` prefix from Issue #41 round-trips through it.
- `muyan_pilot.py status` live lines show `action`/`result`; README documents the new format with a default `journalctl` tail example (example only, not a product step).

## Verification

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → **194 passed**, **100% line and branch coverage** (bootstrap_runner.py, muyan_pilot.py, pi_activity.py).
- Real simulated runs (fake pi child process) verified end to end: `run_start` → `activity`/`heartbeat` sequence → `run_end` on success and `run_failed` (full scene + reason) on exit code 3; full worktree/session paths appear only on start/failure lines.
- Base freshness: `origin/main` advanced (PR #43 / Issue #41 run-id correlation) while working; merged into the task branch, conflicts resolved manually, full suite + review rerun after the merge.
