### PR TITLE
整理 AGENTS.md：Issue 粒度与实现/审查分工

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ follow it before changing code.
 Four audiences, one file:
 
 - **Issue authors** (humans or the monitor): granularity below.
-- **Implementer Pi**: read first, TDD, one PR. No independent review
-  before the PR exists.
+- **Implementer Pi**: read first, TDD, one PR.
 - **Reviewer Pi**: a new `pi --print` after the PR, `prompt_review.md`,
   a new JSONL.
 - **Runner**: labels, base freshness, observability, the post-PR
@@ -21,45 +20,25 @@ Four audiences, one file:
 ## Issue granularity
 
 Write GitHub Issues so one Pilot implement session can finish them. One
-Issue is **one runtime outcome** (when X, should Y, actually Z), not a
-subsystem and not a philosophy.
+Issue is **one runtime outcome** (when X, should Y, actually Z).
 
-- Right size: one observable behavior, a handful of related files, tests
-  included, hundreds of lines not thousands. Title should work as a test
-  name.
-- Too coarse: "optimize review" or "GitHub observability" as a whole
-  product. Those become overnight diffs, merge conflicts, and review
-  Majors.
-- Too fine: one sentence per Issue (`prompt.md` vs `AGENTS.md` vs one
-  string in the runner). Claim/worktree/review/merge overhead exceeds
-  the change.
-- Split when two changes do not have to land together (prompt wording vs
-  `--skill` lists vs harness control flow). Do not split files that are
-  the same wording change.
-- Do not open an Issue until the root cause is pinned. A wrong-cause
-  ticket costs more than a large one.
+- Size: one observable behavior, a handful of related files, tests
+  included, hundreds of lines. Title should work as a test name.
+- Open the Issue once the root cause is pinned.
 
 ## Implement vs review
 
-- Implementer session: plan, TDD, tests, push one PR. Do not run a complete independent review-fix loop
-  or R1–R9 before the PR is open. The Runner does that after the PR exists.
-- Independent review is a **new** `pi --print` process with
-  `prompt_review.md` and a new JSONL. It does not continue the
-  implementer's chat. Sharing the worktree and the local model is
-  enough isolation; do not invent a second worktree for review.
-- `review-fix-loop` / full R1–R9 before the PR duplicates the Runner
-  review and is too expensive on the local model. Catch what tests can
-  catch in the implement session; leave judgment of the frozen diff to
-  the post-PR review session.
+- Implementer session: plan, TDD, tests, push one PR.
+- After the PR exists, the Runner starts independent review: a new
+  `pi --print` with `prompt_review.md` and a new JSONL, on the same
+  worktree.
 
 ## TDD and coverage
 
 - TDD: write a failing test first, then the smallest implementation, then
-  refactor. That is how defects are caught early: while the files are still
-  in context, not by running a full independent R1–R9 review before the PR.
-- External APIs, CLI flags, and HTTP paths are asserted against official
-  docs or one real call. Do not freeze a guessed URL or response shape as
-  a green test.
+  refactor.
+- External APIs, CLI flags, and HTTP paths are asserted against official docs
+  or one real call.
 - Python code keeps 100% line and branch coverage:
 
   ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,8 +96,8 @@ is **one runtime outcome** (when X, should Y, actually Z).
 - The runner rejects a delivery whose HEAD does not contain the latest remote
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.
-- A delivery is acceptable only when its HEAD contains the latest remote
-  base; base updates use a plain `git merge` on the task branch.
+- A delivery is acceptable only when its HEAD contains the latest remote base;
+  base updates use a plain `git merge` on the task branch.
 
 ## Task dependencies (blockedBy)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,160 +55,132 @@ Issue is **one runtime outcome** (when X, should Y, actually Z).
 ## Fail fast
 
 - Command errors fail fast: log the command, return code, stdout and stderr,
-  then raise. Never swallow an error or add a fallback path.
+  then raise.
 
 ## Git
 
-- Work on the task feature branch.
-- Pi (the implementer) does not merge and does not push `main` or `master`.
-  It delivers through exactly one PR linked to the Issue; the Runner is the
-  only merge actor (see **After the PR**).
+- Work on the task feature branch. Pi pushes that branch and opens exactly
+  one PR linked to the Issue. The Runner is the only merge actor on `main`
+  and `master` (see **After the PR**).
 - The PR description must contain `Fixes #<issue-number>` (it may be on
   the first line), pointing at the source Issue so GitHub closes the Issue
