### PR TITLE
test: guard AGENTS.md against implementer review-fix-loop wording (Issue #78)

### DIFF
--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -92,3 +92,18 @@ def test_agents_md_keeps_every_required_contract_item():
         name for name, needle in REQUIRED_ITEMS if needle.lower() not in text
     ]
     assert not missing, f"AGENTS.md is missing contract items: {missing}"
+
+
+def test_agents_md_does_not_require_implementer_review_fix_loop():
+    """Issue #78: the implementer only does plan -> TDD -> tests -> push
+    one PR; the independent review runs AFTER the PR is opened (the
+    Runner's review session). The implement-phase wording must not demand
+    a complete review — the old base-freshness bullet ("rerun the full
+    tests and the complete review-fix loop, then push the task branch")
+    made the local Pi self-review for hours (#18/#34)."""
+    text = CONTRACT.read_text(encoding="utf-8").lower()
+    assert "complete review" not in text
+    # The implementer session is pinned to the delivery-only flow, and the
+    # review is explicitly positioned after the PR exists.
+    assert "plan, tdd, tests, push one pr" in text
+    assert "after the pr exists" in text


### PR DESCRIPTION
Fixes #78

<!-- muyan-pilot:run=dd051c55 -->

run_id=dd051c55

## What

Issue #78: the implementer must not run the independent review-fix loop
before opening the PR. Text-only fix in three locations:

1. **prompt.md** — already in the post-fix state on main (cfcfcb9,
   landed via PR #84 for Issue #80): "Do NOT run a review-fix loop or
   any independent review before opening the PR (Issue #78)"; the
   base-advance step is merge + rerun tests only. Guarded by
   test_bootstrap_runner.py::test_prompt_does_not_require_review_fix_loop_before_pr.
2. **AGENTS.md** — already in the post-fix state on main (468ecc9):
   "Implementer session: plan, TDD, tests, push one PR."; the
   base-freshness bullet no longer says "and the complete
   review-fix loop". This PR adds the missing guard test
   (test_agents_md.py::test_agents_md_does_not_require_implementer_review_fix_loop):
   the implement-phase wording must not demand a complete review. The
   guard fails against the pre-fix wording (468ecc9~1:AGENTS.md, red
   demonstrated in test.log) and pins the positive flow.
3. **run_pi "Existing PR" context** — already removed on main (191b983,
   Issue #82 deleted the cold-start fixer entirely; the implementer is
   never resumed for fixes). Guarded by
   test_resume_pr.py::test_run_pi_fresh_context_has_no_existing_pr.

No change to the toml skill list, no change to run_review --skill, no
new prompt file (per the Issue).

## Changed files

- tests/test_agents_md.py — new guard test (15 lines)

## Tests

- /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q → 610 passed
- /usr/bin/python3 -m coverage report --show-missing → 100% line and
  branch coverage (TOTAL 8037 stmts / 1118 branches, 0 missed)
- Details: test.log in the task worktree (gitignored per-run artifact)
