### PR TITLE
fix: pass role-specific --skill lists to implement vs review Pi

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1084,7 +1084,10 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "ISSUE_BODY": issue.get("body", ""),
             "WORKSPACE_ROOT": str(config["workspace_root"]),
             "CONTEXT_FILES": "\n".join(str(path) for path in config["context_files"]),
-            "SKILLS": "\n".join(str(path) for path in config["skills"]),
+            "SKILLS": "\n".join(
+                str(path)
+                for path in _skills_for(config, IMPLEMENT_EXCLUDED_SKILLS)
+            ),
             "BASE_BRANCH": config["base_branch"],
             "BASE_SHA": config["base_sha"],
             "RUN_ID": config["run_id"],
@@ -1108,9 +1111,9 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "protected branch.\n"
         )
     context += "Complete the delivery process in the system prompt."
-    skill_args = [item for skill in config["skills"] for item in ("--skill", str(skill))]
     command = [
-        "pi", *skill_args, "--print", "--session-dir",
+        "pi", *_skill_args(_skills_for(config, IMPLEMENT_EXCLUDED_SKILLS)),
+        "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
     return stream_pi(
@@ -1333,9 +1336,43 @@ def freeze_pr(worktree: Path, branch: str, base_branch: str) -> dict:
     }
 
 
-def _agent_skill_args(config: dict) -> list[str]:
+# Role-specific skill filtering (Issue #83): the review session is
+# read-only and ends with a single REVIEW_VERDICT line, so the
+# delivery-oriented skills must not be loaded there (tdd-dev would
+# steer it into the implement/test/PR flow, review-fix-loop would
+# open another fix/review round). The implementer/fixer keeps
+# tdd-dev and code-review but not review-fix-loop: the Runner itself
+# runs the independent review/fix loop once the PR is open.
+REVIEW_EXCLUDED_SKILLS = frozenset({"tdd-dev", "review-fix-loop"})
+IMPLEMENT_EXCLUDED_SKILLS = frozenset({"review-fix-loop"})
+
+
+def _skill_name(entry: str | Path) -> str:
+    """Return the skill name of one configured skill entry.
+
+    Entries point at the SKILL.md file inside the skill directory
+    (e.g. .../skills/tdd-dev/SKILL.md); the skill name is the parent
+    directory. A bare markdown entry (e.g. my-skill.md) or a skill
+    directory is named after its own stem.
+    """
+    path = Path(entry)
+    if path.name == "SKILL.md":
+        return path.parent.name
+    return path.stem
+
+
+def _skills_for(config: dict, excluded: frozenset[str]) -> list[str | Path]:
+    """Return one role's configured skills, dropping excluded names."""
     return [
-        item for skill in config["skills"]
+        skill for skill in config["skills"]
+        if _skill_name(skill) not in excluded
+    ]
+
+
+def _skill_args(skills: list[str | Path]) -> list[str]:
+    """Return the --skill command args for one role's skill list."""
+    return [
+        item for skill in skills
         for item in ("--skill", str(skill))
     ]
 
@@ -1370,7 +1407,8 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
         "and end with a single REVIEW_VERDICT line."
     )
     command = [
-        "pi", *_agent_skill_args(config), "--print", "--session-dir",
+        "pi", *_skill_args(_skills_for(config, REVIEW_EXCLUDED_SKILLS)),
+        "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt,
         context,
     ]

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3177,6 +3177,150 @@ def test_run_review_passes_progress_callback_to_stream_pi(
     assert seen["role"] == "review"
 
 
+# --- role-specific --skill lists (Issue #83) ---------------------------------
+
+
+def _skill_config(tmp_path, *names):
+    """Build a config whose skills point at <name>/SKILL.md files."""
+    skills = []
+    for name in names:
+        skill_dir = tmp_path / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("skill", encoding="utf-8")
+        skills.append(skill_dir / "SKILL.md")
+    return {
+        "prompt": tmp_path / "prompt.md",
+        "prompt_review": tmp_path / "prompt_review.md",
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": skills,
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "a1b2c3d4",
+    }
+
+
+def _command_skills(command):
+    """Return the --skill values of an assembled pi command."""
+    return [
+        value for index, item in enumerate(command)
+        if item == "--skill" and (value := command[index + 1])
+    ]
+
+
+def test_run_pi_keeps_tdd_dev_and_code_review_drops_review_fix_loop(
+    monkeypatch, tmp_path,
+):
+    """Issue #83: the implementer/fixer keeps the delivery skills
+    (tdd-dev, code-review) but not review-fix-loop — the Runner runs
+    the independent review/fix loop itself after the PR is open."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "done",
+    )
+    config = _skill_config(
+        tmp_path, "tdd-dev", "code-review", "review-fix-loop",
+    )
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    skills = _command_skills(calls[0])
+    assert any("tdd-dev" in skill for skill in skills)
+    assert any("code-review" in skill for skill in skills)
+    assert not any("review-fix-loop" in skill for skill in skills)
+
+
+def test_run_review_keeps_only_code_review(monkeypatch, tmp_path):
+    """Issue #83: the read-only review session must not load the
+    delivery-oriented skills (tdd-dev would steer it into the
+    implement/test/PR flow, review-fix-loop would open another
+    fix/review round); code-review stays."""
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "ok",
+    )
+    config = _skill_config(
+        tmp_path, "tdd-dev", "code-review", "review-fix-loop",
+    )
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    skills = _command_skills(calls[0])
+    assert not any("tdd-dev" in skill for skill in skills)
+    assert not any("review-fix-loop" in skill for skill in skills)
+    assert any("code-review" in skill for skill in skills)
+
+
+def test_run_pi_and_run_review_skill_lists_differ(monkeypatch, tmp_path):
+    """Issue #83 acceptance: the two assembled command lines carry
+    different --skill lists."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "done",
+    )
+    config = _skill_config(
+        tmp_path, "tdd-dev", "code-review", "review-fix-loop",
+    )
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    implement_skills = _command_skills(calls[0])
+    review_skills = _command_skills(calls[1])
+    assert implement_skills != review_skills
+
+
+def test_skill_name_of_skill_md_inside_skill_directory(tmp_path):
+    path = tmp_path / "skills" / "tdd-dev" / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    assert runner._skill_name(path) == "tdd-dev"
+
+
+def test_skill_name_of_bare_markdown_entry(tmp_path):
+    path = tmp_path / "my-skill.md"
+    assert runner._skill_name(path) == "my-skill"
+
+
+def test_run_review_keeps_non_delivery_skill_names(monkeypatch, tmp_path):
+    """Only tdd-dev/review-fix-loop are excluded from the review; any
+    other configured skill (including code-review) passes through.
+    """
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "ok",
+    )
+    config = _skill_config(tmp_path, "code-review", "platform-qa")
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    skills = _command_skills(calls[0])
+    assert any("code-review" in skill for skill in skills)
+    assert any("platform-qa" in skill for skill in skills)
+
+
 # --- max_concurrency config (Issue #39) --------------------------------------
 
 