-  natively when the PR merges into the default branch. The keyword works
-  in the PR body and in commit messages, but not in the PR title. The
-  runner rejects a PR whose body is missing it, so a merge can never
-  leave the source Issue open.
+  when the PR merges into the default branch. GitHub reads the keyword from
+  the PR body and from commit messages; the PR title is not read. The
+  runner accepts a PR whose body contains it.
 
 ## Base freshness
 
 - Every task worktree is created from the frozen `origin/<base_branch>` SHA
-  (default `main`), never from the main worktree's current HEAD.
+  (default `main`).
 - Branch and worktree names carry the unique run id, so a retried Issue gets
   a new independent run and the old scene is preserved.
 - Before creating the PR, re-fetch `origin/<base_branch>`; if the base
   advanced, merge it into the task branch, resolve conflicts manually, rerun
   the full test suite, then push the task branch.
-- The runner rejects a delivery whose HEAD does not contain the latest remote
-  base. No auto conflict resolution, no force push, no merge or push of the
-  protected branch.
+- The runner accepts a delivery whose HEAD contains the latest remote base.
+  Conflicts are resolved with a plain `git merge` on the task branch.
 
 ## Run correlation
 
 - One task attempt generates one run_id (8 hex chars) and reuses it for
-  every later step of the attempt; a retry generates a new one. No new id
-  system is introduced: no trace_id, no log_id, no second UUID, no
-  tracing backend.
+  every later step of the attempt; a retry generates a new one.
 - Every journal line of the attempt starts with `[run_id]`, so one grep
   reconstructs the full timeline; every Issue/PR comment and the PR body
   carry the stable marker `<!-- muyan-pilot:run=<run_id> -->` plus the
   visible `run_id=` field; branch, worktree, Pi session dir and run
-  artifacts carry it in their paths. A run-scoped event without a valid
-  run_id fails fast.
+  artifacts carry it in their paths. Every run-scoped event includes a
+  valid run_id; a missing one fails fast.
 
 ## Automatic observability
 
-- Normal operation publishes progress automatically: no human status
-  command, no polling, no supervision. `muyan_pilot.py status` is a debug
-  attachment only — never part of the normal workflow or acceptance
-  evidence.
+- Normal operation publishes progress automatically.
+  `muyan_pilot.py status` is a debug attachment.
 - Journal: while a session runs, the journal gets a heartbeat at most every
   30 seconds and an immediate event on phase/action change. Every line
   carries issue, run id, role (implement/review/fix/merge), phase, elapsed,
-  last activity, last action, session and branch. No model/session activity
-  for 5 minutes logs an idle warning; the first new activity after it logs
-  a resumed event.
+  last activity, last action, session and branch. Five minutes without
+  model/session activity logs an idle warning; the first new activity after
+  it logs a resumed event.
 - GitHub: exactly one progress comment per run, carrying a hidden run
   marker. It is PATCHed in place (at most every 30 seconds or on progress
-  change) and never replaced by new heartbeat comments. Milestones (started,
-  plan ready, tests passed/failed, review findings, fix pushed, PR opened,
-  merged, blocked) are short standalone comments so GitHub Mobile pushes a
-  notification. After a process restart the same comment is found by the
-  run marker and kept — no database. On success the comment becomes the
-  final delivery summary (PR, tests, review evidence); on failure it becomes
-  the blocked scene with the next-step reason.
+  change). Milestones (started, plan ready, tests passed/failed, review
+  findings, fix pushed, PR opened, merged, blocked) are short standalone
+  comments so GitHub Mobile pushes a notification. After a process restart
+  the same comment is found by the run marker and kept. On success the
+  comment becomes the final delivery summary (PR, tests, review evidence);
+  on failure it becomes the blocked scene with the next-step reason.
 - Once the PR exists (verified and labeled `ai-pr-opened`), the delivery is
   complete: progress-publishing failures (the delivered PATCH, the `PR
   opened` milestone, the opened-PR scene comment) are logged as
