### PR TITLE
Runner 尊重 GitHub 原生 blockedBy 依赖;正文 Depends on 约定迁移 (Issue #54)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,28 @@ follow it before changing code.
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.
 
+## Task dependencies (blockedBy)
+
+- Task dependencies use GitHub's native `blockedBy` relation
+  (`gh issue edit N --add-blocked-by M`); never write `Depends on #N`
+  in the Issue body — the body is not part of `blockedBy` and the
+  runner does not parse body dependencies.
+- Before claiming an `ai-ready` Issue the runner reads `blockedBy`
+  (`gh issue list --json blockedBy`). Open blockers (blocker nodes with
+  `state: "OPEN"`) mean the Issue is not claimed: no `ai-in-progress`,
+  no label change, no worktree; a structured
+  `blocked_by issue=N repo=... blockers=M1,M2` log line is written and
+  the next ready Issue of the same repo is considered. A closed blocker
+  no longer blocks: GitHub keeps the relation listed with
+  `state: "CLOSED"` (inert, verified against the live API) and the
+  runner counts only open blockers — the next tick claims the Issue
+  with no bookkeeping.
+- A failed `blockedBy` query fails open (treated as unblocked: the tick
+  claims nothing from that repo, logs `blocked_by_check_failed`, and
+  the next tick retries) — an API error must never deadlock the queue.
+- No DAG, topological sort, or multi-worker scheduling: single-slot
+  serial execution only reads the field, skips, and waits.
+
 ## Review and fix loop (same PR)
 
 - After a PR is opened, the Issue is in a recoverable review/fix state,

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ python3 muyan_pilot.py status --config muyan-pilot.toml
 
 `add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
 
+## 任务依赖（blockedBy）
+
+任务之间的依赖一律用 GitHub **原生依赖关系**（`blockedBy`/`blocking`，gh 2.94+）标注；**不要**在 Issue 正文写 `Depends on #N`——正文不进入 `blockedBy`，Runner 不解析正文依赖：
+
+```bash
+# 派发新 Issue 后标注依赖（N = 新 Issue，M = 前置 Issue）
+gh issue edit N --repo xqliu/muyan-pilot --add-blocked-by M
+# 解除依赖
+gh issue edit N --repo xqliu/muyan-pilot --remove-blocked-by M
+```
+
+Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引入 DAG、拓扑排序或多 worker 调度）：
+
+- 领取 `ai-ready` Issue 前，Runner 读取原生 `blockedBy`（`gh issue list --json blockedBy`）；
+- 存在未关闭 blocker（blocker 节点 `state=OPEN`）→ **不领取**：不加 `ai-in-progress`、不改任何标签、不建 worktree，记录结构化日志 `blocked_by issue=N repo=... blockers=M1,M2`，继续检查同 repo 后面的 ready Issue；
+- blocker 关闭后不再阻塞：GitHub 会把该关系保留在列表中（节点 `state=CLOSED`，惰性，已对真实 API 验证），Runner 只统计未关闭 blocker——无需人工操作，下一 tick 该 Issue 自然可领；
+- `blockedBy` 查询失败 → **fail open**（视为未阻塞：本 tick 不从该 repo 领取，记录 `blocked_by_check_failed`，下一 tick 重试查询），API 异常不会死锁队列。
+
 ## 自动可观测（正常运行不需要执行任何命令）
 
 正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -262,19 +262,79 @@ def parse_issue_list(raw: str) -> dict | None:
     return issues[0] if issues else None
 
 
+def open_blocker_numbers(issue: dict) -> list[int]:
+    """Return the numbers of the issue's OPEN native GitHub blockers.
+
+    `gh issue list --json blockedBy` (gh 2.94+) carries the native
+    dependency relation as `{"nodes": [...], "totalCount": N}`. GitHub
+    keeps a relation listed after its blocker closes (the node then
+    carries `state: "CLOSED"` and is inert — verified against the live
+    API, Issue #54), so only OPEN blockers actually block: a closed
+    blocker clears the dependency without any runner-side bookkeeping,
+    and the next tick claims the Issue. A node without an explicit
+    `state` counts as open (claiming a possibly-blocked Issue costs a
+    full run; waiting one tick does not). A missing or malformed field
+    means "no known blockers" (fail open): an API shape change must
+    never deadlock the queue.
+    """
+    blocked_by = issue.get("blockedBy")
+    if not isinstance(blocked_by, dict):
+        return []
+    nodes = blocked_by.get("nodes")
+    if not isinstance(nodes, list):
+        return []
+    numbers: list[int] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        number = node.get("number")
+        if not isinstance(number, int) or isinstance(number, bool):
+            continue
+        if node.get("state", "OPEN") != "OPEN":
+            continue
+        numbers.append(number)
+    return numbers
+
+
 def pick_issue(repo: str) -> dict | None:
     # A merged delivery keeps `ai-ready` + `ai-merged` on the (still
     # open) Issue; `ai-merged` is the success terminal state, so it is
     # excluded from the ready scan like every other delivery state.
-    raw = run_command([
-        "gh", "issue", "list", "--repo", repo, "--state", "open",
-        "--search",
-        "label:ai-ready -label:ai-in-progress -label:ai-pr-opened "
-        f"-label:{FIX_NEEDED_LABEL} -label:{MERGED_LABEL} "
-        f"-label:{BLOCKED_LABEL}",
-        "--json", "number,title,body", "--limit", "1",
-    ])
-    return parse_issue_list(raw)
+    # The scan fetches the ready queue (not just the first Issue) and
+    # reads the native GitHub dependency per Issue (Issue #54): an
+    # Issue with open blockers is skipped — no claim, no label change,
+    # no worktree — and the next ready Issue is considered instead.
+    try:
+        raw = run_command([
+            "gh", "issue", "list", "--repo", repo, "--state", "open",
+            "--search",
+            "label:ai-ready -label:ai-in-progress -label:ai-pr-opened "
+            f"-label:{FIX_NEEDED_LABEL} -label:{MERGED_LABEL} "
+            f"-label:{BLOCKED_LABEL}",
+            "--json", "number,title,body,blockedBy", "--limit", "200",
+        ])
+        issues = parse_issue_array(raw)
+    except Exception as exc:
+        # Fail open (Issue #54): a failed blockedBy query must never
+        # deadlock the queue. This tick claims nothing from this repo
+        # and the next tick retries the query; the error is logged,
+        # never raised, and no label is touched.
+        LOGGER.error(
+            "blocked_by_check_failed repo=%s error=%s",
+            repo, exc,
+        )
+        return None
+    for issue in issues:
+        blockers = open_blocker_numbers(issue)
+        if blockers:
+            LOGGER.info(
+                "blocked_by issue=%s repo=%s blockers=%s",
+                issue.get("number"), repo,
+                ",".join(str(number) for number in blockers),
+            )
+            continue
+        return issue
+    return None
 
 
 def pick_in_progress_issue(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -207,7 +207,10 @@ def test_run_command_logs_optional_timeout_and_reraises(tmp_path, caplog):
 
 
 def test_pick_issue_uses_github_queue(monkeypatch):
-    issue = {"number": 9, "title": "task", "body": "body"}
+    issue = {
+        "number": 9, "title": "task", "body": "body",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
     calls = []
 
     def fake_run(command, **kwargs):
@@ -221,8 +224,165 @@ def test_pick_issue_uses_github_queue(monkeypatch):
         "--state", "open", "--search",
         "label:ai-ready -label:ai-in-progress -label:ai-pr-opened "
         "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
-        "--json", "number,title,body", "--limit", "1",
+        "--json", "number,title,body,blockedBy",
+        "--limit", "200",
     ]]
+
+
+def test_open_blocker_numbers_returns_only_open_blockers():
+    # GitHub keeps a relation listed after its blocker closes (the
+    # node carries `state: "CLOSED"` and is inert — verified against
+    # the live API, Issue #54): only OPEN blockers block.
+    issue = {"blockedBy": {"nodes": [
+        {"number": 31, "state": "OPEN", "title": "a"},
+        {"number": 32, "state": "CLOSED", "title": "b"},
+    ], "totalCount": 2}}
+    assert runner.open_blocker_numbers(issue) == [31]
+
+
+def test_open_blocker_numbers_counts_missing_state_as_open():
+    # A node without an explicit state counts as open: claiming a
+    # possibly-blocked Issue costs a full run, waiting one tick does
+    # not (Issue #54).
+    issue = {"blockedBy": {"nodes": [{"number": 31}], "totalCount": 1}}
+    assert runner.open_blocker_numbers(issue) == [31]
+
+
+def test_open_blocker_numbers_fails_open_on_missing_or_malformed_field():
+    # A missing or malformed `blockedBy` field must never block the
+    # queue (Issue #54 fail open): no known blockers, not an error.
+    assert runner.open_blocker_numbers({"number": 9}) == []
+    assert runner.open_blocker_numbers({"blockedBy": "nope"}) == []
+    assert runner.open_blocker_numbers({"blockedBy": {"nodes": "nope"}}) == []
+    assert runner.open_blocker_numbers({"blockedBy": {"nodes": ["nope"]}}) == []
+    assert runner.open_blocker_numbers({"blockedBy": {"nodes": [
+        {"number": 31, "state": "OPEN"},
+        {"title": "no number", "state": "OPEN"},
+        {"number": "32", "state": "OPEN"},
+        {"number": True, "state": "OPEN"},
+    ]}}) == [31]
+
+
+def test_pick_issue_skips_blocked_issue_and_claims_next(monkeypatch, caplog):
+    """A ready Issue with open native blockers (Issue #54) is never
+    claimed: no label change, no worktree — the runner logs a
+    structured `blocked_by` line with the blocker list and moves on to
+    the next ready Issue of the same repo."""
+    blocked = {
+        "number": 54, "title": "blocked task", "body": "",
+        "blockedBy": {"nodes": [
+            {"number": 31, "title": "base"},
+            {"number": 32, "title": "retry"},
+        ], "totalCount": 2},
+    }
+    ready = {
+        "number": 55, "title": "free task", "body": "",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([blocked, ready]),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == ready
+    assert "blocked_by" in caplog.text
+    assert "54" in caplog.text
+    assert "31" in caplog.text
+    assert "32" in caplog.text
+
+
+def test_pick_issue_returns_none_when_all_ready_issues_blocked(
+    monkeypatch, caplog,
+):
+    blocked_a = {
+        "number": 1, "title": "a", "body": "",
+        "blockedBy": {"nodes": [{"number": 9}], "totalCount": 1},
+    }
+    blocked_b = {
+        "number": 2, "title": "b", "body": "",
+        "blockedBy": {"nodes": [{"number": 8}], "totalCount": 1},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([blocked_a, blocked_b]),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") is None
+    assert caplog.text.count("blocked_by") >= 2
+
+
+def test_pick_issue_claims_issue_whose_blocker_is_closed(monkeypatch):
+    """A closed blocker no longer blocks (Issue #54): GitHub keeps the
+    relation listed with `state: "CLOSED"` (verified against the live
+    API), and the runner counts only open blockers — the next tick
+    claims the Issue without any runner-side bookkeeping."""
+    issue = {
+        "number": 54, "title": "unblocked task", "body": "",
+        "blockedBy": {"nodes": [
+            {"number": 31, "state": "CLOSED", "title": "done"},
+        ], "totalCount": 1},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([issue]),
+    )
+    assert runner.pick_issue("xqliu/muyan-pilot") == issue
+
+
+def test_pick_issue_claims_issue_with_empty_blocked_by(monkeypatch):
+    issue = {
+        "number": 54, "title": "free task", "body": "",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([issue]),
+    )
+    assert runner.pick_issue("xqliu/muyan-pilot") == issue
+
+
+def test_pick_issue_stays_blocked_while_any_blocker_is_open(monkeypatch):
+    blocked = {
+        "number": 54, "title": "mixed", "body": "",
+        "blockedBy": {"nodes": [
+            {"number": 31, "state": "CLOSED", "title": "done"},
+            {"number": 32, "state": "OPEN", "title": "pending"},
+        ], "totalCount": 2},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([blocked]),
+    )
+    assert runner.pick_issue("xqliu/muyan-pilot") is None
+
+
+def test_pick_issue_fails_open_when_blocked_by_field_missing(monkeypatch):
+    # Older gh versions or a changed API shape omit the field: the
+    # Issue must still be claimable (fail open, Issue #54).
+    issue = {"number": 9, "title": "task", "body": "body"}
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([issue]),
+    )
+    assert runner.pick_issue("xqliu/muyan-pilot") == issue
+
+
+def test_pick_issue_fails_open_when_blocked_by_query_fails(
+    monkeypatch, caplog,
+):
+    """A failed blockedBy query must not deadlock the queue (Issue
+    #54 fail open): the tick claims nothing this round and the error
+    is logged, never raised — the next tick retries the query."""
+    error = subprocess.CalledProcessError(
+        1, ["gh"], output="boom", stderr="rate limited",
+    )
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(error),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") is None
+    assert "blocked_by_check_failed" in caplog.text
 
 
 def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- muyan-pilot:run=11dadb4f -->

run_id=11dadb4f

## 变更

Runner 在领取 `ai-ready` Issue 前读取 GitHub **原生** `blockedBy` 依赖（gh 2.94+，本机 gh 2.97），被阻塞的 Issue 不领取；正文 `Depends on #N` 约定迁移到原生依赖标注。

### 领取逻辑（bootstrap_runner.py）

- `pick_issue` 的 ready 扫描增加 `blockedBy` 字段（`--json number,title,body,blockedBy`，`--limit 200` 一次取回 ready 队列，遍历顺序与原 `--limit 1` 相同：created desc）；
- 存在**未关闭** blocker（blocker 节点 `state=OPEN`）→ 不领取：不加 `ai-in-progress`、不改任何标签、不建 worktree，记录结构化日志 `blocked_by issue=N repo=... blockers=M1,M2`，继续检查同 repo 后面的 ready Issue；
- **只统计 OPEN blocker**：对真实 API 的受控实验（scratch #64/#65）证实 blocker 关闭后 GitHub 不会移除关系，节点保留 `state=CLOSED` 且惰性——因此 `totalCount > 0` 不是阻塞判据；blocker 关闭后无需任何 runner 侧簿记，下一 tick 自然可领；节点缺少 `state` 按 OPEN 计（误领一个可能阻塞的 Issue 代价是一次完整 run，等待一个 tick 代价为零）；
- 查询失败 **fail open**：本 tick 不从该 repo 领取、记录 `blocked_by_check_failed repo=... error=...`（`run_command` 已先记录 command/returncode/stdout/stderr）、下一 tick 重试——API 异常不会死锁队列；字段缺失/畸形视为无 blocker（可领取）；
- 不引入 DAG、拓扑排序或多 worker 调度——单 slot 串行下只做"读字段-跳过-等待"。

### 约定迁移（README/AGENTS.md + GitHub 操作）

- 新 Issue 依赖一律 `gh issue edit N --add-blocked-by M`（README 含 add/remove 命令示例），不再用正文 `Depends on #N`（正文不进入 blockedBy，Runner 不解析正文依赖）；
- 现有正文依赖迁移：`xqliu/muyan-pilot#34` 的 "Depends on #31" 已转为原生 `blockedBy` 关系（#31 已关闭 → 惰性），正文该行已删除（已验证：#34 `blockedBy=[#31 CLOSED]`、正文无 `Depends on`）。

### 测试与验证

- TDD：先写失败测试（blocked 跳过、全阻塞返回 None、关闭后领取、字段缺失 fail open、查询失败 fail open、OPEN/CLOSED 混合、state 缺失按 OPEN 计），再实现；
- 全量：`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → **520 passed**；`coverage report` → 全部业务模块 **100% line/branch**；
- 真实 API 验收（scratch #66/#67，已清理）：
  - tick 1：#67（ai-ready）被 open #66 阻塞 → 日志 `blocked_by issue=67 repo=xqliu/muyan-pilot blockers=66`，#67 未领取，Runner 领取下一条 ready（#53）；
  - 关闭 #66 后 tick 2：#67 被领取（open blockers = []）；
- 审查：完整 R1–R9 review-fix loop，0 Blocker / 0 Major / 0 Minor（report 在 run artifacts `review.md`）。

### 文件

- `bootstrap_runner.py`：`open_blocker_numbers` + `pick_issue` blockedBy 检查；
- `tests/test_bootstrap_runner.py`：新增/更新 12 个测试；
- `README.md`：新增「任务依赖（blockedBy）」章节（gh 命令示例 + Runner 行为）；
- `AGENTS.md`：新增 "Task dependencies (blockedBy)" 契约。
