### PR TITLE
fix: PATCH the progress comment via the GitHub update route (Issue #58)

### DIFF
--- a/progress.py
+++ b/progress.py
@@ -130,7 +130,15 @@ class ProgressPublisher:
         self.comment_id: int | None = None
 
     def _endpoint(self) -> str:
+        # List/create route (GET and POST): issue-scoped.
         return f"repos/{self.repo}/issues/{self.issue}/comments"
+
+    def _update_endpoint(self, comment_id: int) -> str:
+        # Update an issue comment: PATCH /repos/{owner}/{repo}/issues/
+        # comments/{comment_id} — no issue number. Appending the id to
+        # the list/create endpoint is not a GitHub REST route and 404s
+        # (Issue #58).
+        return f"repos/{self.repo}/issues/comments/{comment_id}"
 
     def _list_comments(self) -> list[dict]:
         raw = self._run_command([
@@ -156,7 +164,7 @@ class ProgressPublisher:
 
     def _patch_comment(self, comment_id: int, body: str) -> None:
         self._run_command([
-            "gh", "api", f"{self._endpoint()}/{comment_id}",
+            "gh", "api", self._update_endpoint(comment_id),
             "--method", "PATCH", "--field", f"body={body}",
         ])
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -695,7 +695,7 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
     patches = [
         command for command in gh_calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-ceo/issues/4/comments/77"
+        and command[2] == "repos/xqliu/muyan-ceo/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "the existing progress comment was not updated"
@@ -3113,7 +3113,7 @@ def test_wait_for_delivery_marks_blocked_when_review_fails(
     patches = [
         command for command in api_calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/owner/repo/issues/39/comments/77"
+        and command[2] == "repos/owner/repo/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"
@@ -3363,7 +3363,7 @@ def test_wait_for_delivery_marks_blocked_when_pr_closed_unmerged(
     patches = [
         command for command in api_calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/owner/repo/issues/39/comments/77"
+        and command[2] == "repos/owner/repo/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -172,10 +172,12 @@ elif args[:2] == ["pr", "merge"]:
     save()
 elif args[:1] == ["api"]:
     # The progress publisher (Issue #18) keeps the single per-run
-    # comment via gh api: list (GET), create (POST), update (PATCH).
-    # Endpoint: repos/<owner>/<repo>/issues/<n>/comments[/<id>]
+    # comment via gh api: list (GET) and create (POST) on
+    # repos/<owner>/<repo>/issues/<n>/comments, update (PATCH) on
+    # repos/<owner>/<repo>/issues/comments/<id> — the GitHub update
+    # route carries no issue number (Issue #58).
     parts = args[1].split("/")
-    num = parts[4]
+    num = parts[4] if parts[4].isdigit() else None
     if "--method" in args:
         method = args[args.index("--method") + 1]
         body = args[args.index("--field") + 1][len("body="):]
@@ -188,7 +190,8 @@ elif args[:1] == ["api"]:
             save()
             print(json.dumps({"id": cid, "body": body}))
         elif method == "PATCH":
-            cid = int(parts[6])
+            # Update route: repos/<owner>/<repo>/issues/comments/<id>
+            cid = int(parts[5])
             for c in state["comments"]:
                 if c.get("id") == cid:
                     c["body"] = body

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -203,7 +203,7 @@ def test_publisher_ensure_patches_existing_progress_comment():
             "--paginate",
         ],
         [
-            "gh", "api", "repos/xqliu/muyan-pilot/issues/18/comments/7",
+            "gh", "api", "repos/xqliu/muyan-pilot/issues/comments/7",
             "--method", "PATCH", "--field", "body=new body",
         ],
     ]
@@ -264,8 +264,37 @@ def test_publisher_patch_updates_the_tracked_comment():
     publisher.ensure("old")
     publisher.patch("updated body")
     assert calls[-1] == [
-        "gh", "api", "repos/xqliu/muyan-pilot/issues/18/comments/7",
+        "gh", "api", "repos/xqliu/muyan-pilot/issues/comments/7",
         "--method", "PATCH", "--field", "body=updated body",
+    ]
+
+
+def test_publisher_patch_uses_the_github_update_comment_endpoint():
+    # Issue #58: the production PATCH 404s because the comment id was
+    # appended to the list/create URL (repos/{repo}/issues/{issue}/
+    # comments/{id}), which is not a GitHub REST route. Update an issue
+    # comment is PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
+    # — no issue number.
+    publisher, calls = make_publisher(comments=[
+        {
+            "id": 7,
+            "body": (
+                "<!-- muyan-pilot:run=abc123 -->\n\n"
+                "**Muyan Pilot progress**"
+            ),
+        },
+    ])
+    publisher.ensure("old")
+    publisher.patch("updated body")
+    assert calls[-1] == [
+        "gh", "api", "repos/xqliu/muyan-pilot/issues/comments/7",
+        "--method", "PATCH", "--field", "body=updated body",
+    ]
+    # List/create keep the issue-scoped endpoint (that route is correct
+    # for GET and POST).
+    assert calls[0] == [
+        "gh", "api", "repos/xqliu/muyan-pilot/issues/18/comments",
+        "--paginate",
     ]
 
 
@@ -328,7 +357,7 @@ def test_publisher_finish_patches_final_summary_into_tracked_comment():
     publisher.ensure("old")
     publisher.finish("final delivery summary")
     assert calls[-1] == [
-        "gh", "api", "repos/xqliu/muyan-pilot/issues/18/comments/7",
+        "gh", "api", "repos/xqliu/muyan-pilot/issues/comments/7",
         "--method", "PATCH", "--field", "body=final delivery summary",
     ]
 

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -454,7 +454,7 @@ def test_process_issue_finishes_progress_comment_with_delivery_summary(
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "--method" in command
         and "PATCH" in command
     ]
@@ -490,7 +490,7 @@ def test_process_issue_failure_updates_progress_comment_with_blocked_scene(
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert final_patches, "no PATCH of the progress comment"
@@ -527,7 +527,7 @@ def test_process_issue_resumes_existing_progress_comment_after_restart(
     patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "existing progress comment was not updated"
@@ -687,7 +687,7 @@ def test_resume_delivery_reuses_existing_progress_comment(monkeypatch, tmp_path)
     patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "existing progress comment was not updated"
@@ -715,7 +715,7 @@ def test_resume_delivery_posts_fix_pushed_milestone_and_finishes(
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert final_patches
@@ -750,7 +750,7 @@ def test_resume_delivery_failure_updates_progress_comment_with_blocked_scene(
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert final_patches
@@ -803,7 +803,7 @@ def test_review_and_merge_posts_review_findings_milestone(monkeypatch, tmp_path)
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert final_patches
@@ -858,7 +858,7 @@ def test_review_and_merge_posts_merged_milestone_and_final_summary(
     final_patches = [
         command for command in calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/18/comments/77"
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
         and "PATCH" in command
     ]
     assert final_patches
@@ -946,7 +946,7 @@ def test_wait_for_delivery_closed_unmerged_posts_blocked_milestone(
     patches = [
         command for command in api_calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/owner/repo/issues/39/comments/77"
+        and command[2] == "repos/owner/repo/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"
@@ -1044,7 +1044,7 @@ def test_wait_for_delivery_review_failure_finishes_progress_comment_with_blocked
     patches = [
         command for command in api_calls
         if command[:2] == ["gh", "api"]
-        and command[2] == "repos/owner/repo/issues/39/comments/77"
+        and command[2] == "repos/owner/repo/issues/comments/77"
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"


### PR DESCRIPTION
<!-- muyan-pilot:run=8c282544 -->

run_id=8c282544

## 变更

修复生产环境 live progress 评论 PATCH 全部 404 的问题（Issue #58）：`progress.py`
`_patch_comment` 把 comment id 拼到 list/create 端点
（`repos/{repo}/issues/{issue}/comments/{id}`），这不是 GitHub REST 路由。
Update an issue comment 的正确路由是
`PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}`（不带 issue 编号）。

- `progress.py`：新增 `_update_endpoint(comment_id)` 生成 PATCH 路由；
  `_endpoint()` 保持 issue-scoped 的 list/create 路由（GET/POST 本来正确）；
  `_patch_comment` 改用 `_update_endpoint`。
- 测试：新增回归测试 `test_publisher_patch_uses_the_github_update_comment_endpoint`
  （TDD：先 RED——断言在旧路径上失败，后 GREEN）；更新 16 处把错误路径
  编码进断言的既有期望（test_progress.py ×3、test_progress_wiring.py ×10、
  test_bootstrap_runner.py ×3）；`test_concurrency_e2e.py` 的 fake `gh`
  原来硬编码了错误路由布局（`parts[4]`=issue、`parts[6]`=id），正确 PATCH
  路径会 IndexError——更新为按真实 GitHub 路由应答（list/create
  issue-scoped，update repo-scoped）。

## 验收证据

- **真实 GitHub API 路由验证**（run #57 的评论 id 5417716347，只读）：
  - 旧路由 `gh api repos/xqliu/muyan-pilot/issues/57/comments/5417716347` → 404 Not Found；
  - 新路由 `gh api repos/xqliu/muyan-pilot/issues/comments/5417716347` → 200，返回评论。
- **真实 PATCH 验证**：在 Issue #58 建一条 scratch 评论（id 5418194436），用
  `_patch_comment` 现在构造的**原样命令**
  `gh api repos/xqliu/muyan-pilot/issues/comments/5418194436 --method PATCH --field body=...`
  更新成功（rc=0，GET 确认 body 已变更），随后删除 scratch 评论。未触碰 run #57 的评论。
- **测试**：全仓库 `511 passed`，100% line/branch coverage（含测试文件）：

  ```
  /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
  /usr/bin/python3 -m coverage report --show-missing
  → TOTAL 6745 0 914 0 100%
  ```

  e2e 并发套件（真实 runner 进程 + fake gh + 真实 git worktree）8/8 通过。
- **review-fix loop**：完整 R1–R9 审查 0 Blocker / 0 Major / 0 Minor
  （报告见 run 产物 `.muyan-pilot/runs/issue-58-8c282544/review-report.md`）。

## 文件

- `progress.py`：`_update_endpoint()` + `_patch_comment` 改走 update 路由
- `tests/test_progress.py`：回归测试 + 3 处路径期望
- `tests/test_progress_wiring.py`：10 处路径期望
- `tests/test_bootstrap_runner.py`：3 处路径期望
- `tests/test_concurrency_e2e.py`：fake `gh` 按真实 GitHub 路由应答