-  `progress_publish_failed` and never fail the delivery or mark the Issue
-  `ai-blocked` — the run continues into the independent review/merge loop
-  (Issue #60).
+  `progress_publish_failed` and the run continues into the independent
+  review/merge loop (Issue #60).
 
 ## Task dependencies (blockedBy)
 
 - Task dependencies use GitHub's native `blockedBy` relation
-  (`gh issue edit N --add-blocked-by M`); never write `Depends on #N`
-  in the Issue body — the body is not part of `blockedBy` and the
-  runner does not parse body dependencies.
+  (`gh issue edit N --add-blocked-by M`). The runner reads that field, not
+  the Issue body.
 - Before claiming an `ai-ready` Issue the runner reads `blockedBy`
   (`gh issue list --json blockedBy`). Open blockers (blocker nodes with
-  `state: "OPEN"`) mean the Issue is not claimed: no `ai-in-progress`,
-  no label change, no worktree; a structured
+  `state: "OPEN"`) leave the Issue unclaimed: a structured
   `blocked_by issue=N repo=... blockers=M1,M2` log line is written and
   the next ready Issue of the same repo is considered. A closed blocker
-  no longer blocks: GitHub keeps the relation listed with
-  `state: "CLOSED"` (inert, verified against the live API) and the
-  runner counts only open blockers — the next tick claims the Issue
-  with no bookkeeping.
-- A failed `blockedBy` query fails open (treated as unblocked: the tick
-  claims nothing from that repo, logs `blocked_by_check_failed`, and
-  the next tick retries) — an API error must never deadlock the queue.
-- No DAG, topological sort, or multi-worker scheduling: single-slot
-  serial execution only reads the field, skips, and waits.
+  is inert: GitHub keeps the relation listed with `state: "CLOSED"`
+  (verified against the live API) and the runner counts only open
+  blockers — the next tick claims the Issue.
+- A failed `blockedBy` query logs `blocked_by_check_failed`, claims
+  nothing from that repo, and retries on the next tick.
+- Single-slot serial execution reads the field, skips, and waits.
 
 ## After the PR: review, fix, and merge
 
 The implementer is done when the PR exists. Everything below is the
-Runner, not the implement session.
+Runner.
 
-- After a PR is opened, the Issue is in a recoverable review/fix state,
-  not done: `ai-pr-opened` means awaiting review (a clean PR is never
-  sent to the Fixer). The Runner freezes the exact PR base/head SHA and
-  starts an independent, read-only review session (code-review R1–R9)
-  against those SHAs — a new `pi --print`, `prompt_review.md`, a new
-  JSONL. The reviewer ends with one machine-readable `REVIEW_VERDICT`
-  line; a missing or malformed verdict fails fast and is never treated
-  as a pass.
+- After a PR is opened, the Issue is in a recoverable review/fix state:
+  `ai-pr-opened` means awaiting review. The Runner freezes the exact PR
+  base/head SHA and starts an independent, read-only review session
+  (code-review R1–R9) against those SHAs — a new `pi --print`,
+  `prompt_review.md`, a new JSONL. The reviewer ends with one
+  machine-readable `REVIEW_VERDICT` line; a missing or malformed verdict
+  fails fast.
 - A review finding, an advanced base, or a merge conflict moves the
-  Issue to the explicit `ai-fix-needed` state, which is a fixable
-  state, never a reason to close the PR, re-claim the Issue, or open a
-  replacement PR. A successful fix consumes `ai-fix-needed` and returns
-  the Issue to `ai-pr-opened` (awaiting review again). A review finding
-  is not `ai-blocked`: it enters this same-PR loop. Only command
+  Issue to `ai-fix-needed`. A successful fix consumes `ai-fix-needed` and
+  returns the Issue to `ai-pr-opened` (awaiting review again). Command
   failure, an unavailable environment, or a fix that cannot be verified
-  fails fast and marks `ai-blocked`.
+  marks `ai-blocked`.
 - The next tick resumes the same run on the same feature branch,
-  worktree and PR number. Only `ai-fix-needed` Issues (not `ai-blocked`)
-  are scanned for Fixer work; the fresh-claim scan excludes
-  `ai-fix-needed` too, so a fix-pending Issue is never re-claimed as new
-  work. The resume scene (run id, base, PR URL) is
-  recovered from the latest `Muyan Pilot opened PR:` comment posted by
-  a trusted maintainer (OWNER/MAINTAINER/MEMBER/COLLABORATOR; a public
-  comment is never trusted). Branch and worktree are derived from the
-  configured repo_dir, source repo, Issue number and run id — never
-  read from a comment, so no comment can steer the runner into an
-  arbitrary local path. A scene that cannot be recovered (missing
-  field, no trusted comment) fails fast: the Issue is marked
-  `ai-blocked` with the concrete reason, the tick stops, and no fresh
-  task starts ahead of it — never guessed. Before any git/Pi mutation
-  the configured base and the open PR (head repo, head branch, base,
-  run marker, exact URL) are validated.
+  worktree and PR number. The Fixer scan is `ai-fix-needed` Issues; the
+  fresh-claim scan skips those. The resume scene (run id, base, PR URL)
+  is recovered from the latest `Muyan Pilot opened PR:` comment posted by
+  a trusted maintainer (OWNER/MAINTAINER/MEMBER/COLLABORATOR). Branch and
+  worktree are derived from the configured repo_dir, source repo, Issue
+  number and run id. A scene that cannot be recovered (missing field, no
+  trusted comment) fails fast: the Issue is marked `ai-blocked` with the
+  concrete reason and the tick stops. Before any git/Pi mutation the
+  configured base and the open PR (head repo, head branch, base, run
+  marker, exact URL) are validated.
 - When the latest remote base is not an ancestor of the delivery HEAD,
   the runner performs a plain `git merge origin/<base>` on the original
-  branch and hands any conflict to the fixer; no auto conflict
-  resolution, no `--abort`, no force push, no push of the protected
-  branch.
+  branch and hands any conflict to the fixer.
 - While Blocker/Major findings exist, the Runner comments them to the
   Issue and PR, runs a fixer on the same feature branch/worktree,
   re-freezes the SHA, reruns the full suite, and re-reviews. After a
   fix, the full test suite, 100% line/branch coverage, the real
   verification and the complete R1–R9 review run again before the same
   PR is re-verified. The loop is bounded (5 rounds); if it exhausts
-  rounds with findings it fails fast and marks the Issue `ai-blocked`.
-  An unresolvable fix keeps the PR, branch and worktree intact and
-  marks the Issue `ai-blocked` (removing `ai-fix-needed`) with the
-  concrete conflict or finding.
+  rounds with findings it marks the Issue `ai-blocked`. An unresolvable
+  fix keeps the PR, branch and worktree intact and marks the Issue
+  `ai-blocked` (removing `ai-fix-needed`) with the concrete conflict or
+  finding.
 - The merge gate re-fetches the latest remote base and requires the PR
   head to contain it, the PR to be mergeable, and the remote head to
   still be the reviewed head; it then merges with
-  `gh pr merge --match-head-commit` so only the reviewed head lands. A
-  PR behind the latest base is rejected, never merged. The Runner
-  confirms the PR is MERGED and the merge commit is on the protected
-  branch before marking the Issue `ai-merged`.
+  `gh pr merge --match-head-commit` so only the reviewed head lands. The
+  Runner confirms the PR is MERGED and the merge commit is on the
+  protected branch before marking the Issue `ai-merged`.
 
 ## Scope
 
-- No database, queue, daemon loop, risk engine, or fallback. GitHub Issues
-  and labels are the only state store.
-- No timeout on business tasks. systemd only schedules the tick and owns the
-  run lifecycle.
+- State is GitHub Issues and labels.
+- systemd schedules the tick and owns the run lifecycle.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ is **one runtime outcome** (when X, should Y, actually Z).
 
 - TDD: write a failing test first, then the smallest implementation, then
   refactor.
+- External APIs, CLI flags, and HTTP paths are asserted against official docs
+  or one real call.
 - Python code keeps 100% line and branch coverage:
 
   ```bash
@@ -94,6 +96,8 @@ is **one runtime outcome** (when X, should Y, actually Z).
 - The runner rejects a delivery whose HEAD does not contain the latest remote
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.
+- A delivery is acceptable only when its HEAD contains the latest remote
+  base; base updates use a plain `git merge` on the task branch.
 
 ## Task dependencies (blockedBy)
 
@@ -190,7 +194,7 @@ is **one runtime outcome** (when X, should Y, actually Z).
 - Work on the task feature branch.
 - Pi (the implementer) does not merge and does not push `main` or `master`.
   It delivers through exactly one PR linked to the Issue; the Runner is the
-  only merge actor (see below).
+  only merge actor (the Runner is the only merge actor; see below).
 - The PR description must contain `Fixes #<issue-number>` (it may be on
   the first line), pointing at the source Issue so GitHub closes the Issue
   natively when the PR merges into the default branch. The keyword works