### PR DESCRIPTION
Fixes #83

<!-- muyan-pilot:run=fb494513 -->

run_id=fb494513

## Change

`run_pi` and `run_review` assembled the identical `--skill` list from
`config["skills"]`, so the read-only review session loaded the
delivery-oriented skills: `tdd-dev` would steer it into the
implement/test/PR flow and `review-fix-loop` would open another
fix/review round — both fight the read-only + `REVIEW_VERDICT`
contract of `prompt_review.md`.

Role-based filtering in code (the smaller option offered by the
Issue: no TOML schema change, no machine-config migration, works
immediately against the existing single `skills` list):

- **Review** (`run_review`): drops `tdd-dev` and `review-fix-loop`;
  keeps `code-review` and any other configured skill.
- **Implement / Fixer** (`run_pi`): keeps `tdd-dev` and
  `code-review`; drops `review-fix-loop` — the Runner itself runs
  the independent review/fix loop once the PR is open. The prompt
  `{{SKILLS}}` line now lists exactly the skills passed to the
  session.

Skills are identified by name: an entry pointing at
`.../<name>/SKILL.md` has skill name `<name>` (parent directory); a
bare markdown entry or skill directory is named after its own stem.
Assembly-only change: no skill file content changes, no change to
whether the review may modify code (#82).

## Files

- `bootstrap_runner.py`: `REVIEW_EXCLUDED_SKILLS`,
  `IMPLEMENT_EXCLUDED_SKILLS`, `_skill_name`, `_skills_for`,
  `_skill_args`; `run_pi`/`run_review` use the per-role lists;
  `_agent_skill_args` removed.
- `tests/test_bootstrap_runner.py`: six new tests asserting the
  per-role `--skill` exclusions, that the two assembled command
  lines differ, and the skill-name derivation.

## Tests

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`
  → `556 passed` (550 baseline + 6 new).
- `/usr/bin/python3 -m coverage report --show-missing` → 100%
  line/branch on all files.
- TDD red evidence: the 5 new behavioral tests failed before the
  implementation (`5 failed, 6 passed, 169 deselected`).
