### PR TITLE
test: pin the upstream-dead failure path and document the kill contract (Issue #75)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,17 @@ is **one runtime outcome** (when X, should Y, actually Z).
   carries issue, run id, role (implement/review/merge), phase, elapsed,
   last activity, last action, session and branch. No model/session activity
   for 5 minutes logs an idle warning; the first new activity after it logs
-  a resumed event.
+  a resumed event. A session frozen in `model_wait` (the newest event is a
+  tool result) past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s) declares
+  the upstream (llama/proxy) dead — the HTTP timeout or connection drop
+  left Pi in epoll_wait and it will never exit on its own: the Runner
+  kills Pi, logs `run_failed ... reason=upstream_dead_stale_...`, and fails
+  fast through the normal failure path (the Issue is marked `ai-blocked`
+  with the scene in the Issue comment, the slot is released by the kernel
+  when the process exits, and the next tick can resume or claim the next
+  `ai-fix-needed`) (Issue #75). It never fires while events keep arriving
+  (a slow model is not a dead upstream) and it is NOT a business task
+  timeout.
 - GitHub: exactly one progress comment per run, carrying a hidden run
   marker. It is PATCHed in place (at most every 30 seconds or on progress
   change) and never replaced by new heartbeat comments. Milestones (started,

--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`boo
 - `resumed issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
 - `pi_idle issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
 - `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed）。
-- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s`——进程异常退出或超时时先记录完整现场再抛出错误；
+- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|upstream_dead_stale_...s`——进程异常退出、超时或上游已死（Issue #75）时先记录完整现场再抛出错误；
 - `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
+
+上游已死检测（Issue #75）：`model_wait` 期间 session JSONL 冻结超过 `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）判定上游（llama/proxy）已死——HTTP 超时或连接断开后 Pi 停在 epoll_wait 永不退出：Runner 杀掉 Pi 进程，记录 `run_failed ... reason=upstream_dead_stale_...s` 后 fail fast（Issue 标记 `ai-blocked`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍可 resume 或领取下一个 `ai-fix-needed`）。事件持续到达时永不触发（慢模型不是死上游），它也不是业务任务 timeout。
 
 所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`。默认 tail 示例（仅用于查看，不是产品步骤）：
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2051,6 +2051,89 @@ def test_process_issue_failure_marks_blocked_and_reraises(monkeypatch, tmp_path)
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure_body
 
 
+def test_process_issue_upstream_dead_failure_marks_blocked(
+    monkeypatch, tmp_path,
+):
+    """Issue #75 acceptance: the upstream-dead failure of the
+    implementer session (the proxy/llama timed out, the session JSONL
+    froze in model_wait, stream_pi killed Pi and raised) flows through
+    the NORMAL failure path: the Issue is marked `ai-blocked` (removing
+    `ai-in-progress`), the `Muyan Pilot failed` comment carries the
+    upstream-dead reason and the run marker (the scene stays in the
+    Issue), and the error re-raises so the tick exits and the kernel
+    releases the slot — the next tick can then resume or claim the
+    next `ai-fix-needed`. No special handling, no fallback."""
+    calls = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    )
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(
+        runner, "create_worktree", Mock(return_value=tmp_path),
+    )
+    upstream_dead = RuntimeError(
+        "Pi is stuck in model_wait with a frozen session for 10m: "
+        "the upstream (llama/proxy) is dead; Pi was killed (Issue #75)"
+    )
+
+    def dead_run_pi(*args, **kwargs):
+        raise upstream_dead
+
+    monkeypatch.setattr(runner, "run_pi", dead_run_pi)
+    monkeypatch.setattr(
+        runner, "activity_snapshot", lambda session_dir: None,
+    )
+    posted = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "list"]:
+            # Restart-resume scan (Issue #18): fresh claim, no label.
+            return "[]"
+        calls.append(("comment", (), {"body": command[-1]}))
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="upstream"):
+        runner.process_issue(
+            {"number": 75, "title": "Upstream dead", "body": ""},
+            {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+             "base_branch": "main"},
+            "xqliu/muyan-pilot",
+        )
+    # The failure happened BEFORE the opened-PR transition: the
+    # terminal state removes the claim label (the edit calls are the
+    # dict entries; the `gh issue comment` traffic is tuple entries).
+    edits = [entry for entry in calls if isinstance(entry, dict)]
+    assert edits == [
+        {"repo": "xqliu/muyan-pilot", "add": "ai-in-progress"},
+        {"repo": "xqliu/muyan-pilot", "add": "ai-blocked",
+         "remove": "ai-in-progress"},
+    ]
+    comment_bodies = [
+        entry[2]["body"] for entry in calls
+        if isinstance(entry, tuple) and entry[0] == "comment"
+    ]
+    failure = [
+        body for body in comment_bodies
+        if "Muyan Pilot failed:" in body
+    ]
+    assert len(failure) == 1
+    # The upstream-dead reason and the run marker stay in the Issue.
+    assert "the upstream (llama/proxy) is dead" in failure[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure[0]
+    # The blocked milestone notification carries the same scene.
+    blocked = [body for body in posted if "Muyan Pilot: blocked" in body]
+    assert blocked
+    assert "the upstream (llama/proxy) is dead" in blocked[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked[0]
+
+
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
     edit_calls = []
 

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -118,3 +118,42 @@ def test_readme_documents_review_verdict_on_github():
     text = README.read_text(encoding="utf-8")
     assert "REVIEW_VERDICT" in text
     assert "回写" in text or "写入" in text
+
+
+def test_readme_documents_upstream_dead_kill():
+    """Issue #75: the upstream-dead contract must be documented in the
+    README journal section: while the newest session event is a tool
+    result (model_wait) and the session JSONL is frozen for the dead
+    threshold (default 600 s, PI_MODEL_WAIT_DEAD_SECONDS), the Runner
+    kills Pi and fails fast with
+    `run_failed ... reason=upstream_dead_stale_...`; the kill never
+    fires while events keep arriving (a slow model is not a dead
+    upstream) and it is NOT a business-task timeout."""
+    text = README.read_text(encoding="utf-8")
+    # The run_failed line carries the upstream-dead reason.
+    assert "upstream_dead_stale_" in text
+    # The kill is documented with its trigger (model_wait + frozen
+    # session) and the default threshold.
+    assert "PI_MODEL_WAIT_DEAD_SECONDS" in text
+    assert "600" in text
+    assert "model_wait" in text
+    # The slow-model boundary: events keep arriving -> no kill.
+    assert "慢模型" in text
+    # It is not a business-task timeout.
+    assert "业务" in text
+
+
+def test_agents_md_documents_upstream_dead_kill():
+    """Issue #75: the development contract (AGENTS.md) must document
+    the same upstream-dead behavior in its observability section: a
+    frozen model_wait past the dead threshold kills Pi and fails fast
+    (slot released via the normal failure path); a slow model that
+    keeps producing events is never killed; this is not a business
+    task timeout."""
+    text = AGENTS.read_text(encoding="utf-8").lower()
+    assert "upstream" in text
+    assert "model_wait" in text
+    assert "600" in text
+    assert "slow" in text
+    # The no-business-timeout scope rule must stay intact next to it.
+    assert "no business task timeout" in text


### PR DESCRIPTION
Fixes #75

<!-- muyan-pilot:run=3bfb0356 -->

run_id=3bfb0356

## Summary

Issue #75: after a llama/proxy timeout or connection drop, Pi must
fail-exit, the Runner fails fast (scene in journal + Issue), and the
slot is released — an infinite `model_wait` hang after the upstream is
dead is not acceptable, while a slow generation (events still
arriving) must never be killed (no business-task timeout).

The runtime behavior already exists in the base: `stream_pi` kills Pi
when the session JSONL is frozen in `model_wait` past
`PI_MODEL_WAIT_DEAD_SECONDS` (600 s), logs
`run_failed ... reason=upstream_dead_stale_...`, and raises through
the normal failure path (Issue marked `ai-blocked`, slot released by
the kernel on process exit). It landed in PR #92, whose body only said
`Fixes #80`, so #75 stayed open with its contract undocumented and its
acceptance chain unpinned. This PR completes the Issue:

- **test** (`tests/test_bootstrap_runner.py`):
  `test_process_issue_upstream_dead_failure_marks_blocked` — the
  upstream-dead failure of the implementer session flows through the
  NORMAL failure path: `ai-blocked` added / `ai-in-progress` removed,
  the `Muyan Pilot failed` comment carries the upstream-dead reason
  and the run marker (the scene stays in the Issue), the blocked
  milestone carries the same scene, and the error re-raises so the
  tick exits and the kernel releases the slot. No special handling,
  no fallback.
- **docs** (`README.md`): the journal section documents the kill —
  trigger (`model_wait` + frozen session JSONL past
  `PI_MODEL_WAIT_DEAD_SECONDS`, default 600 s), the
  `run_failed ... reason=upstream_dead_stale_...s` line, the
  slow-model boundary (events keep arriving -> never fires), and the
  not-a-business-timeout distinction; the `run_failed` reason set
  gains `upstream_dead_stale_...s`.
- **docs** (`AGENTS.md`): the observability section carries the same
  contract (kill, fail fast, slot release, slow-model boundary, not a
  business task timeout).
- **test** (`tests/test_docs_labels.py`): doc-contract tests guard
  both documents so the #75 contract cannot silently drift.

## Verification

- `/usr/bin/python3 -m pytest tests/ -q` — 613 passed
- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` +
  `coverage report --show-missing` — 100% line/branch coverage
- Existing #75 kill tests (kill in model_wait, 600 s default, slow
  model survives, no kill before model_wait) all pass unchanged.