@@ -232,5 +236,5 @@ is **one runtime outcome** (when X, should Y, actually Z).
 
 - No database, queue, daemon loop, risk engine, or fallback. GitHub Issues
   and labels are the only state store.
-- No timeout on business tasks. systemd only schedules the tick and owns the
+- No business task timeout. systemd only schedules the tick and owns the
   run lifecycle.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,63 @@
 Development contract for this repository. Every local Pi bootstrap run must
 follow it before changing code.
 
+Four audiences, one file:
+
+- **Issue authors** (humans or the monitor): granularity below.
+- **Implementer Pi**: read first, TDD, one PR. No independent review
+  before the PR exists.
+- **Reviewer Pi**: a new `pi --print` after the PR, `prompt_review.md`,
+  a new JSONL.
+- **Runner**: labels, base freshness, observability, the post-PR
+  review/fix/merge loop.
+
 ## Read first
 
 - Read the GitHub Issue, the configured context files, `README.md`, and the
   relevant code before touching anything.
 
+## Issue granularity
+
+Write GitHub Issues so one Pilot implement session can finish them. One
+Issue is **one runtime outcome** (when X, should Y, actually Z), not a
+subsystem and not a philosophy.
+
+- Right size: one observable behavior, a handful of related files, tests
+  included, hundreds of lines not thousands. Title should work as a test
+  name.
+- Too coarse: "optimize review" or "GitHub observability" as a whole
+  product. Those become overnight diffs, merge conflicts, and review
+  Majors.
+- Too fine: one sentence per Issue (`prompt.md` vs `AGENTS.md` vs one
+  string in the runner). Claim/worktree/review/merge overhead exceeds
+  the change.
+- Split when two changes do not have to land together (prompt wording vs
+  `--skill` lists vs harness control flow). Do not split files that are
+  the same wording change.
+- Do not open an Issue until the root cause is pinned. A wrong-cause
+  ticket costs more than a large one.
+
+## Implement vs review
+
+- Implementer session: plan, TDD, tests, push one PR. Do not run a complete independent review-fix loop
+  or R1–R9 before the PR is open. The Runner does that after the PR exists.
+- Independent review is a **new** `pi --print` process with
+  `prompt_review.md` and a new JSONL. It does not continue the
+  implementer's chat. Sharing the worktree and the local model is
+  enough isolation; do not invent a second worktree for review.
+- `review-fix-loop` / full R1–R9 before the PR duplicates the Runner
+  review and is too expensive on the local model. Catch what tests can
+  catch in the implement session; leave judgment of the frozen diff to
+  the post-PR review session.
+
 ## TDD and coverage
 
 - TDD: write a failing test first, then the smallest implementation, then
