### PR TITLE
Review session fixes findings in-session; no cold-start fixer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,14 +38,14 @@ follow it before changing code.
   evidence.
 - Journal: while a session runs, the journal gets a heartbeat at most every
   30 seconds and an immediate event on phase/action change. Every line
-  carries issue, run id, role (implement/review/fix/merge), phase, elapsed,
+  carries issue, run id, role (implement/review/merge), phase, elapsed,
   last activity, last action, session and branch. No model/session activity
   for 5 minutes logs an idle warning; the first new activity after it logs
   a resumed event.
 - GitHub: exactly one progress comment per run, carrying a hidden run
   marker. It is PATCHed in place (at most every 30 seconds or on progress
   change) and never replaced by new heartbeat comments. Milestones (started,
-  plan ready, tests passed/failed, review findings, fix pushed, PR opened,
+  plan ready, tests passed/failed, review findings, PR opened,
   merged, blocked) are short standalone comments so GitHub Mobile pushes a
   notification. After a process restart the same comment is found by the
   run marker and kept — no database. On success the comment becomes the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ follow it before changing code.
   a new independent run and the old scene is preserved.
 - Before creating the PR, re-fetch `origin/<base_branch>`; if the base
   advanced, merge it into the task branch, resolve conflicts manually, rerun
-  the full tests and the complete review-fix loop, then push the task branch.
+  the full tests, then push the task branch (the independent review runs
+  after the PR is opened and absorbs any further base advance in-session).
 - The runner rejects a delivery whose HEAD does not contain the latest remote
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.
@@ -93,25 +94,34 @@ follow it before changing code.
 - No DAG, topological sort, or multi-worker scheduling: single-slot
   serial execution only reads the field, skips, and waits.
 
-## Review and fix loop (same PR)
+## Review, in-session fix and merge (same PR)
 
