### PR TITLE
feat: require Fixes #N in the PR body so GitHub closes the Issue natively (Issue #53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,12 @@ follow it before changing code.
 - Pi (the implementer) does not merge and does not push `main` or `master`.
   It delivers through exactly one PR linked to the Issue; the Runner is the
   only merge actor (see below).
+- The PR description must contain `Fixes #<issue-number>` (it may be on
+  the first line), pointing at the source Issue so GitHub closes the Issue
+  natively when the PR merges into the default branch. The keyword works
+  in the PR body and in commit messages, but not in the PR title. The
+  runner rejects a PR whose body is missing it, so a merge can never
+  leave the source Issue open.
 
 ## Auto review, fix and merge
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需�
 
 `.worktrees/` 已加入 `.gitignore`，不会进入版本库。
 
+## PR body 契约：`Fixes #N`（Issue #53）
+
+Pi 创建的 PR description 必须包含 `Fixes #<issue-number>`（可以放在首行），指向其源 Issue。GitHub 原生行为：PR merge 到默认分支（`main`）时，body（或 commit message）中的 `Fixes`/`Closes`/`Resolves #<n>` 关键词会自动关闭对应 Issue；PR title 不支持该关键词。没有这个关键词，merge 后 Issue 仍然 OPEN（例如 #45 的遗留状态），需要人工补关。
+
+- prompt（`prompt.md`）在 PR 创建步骤和 Fixer resume 段都要求携带 `Fixes #<issue-number>`（模板里的 `{{ISSUE_NUMBER}}` 由 Runner 渲染成真实 Issue 编号）；
+- Runner 验收（`verify_pr`）校验 PR body 含 `Fixes #<issue-number>`，缺失即 fail fast 拒绝该 PR（`pr_fixes_missing`），与 run marker 校验同级；
+- 开发契约见 `AGENTS.md`（Git 一节）。
+
 ## PR 创建后的 review/fix 循环（Issue #45）
 
 PR 创建后任务没有结束：Issue 进入可恢复的 review/fix 状态。`ai-pr-opened` 表示**等待 review**（干净 PR 不会被送进 Fixer）；只有显式的 `ai-fix-needed` 状态（Review finding 或 base 前进/冲突）才会触发 Fixer。Review finding、base 前进或 merge conflict 都是可修复状态，不等于任务失败，也不重新进入 ready 队列。
@@ -218,7 +226,7 @@ Pi 不直接 push 保护分支。实现 Agent 只 push feature branch 并创建 
 2. **独立审查**：启动一个独立、只读的 Review Agent（code-review R1–R9），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implement/fix 一样通过 live activity 管道输出（journal 中 `role=review`）。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；读不到合法 verdict 一律 fail fast，绝不当作通过。
 3. **修复循环**：verdict 有 Blocker/Major 时，把 finding 评论到 Issue 和 PR，Issue 标记 `ai-fix-needed`；同一 feature branch/worktree 上的 Fixer（journal 中 `role=fix`）修复并 push 后回到 `ai-pr-opened`，下一轮等待重新冻结 SHA、全量回归、完整复审。审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；超轮仍有 Blocker/Major 则 fail fast 并标记 `ai-blocked`。
 4. **合并门禁**：重新 fetch 最新 `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，只有被审查的 head 能落地。落后最新 base 的 PR 不会被合并（转 `ai-fix-needed`，由 Fixer 吸收最新 base 后重试）。
-5. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 因 PR 关联自动 CLOSED。
+5. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动 CLOSED（见上方「PR body 契约」）。
 
 成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是进入同一 PR 的 fix/review 循环。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1027,7 +1027,8 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
 
 
 def verify_pr(worktree: Path, branch: str, base_branch: str,
-              run_id: str, *, pr_repo: str | None = None,
+              run_id: str, *, issue: int,
+              pr_repo: str | None = None,
               expected_url: str | None = None,
               require_latest_base: bool = True) -> str:
     """Verify that exactly one open PR of the task branch is the delivery.
@@ -1036,8 +1037,11 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     `require_latest_base` is False — the resume pre-validation runs
     before the base merge, when being behind is the expected state),
     exactly one open PR for the head branch, PR base, PR head == local
-    HEAD, and the run marker in the PR body. When `pr_repo` is given
-    (resume path), the PR's head repo must be that repo; when
+    HEAD, the run marker in the PR body, and the `Fixes #<issue>`
+    keyword in the PR body (Issue #53: GitHub closes the source Issue
+    natively only when the body carries the keyword, so a PR without it
+    would leave the Issue open after the merge). When `pr_repo` is
+    given (resume path), the PR's head repo must be that repo; when
     `expected_url` is given, the verified PR URL must exactly equal the
     recovered original PR URL (Issue #45 review: the resume must keep
     the same PR number).