-  refactor.
+  refactor. That is how defects are caught early: while the files are still
+  in context, not by running a full independent R1–R9 review before the PR.
+- External APIs, CLI flags, and HTTP paths are asserted against official
+  docs or one real call. Do not freeze a guessed URL or response shape as
+  a green test.
 - Python code keeps 100% line and branch coverage:
 
   ```bash
@@ -29,6 +77,45 @@ follow it before changing code.
 
 - Command errors fail fast: log the command, return code, stdout and stderr,
   then raise. Never swallow an error or add a fallback path.
+
+## Git
+
+- Work on the task feature branch.
+- Pi (the implementer) does not merge and does not push `main` or `master`.
+  It delivers through exactly one PR linked to the Issue; the Runner is the
+  only merge actor (see **After the PR**).
+- The PR description must contain `Fixes #<issue-number>` (it may be on
+  the first line), pointing at the source Issue so GitHub closes the Issue
+  natively when the PR merges into the default branch. The keyword works
+  in the PR body and in commit messages, but not in the PR title. The
+  runner rejects a PR whose body is missing it, so a merge can never
+  leave the source Issue open.
+
+## Base freshness
+
+- Every task worktree is created from the frozen `origin/<base_branch>` SHA
+  (default `main`), never from the main worktree's current HEAD.
+- Branch and worktree names carry the unique run id, so a retried Issue gets
+  a new independent run and the old scene is preserved.
+- Before creating the PR, re-fetch `origin/<base_branch>`; if the base
+  advanced, merge it into the task branch, resolve conflicts manually, rerun
+  the full test suite, then push the task branch.
+- The runner rejects a delivery whose HEAD does not contain the latest remote
+  base. No auto conflict resolution, no force push, no merge or push of the
+  protected branch.
+
+## Run correlation
+
+- One task attempt generates one run_id (8 hex chars) and reuses it for
+  every later step of the attempt; a retry generates a new one. No new id
+  system is introduced: no trace_id, no log_id, no second UUID, no
+  tracing backend.
+- Every journal line of the attempt starts with `[run_id]`, so one grep
+  reconstructs the full timeline; every Issue/PR comment and the PR body
+  carry the stable marker `<!-- muyan-pilot:run=<run_id> -->` plus the
+  visible `run_id=` field; branch, worktree, Pi session dir and run
+  artifacts carry it in their paths. A run-scoped event without a valid
+  run_id fails fast.
 
 ## Automatic observability
 
