### PR TITLE
ci: run the test contract with 100% coverage on GitHub (Issue #56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+# Remote CI gate for the repository contract (AGENTS.md): the full pytest
+# suite with 100% line/branch coverage, run on GitHub for every pull
+# request and every push to main (Issue #56).
+#
+# KISS: one job, no lint, no matrix, no cache.
+#
+# Python: production runs /usr/bin/python3 (3.14.6) on the Runner machine.
+# GitHub-hosted runners do not have that interpreter at that path, so this
+# workflow pins the same minor version (3.14) via actions/setup-python and
+# runs the contract commands through the pinned `python3` on PATH. The
+# difference is documented in the README section "远程 CI（GitHub Actions）".
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14 (production minor version)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install requirements and the test toolchain
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install pytest coverage pyyaml
+
+      - name: Run the full test suite with branch coverage (contract)
+        run: python3 -m coverage run --branch -m pytest tests/ -q
+
+      - name: Enforce 100% line/branch coverage (contract)
+        run: python3 -m coverage report --fail-under=100 --show-missing

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ systemctl --user list-timers muyan-pilot.timer
 
 手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
 
+## 远程 CI（GitHub Actions）
+
+仓库契约（全量 pytest + 100% line/branch coverage）不只在本机 Runner 上跑：`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次 `push` 到 `main` 时跑同一份契约，测试失败或覆盖率低于 100% 时 CI 变红。单个 job，不加 lint、矩阵或缓存（Issue #56）。
+
+与本地的差异：生产运行时是 Runner 机器的 `/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以 workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过 PATH 上固定的 `python3` 执行（命令与本地相同，只有解释器路径不同）。
+
 ## 任务派发与状态
 
 `muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,144 @@
+"""Regression tests for the GitHub Actions CI workflow (Issue #56).
+
+The repository contract (AGENTS.md) says the full pytest suite must run
+with 100% line/branch coverage via the coverage commands. Until now that
+only happened on the local Runner machine. The workflow in
+`.github/workflows/ci.yml` runs the same contract remotely on every
+`pull_request` and `push` to `main`, so the gate is visible on GitHub.
+
+These tests fail when the workflow file is missing, when it stops
+enforcing the contract (triggers, pinned Python, requirements install,
+contract test commands, 100% coverage), or when it drifts into the extras
+the Issue explicitly forbids (lint, matrix, cache). The README must keep
+documenting what the remote CI is and when it runs.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+README_FILE = REPO_ROOT / "README.md"
+
+# The contract commands (AGENTS.md) run through the pinned interpreter on
+# PATH in CI; the local machine uses the same commands with /usr/bin/python3.
+CONTRACT_RUN = "python3 -m coverage run --branch -m pytest tests/ -q"
+CONTRACT_REPORT = "python3 -m coverage report"
+
+
+def load_workflow() -> dict:
+    """Parse the workflow YAML; fail fast when it is missing or invalid."""
+    assert WORKFLOW_FILE.is_file(), f"missing CI workflow: {WORKFLOW_FILE}"
+    workflow = yaml.safe_load(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), "workflow file is not a YAML mapping"
+    return workflow
+
+
+def on_section(workflow: dict) -> dict:
+    """The `on:` key (YAML 1.1 parses the bare word `on` as boolean True)."""
+    section = workflow.get("on", workflow.get(True))
+    assert isinstance(section, dict), "workflow has no `on:` trigger section"
+    return section
+
+
+def steps_of(workflow: dict) -> list[dict]:
+    """All steps of the (single) job, flattened."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict) and jobs, "workflow has no jobs"
+    flattened: list[dict] = []
+    for job in jobs.values():
+        assert isinstance(job, dict) and job.get("steps"), f"job without steps: {job!r}"
+        flattened.extend(job["steps"])
+    return flattened
+
+
+def step_commands(steps: list[dict]) -> list[str]:
+    """The shell commands of all steps (setup steps have no `run:`)."""
+    return [
+        str(step.get("run", "")).strip()
+        for step in steps
+        if step.get("run")
+    ]
+
+
+def test_ci_workflow_exists_at_repository_root():
+    assert WORKFLOW_FILE.is_file(), f"missing CI workflow: {WORKFLOW_FILE}"
+
+
+def test_ci_workflow_runs_on_pull_request_and_push_to_main():
+    section = on_section(load_workflow())
+    assert "pull_request" in section, "CI must run on every pull_request"
+    push = section.get("push")
+    assert push is not None, "CI must run on push to the protected branch"
+    assert push.get("branches") == ["main"], (
+        f"push trigger must be limited to main, got: {push!r}"
+    )
+
+
+def test_ci_workflow_keeps_one_job_without_lint_matrix_or_cache():
+    workflow = load_workflow()
+    jobs = workflow["jobs"]
+    assert len(jobs) == 1, f"KISS: exactly one job, got {len(jobs)}: {sorted(jobs)}"
+    job = next(iter(jobs.values()))
+    assert "strategy" not in job, "KISS: no test matrix"
+    for step in job["steps"]:
+        uses = str(step.get("uses", ""))
+        assert "actions/cache" not in uses, "KISS: no cache step"
+    for command in step_commands(steps_of(workflow)):
+        assert not re.search(r"\b(ruff|flake8|pylint|bandit|lint)\b", command), (
+            f"KISS: no lint in CI, got: {command!r}"
+        )
+
+
+def test_ci_workflow_pins_python_3_14_like_production():
+    steps = steps_of(load_workflow())
+    setup = [
+        step for step in steps
+        if str(step.get("uses", "")).startswith("actions/setup-python")
+    ]
+    assert setup, "CI must install Python via actions/setup-python"
+    assert len(setup) == 1, f"exactly one setup-python step, got {len(setup)}"
+    with_options = setup[0].get("with", {})
+    assert str(with_options.get("python-version")) == "3.14", (
+        f"CI must pin the production minor version 3.14, got: {with_options!r}"
+    )
+
+
+def test_ci_workflow_installs_requirements_txt():
+    commands = step_commands(steps_of(load_workflow()))
+    assert any(
+        "pip install -r requirements.txt" in command for command in commands
+    ), f"CI must install requirements.txt, steps run: {commands!r}"
+
+
+def test_ci_workflow_runs_the_contract_test_command():
+    commands = step_commands(steps_of(load_workflow()))
+    assert any(
+        CONTRACT_RUN in command for command in commands
+    ), f"CI must run the contract test command {CONTRACT_RUN!r}, steps run: {commands!r}"
+
+
+def test_ci_workflow_enforces_full_line_and_branch_coverage():
+    commands = step_commands(steps_of(load_workflow()))
+    enforcing = [
+        command for command in commands
+        if CONTRACT_REPORT in command and "--fail-under=100" in command
+    ]
+    assert enforcing, (
+        "CI must enforce 100% line/branch coverage "
+        f"({CONTRACT_REPORT} --fail-under=100), steps run: {commands!r}"
+    )
+    assert any("--show-missing" in command for command in enforcing), (
+        "coverage report must keep the local --show-missing shape"
+    )
+
+
+def test_readme_documents_remote_ci():
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert "GitHub Actions" in readme, "README must name the remote CI"
+    assert "pull_request" in readme, "README must say CI runs on pull requests"
+    assert re.search(r"push[^\n]*main|main[^\n]*push", readme), (
+        "README must say CI runs on push to main"
+    )
+    assert "3.14" in readme, "README must document the pinned CI Python version"

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1396,6 +1396,9 @@ def test_main_resumes_resumable_delivery_before_claiming_new(monkeypatch, tmp_pa
         runner, "process_issue",
         lambda *args, **kwargs: processed.append(args) or FAKE_PR_URL,
     )
+    # The dispatch test must not run the real delivery-wait loop (it would
+    # call `gh` against the real PR number of FAKE_PR_URL).
+    monkeypatch.setattr(runner, "wait_for_delivery", lambda *a, **k: None)
     assert runner.main(["--config", str(config)]) == 0
     # The resumable delivery is resumed, not re-claimed as a new task.
     assert len(resumed) == 1
@@ -1422,6 +1425,9 @@ def test_main_still_claims_new_issue_when_no_resumable(monkeypatch, tmp_path):
         runner, "process_issue",
         lambda *args, **kwargs: processed.append(args) or FAKE_PR_URL,
     )
+    # The dispatch test must not run the real delivery-wait loop (it would
+    # call `gh` against the real PR number of FAKE_PR_URL).
+    monkeypatch.setattr(runner, "wait_for_delivery", lambda *a, **k: None)
     assert runner.main(["--config", str(config)]) == 0
     assert len(processed) == 1
     assert processed[0][0] is issue


### PR DESCRIPTION
<!-- muyan-pilot:run=2ba920c0 -->

run_id=2ba920c0

## Summary

Issue #56: add GitHub Actions CI so the repository test contract runs remotely.

- `.github/workflows/ci.yml` — one job on every `pull_request` and on `push` to `main`: installs `requirements.txt` plus the test toolchain (pytest, coverage, pyyaml), pins Python `3.14` (production minor version; the local runner machine's `/usr/bin/python3` is 3.14.6, GitHub-hosted runners do not have that interpreter at that path) via `actions/setup-python`, then runs the contract commands through the pinned `python3` on PATH:
  - `python3 -m coverage run --branch -m pytest tests/ -q`
  - `python3 -m coverage report --fail-under=100 --show-missing`

  KISS: no lint, no matrix, no cache.
- `tests/test_ci_workflow.py` — guard tests (same style as `test_systemd_timer.py`) that fail when the workflow is missing, when it stops enforcing the contract (PR + push-to-main triggers, single KISS job, pinned 3.14, requirements install, contract test commands, 100% line/branch coverage gate), or when it drifts into the extras the Issue forbids (lint/matrix/cache); also guards the README documentation.
- `README.md` — new section 「远程 CI（GitHub Actions）」: what the remote CI is, when it runs, and the interpreter difference.

## Verification (local, run 2ba920c0)

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → 518 passed
- `/usr/bin/python3 -m coverage report --show-missing` → 100% line/branch on all modules (TOTAL 6807 stmts / 920 branches)
- `/usr/bin/python3 -m coverage report --fail-under=100` → exit 0
- Negative check: a deliberately failing test makes the contract pytest step exit 1 (CI red); coverage below 100% makes the report gate exit 2 (CI red)
- Workflow YAML parses with PyYAML (the same parser the guard tests use)

This PR's own GitHub Checks are the remote proof the Issue asks for.
