### PR TITLE
fix: drop the duplicated run= field from high-frequency journal lines (Issue #57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,29 +52,29 @@ verify → independent review → fix → merge，并主动发布过程和最终
 Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把简短活动写入 journal（systemd 日志）；已经打开 `journalctl -f` 时内容持续自动刷新。完整不变现场（branch / worktree / session 文件）只在 run 开始和失败时各记录一次，运行中只输出短的变化字段，避免每 15–30 秒重复整段上下文：
 
 - `run_start run=... issue=owner/repo#n role=implement branch=... worktree=... session=... session_file=... phase=... last_activity=... action=... result=...`——run 开始时记录一次完整现场；
-- `activity run=... issue=... role=... phase=... action="..." result=... state=-|model_wait idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
-- `heartbeat run=... issue=... role=... phase=... state=-|model_wait elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
-- `model_wait run=... issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；
-- `resumed run=... issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
-- `pi_idle run=... issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
-- `pi_resumed run=... issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed）。
+- `activity issue=... role=... phase=... action="..." result=... state=-|model_wait idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
+- `heartbeat issue=... role=... phase=... state=-|model_wait elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
+- `model_wait issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；
+- `resumed issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
+- `pi_idle issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
+- `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed）。
 - `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s`——进程异常退出或超时时先记录完整现场再抛出错误；
 - `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
 
-所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析），可用短 `run` id 串起整个 run；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行还会带 `[run_id]` 前缀（见下文全链路 run_id 一节）。默认 tail 示例（仅用于查看，不是产品步骤）：
+所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`。默认 tail 示例（仅用于查看，不是产品步骤）：
 
 ```bash
 journalctl --user -u muyan-pilot.service -f
 # Aug 25 14:30:01 host muyan-pilot[123]: INFO [e07383c2] run_start run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement branch=muyan-pilot/... worktree=/home/.../.worktrees/... session=sess-1 session_file=/home/.../.pi-session/sess-1.jsonl phase=starting last_activity=- action=- result=-
-# Aug 25 14:30:16 host muyan-pilot[123]: INFO [e07383c2] activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=- state=- idle=6s
-# Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test state=- elapsed=30s idle=15s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait
-# Aug 25 14:41:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait elapsed=11m idle=11m
-# Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] activity run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
-# Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] resumed run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=test state=resumed
-# Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=pr stale_seconds=5m
-# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_resumed run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement phase=pr
+# Aug 25 14:30:16 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=- state=- idle=6s
+# Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=- elapsed=30s idle=15s
+# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
+# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait
+# Aug 25 14:41:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait elapsed=11m idle=11m
+# Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
+# Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] resumed issue=xqliu/muyan-pilot#18 role=implement phase=test state=resumed
+# Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle issue=xqliu/muyan-pilot#18 role=implement phase=pr stale_seconds=5m
+# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=xqliu/muyan-pilot#18 role=implement phase=pr
 # Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/xqliu/muyan-pilot/pull/19 commit=0123456789abcdef0123456789abcdef01234567
 ```
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -730,13 +730,18 @@ def _decode_chunks(chunks: list[bytes]) -> str:
     return b"".join(chunks).decode("utf-8", "replace")
 
 
-def _log_activity(activity: dict, *, run_id: str, issue_ref: str,
+def _log_activity(activity: dict, *, issue_ref: str,
                   role: str, state: str | None = None) -> None:
-    """Log one short activity line with the changed fields only."""
+    """Log one short activity line with the changed fields only.
+
+    No `run=` field (Issue #57): the `[run_id]` prefix added by
+    `RunIdFilter` (Issue #41) is the single run-id carrier on the
+    high-frequency lines, so the id appears exactly once per line.
+    """
     LOGGER.info(
-        "activity run=%s issue=%s role=%s phase=%s action=%s result=%s "
+        "activity issue=%s role=%s phase=%s action=%s result=%s "
         "state=%s idle=%s",
-        run_id, issue_ref, role, activity["phase"],
+        issue_ref, role, activity["phase"],
         quote_value(activity["action"] or "-"),
         activity["result"] or "-",
         state or "-",
@@ -744,19 +749,20 @@ def _log_activity(activity: dict, *, run_id: str, issue_ref: str,
     )
 
 
-def _log_heartbeat(activity: dict, *, run_id: str, issue_ref: str,
+def _log_heartbeat(activity: dict, *, issue_ref: str,
                    role: str, elapsed: float,
                    state: str | None = None) -> None:
     """Log one heartbeat line when nothing changed since the last poll.
 
     `state` carries the model_wait flag while the model is expected to
     reply next, so a slow active model is not reported as idle (Issue
-    #40).
+    #40). No `run=` field (Issue #57): the `[run_id]` prefix is the
+    single run-id carrier on the high-frequency lines.
     """
     LOGGER.info(
-        "heartbeat run=%s issue=%s role=%s phase=%s state=%s elapsed=%s "
+        "heartbeat issue=%s role=%s phase=%s state=%s elapsed=%s "
         "idle=%s",
-        run_id, issue_ref, role, activity["phase"], state or "-",
+        issue_ref, role, activity["phase"], state or "-",
         format_duration(elapsed), format_duration(activity["stale_seconds"]),
     )
 
@@ -881,25 +887,27 @@ def stream_pi(
                 # Only changed fields are repeated; an unchanged poll is a
                 # heartbeat (Issue #40).
                 _log_activity(
-                    activity, run_id=run_id, issue_ref=issue_ref,
+                    activity, issue_ref=issue_ref,
                     role=role,
                     state="model_wait" if activity["model_wait"] else None,
                 )
                 last_visible = visible
             else:
                 _log_heartbeat(
-                    activity, run_id=run_id, issue_ref=issue_ref,
+                    activity, issue_ref=issue_ref,
                     role=role, elapsed=time.monotonic() - start,
                     state="model_wait" if activity["model_wait"] else None,
                 )
             if activity["model_wait"] != last_model_wait:
                 # One transition line per state change: entering model_wait
                 # (the model is expected to reply next) or leaving it
-                # (the next session event arrived: resumed).
+                # (the next session event arrived: resumed). No `run=`
+                # field: the `[run_id]` prefix carries the run id
+                # (Issue #57).
                 LOGGER.info(
-                    "%s run=%s issue=%s role=%s phase=%s state=%s",
+                    "%s issue=%s role=%s phase=%s state=%s",
                     "model_wait" if activity["model_wait"] else "resumed",
-                    run_id, issue_ref, role,
+                    issue_ref, role,
                     activity["phase"],
                     "model_wait" if activity["model_wait"] else "resumed",
                 )
@@ -911,9 +919,11 @@ def stream_pi(
             # logs `pi_resumed`. A slow active model (model_wait) never
             # warns (Issue #40).
             if idle_warned and activity["changed"]:
+                # No `run=` field: the `[run_id]` prefix carries the run
+                # id (Issue #57).
                 LOGGER.info(
-                    "pi_resumed run=%s issue=%s role=%s phase=%s",
-                    run_id, issue_ref, role, activity["phase"],
+                    "pi_resumed issue=%s role=%s phase=%s",
+                    issue_ref, role, activity["phase"],
                 )
                 idle_warned = False
             elif (
@@ -921,10 +931,12 @@ def stream_pi(
                 and not idle_warned
                 and activity["stale_seconds"] >= idle_warn_seconds
             ):
+                # No `run=` field: the `[run_id]` prefix carries the run
+                # id (Issue #57).
                 LOGGER.warning(
-                    "pi_idle run=%s issue=%s role=%s phase=%s "
+                    "pi_idle issue=%s role=%s phase=%s "
                     "stale_seconds=%s",
-                    run_id, issue_ref, role, activity["phase"],
+                    issue_ref, role, activity["phase"],
                     format_duration(activity["stale_seconds"]),
                 )
                 idle_warned = True

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 import pytest
 
 import bootstrap_runner as runner
+import pi_activity
 from tests.test_progress_wiring import make_fake_gh
 
 
@@ -1898,7 +1899,10 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     # activity line; unchanged polls must not repeat it (Issue #40).
     assert len(activities) == 1
     line = activities[0]
-    assert "run=run1" in line
+    # No redundant `run=` field on the high-frequency lines (Issue #57);
+    # the `[run_id]` prefix is the run-id carrier (bound-run tests and
+    # the e2e suite cover the prefix itself).
+    assert "run=run1" not in line
     assert "issue=xqliu/muyan-pilot#24" in line
     assert "role=implement" in line
     assert "phase=test" in line
@@ -1913,7 +1917,7 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     # The idle tail produced heartbeats at the poll interval.
     assert len(heartbeats) >= 1
     for line in heartbeats:
-        assert "run=run1" in line
+        assert "run=run1" not in line
         assert "role=implement" in line
         assert "phase=starting" in line or "phase=test" in line
         assert "elapsed=" in line
@@ -1923,6 +1927,127 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     # The legacy verbose line is gone.
     assert "pi_activity" not in caplog.text
     assert "pi_idle" not in caplog.text
+
+
+def test_stream_pi_high_frequency_lines_carry_run_id_exactly_once(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #57: the `[run_id]` prefix (Issue #41) is the single
+    run-id carrier on the high-frequency lines; the redundant `run=`
+    field is gone, so the 8-hex id appears exactly once per line and a
+    single grep still reconstructs the whole timeline. The run is
+    bound like in the real journal (`process_issue` binds it before
+    starting Pi)."""
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    records = fake_session_records() + [
+        (0.5, {"type": "message", "id": "r1",
+               "timestamp": fresh_timestamp(2),
+               "message": {"role": "toolResult", "toolCallId": "t1",
+                           "toolName": "bash",
+                           "content": [{"type": "text", "text": "ok"}]}}),
+        (1.2, {"type": "message", "id": "a2",
+               "timestamp": fresh_timestamp(3),
+               "message": {"role": "assistant", "content": [
+                   {"type": "text", "text": "done"}]}}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stdout="final answer",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="a1b2c3d4", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    kinds = (
+        "activity", "heartbeat", "model_wait", "resumed",
+        "pi_idle", "pi_resumed",
+    )
+    high_freq = [
+        message for message in caplog.messages
+        if any(f" {kind} " in message for kind in kinds)
+    ]
+    # The record set produces every high-frequency kind except the idle
+    # pair (activity + heartbeats, one model_wait, one resumed).
+    assert any(" activity " in m for m in high_freq)
+    assert any(" heartbeat " in m for m in high_freq)
+    assert any(" model_wait " in m for m in high_freq)
+    assert any(" resumed " in m for m in high_freq)
+    for message in high_freq:
+        assert "run=" not in message, message
+        assert message.startswith("[a1b2c3d4]"), message
+        assert message.count("a1b2c3d4") == 1, message
+
+
+def test_stream_pi_idle_lines_carry_run_id_exactly_once(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #57: `pi_idle` / `pi_resumed` repeat the same rule as the
+    other high-frequency lines: prefix only, no `run=` field."""
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    # a1 is 4s stale when it is polled, so the idle warning fires;
+    # a2 arrives later with a fresh timestamp, so the resume does not
+    # re-trigger the warning.
+    records = [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(-5), "cwd": "/w"}),
+        (0.1, {"type": "message", "id": "a1",
+               "timestamp": fresh_timestamp(-4),
+               "message": {"role": "assistant", "content": [
+                   {"type": "text", "text": "one"}]}}),
+        (1.0, {"type": "message", "id": "a2",
+               "timestamp": fresh_timestamp(1.0),
+               "message": {"role": "assistant", "content": [
+                   {"type": "text", "text": "two"}]}}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stdout="ok",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.5,
+            run_id="a1b2c3d4", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    idles = [m for m in caplog.messages if " pi_idle " in m]
+    resumed = [m for m in caplog.messages if " pi_resumed " in m]
+    assert len(idles) == 1
+    assert len(resumed) == 1
+    for message in idles + resumed:
+        assert "run=" not in message, message
+        assert message.startswith("[a1b2c3d4]"), message
+        assert message.count("a1b2c3d4") == 1, message
+
+
+def test_stream_pi_scene_lines_keep_run_field_for_parse_scene(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #57: the low-frequency scene lines (run_start / run_failed)
+    keep `run=` so `pi_activity.parse_scene` still returns the run id
+    from the lines that need to be parsed. The run is bound like in
+    the real journal."""
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stderr="pi exploded", exit_code=3,
+    )
+    with caplog.at_level("INFO"), pytest.raises(
+        subprocess.CalledProcessError,
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="a1b2c3d4", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    starts = [m for m in caplog.messages if " run_start " in m]
+    failures = [m for m in caplog.messages if " run_failed " in m]
+    assert len(starts) == 1 and len(failures) == 1
+    for message in starts + failures:
+        assert "run=a1b2c3d4" in message, message
+        fields = pi_activity.parse_scene(message)
+        assert fields["run"] == "a1b2c3d4"
+        assert fields["issue"] == "xqliu/muyan-pilot#24"
 
 
 def test_stream_pi_activity_keeps_action_after_tool_result(tmp_path, caplog):
@@ -2114,7 +2239,9 @@ def test_stream_pi_model_wait_then_resumed_no_warning_spam(
     assert len(waits) == 1
     assert len(resumed) == 1
     wait = waits[0]
-    assert "run=run1" in wait
+    # The transition lines carry no redundant `run=` field (Issue #57);
+    # the `[run_id]` prefix is the run-id carrier.
+    assert "run=run1" not in wait
     assert "issue=xqliu/muyan-pilot#24" in wait
     assert "role=implement" in wait
     assert "phase=test" in wait
@@ -2123,7 +2250,7 @@ def test_stream_pi_model_wait_then_resumed_no_warning_spam(
     assert "branch=" not in wait
     assert f"worktree={tmp_path}" not in wait
     resume = resumed[0]
-    assert "run=run1" in resume
+    assert "run=run1" not in resume
     assert "state=resumed" in resume
     assert "phase=test" in resume
     # While waiting, the heartbeats carry the model_wait state and the
@@ -2191,7 +2318,9 @@ def test_stream_pi_logs_idle_warning_once_when_session_stalls(
     idles = [line for line in lines if " pi_idle " in line]
     assert len(idles) == 1, f"exactly one idle warning: {lines}"
     idle = idles[0]
-    assert "run=run1" in idle
+    # No redundant `run=` field (Issue #57); the `[run_id]` prefix is
+    # the run-id carrier.
+    assert "run=run1" not in idle
     assert "issue=xqliu/muyan-pilot#24" in idle
     assert "role=implement" in idle
     assert "phase=starting" in idle
@@ -2230,9 +2359,10 @@ def test_stream_pi_logs_pi_resumed_after_idle_warning(tmp_path, caplog):
     resumed = [line for line in lines if " pi_resumed " in line]
     assert len(idles) == 1
     assert len(resumed) == 1
-    # resumed comes after the warning and carries the run context.
+    # resumed comes after the warning and carries no redundant `run=`
+    # field (Issue #57).
     assert lines.index(resumed[0]) > lines.index(idles[0])
-    assert "run=run1" in resumed[0]
+    assert "run=run1" not in resumed[0]
     assert "issue=xqliu/muyan-pilot#24" in resumed[0]
     assert "role=implement" in resumed[0]
     assert "phase=starting" in resumed[0]

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -667,7 +667,8 @@ def make_failing_gh(monkeypatch, is_failing, comments=None):
 def _progress_patch_of(command) -> bool:
     return (
         command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        # GitHub update route (Issue #58): no issue number.
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "--method" in command
         and "PATCH" in command
     )
@@ -1015,7 +1016,8 @@ def patch_resume_deps_live(monkeypatch, tmp_path):
 def _fix_pushed_patch_of(command) -> bool:
     return (
         command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        # GitHub update route (Issue #58): no issue number.
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "--method" in command
         and "PATCH" in command
     )


### PR DESCRIPTION
<!-- muyan-pilot:run=72d5f8ac -->

run_id=72d5f8ac

Fixes #57

## Change

The `[run_id]` prefix added by `RunIdFilter` (Issue #41) is now the single
run-id carrier on the high-frequency journal lines. The redundant `run=`
field is removed from:

- `activity`, `heartbeat` (the per-poll hot path),
- `model_wait`, `resumed` (transition lines),
- `pi_idle`, `pi_resumed` (same duplication, same rule — Minor M1 in the
  review report; they are not parseable scene lines).

The low-frequency scene lines `run_start` / `run_failed` / `run_end`
(`format_run_scene` / `format_end_scene`) keep `run=`, so
`pi_activity.parse_scene` still returns the run id from the lines that
need to be parsed. `progress_publish_failed` (rare error line) keeps
`run=` so it stays self-describing.

No second id system is introduced; the single-grep timeline contract
(`grep [run_id]`, AGENTS.md Run correlation) is unchanged — every line
still carries the prefix.

## Files

- `bootstrap_runner.py` — drop `run=%s` from the six high-frequency log
  lines and their arguments; docstrings updated.
- `README.md` — journal line contract and example block updated in the
  same change.
- `tests/test_bootstrap_runner.py` — existing assertions updated; three
  new tests:
  - `test_stream_pi_high_frequency_lines_carry_run_id_exactly_once`
    (bound run: prefix is the only carrier, id appears exactly once per
    line),
  - `test_stream_pi_idle_lines_carry_run_id_exactly_once` (same rule for
    `pi_idle` / `pi_resumed`),
  - `test_stream_pi_scene_lines_keep_run_field_for_parse_scene`
    (`run_start` / `run_failed` keep `run=`; `parse_scene` returns it).

## Verification

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` →
  513 passed; `/usr/bin/python3 -m coverage report --show-missing` →
  100% line and branch coverage on all modules.
- Real-journal acceptance check (bound run, real `stream_pi` +
  `RunIdFilter`): every high-frequency line carries the 8-hex run id
  exactly once; all lines carry it, so one grep reconstructs the
  timeline; scene lines keep the `run=` field.
- Review-fix loop (R1–R9): 0 Blocker, 0 Major (round 2 after making the
  new scene test deterministic in any execution order).