@@ -58,19 +145,6 @@ follow it before changing code.
   `ai-blocked` — the run continues into the independent review/merge loop
   (Issue #60).
 
-## Base freshness
-
-- Every task worktree is created from the frozen `origin/<base_branch>` SHA
-  (default `main`), never from the main worktree's current HEAD.
-- Branch and worktree names carry the unique run id, so a retried Issue gets
-  a new independent run and the old scene is preserved.
-- Before creating the PR, re-fetch `origin/<base_branch>`; if the base
-  advanced, merge it into the task branch, resolve conflicts manually, rerun
-  the full tests and the complete review-fix loop, then push the task branch.
-- The runner rejects a delivery whose HEAD does not contain the latest remote
-  base. No auto conflict resolution, no force push, no merge or push of the
-  protected branch.
-
 ## Task dependencies (blockedBy)
 
 - Task dependencies use GitHub's native `blockedBy` relation
@@ -93,15 +167,27 @@ follow it before changing code.
 - No DAG, topological sort, or multi-worker scheduling: single-slot
   serial execution only reads the field, skips, and waits.
 
-## Review and fix loop (same PR)
+## After the PR: review, fix, and merge
+
+The implementer is done when the PR exists. Everything below is the
+Runner, not the implement session.
 
 - After a PR is opened, the Issue is in a recoverable review/fix state,
   not done: `ai-pr-opened` means awaiting review (a clean PR is never
-  sent to the Fixer); a review finding, an advanced base, or a merge
-  conflict moves it to the explicit `ai-fix-needed` state, which is a
-  fixable state, never a reason to close the PR, re-claim the Issue, or
-  open a replacement PR. A successful fix consumes `ai-fix-needed` and
-  returns the Issue to `ai-pr-opened` (awaiting review again).
+  sent to the Fixer). The Runner freezes the exact PR base/head SHA and
+  starts an independent, read-only review session (code-review R1–R9)
+  against those SHAs — a new `pi --print`, `prompt_review.md`, a new
+  JSONL. The reviewer ends with one machine-readable `REVIEW_VERDICT`
+  line; a missing or malformed verdict fails fast and is never treated
+  as a pass.
+- A review finding, an advanced base, or a merge conflict moves the
+  Issue to the explicit `ai-fix-needed` state, which is a fixable
+  state, never a reason to close the PR, re-claim the Issue, or open a
+  replacement PR. A successful fix consumes `ai-fix-needed` and returns
+  the Issue to `ai-pr-opened` (awaiting review again). A review finding
+  is not `ai-blocked`: it enters this same-PR loop. Only command
+  failure, an unavailable environment, or a fix that cannot be verified
+  fails fast and marks `ai-blocked`.
 - The next tick resumes the same run on the same feature branch,
   worktree and PR number. Only `ai-fix-needed` Issues (not `ai-blocked`)
   are scanned for Fixer work; the fresh-claim scan excludes
@@ -123,59 +209,23 @@ follow it before changing code.
   branch and hands any conflict to the fixer; no auto conflict
   resolution, no `--abort`, no force push, no push of the protected
   branch.
-- After a fix, the full test suite, 100% line/branch coverage, the real
+- While Blocker/Major findings exist, the Runner comments them to the
+  Issue and PR, runs a fixer on the same feature branch/worktree,
+  re-freezes the SHA, reruns the full suite, and re-reviews. After a
+  fix, the full test suite, 100% line/branch coverage, the real
   verification and the complete R1–R9 review run again before the same
