### PR TITLE
resume fails fast when the scene base differs from the configured base

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -2476,6 +2476,22 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 scene = resume_scene(
                     issue_comments(number, repo=source_repo),
                 )
+                # Issue #91: the scene freezes the base the PR was
+                # opened against. The config may have moved on (or the
+                # comment is stale): reviewing or merging a PR frozen on
+                # another base against the configured one would run the
+                # freeze/merge gate on the wrong base, so fail fast
+                # before any git/Pi mutation instead of silently
+                # switching bases. The handler below marks the Issue
+                # ai-blocked with both base values named.
+                if scene["base_branch"] != config["base_branch"]:
+                    raise ValueError(
+                        f"resume scene base_branch={scene['base_branch']} "
+                        f"differs from configured base_branch="
+                        f"{config['base_branch']}; the PR is frozen on a "
+                        "different base and must not be reviewed or "
+                        "merged against the configured one"
+                    )
                 worktree = worktree_path(
                     config["repo_dir"], source_repo, number,
                     scene["run_id"],

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4209,6 +4209,132 @@ def test_wait_for_delivery_marks_blocked_when_review_fails_while_fix_needed(
     assert "- role: review" in blocked
 
 
+def test_wait_for_delivery_blocks_when_scene_base_differs_from_config(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #91: the scene freezes the base the PR was opened against.
+    When the configured base differs (config changed, or the comment is
+    stale), the resume must fail fast BEFORE any git/Pi mutation: no
+    review is started, nothing is merged, and the Issue is marked
+    ai-blocked with BOTH base values named — never silently switch to
+    the configured base for a PR frozen on another one.
+    """
+    api_calls: list = []
+    existing = {
+        "id": 77,
+        "body": (
+            "<!-- muyan-pilot:run=a1b2c3d4 -->\n\n"
+            "**Muyan Pilot progress**\n\nawaiting review"
+        ),
+    }
+
+    states = ["OPEN", "MERGED"]
+    pr_calls = {"n": 0}
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            pr_calls["n"] += 1
+            return json.dumps({"state": states[pr_calls["n"] - 1]})
+        if command[:2] == ["gh", "api"]:
+            api_calls.append(command)
+            if "--method" not in command:
+                # The run's live progress comment exists.
+                return json.dumps([existing])
+            method = command[command.index("--method") + 1]
+            if method == "POST":
+                body = command[command.index("--field") + 1]
+                return json.dumps({"id": 78, "body": body[len("body="):],
+                                   "url": "https://x/78"})
+            return ""
+        if command[-1] == "comments":
+            # The trusted scene freezes base_branch=develop.
+            return json.dumps({"comments": [
+                {
+                    "body": (
+                        "<!-- muyan-pilot:run=a1b2c3d4 -->\n"
+                        "Muyan Pilot opened PR: "
+                        f"{PR_URL} (base_branch=develop "
+                        "base_sha=abc123def456 run_id=a1b2c3d4)"
+                    ),
+                    "authorAssociation": "OWNER",
+                },
+            ]})
+        return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(runner.time, "sleep", lambda s: None)
+    edits: list = []
+    comments: list = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: comments.append((args, kwargs)),
+    )
+    # The independent review must never run: the base mismatch is
+    # terminal before any git/Pi mutation.
+    reviews: list = []
+    monkeypatch.setattr(
+        runner, "review_and_merge_if_clean",
+        lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
+    )
+    issue = {"number": 39, "title": "task", "body": ""}
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    caplog.set_level("INFO")
+    # The configured base is main; the scene froze develop.
+    runner.wait_for_delivery(
+        PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
+        "owner/repo",
+    )
+    # No review was started and nothing was merged.
+    assert reviews == []
+    # The mismatch is terminal on the FIRST poll: the wait returns
+    # instead of re-checking the PR state.
+    assert pr_calls["n"] == 1
+    # The Issue is marked ai-blocked (removing ai-pr-opened) ...
+    assert edits[0][1] == {
+        "repo": "owner/repo",
+        "add": "ai-blocked",
+        "remove": "ai-pr-opened",
+    }
+    # ... with a failure comment that names BOTH base values and carries
+    # the run marker.
+    body = comments[0][1]["body"]
+    assert "Muyan Pilot failed:" in body
+    assert f"<!-- muyan-pilot:run=a1b2c3d4 -->" in body
+    assert "base_branch=develop" in body
+    assert "base_branch=main" in body
+    assert "delivery_review_failed" in caplog.text
+    # The terminal failure also posts the blocked milestone (Issue #18)
+    # AND the tracked progress comment becomes the blocked scene.
+    posted_bodies = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in api_calls
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: blocked" in body for body in posted_bodies)
+    assert any(
+        "base_branch=develop" in body and "base_branch=main" in body
+        for body in posted_bodies
+    )
+    # No second progress comment: the tracked one (id 77) is PATCHed
+    # into the blocked scene in place.
+    patches = [
+        command for command in api_calls
+        if command[:2] == ["gh", "api"]
+        and command[2] == "repos/owner/repo/issues/comments/77"
+        and "PATCH" in command
+    ]
+    assert patches, "the tracked progress comment was not updated"
+    blocked = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot blocked" in blocked
+    assert "base_branch=develop" in blocked
+    assert "base_branch=main" in blocked
+    assert "next step:" in blocked
+
+
 def test_wait_for_delivery_runs_review_when_fix_needed(
     monkeypatch, caplog, tmp_path,
 ):


### PR DESCRIPTION
Fixes #91

<!-- muyan-pilot:run=9240f1e4 -->

run_id=9240f1e4

## Problem

After #82 removed the old `resume_delivery`, the resume path in
`wait_for_delivery` re-parses the trusted scene on every iteration but
passed `config["base_branch"]` to `review_and_merge_if_clean`, ignoring
the base the PR was frozen on. When the config base changed (or the
comment is stale), the freeze/merge gate ran on the wrong base instead
of refusing the delivery. The old guard test
`test_resume_delivery_fails_fast_when_scene_base_differs_from_config`
was deleted with the old code.

## Change

`bootstrap_runner.py::wait_for_delivery`: right after the scene is
re-parsed and before any git/Pi mutation, compare
`scene["base_branch"]` with the configured `base_branch`. On mismatch
raise `ValueError` naming both values; the existing terminal-failure
handler marks the Issue `ai-blocked` (removing `ai-pr-opened` and any
leftover `ai-fix-needed`) with the failure comment (run marker), the
blocked milestone and the blocked progress scene. No review is started,
nothing is merged, the configured base is never silently substituted
for a PR frozen on another base, and no Fixer is introduced.

## Tests

TDD: `test_wait_for_delivery_blocks_when_scene_base_differs_from_config`
(scene `base_branch=develop` vs config `main`) — RED before the guard
(the review ran against the configured base), GREEN after; asserts no
review call, terminal on the first poll, the `ai-blocked` edit, and
both base values in the failure comment / blocked milestone / blocked
progress scene. Normal same-base resumes are covered by the existing
wait-loop tests (unchanged, passing).

```
/usr/bin/python3 -m pytest tests/ -q
592 passed

/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
/usr/bin/python3 -m coverage report --show-missing
TOTAL  7577 stmts, 1068 branches, 100% (line and branch)
```

Full log: `.muyan-pilot/runs/issue-91-9240f1e4/test.log` (run artifact,
not committed).