### PR TITLE
docs: add v0.1.0 open-source docs site under docs/ (Issue #104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 开发契约见 [AGENTS.md](AGENTS.md)：每次本地 Pi 自举开发前先读 Issue、context files、README 和相关代码，TDD、100% 覆盖率、UI 用 Playwright、失败 fail fast、不 merge、不 push 保护分支、不引入数据库/队列/daemon/fallback、不设业务任务 timeout。
 
+## 文档站
+
+面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。Mintlify 默认地址为 <https://muyan-pilot.mintlify.site>（若绑定了自定义域名，以 Mintlify 控制台配置的地址为准）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
+
 ## 当前运行
 
 ```bash
@@ -243,7 +247,7 @@ journalctl --user -u muyan-pilot.service | grep e07383c2
 gh search issues "e07383c2" --repo xqliu/muyan-pilot
 
 # 本地在 repo 中搜索 run_id 找到 worktree、session 和 run artifacts
-grep -r e07383c2 /home/xqianliu/Documents/muyan/muyan-pilot/.worktrees/
+grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
 ```
 
 缺少合法 run_id 的 run-scoped 事件（绑定 run、构建 GitHub marker、PR body 校验）会 fail fast，不做回退。

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,0 +1,83 @@
+# Contributing
+
+Muyan Pilot is developed the same way it runs: tasks are GitHub Issues,
+deliveries are PRs, and the repository contract (`AGENTS.md`) applies to
+human contributors too.
+
+## Issue granularity
+
+One Issue is **one runtime outcome** (when X, should Y, actually Z): one
+observable behavior, a handful of related files, tests included. The
+title should work as a test name. Open an Issue once the root cause or
+the desired behavior is pinned — not as a vague wish.
+
+- Dependencies between Issues use GitHub's native `blockedBy` relation
+  (`gh issue edit N --add-blocked-by M`); do not write `Depends on #N`
+  in the body — the Runner does not parse body dependencies.
+- Multi-task work is organized as an Epic (see [Workflow](/workflow)):
+  the Epic coordinates, the sub-Issues deliver.
+
+## Creating an Issue
+
+Dispatch a task for the Pilot by creating an Issue and labeling it
+`ai-ready` (the CLI does both in one step):
+
+```bash
+python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+```
+
+or manually:
+
+```bash
+gh issue create --repo OWNER/PILOT-REPO --title "task title" --body "task body"
+gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
+```
+
+A good body states the background, the expected behavior, the acceptance
+criteria, and (for bugs) the reproduction. The Pilot reads the Issue, the
+repository's `AGENTS.md`, README and code before changing anything.
+
+## Reporting a bug
+
+Open an Issue with the `bug` label and include:
+
+- the command that failed and its return code / stdout / stderr;
+- the journal scene (`journalctl --user -u muyan-pilot.service` around
+  the failure, or the `run_failed` line with its run id);
+- the Issue/PR state (labels) and the run id from the progress comment;
+- the environment: OS, Python version, Pi version, model endpoint type.
+
+Bug-labeled `ai-ready` Issues are picked up before new features (P0
+convention), so a broken delivery loop gets fixed first.
+
+## Contributing code
+
+1. Read `AGENTS.md` — it is the development contract (TDD, 100% line and
+   branch coverage, fail fast, no database/queue/daemon/fallback, no
+   business task timeout).
+2. Work on a feature branch; never push the protected branch directly.
+3. Write the failing test first, then the smallest implementation, then
+   refactor. External interfaces (CLI flags, HTTP paths, config fields)
+   are asserted against the official docs or one real call — never
+   against a guessed shape.
+4. Run the full contract locally:
+
+   ```bash
+   /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+   /usr/bin/python3 -m coverage report --fail-under=100 --show-missing
+   ```
+
+5. Open one PR per Issue. The PR description must contain
+   `Fixes #<issue-number>` (it may be on the first line) so GitHub closes
+   the Issue natively on merge.
+6. CI must be green (same contract as local). The independent review and
+   merge are performed by the Runner for Pilot-dispatched work; for
+   human PRs, review and merge follow the repository's normal GitHub
+   flow.
+
+## What not to add
+
+The MVP boundary is intentional: no database, no message queue, no daemon
+loop, no web UI, no task DAG, no risk model, no fallback path, no
+business task timeout. Proposals that add one of these should first
+explain why a real, repeated failure requires them.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "Muyan Pilot",
+  "theme": "mint",
   "colors": {
     "primary": "#1d76db"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "Muyan Pilot",
+  "colors": {
+    "primary": "#1d76db"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": [
+          "index",
+          "getting-started"
+        ]
+      },
+      {
+        "group": "Core Concepts",
+        "pages": [
+          "workflow",
+          "operations"
+        ]
+      },
+      {
+        "group": "Guides",
+        "pages": [
+          "security",
+          "testing",
+          "contributing"
+        ]
+      },
+      {
+        "group": "Optional Components",
+        "pages": [
+          "optional-kv-cache"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,170 @@
+# Getting started
+
+This page takes you from a fresh clone to a first verified tick. Every
+command works at any clone path — nothing here depends on a specific
+machine layout.
+
+## Prerequisites
+
+| Requirement | What it is used for | Check |
+|---|---|---|
+| Python 3.14 | The Runner and the test contract (CI pins the same minor version) | `python3 --version` |
+| [Pi](https://github.com/earendil-works/pi) CLI | The development agent; one full session per task | `pi --version` |
+| Git | Worktrees, branches, base freshness | `git --version` |
+| GitHub CLI (`gh`) | Issues, labels, PRs, merge | `gh auth status` |
+| systemd (user session) | The timer that triggers one tick every 15 minutes | `systemctl --user status` |
+| A working OpenAI-compatible model endpoint | Pi's model provider — a local llama.cpp server or any OpenAI-compatible API | one real `pi --print` call (below) |
+
+Pi must be configured with a provider that can serve a coding agent
+stably (system prompt + tool schemas + long sessions). Verify the endpoint
+with one real call before dispatching work — do not assume the key or the
+model service works:
+
+```bash
+pi --print "reply with the single word: ok"
+```
+
+If this fails, fix the model endpoint first; the Runner will fail fast on
+every task otherwise.
+
+<Note>
+The `local-llm-kv-cache` proxy is an **optional** enhancement (faster
+prefix reuse for local llama.cpp models), not a core prerequisite — see
+[Optional components](/optional-kv-cache).
+</Note>
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/xqliu/muyan-pilot.git
+cd muyan-pilot
+```
+
+## 2. Create the configuration
+
+The repository ships a committed example; the real config is local state
+(gitignored). Copy it and edit it:
+
+```bash
+cp .muyan-pilot.example.toml muyan-pilot.toml
+```
+
+All fields (TOML, relative paths resolve against the config file's
+directory):
+
+| Field | Required | Default | Meaning |
+|---|---|---|---|
+| `source_repos` | yes | — | Ordered list of `owner/repo` task pools scanned each tick (e.g. your pilot repo first, then your backlog repo) |
+| `repo_dir` | no | `.` | The Runner checkout the service starts from (where `bootstrap_runner.py` lives) |
+| `workspace_root` | no | `..` | Directory that contains the task worktrees and the repositories the agent may modify |
+| `prompt` | no | `prompt.md` | Implementer prompt template (placeholders like `{{SOURCE_REPO}}` are rendered by the Runner) |
+| `prompt_review` | no | `prompt_review.md` | Review prompt template for the independent post-PR review session |
+| `base_branch` | no | `main` | Delivery base branch; every task worktree is created from the frozen `origin/<base_branch>` SHA |
+| `max_concurrency` | no | `1` | Concurrent Pilot tasks on this machine (positive integer; a local model/GPU usually serves one stable task) |
+| `skills` | no | `[]` | Optional Pi skill paths (absolute, `~`, or relative to the config file) |
+| `context_files` | no | `[]` | Optional Markdown context files injected into the prompt as paths |
+
+Minimal example:
+
+```toml
+source_repos = [
+  "OWNER/PILOT-REPO",
+  "OWNER/BACKLOG-REPO",
+]
+
+repo_dir = "."
+workspace_root = ".."
+prompt = "prompt.md"
+prompt_review = "prompt_review.md"
+base_branch = "main"
+max_concurrency = 1
+skills = []
+context_files = []
+```
+
+## 3. Initialize the delivery labels
+
+GitHub labels are **external state**: a commit never creates them, and a
+missing label makes the scan silently skip that state. Create them once
+per task-pool repository:
+
+```bash
+for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
+  gh label create "$l" --repo OWNER/PILOT-REPO --force
+  gh label edit "$l" --repo OWNER/PILOT-REPO \
+    --description "Muyan Pilot delivery state (see docs)"
+done
+gh label list --repo OWNER/PILOT-REPO
+```
+
+## 4. Run one tick manually
+
+The manual command is for first verification and troubleshooting only —
+normal operation is scheduled by the timer (step 6):
+
+```bash
+python3 bootstrap_runner.py --config muyan-pilot.toml
+```
+
+One tick does at most one thing: resume an opened PR (review/fix/merge) or
+claim one `ai-ready` Issue (bug-labeled Issues are picked before new
+features), then it exits. With an empty ready queue it exits cleanly
+without claiming anything.
+
+## 5. Smoke walkthrough (from zero)
+
+The smallest end-to-end proof that your setup works. Run it in the clone
+directory from step 1; every command is relative to that directory.
+
+```bash
+# a. Dispatch a tiny task into the first configured source repo.
+#    `add` creates the Issue and labels it ai-ready in one step.
+python3 muyan_pilot.py add "Docs: verify smoke walkthrough" \
+  --body "Read README.md and confirm the smoke walkthrough commands exist." \
+  --config muyan-pilot.toml
+
+# b. Watch the queue: the new Issue is ready.
+python3 muyan_pilot.py status --config muyan-pilot.toml
+
+# c. Run one tick: the Runner claims the Issue, starts Pi in a fresh
+#    worktree, and works toward a PR.
+python3 bootstrap_runner.py --config muyan-pilot.toml
+
+# d. Follow the live activity while the tick runs (second terminal):
+journalctl --user -u muyan-pilot.service -f
+# or, for a manual tick, follow the session JSONL directly:
+python3 muyan_pilot.py session --follow --config muyan-pilot.toml
+
+# e. After the PR is opened, the Issue carries ai-pr-opened and the
+#    delivery continues (independent review, in-session fix, merge) on
+#    later ticks. Watch the Issue and the PR on GitHub.
+gh issue list --repo OWNER/PILOT-REPO --label ai-pr-opened
+```
+
+You are done when: the Issue moves `ai-ready → ai-in-progress →
+ai-pr-opened → ai-merged`, a PR exists with `Fixes #<issue>` in its body,
+and the journal shows `run_end ... result=pr_opened`. If any step fails,
+the Issue is marked `ai-blocked` with the scene — see
+[Operations](/operations) for recovery.
+
+## 6. Enable the timer
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp systemd/muyan-pilot.service systemd/muyan-pilot.timer ~/.config/systemd/user/
+```
+
+The committed units reference the author's clone layout via `%h`
+specifiers (`%h/Documents/muyan/muyan-pilot`). Point `WorkingDirectory`,
+`MUYAN_PILOT_CONFIG` and `ExecStart` at **your** clone path, then:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now muyan-pilot.timer
+systemctl --user list-timers muyan-pilot.timer
+```
+
+The timer fires every 15 minutes, 24 hours a day (00:00–23:45). While a
+task is running, further timer starts are ignored by systemd; the next
+real start picks up the latest code (the service fast-forwards `main`
+before starting — see [Operations](/operations)).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,65 @@
+# Muyan Pilot
+
+Muyan Pilot is a local AI development worker. You put work into GitHub
+Issues; it automatically claims an `ai-ready` Issue, develops it in an
+isolated worktree, runs the real test suite, opens a PR, then completes an
+independent review (with in-session fixes) and merges a clean PR — with the
+whole delivery recorded in GitHub Issues, comments and the PR itself.
+
+## The problem it solves
+
+Small and medium development tasks (a bug, a feature, a docs change, a
+workflow fix) usually follow the same loop: read the context, plan,
+implement, test, open a PR, review, fix, merge. Muyan Pilot runs that loop
+locally and unattended:
+
+- **GitHub Issues are the task pool.** No Web Kanban, no database, no
+  second task system — the Issue, its labels, its comments and its PR are
+  the complete delivery record.
+- **Pi is the developer.** Each task runs one full Pi session (plan →
+  implement → test → verify → PR) in an isolated git worktree; a second,
+  independent Pi session reviews the PR and fixes findings in-session.
+- **The Runner is the thin connector.** A small Python process (`gh` +
+  `git` + `pi` + `systemd`) claims Issues, holds the delivery to merge,
+  publishes progress, and recovers from restarts. It never implements
+  business logic itself.
+
+## When to use it
+
+- You have a GitHub repository (or a small fixed set of repositories) and
+  want tasks to be picked up and delivered as PRs overnight or unattended.
+- You want the delivery evidence (plan, tests, review verdict, PR) to live
+  in GitHub, not in a private tool.
+- You run your own model endpoint (a local llama.cpp server or any
+  OpenAI-compatible API) that can serve a coding agent stably.
+
+## MVP boundary
+
+Muyan Pilot is intentionally an MVP. The boundary is part of the design:
+
+- GitHub Issues and labels are the **only** state store — no database, no
+  message queue, no web UI.
+- The Python Runner is **not a daemon**: a systemd user timer triggers one
+  tick every 15 minutes; each tick processes at most one Issue (or resumes
+  one opened PR) and exits.
+- No task DAG, no multi-agent parallelism, no risk model, no policy
+  engine, no fallback path — a command error fails fast and leaves the
+  scene in the journal and the Issue comment.
+- No business task timeout: a slow model is not a failure. Only command
+  errors, an unavailable environment, or an unresolvable review fail fast.
+
+What it does **not** do: it does not discover repositories, it does not
+merge or push protected branches itself (the Runner is the only merge
+actor, and only through a reviewed PR), and it does not run without a
+working model endpoint.
+
+## Where to go next
+
+- [Getting started](/getting-started): prerequisites, configuration, first
+  start and a from-zero smoke walkthrough.
+- [Workflow](/workflow): the complete Issue → PR → review → merge chain,
+  labels, run markers, Epics, Release tasks and P0 priority.
+- [Operations](/operations): timer, logs, CLI, worktrees and failure
+  recovery.
+- [Security](/security): the boundaries that keep the AI from touching
+  protected branches or leaking secrets.

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -1,0 +1,117 @@
+# Operations
+
+Normal operation is fully automatic: the timer triggers a tick, the tick
+does at most one thing, and progress is published to the journal and
+GitHub by itself. You never need a status command, polling, or
+supervision in the normal path — the commands below are for first
+verification, troubleshooting and recovery.
+
+## The timer
+
+`systemd/muyan-pilot.timer` fires every 15 minutes, 24 hours a day
+(`OnCalendar=*-*-* *:00/15`, `AccuracySec=30s`, `Persistent=false` — a
+missed tick is dropped, never queued). Each tick starts
+`muyan-pilot.service`, which:
+
+1. **Fast-forwards the code first** (`ExecStartPre`, outside the Python
+   process): `git fetch origin main && git merge --ff-only origin/main`.
+   A dirty checkout, a failed fetch or a non-fast-forwardable state fails
+   the preflight: the service does not start and the reason lands in the
+   systemd journal (fail fast). A currently running long task is never
+   hot-updated or killed — while the service is active, systemd ignores
+   the timer's start request, and the next real start picks up the latest
+   code.
+2. **Runs one tick**: resume an opened PR (review/fix/merge) or claim one
+   `ai-ready` Issue, then exit.
+
+```bash
+systemctl --user list-timers muyan-pilot.timer
+systemctl --user status muyan-pilot.service
+```
+
+## Logs (journal)
+
+The journal is the local record. Every line of a run starts with the run
+id prefix `[<run_id>]`, so one grep reconstructs the full timeline:
+
+```bash
+journalctl --user -u muyan-pilot.service -f
+journalctl --user -u muyan-pilot.service | grep e07383c2
+```
+
+Stable `key=value` lines you will see:
+
+- `run_start` / `run_end` — the full scene (branch, worktree, session
+  file) at start, and the result (PR URL, commit) at the end;
+- `activity` / `heartbeat` / `model_wait` / `resumed` — live Pi activity
+  while a session runs (phase, last action, elapsed, idle);
+- `pi_idle` — one WARNING when there is no model/session activity for
+  more than 5 minutes (`PI_IDLE_WARN_SECONDS=300`) and the model is not
+  expected to reply; a slow active model (`model_wait`) never warns;
+- `run_failed` — the full scene plus the reason
+  (`pi_exit_N`, `timeout_...s`, or `upstream_dead_stale_...s` when a
+  frozen `model_wait` past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s)
+  declares the upstream model dead and the Runner kills Pi).
+
+The idle warning and the upstream-dead kill are log/health thresholds —
+they are not the 15-minute schedule and not a business task timeout.
+
+## The CLI (`muyan_pilot.py`)
+
+```bash
+# Create an Issue in a configured source repo and label it ai-ready
+python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+python3 muyan_pilot.py add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
+
+# Read-only queue view: current (ai-in-progress) task with live Pi
+# activity, the next ready Issue, and the most recent result per source
+# repo (ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked)
+python3 muyan_pilot.py status --config muyan-pilot.toml
+
+# Print the live Pi session JSONL path (fail fast when no session exists)
+python3 muyan_pilot.py session --config muyan-pilot.toml
+python3 muyan_pilot.py session --follow --config muyan-pilot.toml   # tail -f
+python3 muyan_pilot.py session --pretty --config muyan-pilot.toml   # one-line summaries
+```
+
+All commands accept the config via `--config` or the
+`MUYAN_PILOT_CONFIG` environment variable (default
+`muyan-pilot.toml`). `status` and `session` are debug attachments — the
+journal and GitHub remain the normal observability path.
+
+## Worktrees and base freshness
+
+Each claim freezes `origin/<base_branch>` (fetched first) and creates the
+task worktree and feature branch from that exact SHA — never from the
+main worktree's current HEAD. Branch and worktree names carry the run id
+(e.g. `.worktrees/<...>-issue-14-e07383c2`), so a retried Issue gets a
+new independent run and the old scene is preserved. `.worktrees/` is
+gitignored.
+
+Before creating the PR, the implementer re-fetches the base: if
+`origin/<base_branch>` advanced, it merges the latest base into the task
+branch, resolves conflicts manually, reruns the full test suite, and only
+then pushes. The Runner verifies with
+`git merge-base --is-ancestor origin/<base_branch> HEAD` and rejects a
+delivery whose head does not contain the latest remote base.
+
+## Failure recovery
+
+| State | What happened | What to do |
+|---|---|---|
+| `ai-blocked` | The Runner failed fast (command error, unrecoverable scene, review exhausted) | Read the Issue comment (scene + reason) and the journal. Fix the environment or the task, then either relabel the same PR path as `ai-fix-needed` (same run continues) or remove the labels and re-dispatch as a fresh `ai-ready` (new run). It is never auto-recovered. |
+| `ai-fix-needed` | The PR head is not mergeable yet (review finding or base conflict) | Nothing — the next tick starts the next review session on the same PR, which absorbs the latest base in-session. |
+| Leftover `ai-in-progress` after a kill | The Runner was SIGKILLed mid-task | The next tick's resume scan picks it up (only when no other Runner is alive): same run id, same worktree, same progress comment — no new run. |
+
+The run artifacts (plan, test log, session JSONL) stay in the task
+worktree as the local record; GitHub carries the delivery record.
+
+## Concurrency
+
+`max_concurrency` (default 1) bounds the number of concurrent deliveries
+on the machine. A slot is an exclusive `flock(2)` lock on
+`<repo_dir>/.muyan-pilot/slots/slot-N`, taken before any claim and held
+for the whole delivery lifecycle (implement → review → merge); the kernel
+releases it when the process exits, however it exits. A Runner that
+cannot take a slot logs `capacity_full` and exits without claiming an
+Issue.

--- a/docs/optional-kv-cache.mdx
+++ b/docs/optional-kv-cache.mdx
@@ -1,0 +1,72 @@
+# Optional: local-llm-kv-cache proxy
+
+The [`local-llm-kv-cache`](https://github.com/xqliu/local-llm-kv-cache)
+proxy is an **optional enhancement** for local llama.cpp setups: it adds
+a two-level KV cache (in-memory hot session cache + disk-backed cold
+prefix cache) so coding agents do not re-prefill the stable system prompt
+and tool schemas on every new session. It is a separate project with its
+own repository, tests and README — this page only records how it
+connects to Muyan Pilot. It is **not** a core prerequisite: the Pilot
+works directly against any OpenAI-compatible endpoint without it.
+
+## What it changes for the Pilot
+
+- The proxy listens on `127.0.0.1:18082` (default) and forwards to the
+  llama.cpp server (default upstream `127.0.0.1:8080`).
+- Point Pi's (and any other agent's) provider URL at the proxy
+  (`http://127.0.0.1:18082/v1`) instead of the llama server directly.
+- The Pilot itself is unchanged: it only ever talks to the configured
+  OpenAI-compatible endpoint.
+
+## Installation
+
+Follow the upstream repository's README for the full instructions; the
+short form (its own clone path, e.g. under your home directory):
+
+```bash
+git clone https://github.com/xqliu/local-llm-kv-cache.git
+cd local-llm-kv-cache
+mkdir -p ~/.config/systemd/user
+cp local-llm-kv-cache.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now local-llm-kv-cache.service
+curl -fsS http://127.0.0.1:18082/health
+```
+
+Requirements: Python 3.10+ and a llama.cpp server with slot
+save/restore enabled. Hybrid/recurrent models (e.g. Qwen3.8) need a
+llama.cpp build with the checkpoint persistence fix — see the upstream
+README for the exact branch/commit and the upstream PR reference.
+
+## Configuration
+
+The user unit carries the settings as environment variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PI_LLAMA_UPSTREAM` | `http://127.0.0.1:8080` | The llama.cpp server the proxy forwards to |
+| `PI_LLAMA_CACHE_HOST` | `127.0.0.1` | Bind address of the proxy |
+| `PI_LLAMA_CACHE_PORT` | `18082` | Proxy port (agents point here) |
+| `PI_LLAMA_CACHE_DIR` | `~/.llama-slot-cache` | Disk-backed KV state directory |
+| `PI_LLAMA_CACHE_MAX_GIB` | `12` | Disk cache size cap |
+| `PI_LLAMA_CACHE_WAIT_SECONDS` | `120` | Max wait for a slot restore |
+| `PI_LLAMA_CACHE_PREFIX_SEED_DELAY` | `2` | Delay before prefix seeding |
+
+Edit the unit, then `systemctl --user daemon-reload &&
+systemctl --user restart local-llm-kv-cache.service`.
+
+## Troubleshooting
+
+- `curl -fsS http://127.0.0.1:18082/health` fails → the proxy is not
+  running: `systemctl --user status local-llm-kv-cache.service` and the
+  journal for the unit.
+- Requests time out → check `PI_LLAMA_UPSTREAM` reaches a live llama.cpp
+  server; the proxy never serves model output on its own.
+- Cache never hits → the proxy does not fake hits; verify the llama.cpp
+  build supports checkpoint persistence for your model type (upstream
+  README), and that the agent's stable prefix (system prompt + tool
+  schemas) is actually stable between sessions.
+- To stop using it: disable the unit, point the agent's provider URL
+  back at the llama server, and delete the KV cache directory if you do
+  not want the cached prompt state kept locally (see
+  [Security](/security) on why that directory is sensitive).

--- a/docs/optional-kv-cache.mdx
+++ b/docs/optional-kv-cache.mdx
@@ -11,8 +11,10 @@ works directly against any OpenAI-compatible endpoint without it.
 
 ## What it changes for the Pilot
 
-- The proxy listens on `127.0.0.1:18082` (default) and forwards to the
-  llama.cpp server (default upstream `127.0.0.1:8080`).
+- The proxy listens on `127.0.0.1:18082` when installed with the
+  committed systemd unit (the proxy's own code default port is `8081`)
+  and forwards to the llama.cpp server (default upstream
+  `127.0.0.1:8080`).
 - Point Pi's (and any other agent's) provider URL at the proxy
   (`http://127.0.0.1:18082/v1`) instead of the llama server directly.
 - The Pilot itself is unchanged: it only ever talks to the configured
@@ -46,7 +48,7 @@ The user unit carries the settings as environment variables:
 |---|---|---|
 | `PI_LLAMA_UPSTREAM` | `http://127.0.0.1:8080` | The llama.cpp server the proxy forwards to |
 | `PI_LLAMA_CACHE_HOST` | `127.0.0.1` | Bind address of the proxy |
-| `PI_LLAMA_CACHE_PORT` | `18082` | Proxy port (agents point here) |
+| `PI_LLAMA_CACHE_PORT` | `8081` (code default; the committed unit sets `18082`) | Proxy port (agents point here) |
 | `PI_LLAMA_CACHE_DIR` | `~/.llama-slot-cache` | Disk-backed KV state directory |
 | `PI_LLAMA_CACHE_MAX_GIB` | `12` | Disk cache size cap |
 | `PI_LLAMA_CACHE_WAIT_SECONDS` | `120` | Max wait for a slot restore |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,0 +1,62 @@
+# Security
+
+Muyan Pilot runs an autonomous coding agent with a GitHub token on your
+machine. The security model is deliberately simple: hard boundaries in
+the delivery contract, local-only secrets, and no remote state store.
+
+## The AI never merges or pushes protected branches
+
+- The implementer Pi **only pushes its feature branch** and opens one PR.
+  It does not merge, does not push `main`/`master`, does not force push,
+  and never auto-resolves conflicts.
+- The **Runner is the only merge actor**, and it merges only through the
+  reviewed PR: a clean `REVIEW_VERDICT`, the merge gate (PR head contains
+  the latest remote base, PR mergeable, remote head still the reviewed
+  head), and `gh pr merge --match-head-commit` so exactly the reviewed
+  head lands.
+- GitHub branch protection on the default branch is the final boundary:
+  keep the protected branch restricted to the account that runs the
+  Runner (or to no one — the Runner's token performs the merge).
+- Delivery state is derived, never trusted from public text: the resume
+  scene is only read from comments posted by a trusted maintainer
+  (OWNER/MAINTAINER/MEMBER/COLLABORATOR), and branch/worktree paths are
+  derived from the configured repo, Issue number and run id — a public
+  comment can never steer the Runner into an arbitrary local path.
+
+## GitHub token
+
+- The Runner authenticates with `gh` (`gh auth status` must succeed). Use
+  a **fine-grained personal access token** scoped to the repositories the
+  Pilot actually works on, with the minimum permissions: contents
+  (read/write), pull requests (read/write), issues (read/write), and
+  metadata (read). Avoid organization-wide or classic broad-scope tokens.
+- The token lives in `gh`'s local credential store on the Runner machine.
+  It is never written into the repository, the config file, the journal,
+  or a GitHub comment.
+- Logs are redacted by construction: command lines carrying secrets are
+  logged as `<redacted>`, and tool summaries are truncated and masked.
+  The full prompt, Issue body and token never reach the journal or the
+  progress comments.
+- Rotate the token on a normal schedule; a compromised token is contained
+  to the repositories it can see.
+
+## Local state files
+
+The Pilot keeps local state that never leaves the machine:
+
+- **Config** (`muyan-pilot.toml`): local, gitignored. The repository only
+  ships the example (`.muyan-pilot.example.toml`).
+- **Run artifacts**: plan, test log, session JSONL and review evidence
+  live in the task worktree (`.worktrees/...`, gitignored).
+- **Slots**: `<repo_dir>/.muyan-pilot/slots/slot-N` lock files (gitignored
+  via the `.muyan-pilot/` directory convention of the checkout).
+- **KV cache files** (only if you run the optional
+  [local-llm-kv-cache](/optional-kv-cache) proxy): the disk-backed prefix
+  and session KV state (e.g. `~/.llama-slot-cache/*.bin`) contains
+  serialized model state derived from your prompts — treat it as
+  sensitive local data, keep it on the same machine, and delete it if you
+  no longer need the cached sessions.
+
+If you run the Pilot on a shared machine, give the Runner user its own
+home directory so the config, worktrees and KV files stay private to that
+user.

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -1,0 +1,46 @@
+# Testing
+
+The repository contract (see `AGENTS.md`) is: the full pytest suite with
+**100% line and branch coverage** for the Python code. The same contract
+runs locally on the Runner machine and remotely on GitHub.
+
+## Local contract commands
+
+Run them from the repository root (production interpreter
+`/usr/bin/python3`, Python 3.14):
+
+```bash
+/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+/usr/bin/python3 -m coverage report --fail-under=100 --show-missing
+```
+
+The second command exits non-zero when any line or branch is below 100%,
+so the pair is a gate, not a report.
+
+## Remote CI (GitHub Actions)
+
+`.github/workflows/ci.yml` runs the same contract on every `pull_request`
+and every push to `main`: one job, Python 3.14 pinned via
+`actions/setup-python` (GitHub-hosted runners do not have the production
+interpreter at the production path, so the workflow pins the same minor
+version and runs the identical commands through `python3` on PATH),
+`requirements.txt` installed, then the two contract commands above. No
+lint, no matrix, no cache.
+
+A PR is not mergeable while CI is red — the Runner's merge gate also
+requires a mergeable PR.
+
+## What the tests cover
+
+- **Behavioral tests** for the runner, the CLI, slots, progress
+  publishing, activity streaming and the resume/review/merge logic (the
+  majority of the suite, including end-to-end tests against real `git`
+  and `gh` fixtures).
+- **Static contract tests** that pin the repository to its own docs and
+  files: `AGENTS.md` contract items, the label set, the systemd units
+  (15-minute schedule, preflight), the CI workflow, the LICENSE, and the
+  documentation site under `docs/` (this page's claims are enforced by
+  `tests/test_docs_site.py`).
+
+When you change code, update or add tests in the same PR and keep the
+coverage gate green.

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -1,0 +1,125 @@
+# Workflow
+
+One Muyan Pilot task is one runtime outcome: when X, should Y, actually Z.
+A task starts as a GitHub Issue and ends as a merged PR (or an
+`ai-blocked` scene that needs a human). This page covers the complete
+automatic chain and the project's GitHub workflow vocabulary.
+
+## The complete chain
+
+```text
+ai-ready                a task is dispatched (muyan_pilot.py add, or a human
+                        adds the label)
+  -> ai-in-progress     the Runner claims it: label added, worktree created
+                        from the frozen origin/<base> SHA, Pi session starts
+  -> ai-pr-opened       the PR passes verification (base freshness, run
+                        marker, Fixes #N); the delivery now awaits review
+  -> review             an independent Pi session reviews the exact
+                        base/head SHAs and FIXES findings in-session
+                        (code, full test suite, 100% coverage, push only
+                        the task branch), then emits a REVIEW_VERDICT
+  -> ai-fix-needed      a finding could not be fixed in-session, or the PR
+                        is behind the latest base / has a merge conflict:
+                        the NEXT tick starts the next review session on
+                        the same run, same branch, same PR
+  -> merge              clean verdict + merge gate (head contains the
+                        latest base, PR mergeable, remote head unchanged)
+  -> ai-merged          success terminal state; the PR body's Fixes #N
+                        closes the Issue natively
+```
+
+Failure at any point fails fast: the Issue is marked `ai-blocked` with the
+concrete scene (command, return code, stdout/stderr, branch, worktree,
+session file), and the automatic loop never touches it again — a human
+decides the next step.
+
+Rules of the chain:
+
+- One task = one run = one feature branch = one worktree = one PR. The PR
+  number never changes during the review/fix loop; only its head may
+  advance.
+- Only the two opened-PR states are picked up automatically:
+  `ai-pr-opened` (awaiting review) and `ai-fix-needed` (awaiting the next
+  review session). `ai-ready` is claimed as new work; `ai-blocked` is
+  never auto-recovered.
+- The review/fix loop is bounded (5 rounds). Exhausting rounds with
+  findings, or a review that cannot be verified, marks the Issue
+  `ai-blocked`; the PR, branch and worktree stay intact.
+- Base advances are absorbed by a plain `git merge` of the latest
+  `origin/<base>` on the task branch (conflicts resolved manually),
+  followed by a full test rerun. No force push, no auto conflict
+  resolution, no push of the protected branch.
+
+## Delivery labels
+
+GitHub labels are the external state machine. They are not created by
+commits — initialize them per repository (see
+[Getting started](/getting-started)):
+
+| Label | Meaning |
+|---|---|
+| `ai-ready` | Explicitly dispatched to the Pilot; may be claimed |
+| `ai-in-progress` | Claimed and running (a leftover after a kill is resumed by the next tick) |
+| `ai-pr-opened` | PR created and verified; awaiting the independent review |
+| `ai-fix-needed` | The PR head is not mergeable yet; the next tick runs the next review session on the same PR |
+| `ai-merged` | Success terminal state; the Runner merged the PR and confirmed the merge commit on the protected branch |
+| `ai-blocked` | The Runner failed fast; a human must decide the next step |
+
+## Run marker and run_id
+
+Every task attempt generates one `run_id` (8 hex chars, e.g.
+`e07383c2`) and reuses it for every step of the attempt; a retry of the
+same Issue generates a new one. The same id appears in:
+
+- every journal line of the attempt (prefix `[e07383c2]`);
+- the Issue/PR comments: visible field `run_id=e07383c2` plus the hidden
+  machine-readable marker `<!-- muyan-pilot:run=e07383c2 -->`;
+- the feature branch and worktree name
+  (`.worktrees/<...>-issue-<n>-e07383c2`);
+- the PR body — the stable marker `<!-- muyan-pilot:run=e07383c2 -->` is
+  part of the PR contract; the Runner rejects a PR without it.
+
+Reconstruct a full timeline with one grep:
+
+```bash
+journalctl --user -u muyan-pilot.service | grep e07383c2
+gh search issues "e07383c2" --repo OWNER/PILOT-REPO
+```
+
+## PR body contract: `Fixes #N`
+
+The PR description must contain `Fixes #<issue-number>` (it may be on the
+first line). GitHub reads the body (not the PR title) and closes the Issue
+natively when the PR merges into the default branch. The Runner verifies
+the keyword during PR acceptance and fails fast when it is missing.
+
+## Epics, Release tasks and P0 priority
+
+The project organizes multi-task work with plain GitHub primitives — no
+DAG, no priority numbers, no separate queues:
+
+- **Epic**: a coordination Issue that groups a set of related tasks (for
+  example the v0.1 release checklist). It is marked with the `ai-epic`
+  label. An Epic is not itself a directly executable task: the actual
+  work is split into independent `ai-ready` Issues, each with one runtime
+  outcome, one PR, one review and one merge. The Epic is closed only
+  after its sub-Issues are done and the release evidence exists on the
+  remote (tag, merged PRs) — typically with a final `Fixes #<epic>`
+  commit/PR.
+- **Release task**: a regular `ai-ready` Issue whose job is release
+  reconciliation — checking that the sub-Issues are merged, the version
+  tag exists on the remote, and the release evidence is complete. Like
+  any task it delivers through one PR (or closes the Epic when the
+  evidence is already on the remote).
+- **P0 priority**: the convention that urgent bug fixes come before new
+  features. The current implementation is deliberately simple: the ready
+  scan picks `bug`-labeled `ai-ready` Issues before plain `ai-ready`
+  Issues (same exclusions, same blockedBy semantics) — if the delivery
+  loop is broken, claiming enhancements only piles up unreviewed PRs.
+  There is no priority number or weighted queue; dispatch order is the
+  only other lever (create the urgent Issue first).
+
+Task dependencies between Issues use GitHub's native `blockedBy`
+relation (`gh issue edit N --add-blocked-by M`); the Runner reads the
+field and skips Issues with open blockers. `Depends on #N` lines in an
+Issue body are not parsed.

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -336,6 +336,29 @@ def test_docs_do_not_resurrect_the_stale_five_minute_timer():
         )
 
 
+def test_docs_kv_cache_page_matches_the_upstream_port_contract():
+    """The upstream proxy's CODE default port is 8081
+    (cache_proxy.py: os.environ.get("PI_LLAMA_CACHE_PORT", "8081"));
+    18082 is the value the committed systemd unit sets (verified against
+    the upstream repo). The docs must keep the two apart: the agent-
+    facing port 18082 stays documented, but the Configuration table must
+    not claim 18082 as the env var's default."""
+    text = page_text("optional-kv-cache")
+    assert "18082" in text, (
+        "the docs must keep the unit's agent-facing port 18082"
+    )
+    row = next(
+        (line for line in text.splitlines()
+         if line.startswith("| `PI_LLAMA_CACHE_PORT`")),
+        None,
+    )
+    assert row is not None, "missing the PI_LLAMA_CACHE_PORT row"
+    default_cell = row.strip("|").split("|")[1].strip()
+    assert "18082" not in default_cell.split("(")[0], (
+        f"the docs claim 18082 as the proxy code default: {row!r}"
+    )
+
+
 def test_readme_keeps_the_docs_site_entry():
     """The root README stays the GitHub homepage and must carry the
     documentation site entry (Mintlify default subdomain for this repo,

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -1,0 +1,349 @@
+"""Documentation site contract for the v0.1.0 open-source release (Issue #104).
+
+The minimal open-source docs live in `docs/` (Mintlify config `docs.json`
+plus `*.mdx` pages) and are the single source of truth: Mintlify only
+builds, searches and hosts them (repository default branch, documentation
+path `/docs`). These tests fail when the docs are missing, when the
+Mintlify navigation drifts from the actual pages, when a required topic
+disappears (problem/scenarios/MVP boundary, install prerequisites, config
+fields, Issue→PR workflow, operations commands, labels/run marker/Epic/
+Release task/P0, security boundary, test+coverage commands, contributing,
+smoke walkthrough), when a doc references a label or config field the
+implementation does not have, or when a doc carries a personal absolute
+path, an unimplemented feature, or the stale 5-minute timer.
+"""
+import json
+import re
+from pathlib import Path
+
+import bootstrap_runner as runner
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+DOCS_CONFIG = DOCS_DIR / "docs.json"
+README = REPO_ROOT / "README.md"
+EXAMPLE_CONFIG = REPO_ROOT / ".muyan-pilot.example.toml"
+
+# The pages the v0.1.0 docs must ship (one page per topic).
+REQUIRED_PAGES = (
+    "index",
+    "getting-started",
+    "workflow",
+    "operations",
+    "security",
+    "testing",
+    "contributing",
+    "optional-kv-cache",
+)
+
+# Every `ai-*` label the docs may mention must exist in the runner's label
+# set (same contract as tests/test_docs_labels.py for README/AGENTS).
+KNOWN_LABELS = frozenset({
+    "ai-ready",
+    "ai-epic",
+    runner.IN_PROGRESS_LABEL,
+    runner.PR_OPENED_LABEL,
+    runner.FIX_NEEDED_LABEL,
+    runner.MERGED_LABEL,
+    runner.BLOCKED_LABEL,
+})
+
+LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")
+
+# Config fields the implementation understands (bootstrap_runner.load_config
+# plus the committed example). A docs field table may document exactly this
+# set — no invented field may sneak in.
+KNOWN_CONFIG_FIELDS = frozenset({
+    "source_repos",
+    "repo_dir",
+    "workspace_root",
+    "prompt",
+    "prompt_review",
+    "base_branch",
+    "max_concurrency",
+    "skills",
+    "context_files",
+})
+
+CONFIG_FIELD_PATTERN = re.compile(
+    r"^\s*([a-z][a-z_]+)\s*=", re.MULTILINE
+)
+
+# Personal absolute paths must never appear in the docs (acceptance: the
+# commands work at any clone path).
+PERSONAL_PATH_PATTERN = re.compile(r"/home/[a-z0-9_]+|/Users/[a-z0-9_]+")
+
+
+def docs_files() -> list[Path]:
+    """All committed Markdown/MDX pages under docs/ (sorted, stable)."""
+    assert DOCS_DIR.is_dir(), f"missing docs directory: {DOCS_DIR}"
+    files = sorted(
+        path for path in DOCS_DIR.iterdir()
+        if path.is_file() and path.suffix in (".md", ".mdx")
+    )
+    assert files, "docs/ contains no Markdown/MDX pages"
+    return files
+
+
+def page_text(slug: str) -> str:
+    path = DOCS_DIR / f"{slug}.mdx"
+    assert path.is_file(), f"missing docs page: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def load_docs_config() -> dict:
+    assert DOCS_CONFIG.is_file(), f"missing Mintlify config: {DOCS_CONFIG}"
+    config = json.loads(DOCS_CONFIG.read_text(encoding="utf-8"))
+    assert isinstance(config, dict), "docs.json is not a JSON object"
+    return config
+
+
+def navigation_pages(config: dict) -> list[str]:
+    """Every page slug referenced by the Mintlify navigation."""
+    navigation = config.get("navigation")
+    assert isinstance(navigation, dict) and navigation, (
+        "docs.json has no navigation section"
+    )
+    pages: list[str] = []
+    groups = navigation.get("groups")
+    assert isinstance(groups, list) and groups, (
+        "docs.json navigation has no groups"
+    )
+    for group in groups:
+        assert isinstance(group, dict) and group.get("group"), (
+            f"navigation group without a name: {group!r}"
+        )
+        group_pages = group.get("pages")
+        assert isinstance(group_pages, list) and group_pages, (
+            f"navigation group {group.get('group')!r} has no pages"
+        )
+        pages.extend(group_pages)
+    return pages
+
+
+def test_docs_config_is_a_mintlify_config_named_muyan_pilot():
+    config = load_docs_config()
+    schema = str(config.get("$schema", ""))
+    assert "mintlify" in schema.lower(), (
+        f"docs.json must point at the Mintlify schema, got: {schema!r}"
+    )
+    assert config.get("name") == "Muyan Pilot", (
+        f"docs.json name must be 'Muyan Pilot', got: {config.get('name')!r}"
+    )
+
+
+def test_docs_navigation_matches_the_actual_pages_exactly():
+    """KISS: one group per topic, every page listed once, no orphan page
+    outside the navigation and no navigation entry without a file."""
+    config = load_docs_config()
+    listed = navigation_pages(config)
+    actual = {path.stem for path in docs_files()}
+    assert len(listed) == len(set(listed)), (
+        f"navigation lists a page twice: {sorted(set(p for p in listed if listed.count(p) > 1))}"
+    )
+    missing = set(listed) - actual
+    assert not missing, f"navigation references missing pages: {sorted(missing)}"
+    orphans = actual - set(listed)
+    assert not orphans, f"pages missing from the navigation: {sorted(orphans)}"
+
+
+def test_docs_ship_every_required_topic_page():
+    for slug in REQUIRED_PAGES:
+        assert (DOCS_DIR / f"{slug}.mdx").is_file(), f"missing docs page: {slug}.mdx"
+
+
+def test_docs_describe_problem_scenarios_and_mvp_boundary():
+    """The overview must say what the project solves, when to use it, and
+    the explicit MVP boundary (GitHub Issues are the only state store; no
+    database, queue, daemon loop or fallback)."""
+    text = page_text("index")
+    assert "GitHub Issue" in text, "overview must name the GitHub Issue task pool"
+    assert "MVP" in text, "overview must state the MVP boundary"
+    for forbidden in ("database", "queue", "daemon"):
+        assert forbidden in text.lower(), (
+            f"overview must name the MVP boundary: no {forbidden}"
+        )
+
+
+def test_docs_document_install_prerequisites():
+    """Core prerequisites: Python (the production minor version, same as
+    CI), Pi, Git + GitHub CLI, systemd, and a working OpenAI-compatible
+    model endpoint. The KV cache proxy is NOT a core prerequisite."""
+    text = page_text("getting-started")
+    assert "Python" in text
+    assert "3.14" in text, "prerequisites must pin the production Python minor version"
+    assert "Pi" in text
+    assert "git" in text.lower()
+    assert "gh" in text, "prerequisites must name the GitHub CLI (gh)"
+    assert "systemd" in text.lower()
+    assert "OpenAI-compatible" in text, (
+        "prerequisites must name the OpenAI-compatible model endpoint"
+    )
+    assert "local-llm-kv-cache" not in text or "optional" in text.lower() or "可选" in text, (
+        "the KV cache proxy must not be presented as a core prerequisite"
+    )
+
+
+def test_docs_config_field_table_matches_the_implementation():
+    """Every config field the docs document must exist in the committed
+    example (and therefore in load_config); no invented field."""
+    text = page_text("getting-started")
+    documented = set(CONFIG_FIELD_PATTERN.findall(text))
+    unknown = documented - KNOWN_CONFIG_FIELDS
+    assert not unknown, f"docs document unknown config fields: {sorted(unknown)}"
+    example = EXAMPLE_CONFIG.read_text(encoding="utf-8")
+    example_fields = set(CONFIG_FIELD_PATTERN.findall(example))
+    missing = example_fields - documented
+    assert not missing, (
+        f"docs field table misses fields of the committed example: {sorted(missing)}"
+    )
+
+
+def test_docs_document_the_full_issue_to_merge_workflow():
+    """The workflow page must cover the complete automatic chain (claim →
+    worktree → implement → test → PR → independent review with in-session
+    fix → merge), the PR body contract, and the run marker."""
+    text = page_text("workflow")
+    for state in (
+        "ai-ready", "ai-in-progress", "ai-pr-opened",
+        "ai-fix-needed", "ai-merged", "ai-blocked",
+    ):
+        assert state in text, f"workflow page misses the {state} state"
+    assert "REVIEW_VERDICT" in text, "workflow must document the review verdict"
+    assert "Fixes #" in text, "workflow must document the PR body Fixes #N contract"
+    assert "muyan-pilot:run=" in text, "workflow must document the run marker"
+
+
+def test_docs_document_labels_run_marker_epic_release_task_and_p0():
+    """The workflow page must give the basic explanation of the project's
+    GitHub workflow vocabulary: the delivery labels, the run marker, Epic
+    coordination issues (ai-epic), Release tasks, and the bug-first (P0)
+    pickup order. Epic/Release task/P0 are workflow concepts — the docs
+    must not claim runner features that are not implemented yet (Issue
+    #93/#98/#101 are still open)."""
+    text = page_text("workflow")
+    assert "ai-epic" in text, "workflow must explain Epic issues (ai-epic)"
+    assert "Release" in text, "workflow must explain Release tasks"
+    assert "P0" in text, "workflow must explain the P0 (bug-first) priority"
+    assert "bug" in text.lower(), "P0 explanation must name the bug label"
+    # The docs only reference labels that exist in the runner's label set.
+    mentioned = set(LABEL_PATTERN.findall(text))
+    unknown = mentioned - KNOWN_LABELS
+    assert not unknown, f"workflow references unknown labels: {sorted(unknown)}"
+
+
+def test_docs_document_operations_commands():
+    """Operations must cover first start, the 15-minute timer, journal
+    logs, the status/session/add CLI, worktrees and failure recovery —
+    with the commands the implementation actually provides."""
+    text = page_text("operations")
+    assert "muyan-pilot.timer" in text
+    assert "15" in text, "operations must document the 15-minute idle polling interval"
+    assert "journalctl" in text, "operations must show the journal command"
+    assert "muyan_pilot.py" in text, "operations must name the CLI"
+    for command in ("status", "session", "add"):
+        assert command in text, f"operations must document the {command} command"
+    assert "worktree" in text.lower(), "operations must explain the task worktree"
+    assert "ai-blocked" in text, "operations must document failure recovery (ai-blocked)"
+    assert "ExecStartPre" in text, "operations must document the code-update preflight"
+
+
+def test_docs_document_the_security_boundary():
+    """Security: the AI never merges or pushes the protected branch (the
+    Runner is the only merge actor), the GitHub token is a local secret,
+    and the local KV/session files are local state that never leaves the
+    machine."""
+    text = page_text("security")
+    assert "merge" in text.lower()
+    assert "protected" in text.lower() or "保护分支" in text, (
+        "security must name the protected branch boundary"
+    )
+    assert "token" in text.lower(), "security must cover the GitHub token"
+    assert "KV" in text, "security must cover the local KV/session files"
+
+
+def test_docs_document_tests_and_coverage_commands():
+    """Testing must show the exact contract commands (full pytest with
+    branch coverage + 100% report) and the remote CI gate."""
+    text = page_text("testing")
+    assert "coverage run --branch -m pytest tests/" in text, (
+        "testing must show the contract coverage-run command"
+    )
+    assert "coverage report" in text, "testing must show the coverage report command"
+    assert "100%" in text, "testing must state the 100% line/branch coverage requirement"
+    assert "GitHub Actions" in text, "testing must name the remote CI gate"
+
+
+def test_docs_document_contributing_paths():
+    """Contributing must show how to create an Issue (with ai-ready),
+    report a bug, and submit a PR (feature branch, Fixes #N, one PR)."""
+    text = page_text("contributing")
+    assert "ai-ready" in text, "contributing must show how to dispatch an Issue"
+    assert "bug" in text.lower(), "contributing must show how to report a bug"
+    assert "PR" in text, "contributing must show how to submit a PR"
+    assert "Fixes #" in text, "contributing must document the PR body contract"
+
+
+def test_docs_smoke_walkthrough_is_clone_path_independent():
+    """The smoke walkthrough must use only relative paths / clone-local
+    paths so it works at any clone location — no personal absolute path
+    anywhere in the docs (acceptance criterion)."""
+    text = page_text("getting-started")
+    assert "smoke" in text.lower(), "getting-started must contain the smoke walkthrough"
+    for path in docs_files():
+        content = path.read_text(encoding="utf-8")
+        match = PERSONAL_PATH_PATTERN.search(content)
+        assert match is None, (
+            f"{path.name} contains a personal absolute path: {match.group(0)}"
+        )
+
+
+def test_docs_do_not_document_unimplemented_runner_features():
+    """Acceptance: no unimplemented feature. The runner does not skip
+    ai-epic Issues yet (Issue #93 open) and has no P0 priority field
+    (Issue #101 open) — the docs may name the concepts but must not
+    claim that behavior from the current code."""
+    text = page_text("workflow").lower()
+    assert "epic_not_claimed" not in text, (
+        "the runner does not log epic_not_claimed yet (Issue #93 is open)"
+    )
+    operations = page_text("operations").lower()
+    assert "priority" not in operations or "bug" in operations, (
+        "operations must not claim a priority queue that does not exist"
+    )
+
+
+def test_docs_do_not_resurrect_the_stale_five_minute_timer():
+    """Acceptance: no stale 5-minute timer convention. The idle polling
+    interval stays 15 minutes (Issue #51 explicitly not in v0.1); the only
+    5-minute number in the contract is the PI_IDLE_WARN_SECONDS idle
+    warning, which is a log threshold, not a schedule."""
+    for path in docs_files():
+        content = path.read_text(encoding="utf-8")
+        assert "5 分钟" not in content and "5分钟" not in content, (
+            f"{path.name} resurrects the stale 5-minute timer"
+        )
+        assert "00/5" not in content, (
+            f"{path.name} resurrects the stale 5-minute OnCalendar"
+        )
+
+
+def test_readme_keeps_the_docs_site_entry():
+    """The root README stays the GitHub homepage and must carry the
+    documentation site entry (Mintlify default subdomain for this repo,
+    with the custom-domain caveat)."""
+    text = README.read_text(encoding="utf-8")
+    assert "muyan-pilot.mintlify.site" in text, (
+        "README must link the Mintlify documentation site"
+    )
+    assert "docs/" in text, "README must point at the in-repo docs/ source"
+
+
+def test_docs_only_reference_existing_labels_everywhere():
+    for path in docs_files():
+        content = path.read_text(encoding="utf-8")
+        mentioned = set(LABEL_PATTERN.findall(content))
+        unknown = mentioned - KNOWN_LABELS
+        assert not unknown, (
+            f"{path.name} references unknown labels: {sorted(unknown)}"
+        )

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -130,6 +130,14 @@ def test_docs_config_is_a_mintlify_config_named_muyan_pilot():
     assert config.get("name") == "Muyan Pilot", (
         f"docs.json name must be 'Muyan Pilot', got: {config.get('name')!r}"
     )
+    # The official Mintlify schema (mintlify.com/docs.json) and settings
+    # reference mark `theme` as required: a config without it does not
+    # validate against its own declared schema, so the site build contract
+    # would break. Pin the value the build expects.
+    assert config.get("theme") == "mint", (
+        f"docs.json must set the required Mintlify theme, "
+        f"got: {config.get('theme')!r}"
+    )
 
 
 def test_docs_navigation_matches_the_actual_pages_exactly():


### PR DESCRIPTION
Fixes #104

run_id=19edd84a

## What

v0.1.0 最小开源文档：`docs/docs.json` + `docs/*.mdx`（Mintlify 配置 + 8 个页面）作为唯一事实源，Mintlify 只负责构建/搜索/托管（默认分支 `main`、documentation path `/docs`，每次合并自动构建发布）。根 README 保留 GitHub 首页与运行契约概览，新增文档站入口；run_id grep 示例中的作者本机绝对路径改为 clone 相对路径。

页面：
- `index` — 项目解决的问题、适用场景、MVP 边界（无数据库/队列/daemon/fallback、无业务 timeout）；
- `getting-started` — 安装前提（Python 3.14、Pi、Git/gh、systemd、OpenAI-compatible model endpoint）、配置文件示例与全部字段说明、label 初始化、首次启动、从零 smoke walkthrough（任意 clone 路径可用）；
- `workflow` — GitHub Issue → PR → 独立审查（会话内修复）→ merge 完整链路、delivery 标签表、run marker/run_id、`Fixes #N` 契约、Epic（ai-epic）/Release task/P0（bug 优先）基本说明、blockedBy；
- `operations` — timer（15 分钟）、ExecStartPre 代码更新、journal 日志、`muyan_pilot.py add/status/session`、worktree 与 base 新鲜度、失败恢复（ai-blocked / ai-fix-needed / kill 残留）、并发 slot；
- `security` — AI 不 merge/push 保护分支（Runner 是唯一 merge actor）、GitHub token 最小权限与脱敏、本地 KV/session/config 文件注意事项；
- `testing` — 本地契约命令（全量 pytest + 100% line/branch coverage）与 GitHub Actions 远程门禁；
- `contributing` — 如何创建 Issue（ai-ready）、报告 bug（bug 标签）、贡献代码与提交 PR（feature branch、Fixes #N、覆盖率门禁）；
- `optional-kv-cache` — `local-llm-kv-cache` proxy 作为可选增强单独记录（安装、配置、故障排查），不作为核心前提。

## Tests

- 新增 `tests/test_docs_site.py`（17 个静态契约测试）：Mintlify navigation 与实际页面一一对应、必备主题齐全、config 字段/标签与实现一致、无个人绝对路径、未实现功能（#93/#98/#101）不写成已实现、无过时 5 分钟 timer、README 保留文档站入口。
- 全量：`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` → 630 passed；`/usr/bin/python3 -m coverage report --fail-under=100 --show-missing` → TOTAL 8240 stmts, 100% line/branch。

## Verification

- 文档中所有命令均对照实现核实（`muyan_pilot.py` 子命令与 `--follow/--pretty`、`bootstrap_runner.py --config`、`gh label/issue/pr` 用法、timer/service unit、`MUYAN_PILOT_CONFIG`、`capacity_full`/`pi_exit_*`/`upstream_dead_stale_*` 日志字段、`MAX_REVIEW_ROUNDS=5`、`PI_IDLE_WARN_SECONDS=300`、`PI_MODEL_WAIT_DEAD_SECONDS=600`、bug-first ready scan）；
- 文档引用的 label 全部在 runner label set 内（含 `ai-epic`）；config 字段与 `load_config`/example toml 完全一致；
- `docs/` 与 README 无个人绝对路径、无 5 分钟 timer 约定、无未实现功能描述；
- 文档站入口使用 Mintlify 默认子域（自定义域名以控制台为准），未写死其他外部地址。

<!-- muyan-pilot:run=19edd84a -->