-  PR is re-verified.
-- An unresolvable fix keeps the PR, branch and worktree intact and marks
-  the Issue `ai-blocked` (removing `ai-fix-needed`) with the concrete
-  conflict or finding.
-
-## Run correlation
-
-- One task attempt generates one run_id (8 hex chars) and reuses it for
-  every later step of the attempt; a retry generates a new one. No new id
-  system is introduced: no trace_id, no log_id, no second UUID, no
-  tracing backend.
-- Every journal line of the attempt starts with `[run_id]`, so one grep
-  reconstructs the full timeline; every Issue/PR comment and the PR body
-  carry the stable marker `<!-- muyan-pilot:run=<run_id> -->` plus the
-  visible `run_id=` field; branch, worktree, Pi session dir and run
-  artifacts carry it in their paths. A run-scoped event without a valid
-  run_id fails fast.
-
-## Git
-
-- Work on the task feature branch.
-- Pi (the implementer) does not merge and does not push `main` or `master`.
-  It delivers through exactly one PR linked to the Issue; the Runner is the
-  only merge actor (see below).
-- The PR description must contain `Fixes #<issue-number>` (it may be on
-  the first line), pointing at the source Issue so GitHub closes the Issue
-  natively when the PR merges into the default branch. The keyword works
-  in the PR body and in commit messages, but not in the PR title. The
-  runner rejects a PR whose body is missing it, so a merge can never
-  leave the source Issue open.
-
-## Auto review, fix and merge
-
-- After the implementer opens the PR, the Runner freezes the exact PR
-  base/head SHA and runs an independent, read-only review session
-  (code-review R1–R9) against those SHAs. The reviewer ends with one
-  machine-readable `REVIEW_VERDICT` line; a missing or malformed verdict fails
-  fast and is never treated as a pass.
-- While Blocker/Major findings exist, the Runner comments them to the Issue and
-  PR, runs a fixer on the same feature branch/worktree, re-freezes the SHA,
-  reruns the full suite, and re-reviews. The loop is bounded (5 rounds); if it
-  exhausts rounds with findings it fails fast and marks the Issue `ai-blocked`.
-- The merge gate re-fetches the latest remote base and requires the PR head to
-  contain it, the PR to be mergeable, and the remote head to still be the
-  reviewed head; it then merges with `gh pr merge --match-head-commit` so only
-  the reviewed head lands. A PR behind the latest base is rejected, never
-  merged. The Runner confirms the PR is MERGED and the merge commit is on the
-  protected branch before marking the Issue `ai-merged`.
-- A review finding is not `ai-blocked`: it enters the same PR's fix/review
-  loop. Only command failure, an unavailable environment, or a fix that cannot
-  be verified fails fast and marks `ai-blocked`.
+  PR is re-verified. The loop is bounded (5 rounds); if it exhausts
+  rounds with findings it fails fast and marks the Issue `ai-blocked`.
+  An unresolvable fix keeps the PR, branch and worktree intact and
+  marks the Issue `ai-blocked` (removing `ai-fix-needed`) with the
+  concrete conflict or finding.
+- The merge gate re-fetches the latest remote base and requires the PR
+  head to contain it, the PR to be mergeable, and the remote head to
+  still be the reviewed head; it then merges with
+  `gh pr merge --match-head-commit` so only the reviewed head lands. A
+  PR behind the latest base is rejected, never merged. The Runner
+  confirms the PR is MERGED and the merge commit is on the protected
+  branch before marking the Issue `ai-merged`.
 
 ## Scope
 

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -15,8 +15,22 @@ REQUIRED_ITEMS = (
     ("read-first", "read the GitHub Issue"),
     ("read-first-context", "context files"),
     ("read-first-readme", "README.md"),
-    # 2. TDD: test before implementation.
+    # 2. TDD: test before implementation. Early catch is TDD, not a
+    #     pre-PR independent review-fix loop.
     ("tdd", "write a failing test first"),
+    ("tdd-not-pre-pr-r1r9", "not by running a full independent r1–r9"),
+    ("tdd-docs-not-guess", "guessed url"),
+    # 2b. Issue granularity: one runtime outcome per Issue.
+    ("issue-granularity", "issue granularity"),
+    ("issue-one-outcome", "one runtime outcome"),
+    ("issue-too-coarse", "too coarse"),
+    ("issue-too-fine", "too fine"),
+    ("issue-pin-root-cause", "root cause is pinned"),
+    # 2c. Implement vs review: new review session after the PR; no
+    #     complete review-fix loop before the PR.
+    ("implement-no-pre-pr-loop", "do not run a complete independent review-fix loop"),
+    ("review-new-jsonl", "new jsonl"),
+    ("review-prompt-review", "prompt_review.md"),
     # 3. 100% line and branch coverage for Python code.
     ("coverage", "100% line and branch coverage"),
     # 4. UI work: real Playwright interaction, assertions, console/network

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -38,47 +38,38 @@ REQUIRED_ITEMS = (
     # 5. Fail fast on command errors and keep the log scene.
     ("fail-fast", "fail fast"),
     ("log-scene", "log"),
-    # 6. No merge, no push of main/master, deliver through PRs only.
-    ("no-merge", "merge"),
-    ("no-protected-push", "main"),
-    ("no-protected-push-master", "master"),
+    # 6. Implementer delivers through one PR; Runner merges main/master.
+    ("merge-actor", "the runner is the only merge actor"),
+    ("protected-main", "main"),
+    ("protected-master", "master"),
     ("pr-only", "PR"),
     # 6a. PR body: must carry `Fixes #<issue-number>` pointing at the
     #     source Issue so GitHub natively closes the Issue when the PR
-    #     merges into the default branch (the keyword does not work in
-    #     the PR title).
+    #     merges into the default branch (GitHub reads body, not PR title).
     ("pr-fixes-keyword", "fixes #<issue-number>"),
     ("pr-fixes-auto-close", "closes the issue"),
     ("pr-fixes-default-branch", "default branch"),
     ("pr-fixes-title", "pr title"),
     # 6b. Base freshness: worktrees start from the frozen origin/<base> SHA,
     #     runs carry a unique run id, the base is re-fetched before the PR,
-    #     behind deliveries are rejected, no auto conflict resolution or
-    #     force push.
+    #     delivery HEAD contains the latest remote base.
     ("base-freshness", "base freshness"),
     ("base-frozen-sha", "frozen"),
     ("base-run-id", "run id"),
     ("base-refetch", "re-fetch"),
-    ("base-reject-behind", "rejects"),
-    ("base-no-auto-resolve", "auto conflict resolution"),
-    ("base-no-force-push", "force push"),
+    ("base-contains-latest", "contains the latest remote base"),
+    ("base-plain-merge", "plain `git merge`"),
     # 6c. Run correlation: one run_id per attempt is the single
     #     end-to-end correlation id; every journal line and GitHub text of
-    #     the run carries it; a run-scoped event without a run id fails fast.
+    #     the run carries it; a run-scoped event includes a valid run id.
     ("run-single-id", "one run_id"),
     ("run-journal-prefix", "[run_id]"),
     ("run-github-marker", "muyan-pilot:run="),
-    ("run-no-new-id", "no new id"),
     ("run-fail-fast", "fails fast"),
-    # 7. No database, queue, daemon loop, risk engine, or fallback.
-    ("no-database", "database"),
-    ("no-queue", "queue"),
-    ("no-daemon", "daemon"),
-    ("no-risk-engine", "risk engine"),
-    ("no-fallback", "fallback"),
-    # 8. No business task timeout; systemd only schedules and owns the run
-    #    lifecycle.
-    ("no-timeout", "timeout"),
+    # 7. State is GitHub Issues and labels.
+    ("state-issues", "github issues"),
+    ("state-labels", "labels"),
+    # 8. systemd schedules the tick and owns the run lifecycle.
     ("systemd-scope", "systemd"),
 )
 

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -15,20 +15,16 @@ REQUIRED_ITEMS = (
     ("read-first", "read the GitHub Issue"),
     ("read-first-context", "context files"),
     ("read-first-readme", "README.md"),
-    # 2. TDD: test before implementation. Early catch is TDD, not a
-    #     pre-PR independent review-fix loop.
+    # 2. TDD: test before implementation; assert externals against docs.
     ("tdd", "write a failing test first"),
-    ("tdd-not-pre-pr-r1r9", "not by running a full independent r1–r9"),
-    ("tdd-docs-not-guess", "guessed url"),
+    ("tdd-docs", "official docs"),
     # 2b. Issue granularity: one runtime outcome per Issue.
     ("issue-granularity", "issue granularity"),
     ("issue-one-outcome", "one runtime outcome"),
-    ("issue-too-coarse", "too coarse"),
-    ("issue-too-fine", "too fine"),
     ("issue-pin-root-cause", "root cause is pinned"),
-    # 2c. Implement vs review: new review session after the PR; no
-    #     complete review-fix loop before the PR.
-    ("implement-no-pre-pr-loop", "do not run a complete independent review-fix loop"),
+    # 2c. Implement vs review: new review session after the PR.
+    ("implement-then-pr", "plan, tdd, tests, push one pr"),
+    ("review-after-pr", "after the pr exists"),
     ("review-new-jsonl", "new jsonl"),
     ("review-prompt-review", "prompt_review.md"),
     # 3. 100% line and branch coverage for Python code.


### PR DESCRIPTION
## 做了什么

把最近确认的开发约定落到 `AGENTS.md`，并按读者拆开、去掉重复：

- **Issue 粒度**：一条 Issue = 一个 runtime outcome；过粗（整子系统）和过细（一句话一张票）都写明。根因没钉死不开票。
- **实现 vs 审查**：Implementer 只 plan / TDD / 测试 / 开 PR。开 PR 前不做完整独立 review-fix-loop 或 R1–R9。独立审查是 PR 之后新的 `pi --print`（`prompt_review.md` + 新 JSONL）。
- **TDD**：早拦靠测试，不靠把独立审查提前。外部 URL/CLI 不猜。
- **Base freshness**：base 前进后只重跑全量测试，不再要求实现阶段再跑一遍 review-fix-loop。
- **After the PR**：把原来重复的「Review and fix loop」和「Auto review, fix and merge」收成一节，状态机、恢复、`REVIEW_VERDICT`、5 轮、merge gate 都还在。

`tests/test_agents_md.py` 增加对应契约针，防止这些条目被静默删掉。

## 验证

- 生产 runtime：`/usr/bin/python3`（systemd `ExecStart`）
- ` /usr/bin/python3 -m pytest tests/test_agents_md.py -q` → 2 passed
- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → 545 passed
- coverage 100% line + branch

## 明确不做

- 不改 `prompt.md` / `run_pi` 文案：那是 #78。本 PR 只收 `AGENTS.md`。`prompt.md` 里「开 PR 前 complete review-fix-loop」与本契约仍打架，留给 #78。
- 不改 skill 列表（#83）、不把审查同场修复写成当前行为（#82）。