-- After a PR is opened, the Issue is in a recoverable review/fix state,
-  not done: `ai-pr-opened` means awaiting review (a clean PR is never
-  sent to the Fixer); a review finding, an advanced base, or a merge
-  conflict moves it to the explicit `ai-fix-needed` state, which is a
-  fixable state, never a reason to close the PR, re-claim the Issue, or
-  open a replacement PR. A successful fix consumes `ai-fix-needed` and
-  returns the Issue to `ai-pr-opened` (awaiting review again).
-- The next tick resumes the same run on the same feature branch,
-  worktree and PR number. Both opened-PR states are scanned (Issue
-  #70): `ai-fix-needed` (the next tick runs the Fixer on the same PR)
-  and `ai-pr-opened` (awaiting review — the next tick runs the
-  independent review on the same PR; a clean PR is still never sent to
-  the Fixer). The `ai-pr-opened` scan exists because the delivery that
-  opened the PR can be gone (a killed runner, or the progress failure
-  behind Issue #70 that used to block the Issue before the review
-  started): without it a valid MERGEABLE PR is stranded with no owner.
-  `ai-blocked` Issues are excluded (they need a human decision first),
+- The review session is independent (a new Pi process, `prompt_review.md`,
+  a new JSONL) and, since Issue #82, ALSO the fixer: the reviewer may
+  modify code, run the full test suite with 100% line/branch coverage,
+  commit, and push ONLY the task branch — then re-emit the
+  `REVIEW_VERDICT` for the fixed head. There is no cold-start Fixer and
+  no third review session: a `pass` verdict means zero Blocker/Major
+  findings AFTER the in-session fixes. The review prompt never attaches
+  the `review-fix-loop` or `tdd-dev` skills: the reviewer applies the
+  code-review R1–R9 criteria directly and fixes findings in-session
+  (no nested review/fix loop).
+- After a PR is opened the Issue is in a recoverable review state, not
+  done: `ai-pr-opened` means awaiting review. `ai-fix-needed` marks a
+  delivery whose head is not mergeable yet (the review found a finding
+  the session could not fix, or the PR is behind the latest base / has a
+  merge conflict): the NEXT tick resumes the same run on the same
+  feature branch, worktree and PR number and runs the next independent
+  review session, which merges the latest `origin/<base>` into the
+  branch IN-SESSION, resolves any conflict, re-runs the full suite and
+  re-emits the verdict. Both opened-PR states are scanned (Issue #70).
+  The `ai-pr-opened` scan exists because the delivery that opened the
+  PR can be gone (a killed runner, or the progress failure behind Issue
+  #70 that used to block the Issue before the review started): without
+  it a valid MERGEABLE PR is stranded with no owner. `ai-fix-needed` is
+  never a reason to close the PR, re-claim the Issue, or open a
+  replacement PR; a successful merge moves the Issue to `ai-merged`.
+- `ai-blocked` Issues are excluded (they need a human decision first),
   as are merged and in-flight Issues; the fresh-claim scan excludes
   both opened-PR states, so an opened-PR Issue is never re-claimed as
   new work. The resume scene (run id, base, PR URL) is
@@ -126,17 +136,18 @@ follow it before changing code.
   task starts ahead of it — never guessed. Before any git/Pi mutation
   the configured base and the open PR (head repo, head branch, base,
   run marker, exact URL) are validated.
-- When the latest remote base is not an ancestor of the delivery HEAD,
-  the runner performs a plain `git merge origin/<base>` on the original
-  branch and hands any conflict to the fixer; no auto conflict
-  resolution, no `--abort`, no force push, no push of the protected
-  branch.
-- After a fix, the full test suite, 100% line/branch coverage, the real
-  verification and the complete R1–R9 review run again before the same
-  PR is re-verified.
-- An unresolvable fix keeps the PR, branch and worktree intact and marks
-  the Issue `ai-blocked` (removing `ai-fix-needed`) with the concrete
-  conflict or finding.
+- The Harness merge gate is unchanged: it re-fetches the latest remote
+  base and requires the PR head to contain it, the PR to be mergeable,
+  and the remote head to still be the reviewed head. After a clean
+  verdict the PR is RE-FROZEN (the reviewer may have pushed an
+  in-session fix, advancing the head) and the gate runs against the
+  re-frozen head; `gh pr merge --match-head-commit` then lands exactly
+  that head. No auto conflict resolution by the Runner, no `--abort`,
+  no force push, no merge or push of the protected branch.
+- An unresolvable review (Pi failure, exhausted review rounds, a
+  finding the session could not fix) keeps the PR, branch and worktree
+  intact and marks the Issue `ai-blocked` (removing the opened-PR
+  state) with the concrete finding.
 
 ## Run correlation
 
@@ -167,23 +178,32 @@ follow it before changing code.
 ## Auto review, fix and merge
 
 - After the implementer opens the PR, the Runner freezes the exact PR
-  base/head SHA and runs an independent, read-only review session
-  (code-review R1–R9) against those SHAs. The reviewer ends with one
-  machine-readable `REVIEW_VERDICT` line; a missing or malformed verdict fails
-  fast and is never treated as a pass.
-- While Blocker/Major findings exist, the Runner comments them to the Issue and
-  PR, runs a fixer on the same feature branch/worktree, re-freezes the SHA,
-  reruns the full suite, and re-reviews. The loop is bounded (5 rounds); if it
-  exhausts rounds with findings it fails fast and marks the Issue `ai-blocked`.
+  base/head SHA and runs an independent review session (code-review R1–R9)
+  against those SHAs. Since Issue #82 the reviewer is also the fixer: it may
+  modify code, run the full suite with 100% line/branch coverage, commit and
+  push ONLY the task branch, then re-emit the verdict for the fixed head. The
+  reviewer ends with one machine-readable `REVIEW_VERDICT` line; a missing or
+  malformed verdict fails fast and is never treated as a pass.
+- A `pass` verdict means zero Blocker/Major findings AFTER the in-session
+  fixes: the Runner re-freezes the PR (the head may have advanced), runs the
+  merge gate against the re-frozen head, and merges with `gh pr merge
+  --match-head-commit` so only the reviewed head lands. A finding the session
+  could not fix (or a PR behind the latest base / with a merge conflict)
+  leaves the head unmergeable: the Issue is marked `ai-fix-needed` and the
+  NEXT tick runs the next independent review session on the same PR, which
+  absorbs the latest base in-session, resolves conflicts, re-runs the suite
+  and re-emits the verdict. The review loop is bounded (5 rounds); if it
+  exhausts rounds with findings it fails fast and marks the Issue
+  `ai-blocked`.
 - The merge gate re-fetches the latest remote base and requires the PR head to
   contain it, the PR to be mergeable, and the remote head to still be the
-  reviewed head; it then merges with `gh pr merge --match-head-commit` so only
-  the reviewed head lands. A PR behind the latest base is rejected, never
+  reviewed head. A PR behind the latest base is rejected, never
   merged. The Runner confirms the PR is MERGED and the merge commit is on the
   protected branch before marking the Issue `ai-merged`.
-- A review finding is not `ai-blocked`: it enters the same PR's fix/review
-  loop. Only command failure, an unavailable environment, or a fix that cannot
-  be verified fails fast and marks `ai-blocked`.
+- A review finding is not `ai-blocked`: it is fixed in the review session
+  (or in the next review session on the same PR). Only command failure, an
+  unavailable environment, or a review that cannot be verified fails fast and
+  marks `ai-blocked`.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Muyan Pilot
 
-最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR；随后 Runner 自动完成独立审查、修复循环和合并（见下方「自动审查、修复与合并」）。
+最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并（见下方「自动审查、修复与合并」）。
 
 开发契约见 [AGENTS.md](AGENTS.md)：每次本地 Pi 自举开发前先读 Issue、context files、README 和相关代码，TDD、100% 覆盖率、UI 用 Playwright、失败 fail fast、不 merge、不 push 保护分支、不引入数据库/队列/daemon/fallback、不设业务任务 timeout。
 
@@ -67,7 +67,7 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 
 正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。
 任务进入 GitHub Issue 池后，Runner 自己完成领取 → plan → implement → test →
-verify → independent review → fix → merge，并主动发布过程和最终结果。
+verify → independent review（会话内修复）→ merge，并主动发布过程和最终结果。
 `muyan_pilot.py status` 只保留为开发/故障排查附件，不是产品入口，也不能作为
 自动可观测性的验收证据。
 
@@ -102,16 +102,16 @@ journalctl --user -u muyan-pilot.service -f
 # Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/xqliu/muyan-pilot/pull/19 commit=0123456789abcdef0123456789abcdef01234567
 ```
 
-每行都带 issue、run id、role（implement / review / fix / merge）、phase、
-elapsed、last activity、last action、session、branch。implementer、reviewer、
-fixer 三种 Pi session 用同一个机制观测，role 由 Runner 在启动 session 时传入。
+每行都带 issue、run id、role（implement / review / merge）、phase、
+elapsed、last activity、last action、session、branch。implementer、reviewer
+两种 Pi session 用同一个机制观测，role 由 Runner 在启动 session 时传入。
 
 ### GitHub（手机，自动更新）
 
 领取任务后，Runner 在 source Issue 上创建一条带隐藏 run marker
 （`<!-- muyan-pilot:run=<run_id> -->`）的进度评论，之后只 PATCH 同一条
 评论（进度变化时立即，且间隔不超过 30 秒），不新增 heartbeat 垃圾评论。
-**Pi 运行期间就是活的**：implementer、reviewer、fixer 三种 session 的每次
+**Pi 运行期间就是活的**：implementer、reviewer 两种 session 的每次
 活动变化/心跳都会渲染当前状态并 PATCH 同一条评论（不是等 Pi 退出后才
 回写），手机用户看到的始终是进行中的进展，而不是一条静态的 starting
 评论。评论始终显示：当前阶段、role、已运行时间、最近活动时间、最近动作、
@@ -120,7 +120,7 @@ fixer 三种 Pi session 用同一个机制观测，role 由 Runner 在启动 ses
 
 关键 milestone 单独发布简短评论（`Muyan Pilot: ...`），让 GitHub Mobile
 主动推送通知：started、plan ready、tests passed/failed、review findings、
-fix pushed、PR opened、merged、blocked。完成后进度评论更新为最终交付摘要
+PR opened、merged、blocked。完成后进度评论更新为最终交付摘要
 （PR、测试、审查证据）；真正失败时更新为 blocked 现场和下一步原因，同时
 Issue 标记 `ai-blocked`。
 
@@ -161,14 +161,14 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 # 编辑 muyan-pilot.toml
 ```
 
-Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在整个 implement → review → fix → merge 期间持有并发 slot，PR 合并或终态失败后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。并发上限见下一节 `max_concurrency`：拿不到 slot 的 Runner 记录 `capacity_full` 后正常退出，不领取 Issue。
+Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在整个 implement → review（会话内修复）→ merge 期间持有并发 slot，PR 合并或终态失败后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。并发上限见下一节 `max_concurrency`：拿不到 slot 的 Runner 记录 `capacity_full` 后正常退出，不领取 Issue。
 
 ## 并发限制（max_concurrency）
 
 本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是正整数，缺失时默认 1（本地 AI/GPU 只能稳定服务一个任务）；非整数、布尔值、0 或负数启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
 
-- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review → fix → merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与空闲 timer 同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding 或 base 冲突）时，由**同一个持有 slot 的 Runner** 在同一 run 上修复同一个 PR（见下节），不会为同一个 run 启动第二个 Pi，也不会让新 Runner 插队领取新 Issue；
-- 同一任务内部 implement/review/fix 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
+- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与空闲 timer 同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding 或 base 冲突）时，**下一个 tick 在同一 run、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
+- 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
 - 达到 `max_concurrency` 时，新 Runner 不领取 Issue、不修改标签、不调用 Pi，记录结构化日志 `capacity_full max_concurrency=... slot_dir=...` 后正常退出（退出码 0），等 systemd timer 下次触发；
 - slot 锁由打开的文件描述符持有：进程正常结束、SIGTERM/SIGINT（systemd stop / Ctrl+C）或被 SIGKILL 时，内核自动释放锁——活着的持有者永远不会因为时间或 PID 检查丢失 slot，死掉的持有者永远不会占住 slot，异常退出不会造成永久锁死；slot 文件本身保留（它是锁目标，不是令牌），`status` 按锁的实际状态报告占用；
 - `muyan_pilot.py status` 显示配置容量和当前已占用 slot（`capacity: N`、`slots: k/N`、`slot-N: pid=...`）；占用判定用非阻塞 `flock` 探测（探测成功即空闲并立即解锁），PID 仅用于展示；
@@ -176,7 +176,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 
 ## 全链路 run_id（correlation ID）
 
-每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、fix、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
+每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
 
 同一个 run_id 出现在：
 
@@ -186,7 +186,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 - Pi session 目录（worktree 内 `.pi-session/`）与 plan/test/verify/review 等 run artifacts 的路径；
 - 注入 Pi 的 prompt context（`Run id: ...`）；
 - PR body 的稳定 machine-readable marker `<!-- muyan-pilot:run=e07383c2 -->`——Runner 验收时校验，缺失即 fail fast，拒绝该 PR；
-- Pi 自己发出的 progress / review / fix / 最终评论（prompt 要求携带同一 marker 和 `run_id=` 字段）。
+- Pi 自己发出的 progress / review / 最终评论（prompt 要求携带同一 marker 和 `run_id=` 字段）。
 
 查询方式（不依赖内存映射，进程重启后仍可恢复关联）：
 
@@ -211,7 +211,7 @@ grep -r e07383c2 /home/xqianliu/Documents/muyan/muyan-pilot/.worktrees/
 
 Runner 被 SIGKILL 时无法执行任何清理：任务 worktree 和 `ai-in-progress` 领取标签会留在 GitHub 上（Issue 仍带 `ai-ready`）。下一个 tick 的领取扫描在 ready 队列之前先扫描 `ai-ready`+`ai-in-progress`（且未处于其他交付状态）的 open Issue——**仅当没有其他 Runner 活着时**（其他 slot 被占用证明有活着的 Runner 在处理，此时 `ai-in-progress` 是“进行中”而不是“孤儿”，绝不为活着的 run 启动第二个 Pi；flock 锁是唯一事实源）。找到后走 `process_issue` 的恢复分支：复用最新 worktree 的 run id（branch、worktree、进度评论都由它驱动），按隐藏 run marker 找回同一条进度评论继续 PATCH，不新建 run、不新建 worktree、不新建评论。已完成 run 的 worktree 保留为证据但标签已移除，重新领取永远新 run。
 
-Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需合入最新 base、手工解决冲突、重跑完整测试与 review 后再推送。Runner 在验收时用 `git merge-base --is-ancestor origin/<base_branch> HEAD` 验证最新远端 base 是交付 HEAD 的祖先；不满足则 fail fast，不接受 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
+Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需合入最新 base、手工解决冲突、重跑完整测试后再推送。Runner 在验收时用 `git merge-base --is-ancestor origin/<base_branch> HEAD` 验证最新远端 base 是交付 HEAD 的祖先；不满足则 fail fast，不接受 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
 
 `.worktrees/` 已加入 `.gitignore`，不会进入版本库。
 
@@ -219,39 +219,38 @@ Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需�
 
 Pi 创建的 PR description 必须包含 `Fixes #<issue-number>`（可以放在首行），指向其源 Issue。GitHub 原生行为：PR merge 到默认分支（`main`）时，body（或 commit message）中的 `Fixes`/`Closes`/`Resolves #<n>` 关键词会自动关闭对应 Issue；PR title 不支持该关键词。没有这个关键词，merge 后 Issue 仍然 OPEN（例如 #45 的遗留状态），需要人工补关。
 
-- prompt（`prompt.md`）在 PR 创建步骤和 Fixer resume 段都要求携带 `Fixes #<issue-number>`（模板里的 `{{ISSUE_NUMBER}}` 由 Runner 渲染成真实 Issue 编号）；
+- prompt（`prompt.md`）在 PR 创建步骤要求携带 `Fixes #<issue-number>`（模板里的 `{{ISSUE_NUMBER}}` 由 Runner 渲染成真实 Issue 编号）；
 - Runner 验收（`verify_pr`）校验 PR body 含 `Fixes #<issue-number>`，缺失即 fail fast 拒绝该 PR（`pr_fixes_missing`），与 run marker 校验同级；
 - 开发契约见 `AGENTS.md`（Git 一节）。
 
-## PR 创建后的 review/fix 循环（Issue #45）
+## PR 创建后的 review/修复 循环（Issue #45、#82）
 
-PR 创建后任务没有结束：Issue 进入可恢复的 review/fix 状态。`ai-pr-opened` 表示**等待 review**（干净 PR 不会被送进 Fixer）；只有显式的 `ai-fix-needed` 状态（Review finding 或 base 前进/冲突）才会触发 Fixer。Review finding、base 前进或 merge conflict 都是可修复状态，不等于任务失败，也不重新进入 ready 队列。
+PR 创建后任务没有结束：Issue 进入可恢复的 review 状态。`ai-pr-opened` 表示**等待 review**；`ai-fix-needed` 表示当前 head 尚不可合并（审查会话未能修复的 finding，或 PR 落后最新 base / 存在 merge conflict）——下一个 tick 在同一 run、同一 PR 上启动**下一个独立审查会话**，由审查会话在会话内吸收最新 base 并修复 finding（Issue #82：不再冷启动 Fixer，也没有第三次 review）。Review finding、base 前进或 merge conflict 都是可修复状态，不等于任务失败，也不重新进入 ready 队列。
 
-- 每个 tick 先按顺序扫描 source repos 中两个 opened-PR 状态的 open Issue（Issue #70）：`ai-fix-needed`（review finding 或 base 冲突 → 同一 PR 的 Fixer）和 `ai-pr-opened`（等待 review → 同一 PR 的独立审查；干净 PR 仍不会送进 Fixer）。`ai-pr-opened` 被扫描是因为开 PR 的那次 delivery 可能已经不在（Runner 被杀，或 Issue #70 背后的进度 PATCH 404 曾把已交付的 Issue 在审查开始前就标成 `ai-blocked`）：没有这个扫描，一个有效的 MERGEABLE PR 会永远没有 owner。`ai-blocked` 的 Issue 被排除（先要人工决策），`ai-merged` 和 `ai-in-progress` 同样被排除；找到时，Runner 只信任由维护者（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的最新 `Muyan Pilot opened PR:` 评论（公开评论永远不可信），从中恢复 run 现场（`run_id`、base_branch、base_sha、PR URL），branch 和 worktree 由配置的 repo、Issue 编号和 run_id **推导**（绝不从评论读取，评论无法指定任意本地路径），在**原 worktree、原 branch、同一 PR** 上继续（`ai-fix-needed` 继续修复，`ai-pr-opened` 直接进入审查等待），而不是领取新 Issue。现场无法恢复（评论缺少完整现场、无可信评论）时 fail fast：Issue 标记 `ai-blocked` 并写明具体原因，本 tick 停止，不做猜测，也不让新任务插队。任何 git/Pi 变更前，Runner 先校验配置的 base 和 open PR（head repo、head branch、base、run marker、精确 URL）。
-- 恢复后先重新 fetch：若最新远端 base 不是 worktree HEAD 的祖先，Runner 在原 branch 上执行普通 `git merge origin/<base>`；出现冲突时冲突原样保留交给 Fixer（Pi）解决，Runner 不自动解决、不 `--abort`、不 force push、不 push 保护分支。
-- Fixer 在原 worktree 中解决冲突和 review finding，重跑完整测试、100% 覆盖率、验证和完整 review 后，只 push 原 task branch；PR 头分支前进，**PR number 保持不变**，Runner 重新验收同一个 PR 并写 `Muyan Pilot fixed PR:` 进度评论（同一 run marker 和 `run_id=` 字段）。
-- 修复成功：Runner 重新验收同一个 PR 后，Issue 从 `ai-fix-needed` 回到 `ai-pr-opened`（等待 review），`ai-fix-needed` 被消费，后续 tick 不会重复启动 Fixer。
-- 恢复、merge、fix 或验收任一步失败：Issue 标记 `ai-blocked`（移除 `ai-fix-needed`），评论写明具体失败和完整现场；PR、branch、worktree 原样保留，不删除、不关闭、不重建。
-- Runner/服务重启后，仅凭 Issue 标签、评论 marker、PR head、branch 和 worktree 即可恢复该 fix loop；implement/review/fix/merge 串行占用同一个并发 slot，不会为同一个 run 启动第二个 Pi。
+- 每个 tick 先按顺序扫描 source repos 中两个 opened-PR 状态的 open Issue（Issue #70）：`ai-fix-needed`（finding 或 base 冲突 → 同一 PR 的下一个审查会话）和 `ai-pr-opened`（等待 review → 同一 PR 的独立审查）。`ai-pr-opened` 被扫描是因为开 PR 的那次 delivery 可能已经不在（Runner 被杀，或 Issue #70 背后的进度 PATCH 404 曾把已交付的 Issue 在审查开始前就标成 `ai-blocked`）：没有这个扫描，一个有效的 MERGEABLE PR 会永远没有 owner。`ai-blocked` 的 Issue 被排除（先要人工决策），`ai-merged` 和 `ai-in-progress` 同样被排除；找到时，Runner 只信任由维护者（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的最新 `Muyan Pilot opened PR:` 评论（公开评论永远不可信），从中恢复 run 现场（`run_id`、base_branch、base_sha、PR URL），branch 和 worktree 由配置的 repo、Issue 编号和 run_id **推导**（绝不从评论读取，评论无法指定任意本地路径），在**原 worktree、原 branch、同一 PR** 上继续（`ai-fix-needed` 与 `ai-pr-opened` 都直接进入审查等待），而不是领取新 Issue。现场无法恢复（评论缺少完整现场、无可信评论）时 fail fast：Issue 标记 `ai-blocked` 并写明具体原因，本 tick 停止，不做猜测，也不让新任务插队。任何 git/Pi 变更前，Runner 先校验配置的 base 和 open PR（head repo、head branch、base、run marker、精确 URL）。
+- 审查会话（journal 中 `role=review`）在会话内完成修复：修改代码、重跑完整测试与 100% 行/分支覆盖率、commit 并**只 push 原 task branch**，然后对修复后的 head 重新输出 `REVIEW_VERDICT`。PR 头分支前进，**PR number 保持不变**。
+- 审查会话无法修复的 finding（或 PR 落后最新 base / merge conflict）：Issue 标记 `ai-fix-needed`，等待下一个 tick 的下一个审查会话（会话内 `git merge origin/<base>` 吸收最新 base、解决冲突、全量回归后重新输出 verdict）。Runner 自己不自动解决冲突、不 `--abort`、不 force push、不 push 保护分支。
+- 审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）：超轮仍有 Blocker/Major、审查 Pi 失败或无法验证时，Issue 标记 `ai-blocked`（移除 opened-PR 状态），评论写明具体失败和完整现场；PR、branch、worktree 原样保留，不删除、不关闭、不重建。
+- Runner/服务重启后，仅凭 Issue 标签、评论 marker、PR head、branch 和 worktree 即可恢复该循环；implement/review/merge 串行占用同一个并发 slot，不会为同一个 run 启动第二个 Pi。
 
 状态语义：
 
 ```text
-ai-in-progress → PR opened (ai-pr-opened) → review
-  → fix-needed / base-conflict (ai-fix-needed) → fix same PR
-  → full re-review (ai-pr-opened) → merge → ai-merged
+ai-in-progress → PR opened (ai-pr-opened) → review（会话内修复）
+  → 未修复的 finding / base 冲突 (ai-fix-needed) → 下一个审查会话
+  → clean verdict → merge → ai-merged
 ```
 
-## 自动审查、修复与合并（Issue #34）
+## 自动审查、修复与合并（Issue #34、#82）
 
 Pi 不直接 push 保护分支。实现 Agent 只 push feature branch 并创建 PR；PR 打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
 
 1. **冻结 PR 的 base/head SHA**（`gh pr list` 取唯一 open PR 的 `baseRefOid`/`headRefOid`）。
-2. **独立审查**：启动一个独立、只读的 Review Agent（code-review R1–R9），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implement/fix 一样通过 live activity 管道输出（journal 中 `role=review`）。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；读不到合法 verdict 一律 fail fast，绝不当作通过。
-3. **修复循环**：verdict 有 Blocker/Major 时，把 finding 评论到 Issue 和 PR，Issue 标记 `ai-fix-needed`；同一 feature branch/worktree 上的 Fixer（journal 中 `role=fix`）修复并 push 后回到 `ai-pr-opened`，下一轮等待重新冻结 SHA、全量回归、完整复审。审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；超轮仍有 Blocker/Major 则 fail fast 并标记 `ai-blocked`。
-4. **合并门禁**：重新 fetch 最新 `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，只有被审查的 head 能落地。落后最新 base 的 PR 不会被合并（转 `ai-fix-needed`，由 Fixer 吸收最新 base 后重试）。
-5. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动 CLOSED（见上方「PR body 契约」）。
+2. **独立审查（同时是修复者，Issue #82）**：启动一个独立的 Review Agent（code-review R1–R9，不附加 `review-fix-loop`/`tdd-dev` skill），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implementer 一样通过 live activity 管道输出（journal 中 `role=review`）。审查者**可以修改代码**：发现 Blocker/Major 时在同一会话内修复、重跑完整测试与 100% 行/分支覆盖率、commit 并只 push task branch，然后对修复后的 head 重新输出 verdict——没有冷启动 Fixer，也没有第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；`pass` 表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，绝不当作通过。
+3. **重新冻结并合并门禁**：clean verdict 后 Runner 重新冻结 PR（审查者可能已 push 修复，head 前进），重新 fetch 最新 `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，只有被审查的 head 能落地。
+4. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动 CLOSED（见上方「PR body 契约」）。
+5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。审查循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；超轮仍有 Blocker/Major、审查 Pi 失败或无法验证时 fail fast 并标记 `ai-blocked`。
 
-成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是进入同一 PR 的 fix/review 循环。
+成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是在同一 PR 的审查会话内修复（或交给下一个审查会话）。
 
-两个 prompt 由配置提供（默认 `prompt.md` 实现、`prompt_review.md` 审查）；Fixer 复用 `prompt.md`（PR 已存在时注入 resume 段）。
+两个 prompt 由配置提供（默认 `prompt.md` 实现、`prompt_review.md` 审查+会话内修复）；审查 prompt 不附加 `review-fix-loop`/`tdd-dev` skill。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -4,21 +4,22 @@
 This is intentionally small. It claims one ready GitHub Issue, gives it to
 Pi in an isolated worktree, and accepts success only when one open PR exists.
 After the implementer opens the PR, the Runner closes the loop itself: it
-freezes the exact PR base/head SHA, runs an independent review session, loops
-a fixer session on the same feature branch/worktree while Blocker/Major
-findings exist, re-checks the merge gate against the latest remote base, and
-merges via `gh pr merge --match-head-commit`. Pi never pushes the protected
-branch; the Runner is the only merge actor. Any command failure is logged and
+freezes the exact PR base/head SHA, runs one independent review session that
+reviews the diff AND fixes Blocker/Major findings in the same session
+(modify code, run tests, push the task branch — Issue #82: no cold-start
+fixer, no third review), re-freezes the head after a clean verdict,
+re-checks the merge gate against the latest remote base, and merges via
+`gh pr merge --match-head-commit`. Pi never pushes the protected branch;
+the Runner is the only merge actor. Any command failure is logged and
 raised. There is no fallback, queue, daemon, or multi-agent framework.
 
 Throughout the whole lifecycle the Runner publishes live progress
 automatically (Issue #18): one per-run GitHub progress comment carrying a
 hidden run marker is PATCHed in place on every activity change and at most
-every 30 seconds while any Pi session (implementer, reviewer or fixer)
-runs, and short milestone comments (started, plan ready, tests
-passed/failed, review findings, fix pushed, PR opened, merged, blocked)
-notify GitHub Mobile. No human command, poll or status check is part of
-the normal workflow.
+every 30 seconds while any Pi session (implementer or reviewer) runs, and
+short milestone comments (started, plan ready, tests passed/failed, review
+findings, PR opened, merged, blocked) notify GitHub Mobile. No human
+command, poll or status check is part of the normal workflow.
 """
 from __future__ import annotations
 
@@ -71,12 +72,13 @@ PI_HEARTBEAT_SECONDS = 30.0
 PI_IDLE_WARN_SECONDS = 300.0
 
 # The bootstrap runner streams every Pi session of a run through the same
-# live activity pipeline (Issue #24/#40); implement/review/fix share the
-# same line format and carry their role (Issue #41: one run_id end to
-# end, the roles are steps of the same run).
+# live activity pipeline (Issue #24/#40); implement/review share the same
+# line format and carry their role (Issue #41: one run_id end to end, the
+# roles are steps of the same run). Issue #82 removed the cold-start fixer
+# role: the review session fixes findings in the same session, so a run
+# has at most two Pi sessions (implement, then review).
 ROLE_IMPLEMENT = "implement"
 ROLE_REVIEW = "review"
-ROLE_FIX = "fix"
 
 # Run correlation (Issue #41): one task attempt generates one run_id and
 # every journal line of the attempt starts with `[run_id]`, so a single
@@ -86,12 +88,15 @@ RUN_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
 _CURRENT_RUN_ID: str | None = None
 
 # GitHub labels are the only state store (Issue #45). After a PR is
-# opened the Issue is in a recoverable review/fix state: `ai-pr-opened`
-# means awaiting review, and only the explicit `ai-fix-needed` state
-# (a review finding or a base conflict) is scanned for Fixer work. The
-# next tick resumes that same run on the same branch, worktree and PR
-# instead of claiming a new Issue. `ai-merged` is the success terminal
-# state the Runner sets after it merges the PR itself (Issue #34).
+# opened the Issue is in a recoverable review state: `ai-pr-opened`
+# means awaiting review, and the explicit `ai-fix-needed` state (a review
+# finding the reviewer could not fix in-session, or a base conflict)
+# means awaiting the next review session — Issue #82: the review session
+# itself fixes findings in the same session, so both labels resume into
+# the same independent review (no cold-start fixer). The next tick
+# resumes that same run on the same branch, worktree and PR instead of
+# claiming a new Issue. `ai-merged` is the success terminal state the
+# Runner sets after it merges the PR itself (Issue #34).
 IN_PROGRESS_LABEL = "ai-in-progress"
 PR_OPENED_LABEL = "ai-pr-opened"
 FIX_NEEDED_LABEL = "ai-fix-needed"
@@ -421,19 +426,6 @@ def issue_comments(number: int, *, repo: str) -> list[dict]:
     return comments
 
 
-def issue_body(number: int, *, repo: str) -> str:
-    """Return the Issue body; the fixer works from the original task."""
-    raw = run_command([
-        "gh", "issue", "view", str(number), "--repo", repo,
-        "--json", "body",
-    ])
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ValueError("issue view must be a JSON object")
-    body = data.get("body")
-    return body if isinstance(body, str) else ""
-
-
 def new_run_id() -> str:
     """Return a unique short run identifier for one task attempt."""
     return uuid.uuid4().hex[:8]
@@ -561,20 +553,21 @@ def pick_resumable_delivery(
 ) -> tuple[dict, dict] | None:
     """Return the newest opened-PR delivery and its resume scene.
 
-    Both opened-PR states are scanned (Issue #70): `ai-fix-needed` (a
-    review finding or a base conflict — the next tick runs the Fixer on
-    the same branch, worktree and PR, Issue #45) and `ai-pr-opened`
-    (awaiting review — the next tick runs the independent review; a
-    clean PR is still never sent to the Fixer, Issue #45 round-5
-    contract). The `ai-pr-opened` scan exists because the delivery that
-    opened the PR can be gone: the progress-publishing failure behind
-    Issue #70 used to label the delivered Issue `ai-blocked` before the
-    review started, and a killed runner can die inside the delivery
-    wait loop, leaving a valid MERGEABLE PR with no owner. Without the
-    scan such a delivery is picked up by no other scan (`pick_issue`
-    excludes `ai-pr-opened`) and is stranded forever. `ai-blocked`
-    Issues are excluded (they need a human decision first), as are
-    merged and in-flight Issues and closed Issues. A scene that cannot
+    Both opened-PR states are scanned (Issue #70): `ai-fix-needed`
+    (awaiting the next review session after a finding or a base
+    conflict — Issue #82: the review session fixes findings in the same
+    session, so the next tick runs the same independent review on the
+    same branch, worktree and PR) and `ai-pr-opened` (awaiting review —
+    the next tick runs the independent review). The `ai-pr-opened`
+    scan exists because the delivery that opened the PR can be gone: the
+    progress-publishing failure behind Issue #70 used to label the
+    delivered Issue `ai-blocked` before the review started, and a killed
+    runner can die inside the delivery wait loop, leaving a valid
+    MERGEABLE PR with no owner. Without the scan such a delivery is
+    picked up by no other scan (`pick_issue` excludes `ai-pr-opened`)
+    and is stranded forever. `ai-blocked` Issues are excluded (they need
+    a human decision first), as are merged and in-flight Issues and
+    closed Issues. A scene that cannot
     be recovered is an unresolvable state: the Issue is marked
     `ai-blocked` with the concrete reason and the error re-raised, so
     the tick stops instead of silently skipping the delivery while a
@@ -616,9 +609,6 @@ def pick_resumable_delivery(
         scene = resume_scene(comments)
     except ValueError as exc:
         block_scene_failure(issue, exc, repo, comments)
-    # The fixer works from the original task, so the resumable issue
-    # carries its body like a freshly claimed one.
-    issue["body"] = issue_body(int(issue["number"]), repo=repo)
     return issue, scene
 
 
@@ -694,55 +684,6 @@ def pick_next_delivery(
         if issue is not None:
             return repo, issue, None
     return None
-
-
-def merge_in_progress(worktree: Path) -> bool:
-    """True when the worktree is mid-merge (conflicts staged for a commit)."""
-    try:
-        run_command(
-            ["git", "rev-parse", "-q", "--verify", "MERGE_HEAD"],
-            cwd=worktree,
-        )
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
-def merge_latest_base(worktree: Path, base_branch: str) -> bool:
-    """Fetch `origin/<base>` and merge it when the delivery is behind.
-
-    Returns True when a merge was started. A conflicted merge is left
-    staged for the fixer (Pi) to resolve: the runner never auto-resolves,
-    force-pushes, or pushes the protected branch (Issue #45). A merge
-    failure that is not a conflict fails fast.
-    """
-    run_command(["git", "fetch", "origin", base_branch], cwd=worktree)
-    try:
-        run_command(
-            ["git", "merge-base", "--is-ancestor",
-             f"origin/{base_branch}", "HEAD"],
-            cwd=worktree,
-        )
-    except subprocess.CalledProcessError:
-        LOGGER.info(
-            "base_advanced base_branch=%s worktree=%s; merging into the "
-            "task branch",
-            base_branch, worktree,
-        )
-        try:
-            run_command(
-                ["git", "merge", f"origin/{base_branch}"], cwd=worktree,
-            )
-        except subprocess.CalledProcessError:
-            if not merge_in_progress(worktree):
-                raise
-            LOGGER.warning(
-                "base_merge_conflict base_branch=%s worktree=%s; the "
-                "conflict is left staged for the fixer",
-                base_branch, worktree,
-            )
-        return True
-    return False
 
 
 def worktree_path(repo_dir: Path, source_repo: str, number: int,
@@ -1072,8 +1013,13 @@ def stream_pi(
 
 def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
            *, timeout: int | None = None, branch: str | None = None,
-           pr_url: str | None = None,
            progress: Callable[[dict], None] | None = None) -> str:
+    """Run the implementer Pi session for a freshly claimed Issue.
+
+    Issue #82 removed the fixer reuse of this function: findings are
+    fixed by the review session in the same session, so the implementer
+    is the only user of `prompt.md` now.
+    """
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -1098,18 +1044,6 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         f"Issue body:\n{issue.get('body', '')}\n\n"
         f"Worktree: {worktree}\n"
     )
-    if pr_url is not None:
-        context += (
-            f"Existing PR: {pr_url}\n"
-            "This run already opened that PR. Keep the same PR number, the "
-            "same run id, branch and worktree: never close the PR, never "
-            "create a new PR, never re-claim the Issue. Fix the review "
-            "findings and/or resolve the merge conflicts left in the "
-            "worktree, rerun the full test suite with coverage and the "
-            "complete review, then commit and push ONLY the task branch "
-            "so the same PR updates. No force push, no push of the "
-            "protected branch.\n"
-        )
     context += "Complete the delivery process in the system prompt."
     command = [
         "pi", *_skill_args(_skills_for(config, IMPLEMENT_EXCLUDED_SKILLS)),
@@ -1336,13 +1270,15 @@ def freeze_pr(worktree: Path, branch: str, base_branch: str) -> dict:
     }
 
 
-# Role-specific skill filtering (Issue #83): the review session is
-# read-only and ends with a single REVIEW_VERDICT line, so the
-# delivery-oriented skills must not be loaded there (tdd-dev would
-# steer it into the implement/test/PR flow, review-fix-loop would
-# open another fix/review round). The implementer/fixer keeps
-# tdd-dev and code-review but not review-fix-loop: the Runner itself
-# runs the independent review/fix loop once the PR is open.
+# Role-specific skill filtering (Issue #83): the review session ends
+# with a single REVIEW_VERDICT line and its job is to review this one
+# diff and fix it until it can merge (Issue #82) — not to open another
+# full delivery — so the delivery-oriented skills must not be loaded
+# there (tdd-dev would steer it into the implement/test/PR flow,
+# review-fix-loop would open another fix/review round). The
+# implementer keeps tdd-dev and code-review but not review-fix-loop:
+# the Runner itself runs the independent review loop once the PR is
+# open.
 REVIEW_EXCLUDED_SKILLS = frozenset({"tdd-dev", "review-fix-loop"})
 IMPLEMENT_EXCLUDED_SKILLS = frozenset({"review-fix-loop"})
 
@@ -1381,11 +1317,17 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
                issue: int, branch: str, round: int,
                timeout: int | None = None,
                progress: Callable[[dict], None] | None = None) -> str:
-    """Run one independent, read-only review session for a frozen PR.
+    """Run one independent review session for a frozen PR.
 
-    The review streams live activity through the same pipeline as the
-    implementer and fixer (role=review; Issue #41: one run_id end to end,
-    the roles are steps of the same run).
+    The session is independent (new process, `prompt_review.md`, a new
+    session JSONL) and reviews the exact frozen base/head. Issue #82:
+    when it finds Blocker/Major issues it fixes them IN THIS SAME
+    SESSION (modify code, run the full test suite with coverage, commit
+    and push the task branch) and re-emits the final verdict — there is
+    no cold-start fixer and no third review. The review streams live
+    activity through the same pipeline as the implementer (role=review;
+    Issue #41: one run_id end to end, the roles are steps of the same
+    run).
     """
     system_prompt = render_prompt(
         config["prompt_review"].read_text(encoding="utf-8"),
@@ -1403,8 +1345,9 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     context = (
         f"Independently review PR #{pr['number']} ({pr['url']}) of "
         f"{source_repo} against base {config['base_branch']}@{pr['base_oid']} "
-        f"and head {pr['head_oid']} (round {round}). Follow code-review R1-R9 "
-        "and end with a single REVIEW_VERDICT line."
+        f"and head {pr['head_oid']} (round {round}). Follow code-review R1-R9; "
+        "fix Blocker/Major findings in this same session (push only the "
+        "task branch) and end with a single REVIEW_VERDICT line."
     )
     command = [
         "pi", *_skill_args(_skills_for(config, REVIEW_EXCLUDED_SKILLS)),
@@ -1601,21 +1544,26 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
     """Run one independent review round; merge when the verdict is clean.
 
     The delivery wait loop (which holds the slot) calls this while the
-    PR is open and the Issue awaits review (`ai-pr-opened`). It freezes
-    the PR, runs the independent review (streamed, role=review), and
-    then:
+    PR is open and the Issue awaits review (`ai-pr-opened`) or awaits the
+    next review session (`ai-fix-needed`). It freezes the PR, runs the
+    independent review (streamed, role=review), and then:
 
-    - clean verdict -> merge gate (latest-base ancestor, mergeable,
-      head match, `gh pr merge --match-head-commit`), confirm the merge
-      landed on origin/<base>, sync the deployment checkout, label the
-      Issue `ai-merged`; returns True;
-    - Blocker/Major findings -> comment them to Issue and PR and label
-      the Issue `ai-fix-needed`; the #45 fix loop repairs the same PR
-      and returns the Issue to `ai-pr-opened`, where the next wait
-      iteration re-reviews; returns False;
-    - a gate failure because the head is behind the latest base ->
-      label the Issue `ai-fix-needed` with the absorb-base finding
-      (the fixer merges the latest base); returns False;
+    - clean verdict -> the reviewer may have fixed findings IN THE SAME
+      SESSION and pushed the task branch (Issue #82), so the PR is
+      RE-FROZEN before the merge gate: the gate (latest-base ancestor,
+      mergeable, head match, `gh pr merge --match-head-commit`) then
+      runs against the head the verdict actually covers; confirm the
+      merge landed on origin/<base>, sync the deployment checkout,
+      label the Issue `ai-merged`; returns True;
+    - Blocker/Major findings the reviewer could not fix in-session ->
+      comment them to Issue and PR and label the Issue `ai-fix-needed`;
+      the next wait iteration (or the next tick after a restart) runs
+      the same independent review again — no cold-start fixer, no
+      third review; returns False;
+    - a gate failure because the head is behind the latest base or has
+      a merge conflict -> label the Issue `ai-fix-needed` with the
+      absorb-base finding (the next review session absorbs the latest
+      base in-session); returns False;
     - missing/malformed verdict or an exhausted round budget -> raise;
       the caller marks the Issue `ai-blocked`.
     """
@@ -1657,6 +1605,17 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
         verdict["majors"],
     )
     if review_has_findings(verdict):
+        # The reviewer could not make the PR mergeable in this session
+        # (Issue #82: findings are fixed in the same session; reaching
+        # this branch means the fix was not verifiable or not this
+        # session's to decide). The Issue moves to the explicit
+        # fix-needed state: the next review session retries the same PR
+        # (no cold-start fixer), and the round budget bounds the loop.
+        LOGGER.info(
+            "review_findings_unfixed pr=%s round=%s; the Issue moves to "
+            "ai-fix-needed, the next review session retries the same PR",
+            pr["number"], round,
+        )
         body = (
             f"{marker}\n"
             f"Muyan Pilot review round {round} for PR #{pr['number']}: "
@@ -1678,20 +1637,32 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
         ), outcome=(
             "**Muyan Pilot review findings**\n\n"
             f"round {round}: {verdict['blockers']} blocker(s), "
-            f"{verdict['majors']} major(s); the fix loop repairs the "
-            "same PR automatically"
+            f"{verdict['majors']} major(s); the next review session "
+            "retries the same PR automatically"
         )))
         edit_issue(
             number, repo=source_repo, add=FIX_NEEDED_LABEL,
             remove=PR_OPENED_LABEL,
         )
         return False
+    # Issue #82: the reviewer fixes findings in the same session and
+    # pushes the task branch, so the head the verdict covers may be
+    # NEWER than the frozen head. Re-freeze before the merge gate: the
+    # gate then checks the latest-base ancestor, mergeability and the
+    # exact reviewed head against the current remote head, and merges
+    # only that head via --match-head-commit.
+    refrozen = freeze_pr(worktree, branch, base_branch)
+    if refrozen["head_oid"] != pr["head_oid"]:
+        LOGGER.info(
+            "review_head_advanced pr=%s round=%s frozen=%s reviewed=%s",
+            pr["number"], round, pr["head_oid"], refrozen["head_oid"],
+        )
     try:
-        merged = merge_gate(worktree, pr, base_branch)
+        merged = merge_gate(worktree, refrozen, base_branch)
     except RuntimeError as exc:
         message = str(exc)
-        # Behind and merge-conflict are the same fixer job: absorb
-        # origin/<base>, resolve, retest. Other gate failures
+        # Behind and merge-conflict are the same next-session job:
+        # absorb origin/<base>, resolve, retest. Other gate failures
         # (head moved, etc.) fail fast.
         if (
             "behind latest remote base" not in message
@@ -1702,8 +1673,9 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             f"{marker}\n"
             f"Muyan Pilot review round {round} for PR #{pr['number']}: "
             "the PR is behind the latest base or has a merge conflict; "
-            f"merge the latest origin/{base_branch} into the branch, "
-            "resolve conflicts, and rerun the full test suite"
+            f"the next review session merges the latest "
+            f"origin/{base_branch} into the branch in-session, resolves "
+            "conflicts, and reruns the full test suite"
         )
         comment_issue(number, repo=source_repo, body=body)
         comment_pr(pr["number"], body=body)
@@ -2084,11 +2056,11 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,
         )
-        # No `fix pushed` milestone on a fresh claim: the implementer
-        # always commits the delivery on top of the frozen base, so the
-        # head always advanced — the PR opened milestone below announces
-        # the delivery. `fix pushed` is the fixer's milestone
-        # (resume_delivery), where it marks a real fix on an opened PR.
+        # The PR opened milestone announces the delivery: the
+        # implementer always commits the delivery on top of the frozen
+        # base, so the head always advanced. (Issue #82 removed the
+        # fixer's `fix pushed` milestone: findings are fixed by the
+        # review session, which records its own round comments.)
         edit_issue(
             number, repo=source_repo, add=PR_OPENED_LABEL,
             remove=IN_PROGRESS_LABEL,
@@ -2192,198 +2164,6 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         raise
 
 
-def resume_delivery(issue: dict, scene: dict, config: dict,
-                    source_repo: str) -> str:
-    """Resume the fix loop of an opened PR on the same run (Issue #45).
-
-    The scene (run id, base, PR URL) is recovered from the Issue's
-    trusted `Muyan Pilot opened PR:` comment, so a restart of the runner
-    or the service resumes from GitHub state alone. Branch and worktree
-    are DERIVED from the configured repo_dir, source_repo, Issue number
-    and run id — never read from the comment — so no comment can steer
-    the runner into an arbitrary local path. Before any git or Pi
-    mutation the configured base and the open PR (repo, head branch,
-    base, run marker, exact URL) are validated; the latest remote base is
-    then merged into the ORIGINAL branch (conflicts stay staged for the
-    fixer), Pi fixes the PR in the ORIGINAL worktree, and the SAME PR is
-    re-verified: the returned URL is the one verify_pr verified, which
-    must exactly equal the recovered original PR URL. Any failure marks
-    the Issue `ai-blocked` and preserves the PR, branch and worktree: the
-    run is never re-claimed, the PR is never closed or replaced.
-    """
-    number = int(issue["number"])
-    run_id = validate_run_id(scene["run_id"])
-    # Derive the expected branch and worktree from the runner's own
-    # config and the run id (the values the first run used when it
-    # created them); a comment can never name an arbitrary local path.
-    branch = task_branch(source_repo, number, run_id)
-    worktree = worktree_path(config["repo_dir"], source_repo, number, run_id)
-    base_branch = scene["base_branch"]
-    pr_url = scene["pr_url"]
-    set_run_id(run_id)
-    started = time.monotonic()
-    publisher = ProgressPublisher(
-        number, source_repo, run_id, run_command=run_command,
-    )
-    scene_info = (
-        f"base_branch={base_branch} base_sha={scene['base_sha']} "
-        f"run_id={run_id} branch={branch} worktree={worktree} "
-        f"pr_url={pr_url}"
-    )
-    LOGGER.info("issue=%s resuming opened PR %s", number, scene_info)
-    try:
-        # Validate the configured base before any git/Pi mutation: a
-        # scene frozen on another base branch is never merged.
-        if base_branch != config["base_branch"]:
-            raise RuntimeError(
-                f"base branch mismatch: scene has {base_branch}, config "
-                f"has {config['base_branch']}; the resume must use the "
-                "configured base branch"
-            )
-        if not worktree.is_dir():
-            raise RuntimeError(f"worktree missing: {worktree}")
-        # Validate the open PR before any git/Pi mutation: exactly one
-        # open PR of the derived branch, in the configured source repo,
-        # on the configured base, carrying the run marker, and with the
-        # exact URL of the recovered original PR (same PR number). The
-        # latest-base check is deferred to the post-fix verification:
-        # being behind the base is the expected state the resume exists
-        # to fix (merge_latest_base runs next).
-        verified_url = verify_pr(
-            worktree, branch, base_branch, run_id,
-            issue=number, pr_repo=source_repo, expected_url=pr_url,
-            require_latest_base=False,
-        )
-        merge_latest_base(worktree, base_branch)
-        config = {**config, "base_sha": scene["base_sha"], "run_id": run_id}
-        publisher.ensure(_progress_body(_progress_state(
-            issue=number, run_id=run_id, role=ROLE_FIX,
-            branch=branch, worktree=worktree, started=started,
-            pr_url=verified_url, review_round=0,
-        )))
-        run_pi(
-            issue, worktree, config, source_repo,
-            branch=branch, pr_url=verified_url,
-            progress=LiveProgressThrottle(
-                publisher, issue=number, run_id=run_id,
-                role=ROLE_FIX, branch=branch, worktree=worktree,
-                started=started, pr_url=verified_url, review_round=0,
-            ),
-        )
-        # Re-verify the SAME PR after the fixer pushed: the verified URL
-        # must still exactly equal the recovered original PR URL.
-        verified_url = verify_pr(
-            worktree, branch, base_branch, run_id,
-            issue=number, pr_repo=source_repo, expected_url=pr_url,
-        )
-        # The state transition comes first: the Issue leaves the
-        # fix-needed state before the progress comment is recorded, so
-        # an observer never sees a "fixed PR" comment on an Issue that
-        # is still fix-needed (a crash in between re-runs the fixer,
-        # which is idempotent; the comment is a record, the label is
-        # the state).
-        edit_issue(
-            number, repo=source_repo, add=PR_OPENED_LABEL,
-            remove=FIX_NEEDED_LABEL,
-        )
-        # The fix is delivered here: the PR is re-verified and the
-        # Issue is back in `ai-pr-opened`. From here on only the
-        # delivery-record publishing remains, and a failure there must
-        # NOT fail the delivery (Issue #60, same contract as the fresh
-        # claim): each step is best-effort and independent — an error
-        # is logged (`progress_publish_failed`) and the next step
-        # still runs — and the run continues into the review/merge
-        # wait loop either way.
-        for step in (
-            lambda: comment_issue(
-                number, repo=source_repo,
-                body=(
-                    f"{run_marker(run_id)}\n"
-                    f"Muyan Pilot fixed PR: {verified_url} ({scene_info})"
-                ),
-            ),
-            lambda: publisher.milestone(
-                f"fix pushed: {verified_url} ({scene_info})"
-            ),
-            lambda: publisher.finish(_progress_body(_progress_state(
-                issue=number, run_id=run_id, role=ROLE_FIX,
-                branch=branch, worktree=worktree, started=started,
-                pr_url=verified_url, review_round=0,
-            ), outcome=(
-                "**Muyan Pilot fix pushed**\n\n"
-                "the same PR is awaiting review again; the independent "
-                "review and merge happen automatically"
-            ))),
-        ):
-            try:
-                step()
-            except Exception:
-                LOGGER.exception(
-                    "progress_publish_failed run=%s issue=%s role=%s",
-                    run_id, issue_context(source_repo, number), ROLE_FIX,
-                )
-    except Exception as exc:
-        LOGGER.exception("issue=%s resume failed", number)
-        activity_scene = ""
-        try:
-            snapshot = activity_snapshot(worktree / ".pi-session")
-            if snapshot is None:
-                # No session file yet: the scene still carries the full
-                # debug entry (worktree, branch) with '-' session fields.
-                snapshot = {
-                    "session_id": None, "session_file": None,
-                    "phase": "starting", "last_activity": None,
-                    "action": None, "result": None,
-                }
-            activity_scene = format_run_scene(
-                snapshot,
-                run_id=run_id, issue=issue_context(source_repo, number),
-                role=ROLE_IMPLEMENT, branch=branch, worktree=str(worktree),
-            )
-        except Exception:
-            LOGGER.exception("issue=%s activity scene failed", number)
-        try:
-            edit_issue(
-                number, repo=source_repo, add=BLOCKED_LABEL,
-                remove=FIX_NEEDED_LABEL,
-            )
-            detail = _failure_detail(exc)
-            body = (
-                f"{run_marker(run_id)}\n"
-                f"Muyan Pilot failed: {detail} ({scene_info})"
-            )
-            if activity_scene:
-                body += f" {activity_scene}"
-            comment_issue(number, repo=source_repo, body=body)
-            # The blocked milestone is posted even when the progress
-            # comment was never created (a failure before `ensure`):
-            # the mobile notification of the terminal failure must not
-            # depend on it.
-            publisher.milestone(
-                f"blocked: {sanitize(detail)} ({scene_info})"
-            )
-            if publisher.comment_id is not None:
-                publisher.finish(_progress_body(_progress_state(
-                    issue=number, run_id=run_id, role=ROLE_FIX,
-                    branch=branch, worktree=worktree,
-                    started=started, pr_url=pr_url,
-                    review_round=0,
-                ), outcome=(
-                    "**Muyan Pilot blocked**\n\n"
-                    f"failure: {detail}\n"
-                    "next step: fix the failure above and resume this "
-                    "same PR (branch, worktree and PR are preserved)"
-                )))
-        except Exception:
-            LOGGER.exception("issue=%s failure reporting failed", number)
-        raise
-    # The fix succeeded: the Issue is back in awaiting review (the
-    # transition happened before the progress comment), so the next
-    # tick does not re-run the Fixer (a clean PR is simply waiting for
-    # review now).
-    return verified_url
-
-
 def pr_state(pr_url: str) -> str:
     """Return the GitHub state of one PR: `OPEN`, `MERGED` or `CLOSED`.
 
@@ -2428,21 +2208,22 @@ def _finish_blocked_progress(
     number: int, run_id: str | None, source_repo: str,
     worktree: Path | None, branch: str | None, pr_url: str,
     detail: str, next_step: str,
-    role: str = ROLE_FIX, review_round: int = 0,
+    role: str = ROLE_REVIEW, review_round: int = 0,
 ) -> None:
     """Finish the tracked progress comment with the blocked scene.
 
     The contract (Issue #18): on failure the progress comment becomes
     the blocked scene with the next-step reason — the same terminal
-    body the `process_issue` and `resume_delivery` failure paths write.
-    `ensure` finds the run's existing progress comment by its hidden
-    marker (PATCHing it in place) or creates it when the run never
-    reached one; either way the blocked scene is the final state.
-    `role` and `review_round` are the actual role and completed review
-    rounds of the blocked run (review round 2, PR #42): the caller
-    derives them from the Issue's delivery label and trusted
-    review-round comments, so the terminal comment never shows a stale
-    hardcoded `fix`/`0`.
+    body the `process_issue` failure path writes. `ensure` finds the
+    run's existing progress comment by its hidden marker (PATCHing it
+    in place) or creates it when the run never reached one; either way
+    the blocked scene is the final state. `role` and `review_round`
+    are the actual role and completed review rounds of the blocked run
+    (review round 2, PR #42): the caller derives them from the
+    Issue's trusted review-round comments, so the terminal comment
+    never shows a stale hardcoded role/round. Issue #82: the only
+    post-PR role is `review` (the review session fixes findings in the
+    same session), so the default is `ROLE_REVIEW`.
     """
     if run_id is None:
         return
@@ -2466,7 +2247,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
     """Own the delivery lifecycle: hold the slot until merge or failure.
 
     The slot is acquired by `main` before the claim and must stay
-    occupied through implement -> review -> fix -> merge (Issue #39): a
+    occupied through implement -> review -> merge (Issue #39): a
     delivery whose PR is open still needs the machine, and no other
     Runner may start a second Pi while it is held. The Runner is the
     owner of that lifecycle, so it re-checks the delivery every
@@ -2479,20 +2260,18 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
       marked `ai-blocked` (removing `ai-pr-opened`/`ai-fix-needed`) with
       a failure comment carrying the run marker, then the slot is
       released by the caller;
-    - Issue in the explicit `ai-fix-needed` state (a review finding or
-      a base conflict) -> the Runner runs the SAME-PR fix (Issue #45)
-      itself, on the same run, in the same worktree, while still holding
-      the slot; the fix returns the Issue to `ai-pr-opened` and the
-      wait continues. A new Runner can never take the slot to fix this
-      delivery while it is held, so the fix must happen here;
-    - Issue awaiting review (`ai-pr-opened`) -> the Runner runs the
-      independent review of the frozen PR (Issue #34) itself, on the
-      same run, while still holding the slot: a clean verdict merges
-      the PR via the merge gate, confirms the merge, syncs the
-      deployment checkout and labels the Issue `ai-merged` (terminal,
-      the slot is released); findings label the Issue `ai-fix-needed`
-      and the fix step above repairs the same PR before the next
-      iteration re-reviews;
+    - Issue in an opened-PR state (`ai-pr-opened` awaiting review, or
+      `ai-fix-needed` awaiting the next review session after a finding
+      or a base conflict) -> the Runner runs the independent review of
+      the frozen PR (Issue #34) itself, on the same run, while still
+      holding the slot: the review session fixes Blocker/Major findings
+      IN THE SAME SESSION (Issue #82 — no cold-start fixer, no third
+      review), a clean verdict re-freezes the head and merges the PR
+      via the merge gate, confirms the merge, syncs the deployment
+      checkout and labels the Issue `ai-merged` (terminal, the slot is
+      released); unfixed findings or a behind/conflict gate label the
+      Issue `ai-fix-needed` and the next iteration re-runs the same
+      independent review;
     - otherwise -> keep holding the slot and re-check.
 
     There is no timeout: systemd owns the run lifecycle and kills the
@@ -2525,6 +2304,13 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 number, repo=source_repo, add=BLOCKED_LABEL,
                 remove=PR_OPENED_LABEL,
             )
+            # A PR closed while in `ai-fix-needed` (awaiting the next
+            # review session) leaves that label behind: remove it too,
+            # so the terminal state is `ai-blocked` alone.
+            if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
+                edit_issue(
+                    number, repo=source_repo, remove=FIX_NEEDED_LABEL,
+                )
             body = (
                 f"Muyan Pilot failed: PR {pr_url} was closed without "
                 "a merge; the delivery is terminally failed"
@@ -2542,15 +2328,11 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 )
                 # The blocked scene carries the actual role and the
                 # completed review rounds (review round 2, PR #42):
-                # the delivery label says which role was in flight
-                # (ai-fix-needed -> fix, otherwise the awaiting-review
-                # review), and the trusted review-round comments bound
-                # the round count (GitHub is the only state store).
-                blocked_role = (
-                    ROLE_FIX if FIX_NEEDED_LABEL in
-                    issue_labels(number, source_repo)
-                    else ROLE_REVIEW
-                )
+                # Issue #82 — both opened-PR states are review states
+                # (the review session fixes findings in the same
+                # session), so the role is always `review`, and the
+                # trusted review-round comments bound the round count
+                # (GitHub is the only state store).
                 blocked_round = review_rounds_so_far(
                     issue_comments(number, repo=source_repo),
                 )
@@ -2563,34 +2345,27 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     "delivery is terminally failed",
                     "investigate why the PR was closed and re-open the "
                     "delivery or start a fresh run on the Issue",
-                    role=blocked_role, review_round=blocked_round,
+                    role=ROLE_REVIEW, review_round=blocked_round,
                 )
             return
         labels = issue_labels(number, source_repo)
-        if FIX_NEEDED_LABEL in labels and BLOCKED_LABEL not in labels:
-            # The review found a problem (or the base advanced): fix the
-            # SAME PR on the SAME run while still holding the slot.
-            LOGGER.info(
-                "issue=%s delivery_fix_needed pr=%s; resuming the fix "
-                "loop of the same PR",
-                number, pr_url,
-            )
-            scene = resume_scene(issue_comments(number, repo=source_repo))
-            fix_issue = dict(issue)
-            fix_issue["body"] = issue_body(number, repo=source_repo)
-            resume_delivery(fix_issue, scene, config, source_repo)
-            continue  # the fix returned the Issue to awaiting review
-        if (PR_OPENED_LABEL in labels and BLOCKED_LABEL not in labels
+        if ((PR_OPENED_LABEL in labels or FIX_NEEDED_LABEL in labels)
+                and BLOCKED_LABEL not in labels
                 and MERGED_LABEL not in labels):
-            # The PR is awaiting review: run the independent review of
-            # the frozen PR on the same run (Issue #34). A clean
-            # verdict merges and returns True (terminal); findings
-            # label the Issue `ai-fix-needed` and the fix step above
-            # repairs the same PR before the next iteration re-reviews.
-            # A review that cannot run (unrecoverable scene, missing
-            # worktree, missing/malformed verdict, exhausted rounds)
-            # is a real failure: the Issue is marked `ai-blocked` so
-            # it is never stranded in awaiting review without an owner.
+            # The PR is in an opened-PR review state: run the
+            # independent review of the frozen PR on the same run
+            # (Issue #34). `ai-pr-opened` awaits review; `ai-fix-needed`
+            # awaits the next review session after a finding or a base
+            # conflict (Issue #82: the review session fixes findings in
+            # the same session, so both states run the same review). A
+            # clean verdict re-freezes the head, merges and returns
+            # True (terminal); unfixed findings or a behind/conflict
+            # gate label the Issue `ai-fix-needed` and the next
+            # iteration re-runs the same independent review. A review
+            # that cannot run (unrecoverable scene, missing worktree,
+            # missing/malformed verdict, exhausted rounds) is a real
+            # failure: the Issue is marked `ai-blocked` so it is never
+            # stranded in an opened-PR state without an owner.
             worktree = None
             branch = None
             try:
@@ -2660,7 +2435,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     number, pr_url,
                 )
                 return
-            continue  # findings: the fix loop repairs, then re-review
+            continue  # findings: the next iteration re-runs the review
         LOGGER.info(
             "issue=%s delivery_awaiting pr=%s state=%s",
             number, pr_url, state,
@@ -2706,29 +2481,25 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         source_repo, issue, scene = selected
         if scene is not None:
-            # An open PR is a recoverable review/fix state: resume the
+            # An open PR is a recoverable review state: resume the
             # same run on the same branch, worktree and PR (Issue #45).
             # Bind the scene's run id first so every journal line and
             # GitHub comment of the resumed delivery carries it
-            # (Issue #41). The explicit `ai-fix-needed` state runs the
-            # Fixer on the same PR; a delivery that is simply awaiting
-            # review (`ai-pr-opened`, stranded by a dead runner or the
-            # progress failure of Issue #70) goes straight to the
-            # independent review — a clean PR is never sent to the
-            # Fixer (Issue #45 round-5 contract).
+            # (Issue #41). Both opened-PR states go straight to the
+            # delivery wait: `ai-pr-opened` awaits review, and
+            # `ai-fix-needed` awaits the next review session —
+            # Issue #82: the review session itself fixes findings in the
+            # same session, so there is no cold-start fixer to run
+            # here (a stranded `ai-pr-opened` delivery, dead runner or
+            # the progress failure of Issue #70, is reviewed the same
+            # way).
             set_run_id(scene["run_id"])
-            labels = issue_labels(int(issue["number"]), source_repo)
-            if FIX_NEEDED_LABEL in labels:
-                pr_url = resume_delivery(
-                    issue, scene, config, source_repo,
-                )
-            else:
-                pr_url = scene["pr_url"]
+            pr_url = scene["pr_url"]
         else:
             pr_url = process_issue(issue, config, source_repo)
         # The delivery is not done when the PR is open: hold the slot
-        # through review -> fix -> merge and release it only after the
-        # PR is merged or terminally failed (Issue #39).
+        # through review -> merge and release it only after the PR is
+        # merged or terminally failed (Issue #39).
         wait_for_delivery(pr_url, issue, config, source_repo)
     finally:
         slot.release()

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -2364,8 +2364,10 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
             # iteration re-runs the same independent review. A review
             # that cannot run (unrecoverable scene, missing worktree,
             # missing/malformed verdict, exhausted rounds) is a real
-            # failure: the Issue is marked `ai-blocked` so it is never
-            # stranded in an opened-PR state without an owner.
+            # failure: the Issue is marked `ai-blocked` ALONE (the
+            # opened-PR state label, `ai-pr-opened` or `ai-fix-needed`,
+            # is removed) so it is never stranded in an opened-PR state
+            # without an owner.
             worktree = None
             branch = None
             try:
@@ -2394,6 +2396,15 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     number, repo=source_repo, add=BLOCKED_LABEL,
                     remove=PR_OPENED_LABEL,
                 )
+                # A review failure while the Issue is in `ai-fix-needed`
+                # (awaiting the next review session) leaves that label
+                # behind: remove it too, so the terminal state is
+                # `ai-blocked` alone (Issue #82 routes both opened-PR
+                # states into the same review).
+                if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
+                    edit_issue(
+                        number, repo=source_repo, remove=FIX_NEEDED_LABEL,
+                    )
                 body = (
                     f"Muyan Pilot failed: the independent review of "
                     f"PR {pr_url} failed: {exc}"

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -40,9 +40,10 @@ LOGGER.addFilter(RunIdFilter())
 ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
 READY_LABEL = "ai-ready"
 IN_PROGRESS_LABEL = "ai-in-progress"
-# `ai-pr-opened` (awaiting review), `ai-fix-needed` (Fixer pending),
-# `ai-merged` (the Runner merged the PR itself, Issue #34) and
-# `ai-blocked` are all result states of an opened delivery (Issue #45).
+# `ai-pr-opened` (awaiting review), `ai-fix-needed` (awaiting the next
+# review session, Issue #82), `ai-merged` (the Runner merged the PR
+# itself, Issue #34) and `ai-blocked` are all result states of an
+# opened delivery (Issue #45).
 RESULT_LABELS = ("ai-pr-opened", "ai-fix-needed", "ai-merged", "ai-blocked")
 
 
@@ -99,8 +100,9 @@ def recent_result(repo: str) -> dict | None:
     """Return the newest delivery result Issue, any state.
 
     Result states: `ai-pr-opened` (awaiting review), `ai-fix-needed`
-    (Fixer pending), `ai-merged` (success terminal, the Runner merged
-    the PR itself) and `ai-blocked` (needs human attention).
+    (awaiting the next review session, Issue #82), `ai-merged` (success
+    terminal, the Runner merged the PR itself) and `ai-blocked` (needs
+    human attention).
     """
     newest = None
     for label in RESULT_LABELS:

--- a/progress.py
+++ b/progress.py
@@ -6,7 +6,7 @@ Issue. The comment carries a hidden HTML run marker
 (`<!-- muyan-pilot:run=<run_id> -->`) so a restarted process finds the same
 comment again and keeps PATCHing it in place — no database, no new
 heartbeat comments. Milestone events (started, plan ready, tests
-passed/failed, review findings, fix pushed, PR opened, merged, blocked)
+passed/failed, review findings, PR opened, merged, blocked)
 are published as short standalone comments so GitHub Mobile pushes a
 notification for each one.
 

--- a/prompt.md
+++ b/prompt.md
@@ -57,38 +57,16 @@ Your worktree was created from `{{BASE_SHA}}` (the frozen
 1. Run `git fetch origin {{BASE_BRANCH}}` in the worktree.
 2. If `git merge-base --is-ancestor origin/{{BASE_BRANCH}} HEAD` fails, the
    base advanced while you worked: merge `origin/{{BASE_BRANCH}}` into your
-   task branch, resolve conflicts manually, rerun the full test suite and the
-   complete review-fix loop, then push the updated task branch.
+   task branch, resolve conflicts manually, rerun the full test suite, then
+   push the updated task branch.
 3. The runner rejects a delivery whose HEAD does not contain the latest
    remote base, so do not create the PR until the check passes.
 
-Resuming an existing PR (Issue #45):
-
-If the task context says `Existing PR: <url>`, this run already opened
-that PR, and the runner started this fixer run because the Issue is in
-the `ai-fix-needed` state (a review finding or a base conflict). After
-a successful fix the runner returns the Issue to `ai-pr-opened`
-(awaiting review) — so do the complete fix once, not a partial one.
-The PR number, run id, feature branch and worktree are fixed
-for this run:
-
-- Never close the PR, never create a new PR, never re-claim the Issue;
-  the PR keeps the same number and only its head branch moves.
-- If the worktree is mid-merge (the runner merged the latest
-  `origin/{{BASE_BRANCH}}` into the task branch and a conflict was left
-  staged), resolve the conflict manually, keep both sides' intent, then
-  complete the merge commit.
-- Fix the review findings, rerun the full test suite with 100% line and
-  branch coverage, the real verification and the complete review-fix
-  loop, then commit and push ONLY the task branch so the same PR
-  updates.
-- If the PR body is missing `Fixes #{{ISSUE_NUMBER}}`, add it (for
-  example via `gh pr edit <number> --body ...`) so the merge closes the
-  source Issue natively; the re-verification rejects a PR body without
-  it.
-- If the conflict or the findings cannot be resolved, stop and explain
-  the concrete blocker in the final response; the runner marks the Issue
-  `ai-blocked` and the PR, branch and worktree stay for inspection.
+Post-PR fixes are NOT your job (Issue #82): once the PR is opened the
+runner runs the independent review session (`prompt_review.md`), which
+fixes review findings and absorbs base advances IN THE SAME SESSION on
+the same PR. The implementer is never resumed for fixes — no `Existing
+PR` context is ever injected into this prompt.
 
 Rules:
 

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -1,10 +1,14 @@
 # Muyan Pilot Review Agent
 
-You are an **independent, read-only code reviewer** for one delivered PR. You
-are a separate session from the implementer; you did not write this code and
-you judge it against the Issue and the repository contract. You do **not**
-modify code, do **not** commit, do **not** push, and do **not** merge. Your only
-output is the review verdict.
+You are an **independent reviewer** for one delivered PR. You are a
+separate session from the implementer; you did not write this code and
+you judge it against the Issue and the repository contract. Your job is
+to **review this one diff and fix it until it can merge**: you may
+modify code, run tests, commit and push to the task branch — but you do
+**not** merge, do **not** push the protected branch, do **not** create
+or close PRs, and you do **not** start another full delivery (no new
+plan, no new Issue work, no second review round). Your only output is
+the review verdict.
 
 Runtime context supplied by the runner:
 
@@ -35,19 +39,41 @@ build files, and the changed code plus its callers before judging.
   concrete `file:line`, a reproducible trigger, actual vs expected, and a
   minimal fix direction. No speculative findings.
 
+## Fix in this session
+
+When you find Blocker or Major issues, do **not** stop and hand the work to
+another session: fix them here, in this same session.
+
+- Modify the code on the task branch, rerun the full test suite with 100%
+  line/branch coverage (when Python changed), and commit the fix.
+- Push ONLY the task branch (the PR head branch); never force push, never
+  push the protected branch, never create or close a PR.
+- If the head is behind the latest remote base or has a merge conflict,
+  absorb it here: `git fetch origin {{BASE_BRANCH}}`, plain
+  `git merge origin/{{BASE_BRANCH}}`, resolve conflicts manually, rerun the
+  full test suite with coverage, and push the task branch.
+- After fixing, re-check the diff against R1–R9 and the Issue's acceptance
+  items before emitting the verdict.
+- If you cannot make the PR mergeable (the fix is not verifiable, or the
+  finding is not yours to decide), do **not** emit `pass`: emit `findings`
+  so the loop escalates to a human instead of merging unreviewed work.
+
 ## Verdict
 
 Severity: Blocker (data error, security, main path down, irreversible damage),
 Major (reasonable-scenario functional error or key-contract violation), Minor
 (local maintenance cost, does not affect current correctness).
 
-End your reply with **exactly one** machine-readable line, and nothing after it:
+End your reply with **exactly one** machine-readable line, and nothing after
+it. The verdict describes the state of the PR **after** your in-session
+fixes: `pass` only when the PR is mergeable with 0 Blocker and 0 Major.
 
 ```
 REVIEW_VERDICT {"verdict":"pass|findings","blockers":<int>,"majors":<int>,"minors":<int>,"findings":[{"level":"Blocker|Major|Minor","location":"path:line","note":"...","fix":"..."}]}
 ```
 
 - `verdict` is `pass` only when `blockers == 0` and `majors == 0`.
-- `findings` lists every Blocker/Major/Minor with its `location`.
+- `findings` lists every Blocker/Major/Minor with its `location` (after your
+  fixes, this is what remains).
 - If you cannot form a defensible verdict, do **not** emit `pass`; emit
   `findings` so the loop escalates to a human instead of merging unreviewed.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1958,11 +1958,14 @@ def test_main_processes_one_issue(monkeypatch, tmp_path):
     )
 
 
-def test_main_routes_fix_needed_resume_to_fixer_then_wait(
+def test_main_routes_fix_needed_resume_to_delivery_wait(
     monkeypatch, tmp_path,
 ):
-    """A resumed `ai-fix-needed` delivery runs the Fixer on the same PR
-    (Issue #45) and then enters the delivery wait."""
+    """A resumed `ai-fix-needed` delivery goes straight to the delivery
+    wait (Issue #82: the review session fixes findings in the same
+    session, so there is no cold-start fixer to run). The run id from
+    the scene is bound before the wait so the resumed review's journal
+    lines and comments carry it (Issue #41)."""
     monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
     _write_prompts(tmp_path)
     config = tmp_path / "muyan-pilot.toml"
@@ -1979,23 +1982,6 @@ def test_main_routes_fix_needed_resume_to_fixer_then_wait(
         lambda repos, slot_dir, max_concurrency: (
             "owner/repo", issue, scene,
         ),
-    )
-
-    def fake_run(command, **kwargs):
-        # The dispatch reads the Issue's current labels to choose the
-        # fixer vs the review wait.
-        assert command[:3] == ["gh", "issue", "view"]
-        assert command[-2:] == ["--json", "labels"]
-        return json.dumps({"labels": [
-            {"name": "ai-ready"}, {"name": "ai-fix-needed"},
-        ]})
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    fixes = []
-    monkeypatch.setattr(
-        runner, "resume_delivery",
-        lambda *args, **kwargs: fixes.append((args, kwargs))
-        or scene["pr_url"],
     )
     waits = []
     monkeypatch.setattr(
@@ -2003,10 +1989,10 @@ def test_main_routes_fix_needed_resume_to_fixer_then_wait(
         lambda *args, **kwargs: waits.append((args, kwargs)),
     )
     assert runner.main(["--config", str(config)]) == 0
-    assert len(fixes) == 1
-    assert fixes[0][0][:2] == (issue, scene)
-    # The fixer's verified URL is the one the wait loop holds.
+    # No fixer: the wait runs on the scene's PR URL.
     assert waits[0][0][:2] == (scene["pr_url"], issue)
+    # The resumed review runs under the scene's run id.
+    assert runner.current_run_id() == "a1b2c3d4"
 
 
 def test_main_routes_awaiting_review_resume_to_delivery_wait(
@@ -2014,10 +2000,10 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
 ):
     """A resumed `ai-pr-opened` delivery (stranded by a dead runner or
     the Issue #70 progress 404) goes straight to the delivery wait:
-    the independent review of the same PR runs, and a clean PR is
-    never sent to the Fixer (Issue #45 round-5 contract). The run id
-    from the scene is bound before the wait so the resumed review's
-    journal lines and comments carry it (Issue #41)."""
+    the independent review of the same PR runs (Issue #45 round-5
+    contract: a clean PR is never sent to a fixer). The run id from
+    the scene is bound before the wait so the resumed review's journal
+    lines and comments carry it (Issue #41)."""
     monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
     _write_prompts(tmp_path)
     config = tmp_path / "muyan-pilot.toml"
@@ -2034,21 +2020,6 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
         lambda repos, slot_dir, max_concurrency: (
             "owner/repo", issue, scene,
         ),
-    )
-
-    def fake_run(command, **kwargs):
-        assert command[:3] == ["gh", "issue", "view"]
-        assert command[-2:] == ["--json", "labels"]
-        return json.dumps({"labels": [
-            {"name": "ai-ready"}, {"name": "ai-pr-opened"},
-        ]})
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    fixes = []
-    monkeypatch.setattr(
-        runner, "resume_delivery",
-        lambda *args, **kwargs: fixes.append((args, kwargs))
-        or scene["pr_url"],
     )
     waits = []
     monkeypatch.setattr(
@@ -2057,7 +2028,6 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
     )
     assert runner.main(["--config", str(config)]) == 0
     # No fixer for a clean PR: the wait runs on the scene's PR URL.
-    assert fixes == []
     assert waits[0][0][:2] == (scene["pr_url"], issue)
     # The resumed review runs under the scene's run id.
     assert runner.current_run_id() == "a1b2c3d4"
@@ -3139,7 +3109,7 @@ def test_run_pi_passes_progress_callback_to_stream_pi(monkeypatch, tmp_path):
             "skills": [],
             "context_files": [],
         },
-        "owner/repo", branch="b", pr_url="https://x/pull/4",
+        "owner/repo", branch="b",
         progress=callback,
     )
     assert seen["progress"] is callback
@@ -3589,9 +3559,10 @@ def test_finish_blocked_progress_carries_the_actual_role_and_round(
     assert "- review/fix round: 2" in body
 
 
-def test_finish_blocked_progress_defaults_to_fix_round_zero(monkeypatch):
-    """Without explicit role/round the legacy default (fix/0) is kept,
-    so existing callers stay unchanged."""
+def test_finish_blocked_progress_defaults_to_review_round_zero(monkeypatch):
+    """Without explicit role/round the default is the only post-PR role
+    (Issue #82: the review session fixes findings in the same session,
+    so a blocked delivery is always a review failure)."""
     api_calls = []
 
     def fake_run(command, **kwargs):
@@ -3613,7 +3584,7 @@ def test_finish_blocked_progress_defaults_to_fix_round_zero(monkeypatch):
     ]
     assert len(posts) == 1
     body = posts[0][posts[0].index("--field") + 1][len("body="):]
-    assert "- role: fix" in body
+    assert "- role: review" in body
     assert "- review/fix round: 0" in body
 
 
@@ -3851,12 +3822,13 @@ def test_wait_for_delivery_marks_blocked_when_review_fails(
     assert "- review/fix round: 2" in blocked
 
 
-def test_wait_for_delivery_runs_same_pr_fix_when_fix_needed(
+def test_wait_for_delivery_runs_review_when_fix_needed(
     monkeypatch, caplog, tmp_path,
 ):
-    """While holding the slot, a fix-needed delivery is fixed by the SAME
-    runner on the SAME run (Issue #39 + #45): the fix returns the Issue
-    to awaiting review and the wait continues."""
+    """While holding the slot, a fix-needed delivery runs the SAME
+    independent review as an awaiting-review delivery (Issue #82: the
+    review session fixes findings in the same session — no cold-start
+    fixer): the review reports findings and the wait continues."""
     states = ["OPEN", "OPEN", "MERGED"]
     pr_view_calls = {"n": 0}
     labels_calls = {"n": 0}
@@ -3870,16 +3842,9 @@ def test_wait_for_delivery_runs_same_pr_fix_when_fix_needed(
         if command[:2] == ["gh", "issue"] and command[2] == "view":
             if command[-1] == "labels":
                 labels_calls["n"] += 1
-                # First poll: fix needed; after the fix: awaiting review.
-                if labels_calls["n"] == 1:
-                    return json.dumps({
-                        "labels": [{"name": "ai-fix-needed"}],
-                    })
                 return json.dumps({
-                    "labels": [{"name": "ai-pr-opened"}],
+                    "labels": [{"name": "ai-fix-needed"}],
                 })
-            if command[-1] == "body":
-                return json.dumps({"body": "original task body"})
             return json.dumps({"comments": [
                 {
                     "body": (
@@ -3898,14 +3863,9 @@ def test_wait_for_delivery_runs_same_pr_fix_when_fix_needed(
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
-    fixes = []
-    monkeypatch.setattr(
-        runner, "resume_delivery",
-        lambda *args, **kwargs: fixes.append((args, kwargs)) or PR_URL,
-    )
-    # The second OPEN poll finds the Issue awaiting review again: the
-    # independent review runs (Issue #34) and reports findings, so the
-    # wait continues to the MERGED poll.
+    # The independent review runs for the fix-needed state too (Issue
+    # #82) and reports findings, so the wait continues to the MERGED
+    # poll.
     reviews = []
     monkeypatch.setattr(
         runner, "review_and_merge_if_clean",
@@ -3916,48 +3876,17 @@ def test_wait_for_delivery_runs_same_pr_fix_when_fix_needed(
     caplog.set_level("INFO")
     config = {"repo_dir": tmp_path, "base_branch": "main"}
     runner.wait_for_delivery(PR_URL, issue, config, "owner/repo")
-    assert len(fixes) == 1
-    assert len(reviews) == 1
-    fixed_issue, scene, cfg, repo = fixes[0][0]
-    assert fixed_issue["number"] == 39
-    assert fixed_issue["body"] == "original task body"
-    assert scene["run_id"] == "a1b2c3d4"
-    assert scene["pr_url"] == PR_URL
+    # One review per OPEN+fix-needed poll (two polls before MERGED).
+    assert len(reviews) == 2
+    # No fixer: the review ran on the derived worktree/branch of the
+    # same run.
+    worktree, branch, base_branch, review_config, repo, number = reviews[0][0]
+    assert branch == "muyan-pilot/owner-repo-issue-39-a1b2c3d4"
+    assert base_branch == "main"
+    assert review_config["run_id"] == "a1b2c3d4"
+    assert review_config["base_sha"] == "abc123def456"
     assert repo == "owner/repo"
-    assert "delivery_fix_needed" in caplog.text
-
-
-def test_wait_for_delivery_propagates_fix_failure(monkeypatch):
-    """A failed same-PR fix raises: the Issue is already ai-blocked by
-    resume_delivery, and the slot is released by the caller (main)."""
-    def fake_run(command, **kwargs):
-        if command[:2] == ["gh", "pr"]:
-            return json.dumps({"state": "OPEN"})
-        if command[-1] == "labels":
-            return json.dumps({"labels": [{"name": "ai-fix-needed"}]})
-        return json.dumps({"comments": [
-            {
-                "body": (
-                    "<!-- muyan-pilot:run=a1b2c3d4 -->\n"
-                    "Muyan Pilot opened PR: "
-                    f"{PR_URL} (base_branch=main "
-                    "base_sha=abc123def456 run_id=a1b2c3d4)"
-                ),
-                "authorAssociation": "OWNER",
-            },
-        ]})
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-
-    def failing_resume(*args, **kwargs):
-        raise RuntimeError("fix failed")
-
-    monkeypatch.setattr(runner, "resume_delivery", failing_resume)
-    with pytest.raises(RuntimeError, match="fix failed"):
-        runner.wait_for_delivery(
-            PR_URL, {"number": 39, "title": "t", "body": ""}, {},
-            "owner/repo",
-        )
+    assert number == 39
 
 
 def test_issue_labels_returns_names_and_fails_fast(monkeypatch):
@@ -4060,6 +3989,13 @@ def test_wait_for_delivery_marks_blocked_when_pr_closed_unmerged(
         "add": "ai-blocked",
         "remove": "ai-pr-opened",
     }
+    # ... and the leftover ai-fix-needed label (the delivery was
+    # awaiting the next review session) is removed too, so the
+    # terminal state is ai-blocked alone.
+    assert edits[1][1] == {
+        "repo": "owner/repo",
+        "remove": "ai-fix-needed",
+    }
     # ... with a failure comment carrying the run marker and run_id.
     body = comments[0][1]["body"]
     assert "Muyan Pilot failed:" in body
@@ -4094,10 +4030,10 @@ def test_wait_for_delivery_marks_blocked_when_pr_closed_unmerged(
     assert "closed without a merge" in blocked
     assert "next step:" in blocked
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked
-    # The blocked scene carries the actual role (the delivery label was
-    # ai-fix-needed) and the completed review rounds (review round 2,
-    # PR #42) — not the hardcoded fix/0.
-    assert "- role: fix" in blocked
+    # The blocked scene carries the actual role (Issue #82: both
+    # opened-PR states are review states, so always `review`) and the
+    # completed review rounds (review round 2, PR #42).
+    assert "- role: review" in blocked
     assert "- review/fix round: 2" in blocked
 
 
@@ -4181,7 +4117,19 @@ def test_wait_for_delivery_logs_awaiting_without_bound_run_id(monkeypatch, caplo
     """When no run id is bound the wait still works: the failure comment
     simply carries no marker."""
     monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
-    fake_pr_view(monkeypatch, "CLOSED")
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"] and command[2] == "view":
+            return json.dumps({"state": "CLOSED"})
+        if command[:2] == ["gh", "issue"] and command[-1] == "labels":
+            # No leftover fix-needed label: only ai-pr-opened is removed.
+            return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    # The fake rejects anything that is not a pr/issue view.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
     comments: list = []
     monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
     monkeypatch.setattr(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3822,6 +3822,107 @@ def test_wait_for_delivery_marks_blocked_when_review_fails(
     assert "- review/fix round: 2" in blocked
 
 
+def test_wait_for_delivery_marks_blocked_when_review_fails_while_fix_needed(
+        monkeypatch, caplog, tmp_path,
+):
+    """A review failure while the Issue is `ai-fix-needed` (awaiting the
+    next review session) must leave the terminal state `ai-blocked`
+    ALONE: this PR routes both opened-PR states into the same review, so
+    the leftover `ai-fix-needed` label is removed too (Issue #82).
+    """
+    api_calls: list = []
+    existing = {
+        "id": 77,
+        "body": (
+            "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+            "**Muyan Pilot progress**\n\nawaiting review"
+        ),
+    }
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps({"state": "OPEN"})
+        if command[:2] == ["gh", "api"]:
+            api_calls.append(command)
+            if "--method" not in command:
+                # The run's live progress comment exists.
+                return json.dumps([existing])
+            method = command[command.index("--method") + 1]
+            if method == "POST":
+                body = command[command.index("--field") + 1]
+                return json.dumps({"id": 78, "body": body[len("body="):],
+                                   "url": "https://x/78"})
+            return ""
+        if command[-1] == "comments":
+            # No trusted `Muyan Pilot opened PR:` comment: the scene
+            # cannot be recovered, so the review fails fast.
+            return json.dumps({"comments": [
+                {"body": "public comment", "authorAssociation": "NONE"},
+            ]})
+        # The delivery is in the `ai-fix-needed` state (awaiting the
+        # next review session).
+        return json.dumps({"labels": [{"name": "ai-fix-needed"}]})
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    edits: list = []
+    comments: list = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: comments.append((args, kwargs)),
+    )
+    issue = {"number": 39, "title": "task", "body": ""}
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    caplog.set_level("INFO")
+    runner.wait_for_delivery(
+        PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
+        "owner/repo",
+    )
+    # The Issue is marked ai-blocked (removing ai-pr-opened) ...
+    assert edits[0][1] == {
+        "repo": "owner/repo",
+        "add": "ai-blocked",
+        "remove": "ai-pr-opened",
+    }
+    # ... and the leftover ai-fix-needed label is removed too, so the
+    # terminal state is ai-blocked alone (never
+    # ai-blocked + ai-fix-needed).
+    assert edits[1][1] == {
+        "repo": "owner/repo",
+        "remove": "ai-fix-needed",
+    }
+    assert len(edits) == 2
+    body = comments[0][1]["body"]
+    assert "the independent review of" in body
+    assert f"<!-- muyan-pilot:run=a1b2c3d4 -->" in body
+    assert "delivery_review_failed" in caplog.text
+    # The terminal failure also posts the blocked milestone AND the
+    # tracked progress comment becomes the blocked scene.
+    posted_bodies = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in api_calls
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: blocked" in body for body in posted_bodies)
+    assert any(
+        ("the independent review of" in body for body in posted_bodies),
+    )
+    patches = [
+        command for command in api_calls
+        if command[:2] == ["gh", "api"]
+        and command[2] == "repos/owner/repo/issues/comments/77"
+        and "PATCH" in command
+    ]
+    assert patches, "the tracked progress comment was not updated"
+    blocked = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot blocked" in blocked
+    assert "the independent review of" in blocked
+    assert "- role: review" in blocked
+
+
 def test_wait_for_delivery_runs_review_when_fix_needed(
     monkeypatch, caplog, tmp_path,
 ):

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -6,12 +6,13 @@ executable records every invocation. These prove the acceptance criteria:
 
 - with ``max_concurrency = 1`` a second concurrent runner logs
   ``capacity_full``, claims no Issue, changes no label and never calls Pi;
-- the slot is held for the whole delivery lifecycle (implement → review →
-  fix → merge): after the first runner opens the PR it KEEPS the slot
+- the slot is held for the whole delivery lifecycle (implement → review
+  → merge): after the first runner opens the PR it KEEPS the slot
   (polling the PR state), so a second concurrent runner still sees
   ``capacity_full`` and no second Issue is claimed;
-- when the Issue moves to ``ai-fix-needed`` the next runner resumes the
-  SAME PR (same run id, same slot) instead of claiming a new Issue;
+- the review session fixes findings IN THE SAME SESSION (Issue #82):
+  one review Pi per delivery (no cold-start fixer, no third review),
+  and the runner re-freezes the fixed head before the merge gate;
 - after the PR is merged the first runner exits and releases the slot,
   and the next runner claims the NEXT ready Issue (never the same one
   twice);
@@ -160,25 +161,54 @@ elif args[:2] == ["pr", "view"]:
     # The merge gate and confirm_merged read the full PR state: the
     # head is the current HEAD of the delivery branch (the fake world
     # has no separate PR object), and the merge is recorded when the
-    # test (or the runner via `pr merge`) marks it MERGED.
+    # test (or the runner via `pr merge`) marks it MERGED. The state
+    # is PER BRANCH: concurrent deliveries (two runners, two issues)
+    # each see their own PR state; the global `pr_state` remains the
+    # default for branches without a recorded state.
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    pr_state = state.setdefault("pr_states", {}).get(
+        branch, state.get("pr_state", "OPEN"),
+    )
     print(json.dumps({
-        "state": state.get("pr_state", "OPEN"),
+        "state": pr_state,
         "mergeable": "MERGEABLE",
         "headRefOid": git("rev-parse", "HEAD"),
         "mergedAt": "2026-08-25T00:00:00Z"
-        if state.get("pr_state") == "MERGED" else None,
+        if pr_state == "MERGED" else None,
         "mergeCommit": (
             {"oid": git("rev-parse", "HEAD")}
-            if state.get("pr_state") == "MERGED" else None
+            if pr_state == "MERGED" else None
         ),
     }))
 elif args[:2] == ["pr", "merge"]:
-    # The fake GitHub merge: record the merge on the delivery branch
-    # (the delivery branch is the PR head; the real `gh pr merge`
-    # lands the head on the base). The runner then confirms via
-    # `pr view` and syncs the deployment checkout.
-    state["pr_state"] = "MERGED"
-    state["merged_head"] = git("rev-parse", "HEAD")
+    # The fake GitHub merge: the real `gh pr merge` lands the head on
+    # the base (a merge commit when the base advanced in the meantime),
+    # so the fake merges the delivery head (the PR head is the
+    # delivery branch's HEAD) into origin/main in a throwaway clone.
+    # The runner then confirms via `pr view` and syncs the deployment
+    # checkout.
+    import tempfile
+    head = git("rev-parse", "HEAD")
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run(["git", "clone", git("remote", "get-url",
+                                             "origin"), td],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "config",
+                        "user.email", "pilot@test.local"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "config", "user.name", "Pilot"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "fetch", "origin"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "merge", "--no-ff",
+                        "-m", "Merge PR (fake)", head],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "push", "origin",
+                        "HEAD:main"],
+                       check=True, capture_output=True)
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    state.setdefault("pr_states", {})[branch] = "MERGED"
+    state["merged_head"] = head
     save()
 elif args[:1] == ["api"]:
     # The progress publisher (Issue #18) keeps the single per-run
@@ -220,11 +250,15 @@ else:
 
 # Fake ``pi``: records one line per invocation, then stays busy for a while
 # so concurrent runners overlap while it runs. The review role (system
-# prompt "INDEPENDENT REVIEW") emits a machine-readable verdict: findings
-# for the first review of a run, a clean verdict afterwards, so the
-# full review -> fix -> re-review -> merge loop is exercised.
+# prompt "INDEPENDENT REVIEW") simulates the Issue #82 contract: the
+# independent review session fixes findings IN THE SAME SESSION — the
+# first review of a run finds a major issue, commits and pushes the fix
+# to the task branch (the PR head advances), and ends with a clean
+# verdict covering the fixed head (the runner re-freezes and merges it).
+# A second review of the same run (a restart inside the wait loop) is
+# simply clean.
 FAKE_PI = """#!/usr/bin/env python3
-import json, os, sys, time
+import json, os, subprocess, sys, time
 log = os.environ.get("MUYAN_FAKE_PI_LOG")
 if log:
     with open(log, "a", encoding="utf-8") as handle:
@@ -234,14 +268,11 @@ system_prompt = sys.argv[sys.argv.index("--system-prompt") + 1]
 if "INDEPENDENT REVIEW" in system_prompt:
     run_id = system_prompt.split("run_id=")[1].split()[0]
     marker = os.path.join(os.getcwd(), f".muyan-pilot-review-{run_id}")
-    if os.path.exists(marker):
-        print('REVIEW_VERDICT ' + json.dumps({
-            "verdict": "pass", "blockers": 0, "majors": 0,
-            "minors": 0, "findings": [],
-        }))
-    else:
+    first_review = not os.path.exists(marker)
+    if first_review:
         with open(marker, "w", encoding="utf-8") as handle:
             handle.write("reviewed")
+        # Initial review: one major finding...
         print('REVIEW_VERDICT ' + json.dumps({
             "verdict": "findings", "blockers": 0, "majors": 1,
             "minors": 0,
@@ -250,6 +281,52 @@ if "INDEPENDENT REVIEW" in system_prompt:
                  "note": "first review finding"}
             ],
         }))
+        # ...fixed in this same session: commit the fix (the PR head
+        # advances; the runner must re-freeze and merge the fixed head,
+        # not the frozen one). The fix content is unique per
+        # invocation: a later delivery's base already carries an
+        # earlier delivery's fix file.
+        with open(os.path.join(os.getcwd(), "review-fix.txt"), "a",
+                  encoding="utf-8") as handle:
+            handle.write(f"fixed in the review session (pid {os.getpid()} "
+                         f"at {time.time()})\\n")
+        subprocess.run(["git", "add", "review-fix.txt"], check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=pilot@test.local",
+             "-c", "user.name=Pilot", "commit",
+             "-m", "fix: in-session review fix"],
+            check=True,
+        )
+    # A head behind the latest base is fixed in-session too (Issue
+    # #82), on EVERY review round: the base may advance between rounds.
+    # Absorb origin/main, resolve, retest, push.
+    subprocess.run(["git", "fetch", "origin", "main"], check=True)
+    behind = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
+        capture_output=True,
+    )
+    if behind.returncode != 0:
+        merge = subprocess.run(
+            ["git", "merge", "--no-ff", "-m",
+             "merge main (review session)", "origin/main"],
+            capture_output=True,
+        )
+        if merge.returncode != 0:
+            with open(os.path.join(os.getcwd(), "review-fix.txt"), "a",
+                      encoding="utf-8") as handle:
+                handle.write(f"conflict resolved (pid {os.getpid()})\\n")
+            subprocess.run(["git", "add", "."], check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=pilot@test.local",
+                 "-c", "user.name=Pilot", "commit", "--no-edit"],
+                check=True,
+            )
+    subprocess.run(["git", "push", "origin", "HEAD"], check=True)
+    # Final verdict after the in-session fix: clean.
+    print('REVIEW_VERDICT ' + json.dumps({
+        "verdict": "pass", "blockers": 0, "majors": 0,
+        "minors": 0, "findings": [],
+    }))
 """
 
 
@@ -464,13 +541,14 @@ def set_pr_state(state_path: Path, pr_state: str) -> None:
     atomic_write_json(state_path, state)
 
 
-def test_capacity_one_slot_held_through_review_fix_merge(
+def test_capacity_one_slot_held_through_review_merge(
     clone, tmp_path,
 ):
     """The slot is held for the whole delivery lifecycle (Issue #39):
     after the PR opens the first runner keeps it, runs the independent
-    review (findings -> ai-fix-needed -> same-PR fix -> re-review),
-    auto-merges the clean PR itself (Issue #34) and only then releases
+    review — which fixes the finding IN THE SAME SESSION (Issue #82:
+    no cold-start fixer, no third review) — re-freezes the fixed head
+    and auto-merges the PR itself (Issue #34), and only then releases
     the slot for the next Issue."""
     bin_dir = install_fakes(tmp_path)
     state = tmp_path / "gh-state.json"
@@ -497,10 +575,10 @@ def test_capacity_one_slot_held_through_review_fix_merge(
     assert "ai-in-progress" not in snap["issues"]["7"]["labels"]
     assert snap["issues"]["8"]["labels"] == ["ai-ready"]
 
-    # The first independent review finds a problem: the Issue moves to
-    # ai-fix-needed, and the SAME holder (still holding the slot) fixes
-    # the SAME PR (same run id, same branch) instead of claiming a new
-    # Issue; the re-review passes and the runner merges the PR itself.
+    # The first independent review finds a problem and fixes it IN THE
+    # SAME SESSION (Issue #82): the fixed head is pushed, re-frozen and
+    # merged by the SAME holder (still holding the slot) instead of
+    # claiming a new Issue.
     wait_for(
         lambda: (
             "ai-merged" in read_state(state)["issues"]["7"]["labels"]
@@ -508,23 +586,28 @@ def test_capacity_one_slot_held_through_review_fix_merge(
                     for c in read_state(state)["comments"])
         ),
         timeout=180,
-        what="first runner to review, fix, re-review and merge",
+        what="first runner to review, fix in-session and merge",
     )
     snap = read_state(state)
     assert "ai-merged" in snap["issues"]["7"]["labels"]
     assert "ai-pr-opened" not in snap["issues"]["7"]["labels"]
-    # One Pi invocation per phase of the SAME run: implement, review,
-    # fix, re-review — never a new claim of another Issue.
-    assert len(pi_invocations(pi_log)) == 4
+    # One Pi invocation per phase of the SAME run: implement, review
+    # (the review fixes in-session) — never a new claim of another
+    # Issue, never a cold-start fixer.
+    assert len(pi_invocations(pi_log)) == 2
     assert snap["issues"]["8"]["labels"] == ["ai-ready"]
     started = [
         c for c in snap["comments"] if "Muyan Pilot started Pi:" in c["body"]
     ]
     assert [c["issue"] for c in started] == ["7"]
     bodies = [c["body"] for c in snap["comments"]]
-    assert any("Muyan Pilot review round 1" in b for b in bodies)
-    assert any("Muyan Pilot fixed PR:" in b for b in bodies)
     assert any("Muyan Pilot merged PR:" in b for b in bodies)
+    # The in-session fix landed on the delivery branch: origin/main
+    # carries the review fix file, so the runner merged the RE-FROZEN
+    # head (the fixed one), not the frozen head (Issue #82).
+    assert "review-fix.txt" in git(
+        clone, "ls-tree", "--name-only", "origin/main",
+    )
 
     # The auto-merge released the slot; the runner exited cleanly.
     out, err = first.communicate(timeout=120)
@@ -659,8 +742,9 @@ def test_capacity_two_allows_two_runners_and_rejects_third(clone, tmp_path):
     assert third.returncode == 0, err
     assert "capacity_full" in err
 
-    # Both runners auto-merge their own PRs (review -> fix -> re-review
-    # -> merge, Issue #34) and release their slots.
+    # Both runners auto-merge their own PRs (the review fixes in-session
+    # and the runner merges the re-frozen head, Issues #34/#82) and
+    # release their slots.
     wait_for(
         lambda: "ai-merged" in read_state(state)["issues"]["7"]["labels"]
         and "ai-merged" in read_state(state)["issues"]["8"]["labels"],
@@ -672,9 +756,13 @@ def test_capacity_two_allows_two_runners_and_rejects_third(clone, tmp_path):
         assert runner.returncode == 0, err
         assert "delivery_auto_merged" in err
     assert slots_held(clone, 2) == [(1, None), (2, None)]
-    # One Pi per phase of each run (implement, review, fix, re-review):
-    # four invocations per Issue, no duplicate claim.
-    assert len(pi_invocations(pi_log)) == 8
+    # One Pi per phase of each run (implement, review — the review
+    # fixes in-session, Issue #82): two invocations per Issue at a
+    # minimum. When the first merge advances origin/main while the
+    # second delivery's head is still behind, the second review round
+    # absorbs the base in-session (one extra invocation per affected
+    # delivery) — never a cold-start fixer, never a duplicate claim.
+    assert 4 <= len(pi_invocations(pi_log)) <= 6
     started = [
         c for c in read_state(state)["comments"]
         if "Muyan Pilot started Pi:" in c["body"]
@@ -895,16 +983,15 @@ def test_stranded_pr_opened_delivery_is_resumed_to_review_and_merge(
     assert len(worktrees) == 1
     assert worktrees[0].name.rsplit("-", 1)[-1] == dead_run_id
     # One Pi per phase of the SAME run: implement (first runner),
-    # review, fix, re-review (second runner) — never a second
-    # implement.
-    assert len(pi_invocations(pi_log)) == 4
+    # review (second runner — the review fixes in-session, Issue #82)
+    # — never a second implement, never a cold-start fixer.
+    assert len(pi_invocations(pi_log)) == 2
     started = [
         c for c in snap["comments"] if "Muyan Pilot started Pi:" in c["body"]
     ]
     assert [c["issue"] for c in started] == ["7"]
     # The review actually ran on the resumed delivery.
     bodies = [c["body"] for c in snap["comments"]]
-    assert any("Muyan Pilot review round 1" in b for b in bodies)
     assert any("Muyan Pilot merged PR:" in b for b in bodies)
     assert slots_held(clone) == [(1, None)], (
         "slot must be released after the merge"
@@ -1001,10 +1088,10 @@ def test_live_pr_opened_delivery_is_not_resumed_by_second_runner(
     assert "ai-merged" in snap["issues"]["7"]["labels"]
     assert "ai-blocked" not in snap["issues"]["7"]["labels"]
     # The second runner's Pi work is bounded: its implement plus at
-    # most its own review/fix of issue 8 (the fake world's single
-    # global PR state ends its wait once the first runner merges).
-    # Crucially, none of it is a second review of issue 7's live
-    # delivery: the first run always uses exactly four invocations
-    # (implement, review, fix, re-review).
-    assert 5 <= len(pi_invocations(pi_log)) <= 7
+    # most its own review of issue 8 (the fake world's single global
+    # PR state ends its wait once the first runner merges). Crucially,
+    # none of it is a second review of issue 7's live delivery: the
+    # first run always uses exactly two invocations (implement,
+    # review — the review fixes in-session, Issue #82).
+    assert 3 <= len(pi_invocations(pi_log)) <= 4
     assert slots_held(clone, 2) == [(1, None), (2, None)]

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -1,10 +1,10 @@
 """Tests for the automatic GitHub progress comment wiring (Issue #18).
 
-`process_issue`, `resume_delivery` and `review_and_merge_if_clean` must
-keep exactly one live progress comment per run (hidden run marker),
-PATCH it live while any Pi session runs and at most every 30 seconds,
-post short milestone comments for the key events, and end with either
-the final delivery summary or the blocked scene — in the same comment.
+`process_issue` and `review_and_merge_if_clean` must keep exactly one
+live progress comment per run (hidden run marker), PATCH it live while
+any Pi session runs and at most every 30 seconds, post short milestone
+comments for the key events, and end with either the final delivery
+summary or the blocked scene — in the same comment.
 """
 import json
 import subprocess
@@ -637,8 +637,9 @@ def test_process_issue_never_posts_fix_pushed_on_a_fresh_claim(
     # The implementer always commits the delivery on top of the frozen
     # base, so the head always advanced: a fresh claim must not turn
     # that into a `fix pushed` milestone (the PR opened milestone
-    # announces the delivery; `fix pushed` is the fixer's milestone in
-    # resume_delivery).
+    # announces the delivery; Issue #82 removed the fixer and its
+    # `fix pushed` milestone — findings are fixed by the review
+    # session, which records its own round comments).
     calls, posted = make_fake_gh(monkeypatch)
     patch_process_deps(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "delivery_head_advanced", lambda *args: True)
@@ -880,252 +881,6 @@ def test_process_issue_publishing_failure_is_never_blocked_scene(
     )
 
 
-# --- resume_delivery wiring (the fixer stays observable) ----------------------
-
-
-def scene_for_resume():
-    return {
-        "run_id": "a1b2c3d4",
-        "base_branch": "main",
-        "base_sha": "abc123def456",
-        "pr_url": "https://github.com/xqliu/muyan-pilot/pull/40",
-    }
-
-
-def patch_resume_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
-    worktree = runner.worktree_path(
-        tmp_path, "xqliu/muyan-pilot", 18, "a1b2c3d4",
-    )
-    worktree.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(runner, "verify_pr",
-                        lambda *args, **kwargs:
-                        "https://github.com/xqliu/muyan-pilot/pull/40")
-    monkeypatch.setattr(runner, "merge_latest_base", lambda *args: True)
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "comment_issue", Mock())
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    if run_pi_side_effect is not None:
-        monkeypatch.setattr(runner, "run_pi",
-                            Mock(side_effect=run_pi_side_effect))
-    else:
-        monkeypatch.setattr(runner, "run_pi", Mock(return_value="done"))
-
-
-def test_resume_delivery_reuses_existing_progress_comment(monkeypatch, tmp_path):
-    """The fixer keeps updating the SAME progress comment created by the
-    implementer: ensure finds it by run marker + progress header (no
-    second progress comment)."""
-    existing = {
-        "id": 77,
-        "body": (
-            "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
-            "**Muyan Pilot progress**\n\nstale implementer state"
-        ),
-    }
-    calls, posted = make_fake_gh(monkeypatch, comments=[existing])
-    patch_resume_deps(monkeypatch, tmp_path)
-    runner.resume_delivery(
-        make_issue(), scene_for_resume(), make_config(tmp_path),
-        "xqliu/muyan-pilot",
-    )
-    progress_posts = [
-        body for body in posted
-        if "**Muyan Pilot progress**" in body
-    ]
-    assert progress_posts == [], (
-        f"resume must not create a second progress comment: {posted}"
-    )
-    patches = [
-        command for command in calls
-        if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
-        and "PATCH" in command
-    ]
-    assert patches, "existing progress comment was not updated"
-    # The fixer state is visible in the live comment (role=fix, the PR).
-    first_body = patches[0][patches[0].index("--field") + 1][len("body="):]
-    assert "- role: fix" in first_body
-    assert "- PR: https://github.com/xqliu/muyan-pilot/pull/40" in first_body
-
-
-def test_resume_delivery_posts_fix_pushed_milestone_and_finishes(
-    monkeypatch, tmp_path,
-):
-    calls, posted = make_fake_gh(monkeypatch)
-    patch_resume_deps(monkeypatch, tmp_path)
-    runner.resume_delivery(
-        make_issue(), scene_for_resume(), make_config(tmp_path),
-        "xqliu/muyan-pilot",
-    )
-    milestones = [
-        body for body in posted
-        if any(line.startswith(progress.MILESTONE_PREFIX)
-               for line in body.splitlines())
-    ]
-    assert any("Muyan Pilot: fix pushed" in body for body in milestones)
-    final_patches = [
-        command for command in calls
-        if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
-        and "PATCH" in command
-    ]
-    assert final_patches
-    last_body = final_patches[-1][
-        final_patches[-1].index("--field") + 1
-    ][len("body="):]
-    assert "Muyan Pilot fix pushed" in last_body
-    assert "awaiting review again" in last_body
-
-
-def test_resume_delivery_failure_updates_progress_comment_with_blocked_scene(
-    monkeypatch, tmp_path,
-):
-    calls, posted = make_fake_gh(monkeypatch)
-    patch_resume_deps(
-        monkeypatch, tmp_path,
-        run_pi_side_effect=subprocess.CalledProcessError(
-            3, ["pi"], stderr="fixer exploded",
-        ),
-    )
-    with pytest.raises(subprocess.CalledProcessError):
-        runner.resume_delivery(
-            make_issue(), scene_for_resume(), make_config(tmp_path),
-            "xqliu/muyan-pilot",
-        )
-    milestones = [
-        body for body in posted
-        if any(line.startswith(progress.MILESTONE_PREFIX)
-               for line in body.splitlines())
-    ]
-    assert any("Muyan Pilot: blocked" in body for body in milestones)
-    final_patches = [
-        command for command in calls
-        if command[:2] == ["gh", "api"]
-        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
-        and "PATCH" in command
-    ]
-    assert final_patches
-    last_body = final_patches[-1][
-        final_patches[-1].index("--field") + 1
-    ][len("body="):]
-    assert "Muyan Pilot blocked" in last_body
-    assert "fixer exploded" in last_body
-
-
-# --- Issue #60: the fixer path keeps the same contract after the fix is
-# --- verified (no ai-blocked, no re-raise; progress_publish_failed only) ----
-
-
-def patch_resume_deps_live(monkeypatch, tmp_path):
-    """Like `patch_resume_deps`, but `comment_issue` and `edit_issue` are
-    NOT mocked: the delivery-record calls (fixed-PR scene comment,
-    `fix pushed` milestone, delivered finish) must reach the fake gh so
-    they can fail there (Issue #60). `edit_issue` is recorded."""
-    worktree = runner.worktree_path(
-        tmp_path, "xqliu/muyan-pilot", 18, "a1b2c3d4",
-    )
-    worktree.mkdir(parents=True, exist_ok=True)
-    edits = []
-    monkeypatch.setattr(runner, "verify_pr",
-                        lambda *args, **kwargs:
-                        "https://github.com/xqliu/muyan-pilot/pull/40")
-    monkeypatch.setattr(runner, "merge_latest_base", lambda *args: True)
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
-                        edits.append(kwargs))
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    monkeypatch.setattr(runner, "run_pi", Mock(return_value="done"))
-    return edits
-
-
-def _fix_pushed_patch_of(command) -> bool:
-    return (
-        command[:2] == ["gh", "api"]
-        # GitHub update route (Issue #58): no issue number.
-        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
-        and "--method" in command
-        and "PATCH" in command
-    )
-
-
-def test_resume_delivery_fix_pushed_finish_failure_does_not_fail_delivery(
-    monkeypatch, tmp_path, caplog,
-):
-    """The fix is verified and the Issue is back in `ai-pr-opened`
-    (leaving `ai-fix-needed`) before the `fix pushed` finish() PATCH.
-    That PATCH failing must not fail the delivery: no re-raise, no
-    `ai-blocked`, the error is logged (`progress_publish_failed`) and
-    the verified PR URL is returned so the run continues into the
-    review/merge wait loop."""
-    calls, posted = make_failing_gh(monkeypatch, _fix_pushed_patch_of)
-    edits = patch_resume_deps_live(monkeypatch, tmp_path)
-    caplog.set_level("ERROR")
-
-    pr_url = runner.resume_delivery(
-        make_issue(), scene_for_resume(), make_config(tmp_path),
-        "xqliu/muyan-pilot",
-    )
-
-    assert pr_url == "https://github.com/xqliu/muyan-pilot/pull/40"
-    # The state transition happened (the Issue awaits review again)...
-    assert edits == [{
-        "repo": "xqliu/muyan-pilot", "add": "ai-pr-opened",
-        "remove": "ai-fix-needed",
-    }]
-    # ...and the delivery was NOT marked blocked.
-    assert not any(kwargs.get("add") == "ai-blocked" for kwargs in edits)
-    # The failure is logged like the in-stream callback...
-    assert any(
-        "progress_publish_failed" in line
-        and "run=a1b2c3d4" in line
-        and "issue=xqliu/muyan-pilot#18" in line
-        and "role=fix" in line
-        for line in caplog.text.splitlines()
-    ), caplog.text
-    # ...and the fix summary was attempted (the 404'd PATCH).
-    fix_patches = [c for c in calls if _fix_pushed_patch_of(c)]
-    assert fix_patches, "the fix pushed finish was not attempted"
-    last_body = fix_patches[-1][
-        fix_patches[-1].index("--field") + 1
-    ][len("body="):]
-    assert "Muyan Pilot fix pushed" in last_body
-
-
-def test_resume_delivery_scene_comment_failure_does_not_fail_delivery(
-    monkeypatch, tmp_path, caplog,
-):
-    """The fixed-PR scene comment POST failing after the state transition
-    is the same contract: logged, not fatal; the `fix pushed` milestone
-    and the delivered finish still run (independent publishing steps)."""
-    calls, posted = make_failing_gh(
-        monkeypatch,
-        lambda command: (
-            command[:2] == ["gh", "issue"]
-            and "comment" in command
-            and "Muyan Pilot fixed PR:" in command[-1]
-        ),
-    )
-    edits = patch_resume_deps_live(monkeypatch, tmp_path)
-    caplog.set_level("ERROR")
-
-    pr_url = runner.resume_delivery(
-        make_issue(), scene_for_resume(), make_config(tmp_path),
-        "xqliu/muyan-pilot",
-    )
-
-    assert pr_url == "https://github.com/xqliu/muyan-pilot/pull/40"
-    assert not any(kwargs.get("add") == "ai-blocked" for kwargs in edits)
-    assert any("progress_publish_failed" in line
-               for line in caplog.text.splitlines()), caplog.text
-    # The milestone and the delivered finish still ran.
-    assert any("Muyan Pilot: fix pushed" in body for body in posted)
-    fix_patches = [c for c in calls if _fix_pushed_patch_of(c)]
-    assert fix_patches, "the fix pushed finish was not attempted"
-    last_body = fix_patches[-1][
-        fix_patches[-1].index("--field") + 1
-    ][len("body="):]
-    assert "Muyan Pilot fix pushed" in last_body
-
-
 # --- review_and_merge_if_clean wiring (the reviewer stays observable) ---------
 
 
@@ -1254,9 +1009,11 @@ def test_wait_for_delivery_closed_unmerged_posts_blocked_milestone(
         if command[:2] == ["gh", "pr"]:
             return json.dumps({"state": "CLOSED"})
         if command[:2] == ["gh", "issue"]:
-            # The blocked scene derives the role from the delivery label
-            # and the round from the trusted review-round comments
-            # (review round 2, PR #42).
+            # The blocked scene derives the round from the trusted
+            # review-round comments (review round 2, PR #42); Issue
+            # #82: both opened-PR states are review states, so the
+            # role is always `review` (the label lookup only serves
+            # the leftover-label cleanup below).
             if command[-1] == "labels":
                 return json.dumps({"labels": [{"name": "ai-fix-needed"}]})
             return json.dumps({"comments": [
@@ -1320,10 +1077,10 @@ def test_wait_for_delivery_closed_unmerged_posts_blocked_milestone(
     assert "closed without a merge" in blocked
     assert "next step:" in blocked
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked
-    # The blocked scene carries the actual role (delivery label was
-    # ai-fix-needed) and the completed review rounds (review round 2,
-    # PR #42) — not the hardcoded fix/0.
-    assert "- role: fix" in blocked
+    # The blocked scene carries the actual role (Issue #82: both
+    # opened-PR states are review states, so always `review`) and the
+    # completed review rounds (review round 2, PR #42).
+    assert "- role: review" in blocked
     assert "- review/fix round: 2" in blocked
 
 

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -1,23 +1,27 @@
-"""E2E: continue fixing the same PR after the base advances (Issue #45).
+"""E2E: the review session fixes the same PR in-session (Issues #45, #82).
 
 Real git (local bare origin + clone) plus a fake ``pi`` executable that
 behaves like the delivery agent in both modes:
 
-- fresh mode (no ``Existing PR:`` in the context): writes the run-scoped
-  plan artifact, commits and pushes — the first delivery that opens the PR;
-- resume mode (``Existing PR:`` in the context): resolves the merge
-  conflict left by the runner's plain ``git merge origin/<base>`` and
-  pushes to the SAME branch, so the SAME PR updates.
+- implement mode (``Run id:`` in the system prompt): writes the
+  run-scoped plan artifact, commits and pushes — the first delivery
+  that opens the PR;
+- review mode (system prompt without the run id): Issue #82 — the
+  independent review session fixes findings IN THE SAME SESSION: it
+  absorbs the latest base (plain ``git merge origin/<base>``, resolves
+  the conflict), commits and pushes to the SAME branch, and ends with
+  a clean verdict covering the fixed head.
 
 The acceptance criteria proven here:
 
 - main advances on top of an old delivery and edits the SAME file; the
-  runner merges the latest main into the ORIGINAL branch, the fixer
+  review session merges the latest main into the ORIGINAL branch,
   resolves the conflict, reruns the push, and the PR keeps the same
-  number, head branch, run_id and worktree;
+  number, head branch, run_id and worktree — no cold-start fixer, no
+  third review;
 - exactly one PR exists at the end;
-- a fixer that cannot resolve marks the Issue ``ai-blocked`` and
-  preserves the PR, branch and worktree.
+- a review session that cannot finish marks the Issue ``ai-blocked``
+  and preserves the PR, branch and worktree.
 """
 import json
 import os
@@ -37,44 +41,56 @@ FAKE_PI = """#!/usr/bin/env python3
 import os, re, subprocess, sys
 args = sys.argv[1:]
 prompt = args[args.index("--system-prompt") + 1]
-context = args[-1]
-run_id = re.search(r"Run id: `([0-9a-f]{8})`", prompt).group(1)
 cwd = os.getcwd()
 os.makedirs(os.path.join(cwd, ".pi-session"), exist_ok=True)
-if "Existing PR:" in context:
-    # Resume mode: resolve the merge conflict on the SAME branch.
-    plan = (
-        f"<!-- muyan-pilot:run={run_id} -->\\n"
-        f"# Plan\\n\\nmerged main\\nrun_id={run_id}\\n"
+match = re.search(r"Run id: `([0-9a-f]{8})`", prompt)
+if match is None:
+    # Review mode (Issue #82): the independent review session fixes the
+    # finding IN THE SAME SESSION — absorb the latest base (plain merge
+    # into the SAME branch), resolve the conflict, commit and push, and
+    # end with a clean verdict covering the fixed head.
+    subprocess.run(["git", "fetch", "origin", "main"], cwd=cwd,
+                   check=True, capture_output=True)
+    merge = subprocess.run(
+        ["git", "merge", "--no-ff", "-m", "merge main (review session)",
+         "origin/main"],
+        cwd=cwd, capture_output=True,
     )
-    with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
-        handle.write(plan)
-    for command in (
-        ["git", "add", "."],
-        ["git", "commit", "--no-edit"],
-        ["git", "push", "origin", "HEAD"],
-    ):
-        subprocess.run(command, cwd=cwd, check=True, capture_output=True)
-else:
-    # Fresh mode: first delivery.
-    plan = (
-        f"<!-- muyan-pilot:run={run_id} -->\\n"
-        f"# Plan\\n\\nrun_id={run_id}\\n"
-    )
-    with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
-        handle.write(plan)
-    for command in (
-        ["git", "add", "."],
-        ["git", "commit", "-m", f"plan for run {run_id}"],
-        ["git", "push", "origin", "HEAD"],
-    ):
-        subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+    if merge.returncode != 0:
+        # Conflict: resolve it in this session (never auto-resolved by
+        # the runner).
+        with open(os.path.join(cwd, "plan.md"), "w",
+                  encoding="utf-8") as handle:
+            handle.write("# Plan\\n\\nmerged main\\n")
+        subprocess.run(["git", "add", "."], cwd=cwd, check=True,
+                       capture_output=True)
+        subprocess.run(["git", "commit", "--no-edit"], cwd=cwd,
+                       check=True, capture_output=True)
+    subprocess.run(["git", "push", "origin", "HEAD"], cwd=cwd,
+                   check=True, capture_output=True)
+    print('REVIEW_VERDICT ' + '{"verdict": "pass", "blockers": 0, '
+          '"majors": 0, "minors": 0, "findings": []}')
+    sys.exit(0)
+# Implement mode: first delivery.
+run_id = match.group(1)
+plan = (
+    f"<!-- muyan-pilot:run={run_id} -->\\n"
+    f"# Plan\\n\\nrun_id={run_id}\\n"
+)
+with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+    handle.write(plan)
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", f"plan for run {run_id}"],
+    ["git", "push", "origin", "HEAD"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 """
 
-FAKE_PI_FIXER_FAILING = """#!/usr/bin/env python3
+FAKE_PI_REVIEW_FAILING = """#!/usr/bin/env python3
 import os, sys
 os.makedirs(os.path.join(os.getcwd(), ".pi-session"), exist_ok=True)
-sys.stderr.write("fixer could not resolve the conflict")
+sys.stderr.write("review session could not finish")
 sys.exit(3)
 """
 
@@ -132,19 +148,30 @@ def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
 
 def install_fake_gh(monkeypatch, comments: list[str],
                     edits: list[list[str]] | None = None,
-                    served_comments: list[dict] | None = None) -> None:
+                    served_comments: list[dict] | None = None,
+                    pr: dict | None = None,
+                    labels: list[str] | None = None) -> None:
     """Answer the runner's ``gh`` calls; capture comments and label edits.
 
     ``gh pr list`` answers with the local HEAD as ``headRefOid`` and a PR
     body carrying the marker of the run id embedded in the task branch.
-    ``gh issue view --json comments`` returns the captured comment history
-    in the production shape (a top-level object with a ``.comments``
-    array; every comment carries the owner association of the runner's
-    own account), which is how the resume scene is recovered after a
+    ``gh pr view`` answers the merge gate (state/mergeable/headRefOid =
+    local HEAD) and, once ``pr["merged"]`` is set, the confirm_merged
+    shape (MERGED + mergeCommit = the merged head). ``gh pr merge``
+    lands the head on origin/main like real GitHub (a merge commit in a
+    throwaway clone when the base advanced in the meantime). ``gh issue
+    view --json comments`` returns the captured comment history in the
+    production shape (a top-level object with a ``.comments`` array;
+    every comment carries the owner association of the runner's own
+    account), which is how the resume scene is recovered after a
     restart. Pass ``served_comments`` to serve a fixed comment history
     (e.g. public comments) instead of the captured one.
     """
     comment_ids: list[int] = []
+    if pr is None:
+        pr = {"state": "OPEN", "merged": False}
+    if labels is None:
+        labels = ["ai-pr-opened"]
     real_run = runner.run_command
 
     def fake_run(command, **kwargs):
@@ -157,10 +184,20 @@ def install_fake_gh(monkeypatch, comments: list[str],
                 if command[2] == "edit":
                     if edits is not None:
                         edits.append(command)
+                    if "--add-label" in command:
+                        label = command[command.index("--add-label") + 1]
+                        if label not in labels:
+                            labels.append(label)
+                    if "--remove-label" in command:
+                        label = command[command.index("--remove-label") + 1]
+                        if label in labels:
+                            labels.remove(label)
                     return ""
                 if command[2] == "view":
-                    if command[-1] == "body":
-                        return json.dumps({"body": "original task body"})
+                    if command[-1] == "labels":
+                        return json.dumps({
+                            "labels": [{"name": name} for name in labels],
+                        })
                     if served_comments is not None:
                         return json.dumps({"comments": served_comments})
                     return json.dumps({
@@ -214,14 +251,66 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     for comment_id, body in zip(comment_ids, comments)
                 ])
             if command[1] == "pr":
+                if command[2] == "view":
+                    cwd = kwargs.get("cwd")
+                    if cwd is None:
+                        # `pr_state` only needs the state (no git).
+                        return json.dumps({"state": pr["state"]})
+                    head = real_run(
+                        ["git", "rev-parse", "HEAD"], cwd=cwd,
+                    )
+                    if pr["merged"]:
+                        return json.dumps({
+                            "state": "MERGED",
+                            "mergedAt": "2026-08-26T00:00:00Z",
+                            "mergeCommit": {"oid": pr["merged_head"]},
+                        })
+                    return json.dumps({
+                        "state": pr["state"],
+                        "mergeable": "MERGEABLE",
+                        "headRefOid": head,
+                    })
+                if command[2] == "merge":
+                    # Land the head on origin/main like real GitHub: a
+                    # merge commit in a throwaway clone (the base may
+                    # have advanced in the meantime).
+                    import tempfile
+                    head = real_run(
+                        ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
+                    )
+                    with tempfile.TemporaryDirectory() as td:
+                        real_run(
+                            ["git", "clone",
+                             real_run(["git", "remote", "get-url",
+                                       "origin"], cwd=kwargs["cwd"]),
+                             td],
+                        )
+                        real_run(["git", "config", "user.email",
+                                  "pilot@test.local"], cwd=Path(td))
+                        real_run(["git", "config", "user.name", "Pilot"],
+                                 cwd=Path(td))
+                        real_run(["git", "fetch", "origin"], cwd=Path(td))
+                        real_run(["git", "merge", "--no-ff",
+                                  "-m", "Merge PR (fake)", head],
+                                 cwd=Path(td))
+                        real_run(["git", "push", "origin",
+                                  "HEAD:main"], cwd=Path(td))
+                    pr["merged"] = True
+                    pr["merged_head"] = head
+                    return ""
                 branch = command[command.index("--head") + 1]
                 run_id = branch.rsplit("-", 1)[1]
                 head = real_run(
                     ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
                 )
+                base_oid = real_run(
+                    ["git", "rev-parse", "origin/main"], cwd=kwargs["cwd"],
+                )
                 return json.dumps([{
+                    "number": ISSUE_NUMBER,
                     "url": PR_URL,
                     "baseRefName": "main",
+                    "baseRefOid": base_oid,
                     "headRefName": branch,
                     "headRefOid": head,
                     "headRepository": {
@@ -252,7 +341,10 @@ def write_prompt(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     # validate_config requires the review prompt to exist as well (the
-    # Runner runs the independent review itself).
+    # Runner runs the independent review itself). The review prompt
+    # carries NO `Run id:` line: the fake pi uses that to tell review
+    # mode (Issue #82: the review session fixes in the same session)
+    # from implement mode.
     (tmp_path / "prompt_review.md").write_text("review", encoding="utf-8")
     return prompt
 
@@ -261,6 +353,7 @@ def config_for(clone: Path, tmp_path: Path) -> dict:
     return {
         "repo_dir": clone,
         "prompt": write_prompt(tmp_path),
+        "prompt_review": Path(tmp_path) / "prompt_review.md",
         "base_branch": "main",
         "source_repos": [REPO],
         "workspace_root": tmp_path,
@@ -319,12 +412,17 @@ def test_fake_gh_ignores_unknown_api_methods(monkeypatch):
     assert json.loads(raw) == []
 
 
-def test_e2e_base_advances_and_resume_fixes_the_same_pr(
+def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     clone, tmp_path, monkeypatch, caplog,
 ):
+    """Issue #82: when the base advances with a conflict, the review
+    session absorbs the latest base IN THE SAME SESSION (no cold-start
+    fixer, no third review), pushes the fixed head, and the runner
+    re-freezes and merges the SAME PR."""
     comments: list[str] = []
+    pr = {"state": "OPEN", "merged": False}
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
-    install_fake_gh(monkeypatch, comments)
+    install_fake_gh(monkeypatch, comments, pr=pr)
     caplog.set_level("INFO")
     config = config_for(clone, tmp_path)
 
@@ -358,7 +456,8 @@ def test_e2e_base_advances_and_resume_fixes_the_same_pr(
     assert origin_main not in git(worktree, "log", "--format=%H")
 
     # ---- Resume: the next tick recovers the scene from the Issue
-    #      comments and fixes the SAME PR in the ORIGINAL worktree.
+    #      comments and runs the SAME independent review on the
+    #      ORIGINAL worktree (Issue #82: no cold-start fixer).
     resumed, scene = runner.pick_resumable_delivery(
         REPO, tmp_path / "slots", 1,
     )
@@ -377,22 +476,35 @@ def test_e2e_base_advances_and_resume_fixes_the_same_pr(
         config["repo_dir"], REPO, ISSUE_NUMBER, run_id,
     ) == worktree
 
-    result = runner.resume_delivery(resumed, scene, config, REPO)
-    assert result == PR_URL
+    # The dispatch binds the scene's run id and enters the delivery
+    # wait, which runs the independent review of the frozen PR.
+    runner.set_run_id(run_id)
+    review_config = {
+        **config,
+        "base_sha": scene["base_sha"],
+        "run_id": scene["run_id"],
+    }
+    merged = runner.review_and_merge_if_clean(
+        worktree, branch, "main", review_config, REPO, ISSUE_NUMBER,
+    )
+    assert merged is True
+    assert pr["merged"] is True
 
     # The same run id is bound for the whole resumed attempt.
     assert runner.current_run_id() == run_id
 
-    # The latest base was merged into the ORIGINAL branch: the merge
-    # commit contains both the delivery work and the new main commit.
+    # The latest base was merged into the ORIGINAL branch by the review
+    # session: the head contains both the delivery work and the new
+    # main commit.
     head = git(worktree, "rev-parse", "HEAD")
     assert origin_main in git(worktree, "log", "--format=%H", head)
     assert git(worktree, "branch", "--show-current") == branch
-    # The conflict was resolved by the fixer, not auto-resolved.
+    # The conflict was resolved by the review session, not
+    # auto-resolved.
     assert "merged main" in (worktree / "plan.md").read_text(encoding="utf-8")
 
     # The SAME PR updated: exactly one open PR for the head branch, and
-    # its head is the new local HEAD (pushed by the fixer).
+    # its head is the new local HEAD (pushed by the review session).
     raw = runner.run_command([
         "gh", "pr", "list", "--state", "open", "--head", branch,
         "--json", "url,baseRefName,headRefOid", "--limit", "2",
@@ -402,18 +514,12 @@ def test_e2e_base_advances_and_resume_fixes_the_same_pr(
     assert prs[0]["url"] == PR_URL
     assert prs[0]["headRefOid"] == head
 
-    # The fix progress comment reuses the same marker and run_id.
-    # The fixer publishes on the SAME run: the fixed-PR scene comment
-    # plus the fix pushed milestone (the progress comment is PATCHed in
-    # place, never re-posted).
-    fixed = comments[-2]
-    assert f"Muyan Pilot fixed PR: {PR_URL}" in fixed
-    assert f"<!-- muyan-pilot:run={run_id} -->" in fixed
-    assert f"run_id={run_id}" in fixed
-    assert "Muyan Pilot opened PR" not in fixed
-    fix_milestone = comments[-1]
-    assert "Muyan Pilot: fix pushed" in fix_milestone
-    assert f"<!-- muyan-pilot:run={run_id} -->" in fix_milestone
+    # The runner merged the RE-FROZEN head (the fixed one), not the
+    # frozen head: origin/main carries the in-session fix.
+    assert pr["merged_head"] == head
+    assert origin_main in git(
+        clone, "log", "--format=%H", "origin/main",
+    )
 
     # Every journal line of the resumed attempt carries the same run id.
     for message in caplog.messages:
@@ -422,9 +528,15 @@ def test_e2e_base_advances_and_resume_fixes_the_same_pr(
     # One PR, one branch, one worktree, one run id: nothing was
     # recreated. Six comments from the first delivery (started Pi,
     # progress, started milestone, plan ready milestone, opened PR,
-    # PR opened milestone) plus two from the fixer (fixed PR, fix
-    # pushed milestone).
+    # PR opened milestone) plus two from the review (merged milestone,
+    # merged PR comment).
     assert len(comments) == 8
+    merged_comment = [
+        body for body in comments
+        if "Muyan Pilot merged PR:" in body
+    ]
+    assert merged_comment
+    assert f"<!-- muyan-pilot:run={run_id} -->" in merged_comment[0]
     assert git(worktree, "branch", "--show-current") == branch
     assert worktree.is_dir()
 
@@ -457,13 +569,13 @@ def test_e2e_pr_opened_without_fix_needed_never_starts_a_fixer(
     # The next tick: the resumable scan now also covers `ai-pr-opened`
     # (Issue #70), so the stranded delivery is found and its scene is
     # recovered; the dispatch sends it straight to the delivery wait
-    # (independent review) — no fixer, no fresh claim.
+    # (independent review) — no fixer, no fresh claim (Issue #82).
     # The only gh calls of the awaiting-review tick: the opened-PR
-    # scan (fix-needed OR pr-opened) finds the stranded delivery, the
-    # scene is recovered from the comment history, the dispatch reads
-    # the labels — and the wait (stubbed below) takes over. The
-    # in-flight and ready scans never run (the delivery is resumed, so
-    # nothing is claimed), and the fake rejects anything else.
+    # scan (fix-needed OR pr-opened) finds the stranded delivery and
+    # the scene is recovered from the comment history — and the wait
+    # (stubbed below) takes over. The in-flight and ready scans never
+    # run (the delivery is resumed, so nothing is claimed), and the
+    # fake rejects anything else.
     def fake_run(command, **kwargs):
         if command[:1] == ["gh"] and command[1] == "issue":
             if command[2] == "list":
@@ -477,15 +589,6 @@ def test_e2e_pr_opened_without_fix_needed_never_starts_a_fixer(
                     }])
                 raise AssertionError(f"unexpected command: {command}")
             if command[2] == "view":
-                if command[-1] == "body":
-                    return json.dumps({"body": "original task body"})
-                if command[-1] == "labels":
-                    # Awaiting review: no `ai-fix-needed` label, so the
-                    # dispatch must not start a fixer.
-                    return json.dumps({"labels": [
-                        {"name": "ai-ready"},
-                        {"name": "ai-pr-opened"},
-                    ]})
                 return json.dumps({
                     "comments": [
                         {"id": i + 1, "body": body,
@@ -584,9 +687,13 @@ def test_e2e_public_comment_scene_is_never_resumed(
     assert not any("merge" in " ".join(e) for e in edits)
 
 
-def test_e2e_fixer_failure_keeps_pr_and_marks_blocked(
+def test_e2e_review_failure_keeps_pr_and_marks_blocked(
     clone, tmp_path, monkeypatch, caplog,
 ):
+    """Issue #82: a review session that cannot finish (the fix is not
+    verifiable) fails fast: the Issue is marked ``ai-blocked`` and the
+    PR, branch and worktree are preserved (never deleted, never
+    force-pushed, never re-claimed)."""
     comments: list[str] = []
     edits: list[list[str]] = []
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
@@ -600,28 +707,18 @@ def test_e2e_fixer_failure_keeps_pr_and_marks_blocked(
     branch = f"muyan-pilot/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
     worktree = worktree_for(clone, run_id)
 
-    # origin/main advances with a conflicting edit to the same file.
-    (clone / "plan.md").write_text(
-        "main edited plan.md after the PR was opened\n", encoding="utf-8",
+    # The review session cannot finish (e.g. the in-session fix is not
+    # verifiable): the delivery wait marks the Issue ai-blocked.
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_REVIEW_FAILING)
+    runner.set_run_id(run_id)
+    runner.wait_for_delivery(
+        pr_url, issue(), config, REPO, poll_interval=0.01,
     )
-    git(clone, "add", ".")
-    git(clone, "commit", "-m", "main advances with a conflicting edit")
-    git(clone, "push", "origin", "main")
 
-    resumed, scene = runner.pick_resumable_delivery(
-        REPO, tmp_path / "slots", 1,
-    )
-    assert scene is not None
-
-    # The fixer cannot resolve the conflict.
-    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FIXER_FAILING)
-    with pytest.raises(subprocess.CalledProcessError):
-        runner.resume_delivery(resumed, scene, config, REPO)
-
-    # The Issue is marked ai-blocked (and ai-fix-needed removed)...
+    # The Issue is marked ai-blocked (leaving the opened-PR state)...
     assert [
         "gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
-        "--add-label", "ai-blocked", "--remove-label", "ai-fix-needed",
+        "--add-label", "ai-blocked", "--remove-label", "ai-pr-opened",
     ] in edits
     # ...the PR, branch and worktree are all preserved (never deleted,
     # never force-pushed).
@@ -634,8 +731,63 @@ def test_e2e_fixer_failure_keeps_pr_and_marks_blocked(
     assert "Muyan Pilot failed:" in failure
     assert "returned non-zero exit status 3" in failure
     assert f"<!-- muyan-pilot:run={run_id} -->" in failure
-    assert f"run_id={run_id}" in failure
-    assert "Muyan Pilot fixed PR" not in failure
     blocked = comments[-1]
     assert "Muyan Pilot: blocked" in blocked
-    assert f"run_id={run_id}" in blocked
+    assert f"<!-- muyan-pilot:run={run_id} -->" in blocked
+
+
+def test_e2e_pr_closed_while_fix_needed_removes_leftover_label(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """Issue #82: a PR closed without a merge while the Issue awaits
+    the next review session (`ai-fix-needed`) is terminal: the Issue
+    is marked `ai-blocked` and the leftover `ai-fix-needed` label is
+    removed too, so the terminal state is `ai-blocked` alone."""
+    comments: list[str] = []
+    edits: list[list[str]] = []
+    labels = ["ai-pr-opened"]
+    pr = {"state": "OPEN", "merged": False}
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
+    install_fake_gh(
+        monkeypatch, comments, edits, pr=pr, labels=labels,
+    )
+    caplog.set_level("INFO")
+    config = config_for(clone, tmp_path)
+
+    pr_url = runner.process_issue(issue(), config, REPO)
+    assert pr_url == PR_URL
+    run_id = runner.current_run_id()
+
+    # The review found a finding the session could not fix: the Issue
+    # awaits the next review session.
+    assert "ai-pr-opened" in labels
+    labels.remove("ai-pr-opened")
+    labels.append("ai-fix-needed")
+    # The PR is closed WITHOUT a merge while in that state.
+    pr["state"] = "CLOSED"
+
+    runner.set_run_id(run_id)
+    runner.wait_for_delivery(
+        pr_url, issue(), config, REPO, poll_interval=0.01,
+    )
+
+    # The Issue is marked ai-blocked (leaving the opened-PR state)...
+    assert [
+        "gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
+        "--add-label", "ai-blocked", "--remove-label", "ai-pr-opened",
+    ] in edits
+    # ...and the leftover ai-fix-needed label is removed too (a
+    # remove-only edit).
+    assert [
+        "gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
+        "--remove-label", "ai-fix-needed",
+    ] in edits
+    # The terminal state is ai-blocked alone.
+    assert labels == ["ai-blocked"]
+    # The failure comment carries the run marker.
+    failure = [
+        body for body in comments if "Muyan Pilot failed:" in body
+    ]
+    assert failure
+    assert f"<!-- muyan-pilot:run={run_id} -->" in failure[0]
+    assert "closed without a merge" in failure[0]

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1,11 +1,13 @@
-"""Resume the same PR after review findings or base conflicts (Issue #45).
+"""Resume the same PR from its opened-PR state (Issue #45, #82).
 
-Unit tests for the runner's resume path: an Issue labeled `ai-pr-opened`
-carries a run-scoped scene in its `Muyan Pilot opened PR:` comment. The
-next tick recovers run_id, branch, worktree and PR URL from that comment,
-re-runs the base freshness merge on the ORIGINAL branch, hands the fix to
-Pi in the ORIGINAL worktree, and re-verifies the SAME PR. Failures mark
-the Issue `ai-blocked` and preserve the PR, branch and worktree.
+Unit tests for the runner's resume path: an Issue in an opened-PR state
+(`ai-pr-opened` or `ai-fix-needed`) carries a run-scoped scene in its
+`Muyan Pilot opened PR:` comment. The next tick recovers run_id, branch,
+worktree and PR URL from that comment and resumes the delivery on the
+ORIGINAL branch, worktree and PR. Issue #82 removed the cold-start
+fixer: both states resume into the SAME independent review session,
+which fixes findings in the same session. Failures mark the Issue
+`ai-blocked` and preserve the PR, branch and worktree.
 """
 import json
 import os
@@ -42,6 +44,18 @@ def opened_pr_comment(run_id=FAKE_RUN_ID,
         f"Muyan Pilot opened PR: {pr_url} "
         f"(base_branch={base_branch} base_sha={base_sha} run_id={run_id})"
     )
+
+
+def scene_for() -> dict:
+    # The scene recovered from the trusted `Muyan Pilot opened PR:`
+    # comment. Branch and worktree are NOT part of it: the runner
+    # derives them from its own config, the Issue number and the run id.
+    return {
+        "run_id": FAKE_RUN_ID,
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "pr_url": FAKE_PR_URL,
+    }
 
 
 # ---------------------------------------------------------------- parse
@@ -230,27 +244,6 @@ def test_issue_comments_rejects_payload_without_comments_array(monkeypatch):
         runner.issue_comments(9, repo="owner/repo")
 
 
-def test_issue_body_returns_the_issue_body(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
-        lambda *a, **k: json.dumps({"body": "task text"}),
-    )
-    assert runner.issue_body(9, repo="owner/repo") == "task text"
-
-
-def test_issue_body_returns_empty_string_for_null_body(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
-        lambda *a, **k: json.dumps({"body": None}),
-    )
-    assert runner.issue_body(9, repo="owner/repo") == ""
-
-
-def test_issue_body_rejects_non_object_payload(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "[]")
-    with pytest.raises(ValueError, match="issue view must be a JSON object"):
-        runner.issue_body(9, repo="owner/repo")
-
 
 def test_parse_pr_comment_ignores_field_part_without_key():
     body = opened_pr_comment().replace(")", " =keyless)", 1)
@@ -282,7 +275,6 @@ def issue_payload(state: str = "OPEN") -> str:
 
 
 def make_pick_fake(list_payload: str, view_payload: str | None = None,
-                   body_payload: str | None = None,
                    edits: list[list[str]] | None = None,
                    comments: list[str] | None = None):
     """Fake `gh` for the resumable scan; guard rejects anything else.
@@ -295,8 +287,6 @@ def make_pick_fake(list_payload: str, view_payload: str | None = None,
             if command[2] == "list":
                 return list_payload
             if command[2] == "view":
-                if command[-1] == "body":
-                    return body_payload or json.dumps({"body": ""})
                 return view_payload
             if command[2] == "edit":
                 if edits is not None:
@@ -760,148 +750,11 @@ def test_pick_next_delivery_returns_none_when_nothing_to_do(
     ) is None
 
 
-# ---------------------------------------------------------------- merge
-
-
-def test_merge_latest_base_returns_false_when_head_contains_base(
-    monkeypatch, tmp_path,
-):
-    calls = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-        return ""
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.merge_latest_base(tmp_path, "main") is False
-    assert calls == [
-        ["git", "fetch", "origin", "main"],
-        ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
-    ]
-
-
-def test_merge_latest_base_merges_when_head_is_behind(monkeypatch, tmp_path):
-    calls = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
-            raise subprocess.CalledProcessError(1, command)
-        return ""
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.merge_latest_base(tmp_path, "main") is True
-    assert calls[-1] == ["git", "merge", "origin/main"]
-
-
-def test_merge_latest_base_leaves_conflicts_for_the_fixer(
-    monkeypatch, tmp_path, caplog,
-):
-    """A conflicted merge is left staged; the runner never auto-resolves."""
-    error = subprocess.CalledProcessError(
-        1, ["git", "merge", "origin/main"],
-        stderr="CONFLICT (content): Merge conflict in a.txt",
-    )
-    calls = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
-            raise subprocess.CalledProcessError(1, command)
-        if command[:2] == ["git", "merge"]:
-            raise error
-        # `git rev-parse -q --verify MERGE_HEAD` succeeds: mid-merge.
-        return ""
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    with caplog.at_level("WARNING"):
-        assert runner.merge_latest_base(tmp_path, "main") is True
-    # The conflict is handed to the fixer; no `git merge --abort`, no
-    # force push, and the merge error did not escape.
-    assert not any(
-        "abort" in " ".join(command) or "force" in " ".join(command)
-        for command in calls
-    )
-    assert "base_merge_conflict" in caplog.text
-
-
-def test_merge_latest_base_fails_fast_on_non_conflict_merge_error(
-    monkeypatch, tmp_path,
-):
-    error = subprocess.CalledProcessError(
-        128, ["git", "merge", "origin/main"],
-        stderr="fatal: refusing to merge unrelated histories",
-    )
-
-    def fake_run(command, **kwargs):
-        if command[:2] == ["git", "fetch"]:
-            return ""
-        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
-            raise subprocess.CalledProcessError(1, command)
-        if command[:2] == ["git", "merge"]:
-            raise error
-        # No MERGE_HEAD: this was not a conflict.
-        raise subprocess.CalledProcessError(1, command)
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        runner.merge_latest_base(tmp_path, "main")
-    assert excinfo.value is error
-
-
-def test_merge_in_progress_checks_merge_head(monkeypatch, tmp_path):
-    def fake_run(command, **kwargs):
-        if command[:3] == ["git", "rev-parse", "-q"]:
-            return "abc123"
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.merge_in_progress(tmp_path) is True
-    with pytest.raises(AssertionError, match="unexpected command"):
-        runner.run_command(["git", "status"])
-
-
-def test_merge_in_progress_false_when_merge_head_missing(monkeypatch, tmp_path):
-    def fake_run(command, **kwargs):
-        raise subprocess.CalledProcessError(1, command)
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.merge_in_progress(tmp_path) is False
 
 
 # ---------------------------------------------------------------- run_pi
 
 
-def test_run_pi_resume_context_names_the_existing_pr(monkeypatch, tmp_path):
-    prompt_path = tmp_path / "prompt.md"
-    prompt_path.write_text("SYSTEM {{RUN_ID}}", encoding="utf-8")
-    calls = []
-    monkeypatch.setattr(
-        runner, "stream_pi",
-        lambda command, **kwargs: calls.append((command, kwargs)) or "done",
-    )
-    config = {
-        "prompt": prompt_path,
-        "source_repos": ["owner/repo"],
-        "workspace_root": tmp_path,
-        "context_files": [],
-        "skills": [],
-        "base_branch": "main",
-        "base_sha": "abc123def456",
-        "run_id": FAKE_RUN_ID,
-    }
-    runner.run_pi(
-        {"number": 9, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch=FAKE_BRANCH, pr_url=FAKE_PR_URL,
-    )
-    command, kwargs = calls[0]
-    context = command[-1]
-    assert f"Existing PR: {FAKE_PR_URL}" in context
-    assert "same PR number" in context
-    assert "never close" in context
-    assert "never create a new PR" in context
-    assert "No force push" in context
-    assert kwargs["branch"] == FAKE_BRANCH
 
 
 def test_run_pi_fresh_context_has_no_existing_pr(monkeypatch, tmp_path):
@@ -930,533 +783,21 @@ def test_run_pi_fresh_context_has_no_existing_pr(monkeypatch, tmp_path):
     assert "Existing PR:" not in context
 
 
-# ---------------------------------------------------------- resume_delivery
-
-
-def scene_for() -> dict:
-    # The scene recovered from the trusted `Muyan Pilot opened PR:`
-    # comment. Branch and worktree are NOT part of it: the runner
-    # derives them from its own config, the Issue number and the run id.
-    return {
-        "run_id": FAKE_RUN_ID,
-        "base_branch": "main",
-        "base_sha": "abc123def456",
-        "pr_url": FAKE_PR_URL,
-    }
-
-
-def config_for_resume(repo_dir: Path) -> dict:
-    return {
-        "repo_dir": repo_dir,
-        "base_branch": "main",
-        "source_repos": ["owner/repo"],
-    }
-
-
-def fake_verify_pr_for_resume(calls: list):
-    """`verify_pr` fake that records the call and returns the scene URL."""
-    def fake_verify(worktree, branch, base_branch, run_id, **kwargs):
-        calls.append(("verify", (worktree, branch, base_branch, run_id),
-                      kwargs))
-        return FAKE_PR_URL
-    return fake_verify
-
-
-def derived_worktree(tmp_path: Path) -> Path:
-    """The worktree the runner derives for Issue 9 / FAKE_RUN_ID."""
-    path = runner.worktree_path(tmp_path, "owner/repo", 9, FAKE_RUN_ID)
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def test_resume_delivery_success_keeps_same_run_branch_and_pr(
-    monkeypatch, tmp_path, caplog,
-):
-    calls = []
-    make_fake_gh(monkeypatch)
-    worktree = derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "merge_latest_base",
-                        lambda wt, base: calls.append(("merge", wt, base)) or True)
-    monkeypatch.setattr(runner, "run_pi",
-                        lambda *args, **kwargs: calls.append(("run_pi", args, kwargs)) or "ok")
-    monkeypatch.setattr(
-        runner, "verify_pr",
-        fake_verify_pr_for_resume(calls),
-    )
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *args, **kwargs: calls.append(("comment", args, kwargs)))
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    caplog.set_level("INFO")
-
-    result = runner.resume_delivery(
-        {"number": 9, "title": "ship", "body": ""},
-        scene_for(),
-        config_for_resume(tmp_path),
-        "owner/repo",
-    )
-
-    assert result == FAKE_PR_URL
-    # The ORIGINAL run id is re-bound for the whole resumed attempt.
-    assert runner.current_run_id() == FAKE_RUN_ID
-    # Branch and worktree are DERIVED from the configured repo_dir,
-    # source_repo, Issue number and run id — never read from the comment.
-    derived_branch = runner.task_branch("owner/repo", 9, FAKE_RUN_ID)
-    expected_worktree = runner.worktree_path(
-        tmp_path, "owner/repo", 9, FAKE_RUN_ID,
-    )
-    assert derived_branch == FAKE_BRANCH
-    assert expected_worktree == worktree
-    # Order: pre-verify → merge → fixer → post-verify → edit → comment.
-    assert calls[1] == ("merge", expected_worktree, "main")
-    run_pi_args = calls[2]
-    assert run_pi_args[0] == "run_pi"
-    assert run_pi_args[1][1] == expected_worktree
-    assert run_pi_args[2]["branch"] == derived_branch
-    assert run_pi_args[2]["pr_url"] == FAKE_PR_URL
-    # The PR is verified twice: before any git/Pi mutation (F1, without
-    # the latest-base check — being behind is the state the resume fixes)
-    # and after the fixer pushed (F3, with the full check). Both times it
-    # must be the recovered original PR, in the configured source repo.
-    verify_calls = [call for call in calls if call[0] == "verify"]
-    assert len(verify_calls) == 2
-    for verify_call in verify_calls:
-        assert verify_call[1] == (expected_worktree, derived_branch, "main",
-                                  FAKE_RUN_ID)
-    assert verify_calls[0][2] == {
-        "pr_repo": "owner/repo", "expected_url": FAKE_PR_URL,
-        "require_latest_base": False, "issue": 9,
-    }
-    assert verify_calls[1][2] == {
-        "pr_repo": "owner/repo", "expected_url": FAKE_PR_URL, "issue": 9,
-    }
-    # The pre-mutation verify ran before the merge and the fixer...
-    assert calls.index(verify_calls[0]) < calls.index(
-        ("merge", expected_worktree, "main"))
-    # ...and the fixer ran between the two verifies.
-    assert calls.index(verify_calls[1]) > calls.index(run_pi_args)
-    # The state transition comes before the progress comment: an
-    # observer never sees a "fixed PR" comment on an Issue that is
-    # still fix-needed (a crash in between re-runs the idempotent
-    # fixer; the comment is a record, the label is the state).
-    assert calls[-2] == ("edit", (9,), {
-        "repo": "owner/repo", "add": "ai-pr-opened", "remove": "ai-fix-needed",
-    })
-    comment = calls[-1]
-    assert comment[0] == "comment"
-    body = comment[2]["body"]
-    assert f"Muyan Pilot fixed PR: {FAKE_PR_URL}" in body
-    assert f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->" in body
-    assert f"run_id={FAKE_RUN_ID}" in body
-    # Every journal line of the resumed attempt carries the same run id.
-    for message in caplog.messages:
-        assert message.startswith(f"[{FAKE_RUN_ID}]"), message
-
-
-def test_resume_delivery_fails_fast_when_scene_base_differs_from_config(
-    monkeypatch, tmp_path, caplog,
-):
-    """A scene frozen on another base branch is never merged: the
-    configured base must match before any git/Pi mutation."""
-    calls = []
-    make_fake_gh(monkeypatch)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base",
-                        lambda wt, base: calls.append(("merge", wt, base)) or True)
-    monkeypatch.setattr(runner, "run_pi", lambda *a, **k: "ok")
-    monkeypatch.setattr(runner, "verify_pr", lambda *a, **k: FAKE_PR_URL)
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    caplog.set_level("ERROR")
-
-    scene = scene_for()
-    scene["base_branch"] = "develop"
-    with pytest.raises(RuntimeError, match="base branch mismatch"):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene,
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-    # No merge, no fixer, no verify: the mismatch failed fast before any
-    # mutation, and the Issue is marked ai-blocked with the reason.
-    assert not any(call[0] == "merge" for call in calls)
-    assert calls[0] == ("edit", (9,), {
-        "repo": "owner/repo", "add": "ai-blocked", "remove": "ai-fix-needed",
-    })
-    assert "base branch mismatch" in calls[1][2]["body"]
-    assert "issue=9 resume failed" in caplog.text
-
-
-def test_resume_delivery_fails_fast_when_worktree_missing(
-    monkeypatch, tmp_path, caplog,
-):
-    """The derived worktree (from config + issue number + run id) must
-    exist locally; a comment can no longer point at an arbitrary path."""
-    calls = []
-    make_fake_gh(monkeypatch)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base",
-                        lambda wt, base: calls.append(("merge", wt, base)) or True)
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    caplog.set_level("ERROR")
-
-    with pytest.raises(RuntimeError, match="worktree missing"):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-
-    # ai-blocked with the concrete reason; PR and scene preserved.
-    assert calls[0] == ("edit", (9,), {
-        "repo": "owner/repo", "add": "ai-blocked", "remove": "ai-fix-needed",
-    })
-    failure_body = calls[1][2]["body"]
-    assert "Muyan Pilot failed:" in failure_body
-    assert "worktree missing" in failure_body
-    assert f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->" in failure_body
-    assert f"run_id={FAKE_RUN_ID}" in failure_body
-    assert "pr_url=" + FAKE_PR_URL in failure_body
-    # The merge was never attempted and no fixer was started.
-    assert not any(call[0] == "merge" for call in calls)
-    assert not any(call[0] == "comment" and "fixed PR" in call[2]["body"]
-                   for call in calls)
-    assert "issue=9 resume failed" in caplog.text
-
-
-def _resume_pr_validation_failure_test(monkeypatch, tmp_path, caplog,
-                                        error: str):
-    """Shared shape: the open-PR pre-validation (verify_pr) fails fast
-    before any merge or fixer starts, and the Issue is marked
-    ai-blocked with the concrete reason."""
-    calls = []
-    make_fake_gh(monkeypatch)
-    worktree = derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-
-    def fake_verify(worktree_, branch, base_branch, run_id, **kwargs):
-        calls.append(("verify", (worktree_, branch, base_branch, run_id),
-                      kwargs))
-        raise RuntimeError(error)
-
-    monkeypatch.setattr(runner, "merge_latest_base",
-                        lambda wt, base: calls.append(("merge", wt, base)) or True)
-    monkeypatch.setattr(runner, "run_pi",
-                        lambda *a, **k: calls.append(("run_pi", a, k)) or "ok")
-    monkeypatch.setattr(runner, "verify_pr", fake_verify)
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    caplog.set_level("ERROR")
-
-    with pytest.raises(RuntimeError, match=error):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-    # The PR pre-validation ran with the derived branch/worktree and the
-    # configured source repo + recovered original PR URL (without the
-    # latest-base check: the pre-validation runs before the base merge)...
-    verify_calls = [call for call in calls if call[0] == "verify"]
-    assert verify_calls == [
-        ("verify", (worktree, FAKE_BRANCH, "main", FAKE_RUN_ID),
-         {"pr_repo": "owner/repo", "expected_url": FAKE_PR_URL,
-          "require_latest_base": False, "issue": 9}),
-    ]
-    # ...and it failed before any git mutation or fixer start.
-    assert not any(call[0] == "merge" for call in calls)
-    assert not any(call[0] == "run_pi" for call in calls)
-    # The Issue is marked ai-blocked with the concrete reason.
-    assert calls[-2][0] == "edit"
-    assert calls[-2][1] == (9,)
-    assert calls[-2][2] == {
-        "repo": "owner/repo", "add": "ai-blocked",
-        "remove": "ai-fix-needed",
-    }
-    assert error in calls[-1][2]["body"]
-    assert "issue=9 resume failed" in caplog.text
-    # The worktree is preserved, never deleted.
-    assert worktree.is_dir()
-
-
-def test_resume_delivery_fails_fast_when_pr_is_in_another_repo(
-    monkeypatch, tmp_path, caplog,
-):
-    _resume_pr_validation_failure_test(
-        monkeypatch, tmp_path, caplog,
-        error="PR head repo is other/repo, expected owner/repo",
-    )
-
-
-def test_resume_delivery_fails_fast_when_no_open_pr_exists(
-    monkeypatch, tmp_path, caplog,
-):
-    _resume_pr_validation_failure_test(
-        monkeypatch, tmp_path, caplog,
-        error="expected exactly one open PR for the task branch",
-    )
-
-
-def test_resume_delivery_fails_fast_when_pr_url_differs_from_scene(
-    monkeypatch, tmp_path, caplog,
-):
-    """The verified PR URL must exactly equal the recovered original PR
-    URL (finding 3): a different PR for the same branch is rejected."""
-    _resume_pr_validation_failure_test(
-        monkeypatch, tmp_path, caplog,
-        error=("PR URL https://github.com/owner/repo/pull/99 is not the "
-               "recovered original PR "
-               "https://github.com/owner/repo/pull/9"),
-    )
-
-
-def test_resume_delivery_success_returns_verified_pr_url(
-    monkeypatch, tmp_path,
-):
-    """The returned URL is the one verify_pr verified (pre- and
-    post-fix), not a blind copy of the scene URL (finding 3)."""
-    calls = []
-    make_fake_gh(monkeypatch)
-    derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base", lambda wt, base: True)
-    monkeypatch.setattr(runner, "run_pi", lambda *a, **k: "ok")
-    monkeypatch.setattr(runner, "verify_pr",
-                        lambda *a, **k: calls.append("verified") or FAKE_PR_URL)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append("edit"))
-
-    result = runner.resume_delivery(
-        {"number": 9, "title": "ship", "body": ""},
-        scene_for(),
-        config_for_resume(tmp_path),
-        "owner/repo",
-    )
-    assert result == FAKE_PR_URL
-    assert calls == ["verified", "verified", "edit"]
-
-
-def test_resume_delivery_marks_blocked_and_reraises_when_fixer_fails(
-    monkeypatch, tmp_path, caplog,
-):
-    calls = []
-    make_fake_gh(monkeypatch)
-    worktree = derived_worktree(tmp_path)
-    (worktree / ".pi-session").mkdir()
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base", lambda wt, base: True)
-    monkeypatch.setattr(runner, "verify_pr",
-                        lambda *a, **k: FAKE_PR_URL)
-    monkeypatch.setattr(
-        runner, "run_pi",
-        lambda *a, **k: (_ for _ in ()).throw(
-            subprocess.CalledProcessError(1, ["pi"], stderr="fixer exploded"),
-        ),
-    )
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    monkeypatch.setattr(runner, "activity_snapshot",
-                        lambda session_dir: None)
-    caplog.set_level("ERROR")
-
-    with pytest.raises(subprocess.CalledProcessError):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-
-    assert calls[0] == ("edit", (9,), {
-        "repo": "owner/repo", "add": "ai-blocked", "remove": "ai-fix-needed",
-    })
-    failure_body = calls[1][2]["body"]
-    assert "Muyan Pilot failed:" in failure_body
-    assert "returned non-zero exit status 1" in failure_body
-    assert f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->" in failure_body
-    # The scene (PR, branch, worktree) stays queryable for the next attempt.
-    assert "pr_url=" + FAKE_PR_URL in failure_body
-    assert f"branch={FAKE_BRANCH}" in failure_body
-    assert f"worktree={worktree}" in failure_body
-    # The worktree is the derived one (config + issue + run id).
-    assert worktree == runner.worktree_path(
-        tmp_path, "owner/repo", 9, FAKE_RUN_ID,
-    )
-    # No success comment was posted.
-    assert not any(
-        call[0] == "comment" and "fixed PR" in call[2]["body"]
-        for call in calls
-    )
-    # The worktree is preserved, never deleted.
-    assert worktree.is_dir()
-
-
-def test_resume_delivery_preserves_original_error_when_reporting_fails(
-    monkeypatch, tmp_path, caplog,
-):
-    edit_calls = []
-    make_fake_gh(monkeypatch)
-
-    def edit(*args, **kwargs):
-        edit_calls.append(kwargs)
-        raise RuntimeError("github report failed")
-
-    worktree = derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base", lambda wt, base: True)
-    monkeypatch.setattr(runner, "verify_pr", lambda *a, **k: FAKE_PR_URL)
-    monkeypatch.setattr(
-        runner, "run_pi",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("git failed")),
-    )
-    monkeypatch.setattr(runner, "edit_issue", edit)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    with caplog.at_level("ERROR"), pytest.raises(
-        RuntimeError, match="git failed",
-    ):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-    assert "failure reporting failed" in caplog.text
-
-
-def test_resume_delivery_failure_comment_includes_session_scene(
-    monkeypatch, tmp_path,
-):
-    calls = []
-    make_fake_gh(monkeypatch)
-    worktree = derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base", lambda wt, base: True)
-    monkeypatch.setattr(runner, "verify_pr", lambda *a, **k: FAKE_PR_URL)
-    monkeypatch.setattr(
-        runner, "run_pi",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("git failed")),
-    )
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: {
-        "session_id": "sess-45",
-        "session_file": str(worktree / ".pi-session" / "s.jsonl"),
-        "phase": "base",
-        "last_activity": "2026-08-25T02:30:00Z",
-        "action": "bash git merge origin/main",
-        "result": None,
-    })
-    with pytest.raises(RuntimeError, match="git failed"):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-    failure_body = calls[-1][2]["body"]
-    assert "Muyan Pilot failed: git failed" in failure_body
-    # The failure scene is the same full run_failed scene as process_issue
-    # (Issue #40): run/issue/role/branch/worktree plus the session fields.
-    assert f"run={FAKE_RUN_ID}" in failure_body
-    assert "issue=owner/repo#9" in failure_body
-    assert "role=implement" in failure_body
-    assert f"branch={FAKE_BRANCH}" in failure_body
-    assert f"worktree={worktree}" in failure_body
-    assert "session=sess-45" in failure_body
-    assert "phase=base" in failure_body
-    assert 'action="bash git merge origin/main"' in failure_body
-    assert "result=-" in failure_body
-
-
-def test_resume_delivery_scene_lookup_failure_is_isolated(
-    monkeypatch, tmp_path, caplog,
-):
-    calls = []
-    make_fake_gh(monkeypatch)
-    worktree = derived_worktree(tmp_path)
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "merge_latest_base", lambda wt, base: True)
-    monkeypatch.setattr(runner, "verify_pr", lambda *a, **k: FAKE_PR_URL)
-    monkeypatch.setattr(
-        runner, "run_pi",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("git failed")),
-    )
-    monkeypatch.setattr(runner, "edit_issue",
-                        lambda *a, **k: calls.append(("edit", a, k)))
-    monkeypatch.setattr(runner, "comment_issue",
-                        lambda *a, **k: calls.append(("comment", a, k)))
-    monkeypatch.setattr(
-        runner, "activity_snapshot",
-        lambda session_dir: (_ for _ in ()).throw(OSError("disk error")),
-    )
-    with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
-        runner.resume_delivery(
-            {"number": 9, "title": "ship", "body": ""},
-            scene_for(),
-            config_for_resume(tmp_path),
-            "owner/repo",
-        )
-    assert "activity scene failed" in caplog.text
-    failure_body = calls[-1][2]["body"]
-    assert "Muyan Pilot failed: git failed" in failure_body
-    assert "session=" not in failure_body
 
 
 # -------------------------------------------------------------------- main
 
 
-def test_pick_resumable_delivery_fetches_issue_body_for_the_fixer(
-    monkeypatch, tmp_path,
-):
-    """The fixer needs the Issue body; the resumable issue carries it."""
-    def fake_run(command, **kwargs):
-        if command[1] == "issue":
-            if command[2] == "list":
-                return issue_payload()
-            if command[2] == "view":
-                if command[-1] == "comments":
-                    return gh_comments_payload([opened_pr_comment()])
-                return json.dumps({
-                    "number": 9, "title": "ship",
-                    "body": "the original task description",
-                })
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    issue, scene = runner.pick_resumable_delivery(
-        "owner/repo", tmp_path / "slots", 1,
-    )
-    assert issue["body"] == "the original task description"
-    assert scene["run_id"] == FAKE_RUN_ID
-    with pytest.raises(AssertionError, match="unexpected command"):
-        fake_run(["gh", "release", "list"])
-    with pytest.raises(AssertionError, match="unexpected command"):
-        fake_run(["gh", "issue", "status", "--repo", "owner/repo"])
 
 
 def test_main_resumes_resumable_delivery_before_claiming_new(monkeypatch, tmp_path):
+    """A resumable opened-PR delivery goes straight to the delivery wait
+    (Issue #82: no cold-start fixer — the review session fixes findings
+    in the same session); it is never re-claimed as a new task."""
     issue = {"number": 9, "title": "ship", "body": ""}
     scene = scene_for()
-    resumed = []
     processed = []
+    waits = []
     for name in ("prompt.md", "prompt_review.md"):
         (tmp_path / name).write_text("prompt", encoding="utf-8")
     config = tmp_path / "muyan-pilot.toml"
@@ -1467,34 +808,23 @@ def test_main_resumes_resumable_delivery_before_claiming_new(monkeypatch, tmp_pa
             "owner/repo", issue, scene
         ),
     )
-    # The dispatch reads the Issue's current labels to choose the fixer
-    # vs the review wait (Issue #70): this delivery is fix-needed.
-    def fake_run(command, **kwargs):
-        assert command[:3] == ["gh", "issue", "view"]
-        assert command[-2:] == ["--json", "labels"]
-        return json.dumps({"labels": [
-            {"name": "ai-ready"}, {"name": "ai-fix-needed"},
-        ]})
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(
-        runner, "resume_delivery",
-        lambda *args, **kwargs: resumed.append(args) or FAKE_PR_URL,
-    )
     monkeypatch.setattr(
         runner, "process_issue",
         lambda *args, **kwargs: processed.append(args) or FAKE_PR_URL,
     )
     # The dispatch test must not run the real delivery-wait loop (it would
     # call `gh` against the real PR number of FAKE_PR_URL).
-    monkeypatch.setattr(runner, "wait_for_delivery", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner, "wait_for_delivery",
+        lambda *a, **k: waits.append((a, k)) or None,
+    )
     assert runner.main(["--config", str(config)]) == 0
     # The resumable delivery is resumed, not re-claimed as a new task.
-    assert len(resumed) == 1
-    assert resumed[0][0] is issue
-    assert resumed[0][1] is scene
-    assert resumed[0][3] == "owner/repo"
     assert processed == []
+    assert len(waits) == 1
+    assert waits[0][0][:2] == (FAKE_PR_URL, issue)
+    # The resumed review runs under the scene's run id.
+    assert runner.current_run_id() == FAKE_RUN_ID
 
 
 def test_main_still_claims_new_issue_when_no_resumable(monkeypatch, tmp_path):

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -1,9 +1,11 @@
-"""Unit tests for the auto review/fix/merge orchestration (Issue #34).
+"""Unit tests for the auto review/fix/merge orchestration (Issues #34, #82).
 
 The Runner (not Pi) closes the delivery loop: after the implementer opens a PR
-it freezes the exact PR base/head SHA, runs an independent review session,
-loops a fixer session while Blocker/Major findings exist, re-checks the merge
-gate against the latest origin/main, and merges via `gh pr merge
+it freezes the exact PR base/head SHA, runs one independent review session
+that fixes Blocker/Major findings IN THE SAME SESSION (Issue #82: no
+cold-start fixer, no third review), re-freezes the head after a clean
+verdict (the reviewer may have pushed a fix), re-checks the merge gate
+against the latest origin/main, and merges via `gh pr merge
 --match-head-commit`. Pi never pushes main.
 """
 import json
@@ -655,6 +657,89 @@ def test_review_and_merge_clean_verdict_merges_and_labels_merged(
     # failure must not rewrite a landed merge as ai-blocked.
     assert calls.index(("edit", {"repo": "owner/repo", "add": "ai-merged",
                                  "remove": "ai-pr-opened"})) < calls.index("sync")
+
+
+def test_review_and_merge_refreezes_head_after_in_session_fix(
+        monkeypatch, tmp_path, caplog):
+    """Issue #82: the review session fixes findings in the same session
+    and pushes the task branch, so the head the verdict covers is NEWER
+    than the frozen head. The PR must be RE-FROZEN before the merge
+    gate: the gate (and the `--match-head-commit` merge) run against
+    the fixed head, not the frozen one."""
+    calls = []
+    frozen = _pr()
+    fixed = {**_pr(), "head_oid": "h2"}
+    heads = iter([frozen, fixed])
+
+    def fake_freeze(*a, **k):
+        return next(heads)
+
+    monkeypatch.setattr(runner, "freeze_pr", fake_freeze)
+    monkeypatch.setattr(
+        runner, "issue_comments", lambda *a, **k: [],
+    )
+    monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
+
+    def fake_gate(worktree, pr, base_branch):
+        calls.append(("gate", pr["head_oid"]))
+        return {**pr, "merged": True}
+
+    monkeypatch.setattr(runner, "merge_gate", fake_gate)
+    monkeypatch.setattr(
+        runner, "confirm_merged",
+        lambda *a, **k: {"state": "MERGED", "merge_commit": "m1"},
+    )
+    monkeypatch.setattr(runner, "sync_base_checkout", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    caplog.set_level("INFO")
+    make_fake_gh(monkeypatch)
+    merged = runner.review_and_merge_if_clean(
+        tmp_path, "branch", "main", _review_merge_config(tmp_path),
+        "owner/repo", 4,
+    )
+    assert merged is True
+    # The merge gate ran against the RE-FROZEN (fixed) head...
+    assert calls == [("gate", "h2")]
+    # ...and the head advance is logged for the journal.
+    assert "review_head_advanced" in caplog.text
+    assert "frozen=h1" in caplog.text
+    assert "reviewed=h2" in caplog.text
+
+
+def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
+        monkeypatch, tmp_path, caplog):
+    """Issue #82: when the review session did not push (clean PR,
+    nothing to fix), the re-freeze returns the same head and the merge
+    gate runs against it unchanged (no head-advance log)."""
+    calls = []
+    monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
+    monkeypatch.setattr(
+        runner, "issue_comments", lambda *a, **k: [],
+    )
+    monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
+
+    def fake_gate(worktree, pr, base_branch):
+        calls.append(("gate", pr["head_oid"]))
+        return {**pr, "merged": True}
+
+    monkeypatch.setattr(runner, "merge_gate", fake_gate)
+    monkeypatch.setattr(
+        runner, "confirm_merged",
+        lambda *a, **k: {"state": "MERGED", "merge_commit": "m1"},
+    )
+    monkeypatch.setattr(runner, "sync_base_checkout", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    caplog.set_level("INFO")
+    make_fake_gh(monkeypatch)
+    merged = runner.review_and_merge_if_clean(
+        tmp_path, "branch", "main", _review_merge_config(tmp_path),
+        "owner/repo", 4,
+    )
+    assert merged is True
+    assert calls == [("gate", "h1")]
+    assert "review_head_advanced" not in caplog.text
 
 
 def test_review_and_merge_keeps_merged_when_checkout_sync_fails(


### PR DESCRIPTION
Fixes #82

<!-- muyan-pilot:run=b4e455c8 -->

run_id=b4e455c8

## What

The independent review session (new process, `prompt_review.md`, a new
JSONL) is now also the fixer: it may modify code, run the full test
suite with 100% line/branch coverage, commit and push ONLY the task
branch, then re-emit the `REVIEW_VERDICT` for the fixed head. When
Blocker/Major findings exist they are fixed in-session — no cold-start
Fixer, no third review. A `pass` verdict means zero Blocker/Major
findings AFTER the in-session fixes.

## Changes

- `bootstrap_runner.py`:
  - removed `ROLE_FIX`, `resume_delivery`, `merge_latest_base`,
    `merge_in_progress` and `issue_body`;
  - the delivery wait runs the same independent review for both
    opened-PR states (`ai-pr-opened` awaiting review, `ai-fix-needed`
    awaiting the next review session after a finding or a base
    conflict);
  - after a clean verdict the PR is RE-FROZEN (the reviewer may have
    pushed an in-session fix, advancing the head) and the merge gate
    runs against the re-frozen head — `gh pr merge
    --match-head-commit` unchanged;
  - a PR closed while in `ai-fix-needed` removes the leftover label
    (terminal state is `ai-blocked` alone);
  - the review prompt keeps its skill filtering (no
    `review-fix-loop` / `tdd-dev`); the implementer is never resumed
    for fixes (no `Existing PR` context).
- `prompt_review.md`: the reviewer fixes Blocker/Major findings in the
  same session and absorbs base advances in-session (`git merge
  origin/<base>`, resolve, retest, push the task branch); `pass` only
  when the PR is mergeable with 0 Blocker/0 Major after the fixes.
- `prompt.md`: the stale Fixer resume section is removed.
- `AGENTS.md` / `README.md`: the one-session review-fix contract.
- tests: the concurrency e2e fakes model the in-session fix (the fake
  review commits+pushes a fix and absorbs the base in-session) and
  per-branch PR state; new unit tests for the re-freeze behavior and
  the closed-while-fix-needed cleanup.

## Verification

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` →
  **531 passed**
- `/usr/bin/python3 -m coverage report` → **100% line and branch
  coverage** (all modules and test files)
- `tests/test_concurrency_e2e.py` rerun 9x: stable (the previously
  flaky capacity test now models two concurrent deliveries that each
  absorb the other's merge in their second review round)
- base freshness: `git merge-base --is-ancestor origin/main HEAD`
  passes (frozen base `468fdd4e1251f1b497136ac232d97551d04bdf30`)

Journal acceptance (Issue #82): before merge the flow is
`review run_start → (in-session fix) → review verdict → merge` — no
`review end → new implement/fix run_start → review run_start` sequence.

## Fixer round (this run, after review round 1)

Review round 1 found 1 Major + 3 Minor findings; all fixed in commit
`645a014` (same run, same PR):

- **Major** — `wait_for_delivery`'s review-failure path now removes the
  leftover `ai-fix-needed` label too, so a review failure in the
  `ai-fix-needed` state leaves the terminal state `ai-blocked` alone
  (new unit test asserts exactly that).
- **Minor** — `AGENTS.md` journal role list is `implement/review/merge`;
  the milestone list (AGENTS.md + `progress.py` docstring) drops the
  removed `fix pushed`; `muyan_pilot.py` documents `ai-fix-needed` as
  "awaiting the next review session".

Re-verified: **532 passed**, **100% line and branch coverage**
(`/usr/bin/python3`), concurrency e2e stable over 3 reruns, base
freshness re-checked (`origin/main` is an ancestor of the head).