@@ -1128,6 +1132,18 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
         raise RuntimeError(
             f"PR body is missing the stable run marker {marker}; the PR "
             "must carry the machine-readable run id of this attempt"
+        )
+    fixes = f"Fixes #{issue}"
+    # The number must match exactly, not as a digit prefix: `Fixes #41`
+    # closes Issue 41, not Issue 4 (review F1, Issue #53).
+    if not re.search(rf"Fixes #{issue}(?!\d)", body):
+        LOGGER.error(
+            "pr_fixes_missing issue=%s branch=%s", issue, branch,
+        )
+        raise RuntimeError(
+            f"PR body is missing `{fixes}`; the keyword must point at the "
+            "source Issue so GitHub closes it natively when the PR merges "
+            "into the default branch"
         )
     if expected_url is not None and url != expected_url:
         LOGGER.error(
@@ -1921,7 +1937,9 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         )
         _publish_plan_milestone(publisher, worktree)
         _publish_test_milestone(publisher, worktree)
-        pr_url = verify_pr(worktree, branch, base_branch, run_id)
+        pr_url = verify_pr(
+            worktree, branch, base_branch, run_id, issue=number,
+        )
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,
         )
@@ -2070,7 +2088,7 @@ def resume_delivery(issue: dict, scene: dict, config: dict,
         # to fix (merge_latest_base runs next).
         verified_url = verify_pr(
             worktree, branch, base_branch, run_id,
-            pr_repo=source_repo, expected_url=pr_url,
+            issue=number, pr_repo=source_repo, expected_url=pr_url,
             require_latest_base=False,
         )
         merge_latest_base(worktree, base_branch)
@@ -2093,7 +2111,7 @@ def resume_delivery(issue: dict, scene: dict, config: dict,
         # must still exactly equal the recovered original PR URL.
         verified_url = verify_pr(
             worktree, branch, base_branch, run_id,
-            pr_repo=source_repo, expected_url=pr_url,
+            issue=number, pr_repo=source_repo, expected_url=pr_url,
         )
         # The state transition comes first: the Issue leaves the
         # fix-needed state before the progress comment is recorded, so

--- a/prompt.md
+++ b/prompt.md
@@ -47,7 +47,7 @@ Work through this exact loop:
 4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts.
 5. Run the real project tests/build/smoke checks and record the commands and results in `test.log` inside the task worktree (the automatic `tests passed/failed` milestone and the progress comment's tests field read that file).
 6. Verify the result yourself.
-7. Commit the change, push only the current feature branch, and open exactly one draft or normal PR for this Issue. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.
+7. Commit the change, push only the current feature branch, and open exactly one draft or normal PR for this Issue. The PR body must contain `Fixes #{{ISSUE_NUMBER}}` (it may be on the first line) so GitHub natively closes the source Issue when the PR merges into the default branch — the runner rejects a PR whose body is missing it. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.
 
 Base freshness before creating the PR:
 
@@ -82,6 +82,10 @@ for this run:
   branch coverage, the real verification and the complete review-fix
   loop, then commit and push ONLY the task branch so the same PR
   updates.
+- If the PR body is missing `Fixes #{{ISSUE_NUMBER}}`, add it (for
+  example via `gh pr edit <number> --body ...`) so the merge closes the
+  source Issue natively; the re-verification rejects a PR body without
+  it.
 - If the conflict or the findings cannot be resolved, stop and explain
   the concrete blocker in the final response; the runner marks the Issue
   `ai-blocked` and the PR, branch and worktree stay for inspection.

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -33,6 +33,14 @@ REQUIRED_ITEMS = (
     ("no-protected-push", "main"),
     ("no-protected-push-master", "master"),
     ("pr-only", "PR"),
+    # 6a. PR body: must carry `Fixes #<issue-number>` pointing at the
+    #     source Issue so GitHub natively closes the Issue when the PR
+    #     merges into the default branch (the keyword does not work in
+    #     the PR title).
+    ("pr-fixes-keyword", "fixes #<issue-number>"),
+    ("pr-fixes-auto-close", "closes the issue"),
+    ("pr-fixes-default-branch", "default branch"),
+    ("pr-fixes-title", "pr title"),
     # 6b. Base freshness: worktrees start from the frozen origin/<base> SHA,
     #     runs carry a unique run id, the base is re-fetched before the PR,
     #     behind deliveries are rejected, no auto conflict resolution or

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -99,6 +99,31 @@ def test_render_prompt_replaces_context_values():
     assert rendered == "owner/repo #3 Fix context.md"
 
 
+def test_prompt_template_requires_fixes_keyword_for_the_source_issue():
+    """Issue #53: the Pi prompt must require `Fixes #<issue>` in the PR
+    body so GitHub closes the source Issue natively on merge; the
+    requirement renders with the real issue number."""
+    template = (
+        Path(__file__).resolve().parent.parent / "prompt.md"
+    ).read_text(encoding="utf-8")
+    assert "Fixes #{{ISSUE_NUMBER}}" in template
+    rendered = runner.render_prompt(template, {
+        "SOURCE_REPO": "xqliu/muyan-pilot",
+        "SOURCE_REPOS": "xqliu/muyan-pilot",
+        "ISSUE_NUMBER": "53",
+        "ISSUE_TITLE": "t",
+        "ISSUE_BODY": "b",
+        "WORKSPACE_ROOT": "/tmp",
+        "CONTEXT_FILES": "",
+        "SKILLS": "",
+        "BASE_BRANCH": "main",
+        "BASE_SHA": "abc123",
+        "RUN_ID": "a2241189",
+    })
+    assert "Fixes #53" in rendered
+    assert "{{" not in rendered
+
+
 def test_validate_config_accepts_existing_files(tmp_path):
     prompt = tmp_path / "prompt.md"
     prompt_review = tmp_path / "prompt_review.md"
@@ -639,7 +664,10 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
                 "headRefOid": head,
                 "headRepository": {"name": "muyan-pilot"},
                 "headRepositoryOwner": {"login": "muyantech"},
-                "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
+                "body": (
+                    "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
             return branch
@@ -731,7 +759,10 @@ def test_process_issue_binds_run_id_before_the_resume_scan(
                 "headRefOid": head,
                 "headRepository": {"name": "muyan-pilot"},
                 "headRepositoryOwner": {"login": "muyantech"},
-                "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
+                "body": (
+                    "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
             return branch
@@ -799,7 +830,10 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
                 "headRefOid": head,
                 "headRepository": {"name": "muyan-pilot"},
                 "headRepositoryOwner": {"login": "muyantech"},
-                "body": "<!-- muyan-pilot:run=ffffeeee -->\n\nPlan",
+                "body": (
+                    "<!-- muyan-pilot:run=ffffeeee -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
             return "muyan-pilot/xqliu-muyan-ceo-issue-4-ffffeeee"
@@ -863,7 +897,10 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
                 "headRefOid": head,
                 "headRepository": {"name": "muyan-pilot"},
                 "headRepositoryOwner": {"login": "muyantech"},
-                "body": "<!-- muyan-pilot:run=ffffeeee -->\n\nPlan",
+                "body": (
+                    "<!-- muyan-pilot:run=ffffeeee -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
             return "muyan-pilot/xqliu-muyan-ceo-issue-4-ffffeeee"
@@ -1036,7 +1073,9 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "other-branch")
     with pytest.raises(RuntimeError, match="Pi changed branch"):
-        runner.verify_pr(tmp_path, "muyan-pilot/issue-4", "main", "e07383c2")
+        runner.verify_pr(
+            tmp_path, "muyan-pilot/issue-4", "main", "e07383c2", issue=4,
+        )
 
 
 FAKE_HEAD_SHA = "0123456789abcdef0123456789abcdef01234567"
@@ -1056,7 +1095,10 @@ def fake_verify_pr_payload(**overrides) -> str:
         "headRefOid": FAKE_HEAD_SHA,
         "headRepository": {"name": "muyan-pilot"},
         "headRepositoryOwner": {"login": "muyantech"},
-        "body": f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\nPlan",
+        "body": (
+            f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\n"
+            "Fixes #4\n\nPlan"
+        ),
     }
     payload.update(overrides)
     return json.dumps([payload])
@@ -1087,7 +1129,10 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(monkeypatch, tmp_p
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
     assert "base_branch=main" in caplog.text
 
 
@@ -1102,7 +1147,10 @@ def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
 
 
 def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
@@ -1111,7 +1159,10 @@ def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
 
 
 def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, tmp_path):
@@ -1124,6 +1175,7 @@ def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, t
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+        issue=4,
     ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "fetch", "origin", "main"] in calls
     assert ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"] in calls
@@ -1135,7 +1187,10 @@ def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="open PR has no URL"):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
 
 
 def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
@@ -1148,7 +1203,10 @@ def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError, match="PR base is develop, expected main",
     ):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
 
 
 def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
@@ -1163,7 +1221,10 @@ def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError, match="PR head deadbeef.* is not local HEAD 01234567",
     ):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
 
 
 def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, caplog):
@@ -1176,7 +1237,10 @@ def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, cap
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="missing the stable run marker",
     ):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
     assert "pr_run_marker_missing" in caplog.text
 
 
@@ -1190,7 +1254,106 @@ def test_verify_pr_rejects_pr_body_missing_field(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError, match="missing the stable run marker",
     ):
-        runner.verify_pr(tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID)
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
+
+
+# ------------------------------------------- Fixes #N (Issue #53)
+
+
+def test_verify_pr_accepts_pr_body_with_fixes_keyword(monkeypatch, tmp_path):
+    """The contract keyword `Fixes #<issue>` in the body is accepted, so
+    GitHub closes the source Issue natively when the PR merges."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return fake_verify_pr_payload(
+                body=f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\nFixes #4",
+            )
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.verify_pr(
+        tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+        issue=4,
+    ) == FAKE_PR_URL
+
+
+def test_verify_pr_rejects_pr_body_without_fixes_keyword(
+    monkeypatch, tmp_path, caplog,
+):
+    """A body without `Fixes #<issue>` would leave the source Issue open
+    after the merge: the delivery is rejected."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return fake_verify_pr_payload(
+                body=f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\nPlan",
+            )
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match=r"missing `Fixes #4`",
+    ):
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
+    assert "pr_fixes_missing" in caplog.text
+    assert "issue=4" in caplog.text
+
+
+def test_verify_pr_rejects_pr_body_with_wrong_issue_number(
+    monkeypatch, tmp_path, caplog,
+):
+    """`Fixes #9` does not close Issue #4: the keyword must point at the
+    source Issue of this delivery."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return fake_verify_pr_payload(
+                body=(
+                    f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\n"
+                    "Fixes #9"
+                ),
+            )
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match=r"missing `Fixes #4`",
+    ):
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
+    assert "pr_fixes_missing" in caplog.text
+
+
+def test_verify_pr_rejects_pr_body_with_longer_issue_number(
+    monkeypatch, tmp_path, caplog,
+):
+    """`Fixes #41` closes Issue 41, not Issue 4: the keyword must match
+    the source Issue number exactly, not as a digit prefix (review F1)."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return fake_verify_pr_payload(
+                body=(
+                    f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\n"
+                    "Fixes #41"
+                ),
+            )
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match=r"missing `Fixes #4`",
+    ):
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
+    assert "pr_fixes_missing" in caplog.text
 
 
 def test_verify_pr_queries_base_head_and_accepts_matching_pr(
@@ -1205,6 +1368,7 @@ def test_verify_pr_queries_base_head_and_accepts_matching_pr(
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+        issue=4,
     ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "rev-parse", "HEAD"] in calls
     assert [
@@ -1225,7 +1389,7 @@ def test_verify_pr_accepts_pr_in_expected_repo_and_url(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        pr_repo=FAKE_PR_REPO, expected_url=FAKE_PR_URL,
+        issue=4, pr_repo=FAKE_PR_REPO, expected_url=FAKE_PR_URL,
     ) == FAKE_PR_URL
 
 
@@ -1245,7 +1409,7 @@ def test_verify_pr_rejects_pr_head_in_another_repo(monkeypatch, tmp_path, caplog
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
         )
     assert "pr_repo_mismatch" in caplog.text
 
@@ -1265,7 +1429,7 @@ def test_verify_pr_rejects_pr_head_repo_missing_fields(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
         )
 
 
@@ -1284,7 +1448,7 @@ def test_verify_pr_rejects_pr_head_repo_empty_fields(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
         )
 
 
@@ -1298,13 +1462,17 @@ def test_verify_pr_skips_repo_check_when_pr_repo_not_given(monkeypatch,
                 "url": FAKE_PR_URL,
                 "baseRefName": "main",
                 "headRefOid": FAKE_HEAD_SHA,
-                "body": f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\nPlan",
+                "body": (
+                    f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         return fake_verify_run(command, **kwargs)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+        issue=4,
     ) == FAKE_PR_URL
 
 
@@ -1326,7 +1494,7 @@ def test_verify_pr_rejects_url_different_from_expected(monkeypatch, tmp_path, ca
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, expected_url=FAKE_PR_URL,
+            FAKE_RUN_ID, issue=4, expected_url=FAKE_PR_URL,
         )
     assert "pr_url_mismatch" in caplog.text
 
@@ -1337,6 +1505,7 @@ def test_verify_pr_skips_url_check_when_expected_url_not_given(
     monkeypatch.setattr(runner, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
+        issue=4,
     ) == FAKE_PR_URL
 
 
@@ -1355,7 +1524,7 @@ def test_verify_pr_skips_latest_base_check_when_not_required(
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        require_latest_base=False,
+        issue=4, require_latest_base=False,
     ) == FAKE_PR_URL
     assert not any(c[:3] == ["git", "fetch", "origin"] for c in calls)
     assert not any(
@@ -1388,7 +1557,10 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
                 "headRefOid": head,
                 "headRepository": {"name": "muyan-pilot"},
                 "headRepositoryOwner": {"login": "muyantech"},
-                "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
+                "body": (
+                    "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+                    "Fixes #4\n\nPlan"
+                ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
             return branch

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -129,6 +129,8 @@ elif args[:2] == ["issue", "view"]:
 elif args[:2] == ["pr", "list"]:
     branch = args[args.index("--head") + 1]
     head = git("rev-parse", "HEAD")
+    # Branch shape: muyan-pilot-owner-repo-issue-<n>-<run_id>.
+    issue_num = branch.rsplit("-", 2)[1]
     run_id = branch.rsplit("-", 1)[1]
     print(json.dumps([{
         "number": 99,
@@ -139,7 +141,7 @@ elif args[:2] == ["pr", "list"]:
         "headRefOid": head,
         "headRepository": {"name": "repo"},
         "headRepositoryOwner": {"login": "owner"},
-        "body": f"<!-- muyan-pilot:run={run_id} -->\\n\\nPlan for {branch}",
+        "body": f"<!-- muyan-pilot:run={run_id} -->\\n\\nFixes #{issue_num}\\n\\nPlan for {branch}",
     }]))
 elif args[:2] == ["pr", "comment"]:
     state.setdefault("pr_comments", []).append(

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -120,7 +120,8 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
         RuntimeError, match="behind latest remote base",
     ):
         runner.verify_pr(
-            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
+            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
+            "a1b2c3d4", issue=3,
         )
     assert "base_branch=main" in caplog.text
 
@@ -136,11 +137,15 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
             "url": "https://github.com/owner/repo/pull/3",
             "baseRefName": "main",
             "headRefOid": local_head,
-            "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
+            "body": (
+                "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+                "Fixes #3\n\nPlan"
+            ),
         }]),
     )
     assert runner.verify_pr(
-        clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
+        clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
+        "a1b2c3d4", issue=3,
     ) == "https://github.com/owner/repo/pull/3"
 
 
@@ -156,12 +161,16 @@ def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
             "url": "https://github.com/owner/repo/pull/3",
             "baseRefName": "main",
             "headRefOid": pushed_head,
-            "body": "<!-- muyan-pilot:run=a1b2c3d4 -->\n\nPlan",
+            "body": (
+                "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+                "Fixes #3\n\nPlan"
+            ),
         }]),
     )
     with pytest.raises(RuntimeError, match="is not local HEAD"):
         runner.verify_pr(
-            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main", "a1b2c3d4",
+            clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
+            "a1b2c3d4", issue=3,
         )
 
 

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -415,6 +415,30 @@ def test_process_issue_creates_progress_comment_with_marker(monkeypatch, tmp_pat
     assert "- PR: -" in body
 
 
+def test_process_issue_passes_issue_number_to_verify_pr(
+    monkeypatch, tmp_path,
+):
+    """The fresh path verifies the `Fixes #<issue>` keyword against the
+    source Issue number (Issue #53)."""
+    make_fake_gh(monkeypatch)
+    patch_process_deps(monkeypatch, tmp_path)
+    verify_calls = []
+
+    def fake_verify_pr(*args, **kwargs):
+        verify_calls.append((args, kwargs))
+        return "https://github.com/xqliu/muyan-pilot/pull/40"
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    runner.process_issue(make_issue(), make_config(tmp_path),
+                         "xqliu/muyan-pilot")
+    assert len(verify_calls) == 1
+    args, kwargs = verify_calls[0]
+    assert kwargs.get("issue") == 18, (
+        f"verify_pr must verify the Fixes keyword against the source "
+        f"Issue number, got args={args} kwargs={kwargs}"
+    )
+
+
 def test_process_issue_posts_started_and_pr_opened_milestones(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -230,6 +230,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     },
                     "body": (
                         f"<!-- muyan-pilot:run={run_id} -->\n\n"
+                        f"Fixes #{ISSUE_NUMBER}\n\n"
                         f"Plan for {branch}"
                     ),
                 }])

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -950,10 +950,10 @@ def test_resume_delivery_success_keeps_same_run_branch_and_pr(
                                   FAKE_RUN_ID)
     assert verify_calls[0][2] == {
         "pr_repo": "owner/repo", "expected_url": FAKE_PR_URL,
-        "require_latest_base": False,
+        "require_latest_base": False, "issue": 9,
     }
     assert verify_calls[1][2] == {
-        "pr_repo": "owner/repo", "expected_url": FAKE_PR_URL,
+        "pr_repo": "owner/repo", "expected_url": FAKE_PR_URL, "issue": 9,
     }
     # The pre-mutation verify ran before the merge and the fixer...
     assert calls.index(verify_calls[0]) < calls.index(
@@ -1098,7 +1098,7 @@ def _resume_pr_validation_failure_test(monkeypatch, tmp_path, caplog,
     assert verify_calls == [
         ("verify", (worktree, FAKE_BRANCH, "main", FAKE_RUN_ID),
          {"pr_repo": "owner/repo", "expected_url": FAKE_PR_URL,
-          "require_latest_base": False}),
+          "require_latest_base": False, "issue": 9}),
     ]
     # ...and it failed before any git mutation or fixer start.
     assert not any(call[0] == "merge" for call in calls)

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -196,6 +196,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     "headRefOid": head,
                     "body": (
                         f"<!-- muyan-pilot:run={run_id} -->\n\n"
+                        f"Fixes #{ISSUE_NUMBER}\n\n"
                         f"Plan for {branch}"
                     ),
                 }])


