### PR TITLE
docs: add Apache License 2.0 LICENSE file and README link (Issue #81)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 xqliu
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -254,3 +254,7 @@ Pi 不直接 push 保护分支。实现 Agent 只 push feature branch 并创建 
 成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是在同一 PR 的审查会话内修复（或交给下一个审查会话）。
 
 两个 prompt 由配置提供（默认 `prompt.md` 实现、`prompt_review.md` 审查+会话内修复）；审查 prompt 不附加 `review-fix-loop`/`tdd-dev` skill。
+
+## 许可证
+
+本项目以 [Apache License 2.0](LICENSE)（SPDX 标识 `Apache-2.0`）发布，完整文本见根目录 [LICENSE](LICENSE) 文件。

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,0 +1,71 @@
+"""Guard the public repository license (Issue #81).
+
+`xqliu/muyan-pilot` is public, so the repository root must carry a license
+file GitHub can recognize. The Issue fixes Apache License 2.0 (SPDX
+identifier `Apache-2.0`) as the default and requires the README to link to
+the file. These tests fail when the file is missing, when it stops carrying
+the canonical Apache-2.0 markers GitHub's detector relies on, or when the
+README loses the link.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LICENSE_FILE = REPO_ROOT / "LICENSE"
+README_FILE = REPO_ROOT / "README.md"
+
+
+def read_license() -> str:
+    """The license text; fail fast when the file is missing."""
+    assert LICENSE_FILE.is_file(), f"missing license file: {LICENSE_FILE}"
+    return LICENSE_FILE.read_text(encoding="utf-8")
+
+
+def test_license_exists_at_repo_root() -> None:
+    """GitHub only detects a license from a root-level LICENSE file."""
+    assert LICENSE_FILE.is_file(), "no LICENSE file at the repository root"
+
+
+def test_license_is_canonical_apache_2() -> None:
+    """The file must be the canonical Apache License 2.0 text.
+
+    GitHub's license detection recognizes the exact canonical markers;
+    these are the ones the detector keys on, so the file cannot drift
+    into a home-grown variant.
+    """
+    text = read_license()
+    assert "Apache License" in text, "missing the Apache License title"
+    assert "Version 2.0, January 2004" in text, "missing the version line"
+    assert "http://www.apache.org/licenses/" in text, (
+        "missing the license URL header"
+    )
+    assert "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION" in text, (
+        "missing the terms section"
+    )
+    assert "8. Limitation of Liability" in text, "missing the liability clause"
+    assert "9. Accepting Warranty or Additional Liability" in text, (
+        "missing the accepting-warranty clause"
+    )
+
+
+def test_license_names_the_copyright_owner() -> None:
+    """The placeholder copyright must be replaced with the real owner."""
+    text = read_license()
+    assert "Copyright [yyyy] [name of copyright owner]" not in text, (
+        "the template copyright placeholder is still in the license"
+    )
+    assert re.search(r"Copyright \d{4} xqliu", text), (
+        "no real copyright notice for the repository owner"
+    )
+
+
+def test_readme_links_to_the_license() -> None:
+    """The README must link to the LICENSE file and name Apache License 2.0."""
+    assert README_FILE.is_file(), f"missing README: {README_FILE}"
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert re.search(r"\]\(LICENSE\)", readme), (
+        "README does not link to the LICENSE file"
+    )
+    assert "Apache License 2.0" in readme, (
+        "README does not name the Apache License 2.0"
+    )


### PR DESCRIPTION
Fixes #81

<!-- muyan-pilot:run=9b864d5d -->

run_id=9b864d5d

## 变更

- 新增根目录 `LICENSE`：Apache License 2.0（SPDX 标识 `Apache-2.0`）规范全文，取自 `https://www.apache.org/licenses/LICENSE-2.0.txt`，模板版权占位行替换为 `Copyright 2026 xqliu`（附录指示的替换方式）。
- `README.md` 末尾新增「许可证」小节，链到 `LICENSE` 并注明 Apache License 2.0 / `Apache-2.0`。
- 新增 `tests/test_license.py`（TDD：先红后绿）：LICENSE 存在于根目录、携带规范 Apache-2.0 标记、版权为真实 owner、README 链到 LICENSE。

不改代码行为：未触碰任何 Python 源码、prompt、workflow 或依赖；不加 CLA。

## 测试与覆盖率

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → **536 passed**（532 既有 + 4 新增）。
- `/usr/bin/python3 -m coverage report --show-missing` → **TOTAL 100%**（6965 statements / 964 branches，0 missing）。
- 完整命令与输出见 run 产物 `test.log`（worktree `.muyan-pilot/runs/issue-81-9b864d5d/`，gitignore 内不入库）。

## GitHub license 识别验证

- GitHub 检测器（`licensee` gem）内置的 Apache-2.0 模板（`vendor/choosealicense.com/_licenses/apache-2.0.txt`，去除 front matter）与本文件所用的 apache.org 规范文本**逐字节一致**；本文件仅有一行差异——模板版权字段行替换为 `Copyright 2026 xqliu`，正是模板附录指示的替换（模板自带 `using:` 示例 kubernetes/pdf.js/swift 同样如此）。
- contents API 的 `license` 字段在 PR 合并前不可用（facebook/react 的已识别 MIT LICENSE 也返回 null）；仓库级 license 字段与侧边栏徽章在合入 `main` 后生效。

## 交付约束

- 分支 `muyan-pilot/xqliu-muyan-pilot-issue-81-9b864d5d`，head `546ef79`；base `origin/main`（`7248927`）为 head 祖先（fetch 后校验）。
- 未 merge、未 push 保护分支、未 force push。