### PR DESCRIPTION
<!-- muyan-pilot:run=a2241189 -->

Fixes #53

run_id=a2241189

## Summary

The delivery contract now requires every PR description to carry `Fixes #<issue-number>` pointing at the source Issue, so GitHub natively closes the Issue when the PR merges into the default branch. This removes the "PR merged but Issue still OPEN" legacy state (e.g. #45) that needed manual closing.

## Changes

- **AGENTS.md** (Git section): the PR description must contain `Fixes #<issue-number>` (may be on the first line); the keyword works in the PR body and commit messages, not in the PR title; the runner rejects a PR whose body is missing it.
- **prompt.md**: step 7 (PR creation) requires `Fixes #{{ISSUE_NUMBER}}` in the PR body (rendered with the real issue number); the fixer resume section adds it via `gh pr edit` when a pre-change PR is missing it.
- **bootstrap_runner.py**: `verify_pr` takes the required `issue` keyword and rejects a body missing the exact `Fixes #<issue>` keyword (digit boundary — `Fixes #41` does not satisfy Issue 4), fail fast with `pr_fixes_missing`; all three call sites (fresh claim, resume pre-fix validation, resume post-fix re-verification) pass the source Issue number.
- **README.md**: new "PR body 契约：`Fixes #N`" section; the merge section no longer claims auto-close "by PR association".
- **tests**: contract needles (`test_agents_md.py`), prompt-template guard, `verify_pr` accept / missing / wrong-number / longer-number tests, wiring tests that both call paths pass the issue number, e2e payloads carry `Fixes #<n>`.

## Evidence

- 516 tests passed, 100% line and branch coverage (`test.log` in the task worktree).
- Rendered prompt (real `render_prompt`, `ISSUE_NUMBER=53`) carries the requirement in both the implementer step and the fixer bullet.
- This PR's body carries `Fixes #53` (the first delivery under the new contract): when it merges into `main`, GitHub closes Issue #53 natively.
- Review-fix loop: round 1 found one Major (digit-prefix acceptance, fixed with a boundary regex behind a new failing test); round 2 full R1–R9: 0 Blocker / 0 Major / 0 Minor (`review.md` in the task worktree).