### PR TITLE
feat: systemd deployment consistency — idempotent install, pre-start drift check, doctor (Issue #103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,22 @@ is **one runtime outcome** (when X, should Y, actually Z).
   next real start runs the latest code. No refresh service, worker,
   dispatcher or resident process is added; the 15-minute timer is
   unchanged.
+- Deployment consistency (Issue #103): the repo templates
+  `systemd/muyan-pilot.service` and `systemd/muyan-pilot.timer` are the
+  single source of truth for the installed user units. `muyan_pilot.py
+  install-units` is the idempotent install (copy both templates into the
+  user unit dir, `systemctl --user daemon-reload`, enable the timer, print
+  the deployed commit and unit hashes): it NEVER starts/stops/restarts the
+  service — a running Runner is never killed or restarted by an install,
+  the new config takes effect at the next service start. Every Runner start
+  checks BOTH installed units against the templates BEFORE any slot or
+  claim: drift logs a structured `unit_drift` line per unit (repo path,
+  installed path, sha256s, the install fix command) and fails fast — no
+  slot, no claim, no label change — until the units are synced. `muyan_pilot.py
+  doctor` is the read-only report (repo commit, unit drift, timer/service
+  active, slots, Pi session, current Issue, recent journal). Full sequence:
+  merge to main -> install units -> daemon-reload -> timer next trigger ->
+  ExecStartPre syncs origin/main -> drift check -> Runner starts one Issue.
 
 ## Task dependencies (blockedBy)
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@
 正常运行使用 systemd user timer，全天 24 小时运行，每 15 分钟自动执行一次（触发点覆盖 00:00–23:45）：
 
 ```bash
-mkdir -p ~/.config/systemd/user
-cp systemd/muyan-pilot.service systemd/muyan-pilot.timer ~/.config/systemd/user/
-systemctl --user daemon-reload
-systemctl --user enable --now muyan-pilot.timer
+# 幂等安装用户级 service/timer（仓库模板复制到用户 systemd 目录、
+# daemon-reload、enable timer），并输出部署 commit/hash：
+python3 muyan_pilot.py install-units --config muyan-pilot.toml
 systemctl --user list-timers muyan-pilot.timer
 ```
 
-手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
+`install-units` 是幂等的：重复执行只会把仓库模板重新复制到位并 `daemon-reload`，**不会**启动、停止或重启正在运行的 Runner（新配置从下一次 service 启动生效）。手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
 
 ## 代码更新（Issue #52）
 
@@ -35,6 +34,32 @@ git fetch origin main && git merge --ff-only origin/main
 ```
 
 本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动。当前正在运行的长任务不会被热更新、不会被杀、也不会启动第二个 Runner（service active 时 systemd 忽略 timer 的 start 请求；下一次 service 真正启动时生效）。main 工作区不干净、fetch 失败或无法 fast-forward 时，preflight 命令失败，service 不启动，原因写入 systemd journal（fail fast）。不新增 refresh service、worker、dispatcher 或常驻进程；15 分钟 timer 配置保持不变。
+
+## 部署一致性（Issue #103）
+
+仓库中的 `systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。
+
+**幂等安装**：`python3 muyan_pilot.py install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`、`systemctl --user enable --now muyan-pilot.timer`，并输出部署 commit（部署 checkout 的 HEAD，即模板来源）和每个 unit 的 sha256。安装**不会**启动、停止或重启 service：当前运行中的 Runner 不被中断，新配置从下一次 service 启动生效。
+
+**启动前漂移检查**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 都覆盖）。一致时记录 `unit_drift clean`；发现漂移时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签），直到 unit 同步：
+
+```text
+unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=python3 muyan_pilot.py install-units
+```
+
+**只读诊断**：`python3 muyan_pilot.py doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
+
+**完整部署时序**（从代码合并到下一次 Runner 启动）：
+
+```text
+git merge 到 main
+  -> install units（仓库模板复制到用户 systemd 目录，幂等，不碰运行中的 Runner）
+  -> daemon-reload
+  -> timer 下一次触发
+  -> ExecStartPre 同步 origin/main（fetch + fast-forward）
+  -> 启动前 unit 漂移检查（一致才继续）
+  -> Runner 启动并执行一个 Issue
+```
 
 ## 远程 CI（GitHub Actions）
 
@@ -68,6 +93,15 @@ python3 muyan_pilot.py session --follow --config muyan-pilot.toml
 ```
 
 `session` 是排查附件（日常仍看 journal / GitHub），不是日常入口：没有 session 文件时 fail fast（退出码非零，说明没有正在跑的 Pi），不猜路径；`--pretty` 把 JSONL 打一行摘要（timestamp / role / tool|text|thinking 截断），默认仍是原始 JSONL。不开 tmux、不新包装脚本、不新增 systemd unit（Issue #74）。
+
+```bash
+# 幂等安装 systemd units（见「部署一致性」）：输出部署 commit 和每个 unit 的 sha256
+python3 muyan_pilot.py install-units --config muyan-pilot.toml
+
+# 只读部署/健康报告：repo commit、unit drift、timer/service active、
+# Runner slot、Pi session、当前 Issue、最近 journal 活动
+python3 muyan_pilot.py doctor --config muyan-pilot.toml
+```
 
 ## GitHub Issue 标签（外部状态）
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -47,6 +47,7 @@ from pi_activity import (
     sanitize,
 )
 from progress import ProgressPublisher, format_elapsed, progress_body
+from systemd_deploy import UnitDriftError, check_unit_drift
 
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
@@ -2803,6 +2804,15 @@ def main(argv: list[str] | None = None) -> int:
 
     config = load_config(args.config)
     validate_config(config)
+    # Deployment consistency (Issue #103): BEFORE any slot or claim the
+    # installed systemd units must match the repo templates (the
+    # templates the ExecStartPre-synced checkout just loaded). Drift
+    # logs a structured `unit_drift` line per unit and fails fast:
+    # this start takes no slot, claims no Issue and changes no label
+    # until the units are synced with the idempotent install command
+    # (`muyan_pilot.py install-units`). A currently RUNNING task is
+    # never interrupted — only the next start is blocked.
+    check_unit_drift(config["repo_dir"])
     # Concurrency cap (Issue #39): take one slot BEFORE claiming anything.
     # The slot is held for the whole delivery lifecycle (implement ->
     # review -> fix -> merge) and released only after the delivery is

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -24,6 +24,8 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
+import systemd_deploy
+
 from bootstrap_runner import (
     RunIdFilter,
     freeze_base,
@@ -312,6 +314,95 @@ def slot_lines(state_dir: Path, capacity: int) -> list[str]:
     return lines
 
 
+# Deployment consistency (Issue #103): the repo templates
+# (systemd/muyan-pilot.service + .timer) are the single source of
+# truth. `install-units` deploys them idempotently (it never
+# starts/stops/restarts the service — a running Runner keeps running,
+# the new config takes effect at the next service start); `doctor`
+# is the read-only report (repo commit, unit drift, timer/service
+# state, slots, Pi session, current Issue, recent journal).
+JOURNAL_LINES = 20
+
+
+def install_units_command(config: dict, installed_dir: Path | None) -> str:
+    """Run the idempotent unit install and return the deployment report.
+
+    The report carries the deployed commit (the deployment checkout's
+    HEAD — the commit the installed templates came from) and the
+    installed sha256 of each unit (Issue #103).
+    """
+    result = systemd_deploy.install_units(
+        config["repo_dir"], installed_dir, run_command=run_command,
+    )
+    lines = [
+        (
+            f"deployed commit={result['commit']} "
+            f"installed_dir={result['installed_dir']}"
+        ),
+    ]
+    for name in systemd_deploy.UNIT_NAMES:
+        entry = result["units"][name]
+        lines.append(f"unit={name} sha256={entry['sha256']}")
+    return "\n".join(lines)
+
+
+def doctor_report(config: dict, installed_dir: Path | None) -> str:
+    """Read-only deployment and health report (Issue #103).
+
+    Checks: repo commit, unit drift (both units; the same comparison
+    the pre-start check uses), timer/service active state, Runner
+    slots, the live Pi session, the current Issue per source repo and
+    the recent journal activity. Read-only: no labels, no units, no
+    git mutation. A failed command fails fast (run_command).
+    """
+    repo_dir = config["repo_dir"]
+    if installed_dir is None:
+        installed_dir = systemd_deploy.installed_unit_dir()
+    lines = [f"repo: {repo_dir}"]
+    lines.append(
+        f"commit: {run_command(['git', 'rev-parse', 'HEAD'], cwd=repo_dir)}"
+    )
+    status = systemd_deploy.unit_status(repo_dir, installed_dir)
+    drifted = [entry for entry in status if entry["drifted"]]
+    if drifted:
+        lines.append("unit_drift: DRIFT")
+        for entry in drifted:
+            lines.append(
+                f"  {entry['unit']}: repo={entry['repo_path']} "
+                f"installed={entry['installed_path']} "
+                f"repo_sha256={entry['repo_sha256'] or '-'} "
+                f"installed_sha256={entry['installed_sha256'] or '-'}"
+            )
+        lines.append(f"  fix: {systemd_deploy.FIX_COMMAND}")
+    else:
+        lines.append("unit_drift: clean")
+        for entry in status:
+            lines.append(
+                f"  {entry['unit']}: sha256={entry['installed_sha256']}"
+            )
+    for unit in (systemd_deploy.TIMER_UNIT, systemd_deploy.SERVICE_UNIT):
+        state = run_command([
+            "systemctl", "--user", "show", "-p", "ActiveState",
+            "--value", unit,
+        ])
+        lines.append(f"{unit}: {state}")
+    lines.extend(slot_lines(config["slot_dir"], config["max_concurrency"]))
+    session = find_session_file(repo_dir)
+    lines.append(f"pi: {session if session else 'none'}")
+    for repo in config["source_repos"]:
+        lines.append(f"source: {repo}")
+        current = current_issue(repo)
+        lines.append(f"  current: {format_issue(current) if current else '-'}")
+    journal = run_command([
+        "journalctl", "--user", "-u", systemd_deploy.SERVICE_UNIT,
+        "-n", str(JOURNAL_LINES), "--no-pager",
+    ])
+    lines.append("journal:")
+    for line in journal.splitlines():
+        lines.append(f"  {line}")
+    return "\n".join(lines)
+
+
 def status_report(config: dict) -> str:
     lines = [
         f"capacity: {config['max_concurrency']}",
@@ -370,6 +461,24 @@ def main(argv: list[str] | None = None) -> int:
         "--pretty", action="store_true",
         help="print one-line summaries instead of raw JSONL",
     )
+    install_parser = subparsers.add_parser(
+        "install-units", parents=[common],
+        help="idempotently install the repo's systemd units (never "
+             "restarts a running Runner)",
+    )
+    install_parser.add_argument(
+        "--installed-dir", type=Path, default=None,
+        help="user unit directory (default: the standard user dir)",
+    )
+    doctor_parser = subparsers.add_parser(
+        "doctor", parents=[common],
+        help="read-only report: repo commit, unit drift, timer/service, "
+             "slots, Pi, current Issue, recent journal",
+    )
+    doctor_parser.add_argument(
+        "--installed-dir", type=Path, default=None,
+        help="user unit directory to check (default: the standard dir)",
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format=log_format())
 
@@ -421,6 +530,10 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 print(line)
             sys.stdout.flush()
+    elif args.command == "install-units":
+        print(install_units_command(config, args.installed_dir))
+    elif args.command == "doctor":
+        print(doctor_report(config, args.installed_dir))
     else:
         print(status_report(config))
     return 0

--- a/systemd_deploy.py
+++ b/systemd_deploy.py
@@ -1,0 +1,201 @@
+"""Systemd deployment consistency for Muyan Pilot (Issue #103).
+
+The repo templates ``systemd/muyan-pilot.service`` and
+``systemd/muyan-pilot.timer`` are the single source of truth for the
+user-level units. This module provides:
+
+- an idempotent install (overwrite-copy the templates into the user
+  unit directory, ``systemctl --user daemon-reload``, enable the
+  timer) that NEVER starts/stops/restarts the service: a currently
+  running Runner keeps running, and the new config takes effect at
+  the next service start;
+- a pre-start consistency check that compares BOTH installed units
+  against the templates and fails fast with a structured
+  ``unit_drift`` line (repo path, installed path, hashes, fix
+  command) when they drift.
+
+No database, queue, daemon or second state store: the installed files
+and systemd itself are the only state.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+
+from pi_activity import quote_value
+
+LOGGER = logging.getLogger("muyan_pilot.systemd_deploy")
+
+SERVICE_UNIT = "muyan-pilot.service"
+TIMER_UNIT = "muyan-pilot.timer"
+UNIT_NAMES = (SERVICE_UNIT, TIMER_UNIT)
+
+# The idempotent install command that repairs any drift (carried on
+# every unit_drift line as the fix command).
+FIX_COMMAND = "python3 muyan_pilot.py install-units"
+
+
+class UnitDriftError(RuntimeError):
+    """The installed units have drifted from the repo templates."""
+
+
+def repo_unit_dir(repo_dir: Path) -> Path:
+    """The deployment checkout's unit template directory."""
+    return Path(repo_dir) / "systemd"
+
+
+def installed_unit_dir(unit_dir: str | None = None) -> Path:
+    """The user unit directory of this machine.
+
+    An explicit ``unit_dir`` (or ``$MUYAN_PILOT_UNIT_DIR``, the
+    test/e2e seam) wins; then ``$XDG_CONFIG_HOME/systemd/user``; then
+    ``~/.config/systemd/user`` (the standard systemd user unit
+    location).
+    """
+    override = unit_dir or os.environ.get("MUYAN_PILOT_UNIT_DIR")
+    if override:
+        return Path(override).expanduser()
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        return Path(xdg_config_home).expanduser() / "systemd" / "user"
+    return Path.home() / ".config" / "systemd" / "user"
+
+
+def sha256_hex(path: Path) -> str:
+    """The sha256 of one file's content (the unit's identity)."""
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def unit_status(repo_dir: Path, installed_dir: Path) -> list[dict]:
+    """Compare the installed units against the repo templates.
+
+    One entry per unit (service and timer, in order): the repo and
+    installed paths, both sha256s (None when the file is missing) and
+    whether the unit drifted. A missing template or a missing
+    installed unit is drift: the deployment is not verifiable.
+    """
+    repo_dir = Path(repo_dir)
+    installed_dir = Path(installed_dir)
+    entries: list[dict] = []
+    for name in UNIT_NAMES:
+        repo_path = repo_unit_dir(repo_dir) / name
+        installed_path = installed_dir / name
+        repo_sha = sha256_hex(repo_path) if repo_path.is_file() else None
+        installed_sha = (
+            sha256_hex(installed_path) if installed_path.is_file() else None
+        )
+        entries.append({
+            "unit": name,
+            "repo_path": repo_path,
+            "installed_path": installed_path,
+            "repo_sha256": repo_sha,
+            "installed_sha256": installed_sha,
+            "missing": installed_sha is None,
+            "drifted": (
+                repo_sha is None
+                or installed_sha is None
+                or repo_sha != installed_sha
+            ),
+        })
+    return entries
+
+
+def drift_lines(status: list[dict]) -> list[str]:
+    """One structured ``unit_drift`` line per drifted unit.
+
+    Every line carries the repo path, the installed path, both hashes
+    and the idempotent fix command (Issue #103). Values containing
+    spaces are quoted (the pi_activity.quote_value convention) so the
+    line stays parseable.
+    """
+    lines: list[str] = []
+    for entry in status:
+        if not entry["drifted"]:
+            continue
+        lines.append(
+            "unit_drift "
+            f"unit={entry['unit']} "
+            f"repo={quote_value(str(entry['repo_path']))} "
+            f"installed={quote_value(str(entry['installed_path']))} "
+            f"repo_sha256={entry['repo_sha256'] or '-'} "
+            f"installed_sha256={entry['installed_sha256'] or '-'} "
+            f"fix={FIX_COMMAND}"
+        )
+    return lines
+
+
+def check_unit_drift(repo_dir: Path,
+                     installed_dir: Path | None = None) -> None:
+    """Pre-start deployment check (Issue #103).
+
+    Compares BOTH installed units against the repo templates. Clean:
+    logs ``unit_drift clean`` and returns. Drift: logs one structured
+    ``unit_drift`` line per drifted unit and raises
+    ``UnitDriftError`` — the caller fails fast and claims no Issue
+    until the units are synced with the idempotent install command.
+    """
+    if installed_dir is None:
+        installed_dir = installed_unit_dir()
+    status = unit_status(repo_dir, installed_dir)
+    lines = drift_lines(status)
+    if not lines:
+        LOGGER.info("unit_drift clean installed_dir=%s", installed_dir)
+        return
+    for line in lines:
+        LOGGER.error(line)
+    raise UnitDriftError(
+        "installed systemd units have drifted from the repo templates; "
+        f"sync with: {FIX_COMMAND}\n" + "\n".join(lines)
+    )
+
+
+def install_units(repo_dir: Path, installed_dir: Path | None = None,
+                  *, run_command) -> dict:
+    """Idempotently install the repo templates as the user units.
+
+    Overwrites BOTH installed units with the repo templates (the repo
+    is the single source of truth), runs ``systemctl --user
+    daemon-reload`` and enables the timer (``enable --now`` is
+    idempotent and activates only the timer, never the service). The
+    service is NEVER started, stopped or restarted: a currently
+    running Runner keeps running, and the new config takes effect at
+    the next service start. Returns the deployed commit (the
+    deployment checkout's HEAD) and the installed units' hashes.
+    """
+    repo_dir = Path(repo_dir)
+    if installed_dir is None:
+        installed_dir = installed_unit_dir()
+    installed_dir = Path(installed_dir)
+    for name in UNIT_NAMES:
+        template = repo_unit_dir(repo_dir) / name
+        if not template.is_file():
+            raise FileNotFoundError(
+                f"unit template missing: {template} (the repo "
+                "templates are the single source of truth)"
+            )
+    installed_dir.mkdir(parents=True, exist_ok=True)
+    for name in UNIT_NAMES:
+        (installed_dir / name).write_bytes(
+            (repo_unit_dir(repo_dir) / name).read_bytes(),
+        )
+    run_command(["systemctl", "--user", "daemon-reload"])
+    run_command(["systemctl", "--user", "enable", "--now", TIMER_UNIT])
+    commit = run_command(["git", "rev-parse", "HEAD"], cwd=repo_dir)
+    units = {
+        name: {
+            "installed_path": installed_dir / name,
+            "sha256": sha256_hex(installed_dir / name),
+        }
+        for name in UNIT_NAMES
+    }
+    LOGGER.info(
+        "units_installed commit=%s installed_dir=%s units=%s",
+        commit, installed_dir, ",".join(UNIT_NAMES),
+    )
+    return {
+        "commit": commit,
+        "installed_dir": installed_dir,
+        "units": units,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test fixtures for the Muyan Pilot suite.
+
+The deployment preflight (Issue #103) reads the REAL user unit
+directory on this machine; the in-process dispatch tests use tmp
+repo_dirs that carry no ``systemd/`` templates, so they run with the
+preflight stubbed to a no-op by default. The drift-wiring tests and
+the e2e suites stub or exercise the real check explicitly (a
+``monkeypatch`` always wins over this default).
+"""
+import pytest
+
+import bootstrap_runner as runner
+
+
+@pytest.fixture(autouse=True)
+def _default_unit_drift_preflight(monkeypatch):
+    """Default: the unit drift preflight passes (no-op)."""
+    monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3824,6 +3824,131 @@ def test_main_reacquires_slot_after_previous_release(monkeypatch, tmp_path):
     assert (slot_dir / "slot-1").read_text(encoding="utf-8").strip() == str(os.getpid())
 
 
+# --- deployment consistency preflight (Issue #103) --------------------------
+
+
+def _drift_world(tmp_path, drift: bool) -> tuple[Path, Path]:
+    """A deployment checkout plus an installed unit dir.
+
+    With `drift` the installed timer carries one extra line; without
+    it both units match the repo templates.
+    """
+    import shutil
+
+    repo = tmp_path / "repo"
+    (repo / "systemd").mkdir(parents=True)
+    for name, body in (
+        ("muyan-pilot.service", "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n"),
+        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/15\n"),
+    ):
+        (repo / "systemd" / name).write_text(body, encoding="utf-8")
+    installed = tmp_path / "units"
+    installed.mkdir()
+    for name in ("muyan-pilot.service", "muyan-pilot.timer"):
+        target = installed / name
+        shutil.copyfile(repo / "systemd" / name, target)
+        if drift and name == "muyan-pilot.timer":
+            with target.open("a", encoding="utf-8") as handle:
+                handle.write("# drift\n")
+    return repo, installed
+
+
+def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
+                                                  caplog):
+    """Issue #103: a drifted installed unit fails the start BEFORE any
+    slot or claim: the structured `unit_drift` line (repo path,
+    installed path, hashes, fix command) is logged, the tick raises
+    (non-zero exit), no slot is taken and nothing is claimed — while
+    a currently RUNNING task is never interrupted (only the next
+    start is blocked)."""
+    import systemd_deploy
+
+    repo, installed = _drift_world(tmp_path, drift=True)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    # The real preflight (overrides the conftest default no-op).
+    monkeypatch.setattr(
+        runner, "check_unit_drift", systemd_deploy.check_unit_drift,
+    )
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        f'source_repos = ["owner/repo"]\nrepo_dir = "{repo}"\n',
+        encoding="utf-8",
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("pick_next_delivery must not run on unit drift")
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fail_if_called)
+    # The guard itself must fail loudly if it is ever reached.
+    with pytest.raises(
+        AssertionError, match="must not run on unit drift",
+    ):
+        fail_if_called()
+    with caplog.at_level("ERROR"):
+        with pytest.raises(runner.UnitDriftError, match="unit_drift"):
+            runner.main(["--config", str(config)])
+    # The structured line carries what the Issue requires.
+    assert "unit_drift unit=muyan-pilot.timer" in caplog.text
+    assert f"repo={repo / 'systemd' / 'muyan-pilot.timer'}" in caplog.text
+    assert f"installed={installed / 'muyan-pilot.timer'}" in caplog.text
+    assert "repo_sha256=" in caplog.text
+    assert "installed_sha256=" in caplog.text
+    assert "fix=python3 muyan_pilot.py install-units" in caplog.text
+    # No slot was taken and nothing was claimed.
+    assert not (repo / ".muyan-pilot" / "slots").exists()
+
+
+def test_main_unit_drift_clean_proceeds_to_claim(monkeypatch, tmp_path,
+                                                 caplog):
+    """Issue #103: matching units log `unit_drift clean` and the tick
+    proceeds to the normal claim flow (slot taken, queue scanned)."""
+    import systemd_deploy
+
+    repo, installed = _drift_world(tmp_path, drift=False)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    monkeypatch.setattr(
+        runner, "check_unit_drift", systemd_deploy.check_unit_drift,
+    )
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        f'source_repos = ["owner/repo"]\nrepo_dir = "{repo}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency: None,
+    )
+    with caplog.at_level("INFO"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert "unit_drift clean" in caplog.text
+    # The slot was taken AFTER the preflight passed.
+    assert (repo / ".muyan-pilot" / "slots" / "slot-1").exists()
+
+
+def test_main_preflight_receives_the_configured_repo_dir(
+    monkeypatch, tmp_path,
+):
+    """Issue #103: the preflight checks the configured repo_dir (the
+    ExecStartPre-synced deployment checkout), never a guess."""
+    seen: list[Path] = []
+
+    def fake_check(repo_dir, *args, **kwargs):
+        seen.append(Path(repo_dir))
+
+    monkeypatch.setattr(runner, "check_unit_drift", fake_check)
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency: None,
+    )
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen == [tmp_path]
+
+
 # --- delivery lifecycle: slot held until merge or terminal failure ----------
 
 PR_URL = "https://github.com/owner/repo/pull/46"

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -25,6 +25,7 @@ executable records every invocation. These prove the acceptance criteria:
 """
 import json
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -355,6 +356,10 @@ def clone(tmp_path: Path) -> Path:
     )
     git(clone, "config", "user.email", "pilot@test.local")
     git(clone, "config", "user.name", "Pilot")
+    # The deployment checkout carries the unit templates (Issue #103):
+    # the pre-start drift check compares them against the installed
+    # units, so a synthetic clone without them could never pass it.
+    shutil.copytree(REPO_ROOT / "systemd", clone / "systemd")
     (clone / "a.txt").write_text("a", encoding="utf-8")
     git(clone, "add", ".")
     git(clone, "commit", "-m", "first")
@@ -456,14 +461,30 @@ def write_config(
 _RUNNING: list[subprocess.Popen] = []
 
 
+def install_deployed_units(unit_dir: Path) -> None:
+    """Simulate the deployed machine: the repo templates installed as
+    the user units (the idempotent install the README documents)."""
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("muyan-pilot.service", "muyan-pilot.timer"):
+        shutil.copyfile(REPO_ROOT / "systemd" / name, unit_dir / name)
+
+
 def start_runner(
     config_path: Path, bin_dir: Path,
     state_path: Path, pi_log: Path,
+    unit_dir: Path | None = None,
 ) -> subprocess.Popen:
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["MUYAN_FAKE_GH_STATE"] = str(state_path)
     env["MUYAN_FAKE_PI_LOG"] = str(pi_log)
+    # The pre-start drift check (Issue #103) reads the installed units
+    # from here: a clean deployment by default (the templates as
+    # installed), or an explicit dir for the drift scenarios.
+    if unit_dir is None:
+        unit_dir = config_path.parent / "unit-dir"
+        install_deployed_units(unit_dir)
+    env["MUYAN_PILOT_UNIT_DIR"] = str(unit_dir)
     process = subprocess.Popen(
         ["/usr/bin/python3", str(RUNNER), "--config", str(config_path)],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
@@ -1095,3 +1116,59 @@ def test_live_pr_opened_delivery_is_not_resumed_by_second_runner(
     # review — the review fixes in-session, Issue #82).
     assert 3 <= len(pi_invocations(pi_log)) <= 4
     assert slots_held(clone, 2) == [(1, None), (2, None)]
+
+
+def test_unit_drift_blocks_the_start_without_claiming(clone, tmp_path):
+    """Issue #103: a drifted installed unit fails the start BEFORE any
+    claim: non-zero exit, the structured `unit_drift` line in the log
+    (repo path, installed path, hashes, fix command), no slot, no
+    label change, no Pi — and once the units are synced with the
+    idempotent install the same start passes the preflight and
+    claims normally. A currently RUNNING task is never interrupted;
+    only the next start is blocked."""
+    bin_dir = install_fakes(tmp_path)
+    state = tmp_path / "gh-state.json"
+    write_state(state, {"7": ["ai-ready"]})
+    pi_log = tmp_path / "pi.log"
+    config = write_config(clone, tmp_path, 1)
+
+    # A drifted deployment: the installed timer carries one extra line.
+    unit_dir = tmp_path / "drifted-units"
+    install_deployed_units(unit_dir)
+    with (unit_dir / "muyan-pilot.timer").open(
+        "a", encoding="utf-8",
+    ) as handle:
+        handle.write("# drift\n")
+
+    runner_proc = start_runner(
+        config, bin_dir, state, pi_log, unit_dir=unit_dir,
+    )
+    out, err = runner_proc.communicate(timeout=60)
+    assert runner_proc.returncode != 0, err
+    assert "unit_drift unit=muyan-pilot.timer" in err
+    assert f"repo={clone / 'systemd' / 'muyan-pilot.timer'}" in err
+    assert f"installed={unit_dir / 'muyan-pilot.timer'}" in err
+    assert "repo_sha256=" in err
+    assert "installed_sha256=" in err
+    assert "fix=python3 muyan_pilot.py install-units" in err
+    # Nothing was claimed: no labels, no comments, no Pi, no slot.
+    snap = read_state(state)
+    assert snap["issues"]["7"]["labels"] == ["ai-ready"]
+    assert snap["comments"] == []
+    assert pi_invocations(pi_log) == []
+    assert slot_files(clone) == []
+
+    # After syncing the units (the idempotent install), the same start
+    # passes the preflight and claims normally.
+    install_deployed_units(unit_dir)
+    runner_proc = start_runner(
+        config, bin_dir, state, pi_log, unit_dir=unit_dir,
+    )
+    wait_for(
+        lambda: "ai-in-progress" in read_state(state)["issues"]["7"]["labels"],
+        what="runner to claim after the units are synced",
+    )
+    runner_proc.kill()
+    out, err = runner_proc.communicate(timeout=30)
+    assert "unit_drift clean" in err
+    assert "ai-in-progress" in read_state(state)["issues"]["7"]["labels"]

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1068,3 +1068,267 @@ def test_slot_lines_ignores_corrupted_slot_file(tmp_path):
     (slot_dir / "slot-1").write_text("garbage", encoding="utf-8")
     lines = muyan_pilot.slot_lines(slot_dir, 1)
     assert lines == ["slots: 0/1"]
+
+
+# --- deployment consistency (Issue #103) ------------------------------------
+
+
+def _deploy_world(tmp_path, drift: bool = False) -> tuple[dict, Path]:
+    """A deployment checkout with templates plus an installed unit dir."""
+    import shutil
+
+    repo = tmp_path / "repo"
+    (repo / "systemd").mkdir(parents=True)
+    for name, body in (
+        ("muyan-pilot.service", "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n"),
+        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/15\n"),
+    ):
+        (repo / "systemd" / name).write_text(body, encoding="utf-8")
+    installed = tmp_path / "units"
+    installed.mkdir()
+    for name in ("muyan-pilot.service", "muyan-pilot.timer"):
+        shutil.copyfile(repo / "systemd" / name, installed / name)
+    if drift:
+        (installed / "muyan-pilot.service").write_text(
+            "[Service]\n# drift\n", encoding="utf-8",
+        )
+    config = {
+        "source_repos": ["xqliu/muyan-pilot"],
+        "repo_dir": repo,
+        "base_branch": "main",
+        "max_concurrency": 1,
+        "slot_dir": repo / ".muyan-pilot" / "slots",
+    }
+    return config, installed
+
+
+def _fake_doctor_commands(monkeypatch) -> list:
+    calls: list = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        if command[:2] == ["systemctl", "--user"]:
+            assert command[2:5] == ["show", "-p", "ActiveState"]
+            return "active"
+        if command[:1] == ["journalctl"]:
+            return "line one\nline two"
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(muyan_pilot, "run_command", fake_run)
+    return calls
+
+
+def test_install_units_command_reports_commit_and_hashes(monkeypatch,
+                                                        tmp_path):
+    import systemd_deploy
+
+    config, _ = _deploy_world(tmp_path)
+    installed = tmp_path / "elsewhere"
+    captured = {}
+
+    def fake_install(repo_dir, installed_dir, *, run_command):
+        captured["repo_dir"] = repo_dir
+        captured["installed_dir"] = installed_dir
+        captured["run_command"] = run_command
+        return {
+            "commit": "0123456789abcdef0123456789abcdef01234567",
+            "installed_dir": installed,
+            "units": {
+                name: {"installed_path": installed / name,
+                       "sha256": f"hash-{name}"}
+                for name in systemd_deploy.UNIT_NAMES
+            },
+        }
+
+    monkeypatch.setattr(systemd_deploy, "install_units", fake_install)
+    report = muyan_pilot.install_units_command(config, installed)
+    assert captured["repo_dir"] == config["repo_dir"]
+    assert captured["installed_dir"] == installed
+    assert captured["run_command"] is muyan_pilot.run_command
+    lines = report.splitlines()
+    assert lines[0] == (
+        "deployed commit=0123456789abcdef0123456789abcdef01234567 "
+        f"installed_dir={installed}"
+    )
+    assert f"unit=muyan-pilot.service sha256=hash-muyan-pilot.service" in lines
+    assert f"unit=muyan-pilot.timer sha256=hash-muyan-pilot.timer" in lines
+
+
+def test_main_install_units_prints_report_and_returns_zero(
+    monkeypatch, tmp_path, capsys,
+):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n",
+                      encoding="utf-8")
+    _write_prompts(tmp_path)
+    seen = {}
+
+    def fake_command(cfg, installed_dir):
+        seen["installed_dir"] = installed_dir
+        return "deployed commit=abc installed_dir=/x"
+
+    monkeypatch.setattr(muyan_pilot, "install_units_command", fake_command)
+    assert muyan_pilot.main([
+        "install-units", "--config", str(config),
+        "--installed-dir", str(tmp_path / "u"),
+    ]) == 0
+    assert seen["installed_dir"] == tmp_path / "u"
+    out = capsys.readouterr().out
+    assert "deployed commit=abc installed_dir=/x" in out
+
+
+def test_doctor_report_clean(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    calls = _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert lines[0] == f"repo: {config['repo_dir']}"
+    assert lines[1] == "commit: 0123456789abcdef0123456789abcdef01234567"
+    assert "unit_drift: clean" in lines
+    # Both units are reported with their installed hash.
+    import systemd_deploy
+    status = systemd_deploy.unit_status(config["repo_dir"], installed)
+    for entry in status:
+        assert (
+            f"  {entry['unit']}: sha256={entry['installed_sha256']}"
+        ) in lines
+    assert "muyan-pilot.timer: active" in lines
+    assert "muyan-pilot.service: active" in lines
+    assert "slots: 0/1" in lines
+    assert "pi: none" in lines
+    assert "source: xqliu/muyan-pilot" in lines
+    assert "  current: -" in lines
+    assert "journal:" in lines
+    assert "  line one" in lines
+    assert "  line two" in lines
+    # The exact read-only commands (verified against the live machine).
+    assert [
+        "systemctl", "--user", "show", "-p", "ActiveState", "--value",
+        "muyan-pilot.timer",
+    ] in calls
+    assert [
+        "systemctl", "--user", "show", "-p", "ActiveState", "--value",
+        "muyan-pilot.service",
+    ] in calls
+    assert [
+        "journalctl", "--user", "-u", "muyan-pilot.service",
+        "-n", "20", "--no-pager",
+    ] in calls
+
+
+def test_doctor_report_drift_carries_paths_hashes_and_fix(
+    tmp_path, monkeypatch,
+):
+    config, installed = _deploy_world(tmp_path, drift=True)
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    import systemd_deploy
+    report = muyan_pilot.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert "unit_drift: DRIFT" in lines
+    drifted = [
+        e for e in systemd_deploy.unit_status(
+            config["repo_dir"], installed,
+        ) if e["drifted"]
+    ]
+    assert len(drifted) == 1
+    entry = drifted[0]
+    assert (
+        f"  {entry['unit']}: repo={entry['repo_path']} "
+        f"installed={entry['installed_path']} "
+        f"repo_sha256={entry['repo_sha256']} "
+        f"installed_sha256={entry['installed_sha256']}"
+    ) in lines
+    assert f"  fix: {systemd_deploy.FIX_COMMAND}" in lines
+
+
+def test_doctor_report_missing_installed_unit_is_drift(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    (installed / "muyan-pilot.timer").unlink()
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, installed)
+    assert "unit_drift: DRIFT" in report
+    assert "muyan-pilot.timer" in report
+    assert "installed_sha256=-" in report
+
+
+def test_doctor_report_defaults_to_the_standard_installed_dir(
+    tmp_path, monkeypatch,
+):
+    """Without --installed-dir the report checks the standard user dir
+    (here pointed at the test world via MUYAN_PILOT_UNIT_DIR)."""
+    config, installed = _deploy_world(tmp_path, drift=False)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, None)
+    assert "unit_drift: clean" in report
+
+
+def test_doctor_report_shows_current_issue_and_session(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    issue = {"number": 7, "title": "task",
+             "url": "https://github.com/xqliu/muyan-pilot/issues/7"}
+    monkeypatch.setattr(
+        muyan_pilot, "current_issue", lambda repo: issue,
+    )
+    session = (config["repo_dir"] / ".worktrees" / "w" / ".pi-session"
+               / "s.jsonl")
+    session.parent.mkdir(parents=True)
+    session.write_text("{}", encoding="utf-8")
+    report = muyan_pilot.doctor_report(config, installed)
+    assert "  current: #7 task https://github.com/xqliu/muyan-pilot/issues/7" in report
+    assert f"pi: {session}" in report
+
+
+def test_fake_doctor_commands_rejects_unexpected_commands(
+    tmp_path, monkeypatch,
+):
+    """The doctor fake must fail loudly on any command it does not
+    answer (no silent pass for an unexpected external call)."""
+    _deploy_world(tmp_path)
+    _fake_doctor_commands(monkeypatch)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        muyan_pilot.run_command(["gh", "issue", "list"])
+
+
+def test_doctor_report_fails_fast_when_a_command_fails(tmp_path, monkeypatch):
+    import subprocess
+
+    config, installed = _deploy_world(tmp_path, drift=False)
+    monkeypatch.setattr(
+        muyan_pilot, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, command, stderr="boom"),
+        ),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        muyan_pilot.doctor_report(config, installed)
+
+
+def test_main_doctor_prints_report_and_returns_zero(
+    monkeypatch, tmp_path, capsys,
+):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n",
+                      encoding="utf-8")
+    _write_prompts(tmp_path)
+    seen = {}
+
+    def fake_report(cfg, installed_dir):
+        seen["installed_dir"] = installed_dir
+        return "repo: /x\nunit_drift: clean"
+
+    monkeypatch.setattr(muyan_pilot, "doctor_report", fake_report)
+    assert muyan_pilot.main([
+        "doctor", "--config", str(config),
+        "--installed-dir", str(tmp_path / "u"),
+    ]) == 0
+    assert seen["installed_dir"] == tmp_path / "u"
+    out = capsys.readouterr().out
+    assert "unit_drift: clean" in out

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -1,0 +1,336 @@
+"""Systemd deployment consistency tests (Issue #103).
+
+The repo templates (``systemd/muyan-pilot.service`` and
+``muyan-pilot.timer``) are the single source of truth. The install
+command is idempotent and must never start/stop/restart the service:
+a currently running Runner keeps running, and the new config takes
+effect at the next service start. The pre-start check compares the
+installed units against the templates and fails fast with a
+structured ``unit_drift`` line when they drift.
+"""
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import systemd_deploy
+
+
+def make_repo(tmp_path: Path) -> Path:
+    """A deployment checkout carrying the two unit templates."""
+    repo = tmp_path / "repo"
+    systemd = repo / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "muyan-pilot.service").write_text(
+        "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n",
+        encoding="utf-8",
+    )
+    (systemd / "muyan-pilot.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/15\n", encoding="utf-8",
+    )
+    return repo
+
+
+def make_installed(
+    tmp_path: Path, repo: Path, mutate: str | None = None,
+) -> Path:
+    """An installed unit dir holding copies of the repo templates."""
+    installed = tmp_path / "home" / ".config" / "systemd" / "user"
+    installed.mkdir(parents=True)
+    for name in systemd_deploy.UNIT_NAMES:
+        (installed / name).write_bytes(
+            (repo / "systemd" / name).read_bytes(),
+        )
+    if mutate is not None:
+        (installed / mutate).write_text(
+            (installed / mutate).read_text(encoding="utf-8") + "# drift\n",
+            encoding="utf-8",
+        )
+    return installed
+
+
+def test_unit_names_cover_service_and_timer():
+    # The check must cover BOTH units (Issue #103 requirement).
+    assert systemd_deploy.UNIT_NAMES == (
+        "muyan-pilot.service", "muyan-pilot.timer",
+    )
+
+
+def test_repo_unit_dir_points_at_the_systemd_directory(tmp_path):
+    repo = tmp_path / "repo"
+    assert systemd_deploy.repo_unit_dir(repo) == repo / "systemd"
+
+
+def test_installed_unit_dir_defaults_to_the_user_config_dir(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.delenv("MUYAN_PILOT_UNIT_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert systemd_deploy.installed_unit_dir() == (
+        tmp_path / ".config" / "systemd" / "user"
+    )
+
+
+def test_installed_unit_dir_respects_xdg_config_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("MUYAN_PILOT_UNIT_DIR", raising=False)
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    assert systemd_deploy.installed_unit_dir() == (
+        xdg / "systemd" / "user"
+    )
+
+
+def test_installed_unit_dir_explicit_argument_wins(monkeypatch, tmp_path):
+    monkeypatch.delenv("MUYAN_PILOT_UNIT_DIR", raising=False)
+    target = tmp_path / "elsewhere"
+    assert systemd_deploy.installed_unit_dir(str(target)) == target
+
+
+def test_installed_unit_dir_env_override_wins(monkeypatch, tmp_path):
+    target = tmp_path / "override"
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(target))
+    assert systemd_deploy.installed_unit_dir() == target
+
+
+def test_sha256_hex_matches_the_file_content(tmp_path):
+    path = tmp_path / "unit.service"
+    path.write_bytes(b"[Service]\n")
+    assert systemd_deploy.sha256_hex(path) == hashlib.sha256(
+        b"[Service]\n",
+    ).hexdigest()
+
+
+def test_unit_status_reports_clean_when_templates_match(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    status = systemd_deploy.unit_status(repo, installed)
+    assert [entry["unit"] for entry in status] == list(
+        systemd_deploy.UNIT_NAMES,
+    )
+    for entry in status:
+        assert entry["drifted"] is False
+        assert entry["missing"] is False
+        assert entry["repo_sha256"] == entry["installed_sha256"]
+        assert entry["repo_path"] == repo / "systemd" / entry["unit"]
+        assert entry["installed_path"] == installed / entry["unit"]
+
+
+def test_unit_status_reports_drift_for_a_changed_unit(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.timer")
+    status = systemd_deploy.unit_status(repo, installed)
+    by_unit = {entry["unit"]: entry for entry in status}
+    assert by_unit["muyan-pilot.service"]["drifted"] is False
+    assert by_unit["muyan-pilot.timer"]["drifted"] is True
+    assert by_unit["muyan-pilot.timer"]["missing"] is False
+    assert (
+        by_unit["muyan-pilot.timer"]["repo_sha256"]
+        != by_unit["muyan-pilot.timer"]["installed_sha256"]
+    )
+
+
+def test_unit_status_reports_missing_installed_unit_as_drift(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    (installed / "muyan-pilot.service").unlink()
+    status = systemd_deploy.unit_status(repo, installed)
+    by_unit = {entry["unit"]: entry for entry in status}
+    assert by_unit["muyan-pilot.service"]["drifted"] is True
+    assert by_unit["muyan-pilot.service"]["missing"] is True
+    assert by_unit["muyan-pilot.service"]["installed_sha256"] is None
+    assert by_unit["muyan-pilot.timer"]["drifted"] is False
+
+
+def test_unit_status_reports_missing_template_as_drift(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    (repo / "systemd" / "muyan-pilot.timer").unlink()
+    status = systemd_deploy.unit_status(repo, installed)
+    by_unit = {entry["unit"]: entry for entry in status}
+    assert by_unit["muyan-pilot.timer"]["drifted"] is True
+    assert by_unit["muyan-pilot.timer"]["repo_sha256"] is None
+    assert by_unit["muyan-pilot.service"]["drifted"] is False
+
+
+def test_drift_lines_carry_paths_hashes_and_fix_command(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.service")
+    status = systemd_deploy.unit_status(repo, installed)
+    lines = systemd_deploy.drift_lines(status)
+    assert len(lines) == 1
+    line = lines[0]
+    assert line.startswith("unit_drift unit=muyan-pilot.service ")
+    assert f"repo={repo / 'systemd' / 'muyan-pilot.service'}" in line
+    assert f"installed={installed / 'muyan-pilot.service'}" in line
+    drifted = [e for e in status if e["drifted"]][0]
+    assert f"repo_sha256={drifted['repo_sha256']}" in line
+    assert f"installed_sha256={drifted['installed_sha256']}" in line
+    assert "fix=" in line
+    assert "install-units" in line
+
+
+def test_drift_lines_quote_values_with_spaces(tmp_path):
+    # A repo path that really carries a space: the field must be
+    # quoted (the pi_activity.quote_value convention) so the line
+    # stays parseable.
+    spaced = tmp_path / "my repo"
+    repo = make_repo(spaced)
+    installed = make_installed(spaced, repo, mutate="muyan-pilot.timer")
+    status = systemd_deploy.unit_status(repo, installed)
+    lines = systemd_deploy.drift_lines(status)
+    assert f'repo="{repo / "systemd" / "muyan-pilot.timer"}"' in lines[0]
+    assert f'installed="{installed / "muyan-pilot.timer"}"' in lines[0]
+
+
+def test_drift_lines_is_empty_when_clean(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    status = systemd_deploy.unit_status(repo, installed)
+    assert systemd_deploy.drift_lines(status) == []
+
+
+def test_check_unit_drift_raises_with_all_drifted_units(tmp_path, caplog):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.service")
+    (installed / "muyan-pilot.timer").unlink()
+    with caplog.at_level("ERROR"):
+        with pytest.raises(
+            systemd_deploy.UnitDriftError, match="unit_drift",
+        ) as excinfo:
+            systemd_deploy.check_unit_drift(repo, installed)
+    message = str(excinfo.value)
+    assert "muyan-pilot.service" in message
+    assert "muyan-pilot.timer" in message
+    assert "install-units" in message
+    # Every drifted unit is logged as a structured line.
+    assert "unit_drift unit=muyan-pilot.service" in caplog.text
+    assert "unit_drift unit=muyan-pilot.timer" in caplog.text
+
+
+def test_check_unit_drift_logs_clean_and_returns(tmp_path, caplog):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    with caplog.at_level("INFO"):
+        systemd_deploy.check_unit_drift(repo, installed)
+    assert "unit_drift clean" in caplog.text
+
+
+def test_check_unit_drift_uses_the_default_installed_dir(monkeypatch,
+                                                        tmp_path):
+    """Without an explicit dir the check reads the standard user dir
+    (the MUYAN_PILOT_UNIT_DIR override is honored)."""
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    systemd_deploy.check_unit_drift(repo)  # clean: must not raise
+
+
+def test_install_units_copies_templates_and_reloads(monkeypatch, tmp_path):
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "install"
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        return ""
+
+    result = systemd_deploy.install_units(
+        repo, installed, run_command=fake_run,
+    )
+    # Both templates are installed (overwritten) at the target dir.
+    for name in systemd_deploy.UNIT_NAMES:
+        assert (installed / name).read_bytes() == (
+            repo / "systemd" / name
+        ).read_bytes()
+    # daemon-reload runs, the timer is enabled (idempotent), and the
+    # service is NEVER started/stopped/restarted by the install.
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot.timer",
+    ] in calls
+    for command in calls:
+        if command[:2] == ["systemctl", "--user"]:
+            assert command[2] in ("daemon-reload", "enable")
+    # The deployed commit is the deployment checkout's HEAD.
+    assert result["commit"] == "0123456789abcdef0123456789abcdef01234567"
+    assert result["installed_dir"] == installed
+    assert sorted(result["units"]) == sorted(systemd_deploy.UNIT_NAMES)
+    for name in systemd_deploy.UNIT_NAMES:
+        entry = result["units"][name]
+        assert entry["installed_path"] == installed / name
+        assert entry["sha256"] == systemd_deploy.sha256_hex(
+            repo / "systemd" / name,
+        )
+
+
+def test_install_units_is_idempotent_and_overwrites_drift(
+    monkeypatch, tmp_path,
+):
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "install"
+    first = systemd_deploy.install_units(
+        repo, installed, run_command=lambda command, **kwargs: "",
+    )
+    # Simulate drift after the first install.
+    (installed / "muyan-pilot.service").write_text(
+        "tampered\n", encoding="utf-8",
+    )
+    second = systemd_deploy.install_units(
+        repo, installed, run_command=lambda command, **kwargs: "",
+    )
+    # The repo template wins again: the hashes are identical across
+    # installs (idempotent) and the drift is gone.
+    assert first["units"] == second["units"]
+    status = systemd_deploy.unit_status(repo, installed)
+    assert all(entry["drifted"] is False for entry in status)
+
+
+def test_install_units_defaults_to_the_standard_installed_dir(
+    monkeypatch, tmp_path,
+):
+    """Without an explicit dir the install targets the standard user
+    dir (here pointed at the test world via MUYAN_PILOT_UNIT_DIR)."""
+    repo = make_repo(tmp_path)
+    target = tmp_path / "std"
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(target))
+    result = systemd_deploy.install_units(
+        repo, run_command=lambda command, **kwargs: "",
+    )
+    assert result["installed_dir"] == target
+    for name in systemd_deploy.UNIT_NAMES:
+        assert (target / name).is_file()
+
+
+def test_install_units_fails_fast_when_a_systemctl_step_fails(
+    monkeypatch, tmp_path,
+):
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "install"
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "enable"]:
+            raise subprocess.CalledProcessError(1, command, stderr="nope")
+        return ""
+
+    with pytest.raises(subprocess.CalledProcessError):
+        systemd_deploy.install_units(
+            repo, installed, run_command=fake_run,
+        )
+
+
+def test_install_units_fails_fast_on_missing_template(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / "systemd" / "muyan-pilot.timer").unlink()
+    with pytest.raises(FileNotFoundError, match="muyan-pilot.timer"):
+        systemd_deploy.install_units(
+            repo, tmp_path / "install",
+            run_command=lambda command, **kwargs: "",
+        )
+
+
+def test_unit_drift_error_is_a_runtime_error():
+    assert issubclass(systemd_deploy.UnitDriftError, RuntimeError)

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TIMER_FILE = REPO_ROOT / "systemd" / "muyan-pilot.timer"
 SERVICE_FILE = REPO_ROOT / "systemd" / "muyan-pilot.service"
 README_FILE = REPO_ROOT / "README.md"
+AGENTS_FILE = REPO_ROOT / "AGENTS.md"
 
 
 def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
@@ -147,3 +148,91 @@ def test_parse_unit_rejects_key_before_any_section(tmp_path):
     bad.write_text("Description=orphan\n", encoding="utf-8")
     with pytest.raises(ValueError, match="unparseable unit line"):
         parse_unit(bad)
+
+
+# --- deployment consistency contract (Issue #103) ---------------------------
+
+
+def test_readme_documents_the_idempotent_install_command():
+    """Issue #103: the README must document the idempotent install
+    command (repo templates -> user systemd dir, daemon-reload,
+    enable timer, deployed commit/hash output) and the guarantee that
+    it never kills or restarts a running Runner (the new config takes
+    effect at the next service start)."""
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert "muyan_pilot.py install-units" in readme
+    assert "daemon-reload" in readme
+    # The manual cp is no longer the documented install path.
+    assert "cp systemd/muyan-pilot.service" not in readme
+    # Deployed commit/hash output.
+    assert "commit" in readme
+    assert "sha256" in readme
+    # The no-kill guarantee.
+    assert "不会" in readme
+    assert "重启" in readme
+
+
+def test_readme_documents_the_unit_drift_fail_fast():
+    """Issue #103: the README must document the pre-start drift check:
+    both units are compared against the repo templates, drift logs a
+    structured `unit_drift` line (repo path, installed path, hashes,
+    fix command) and fails fast without claiming any Issue until the
+    units are synced."""
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert "unit_drift" in readme
+    # Both units are covered.
+    assert "muyan-pilot.service" in readme
+    assert "muyan-pilot.timer" in readme
+    # The structured line's fields.
+    assert "repo_sha256=" in readme
+    assert "installed_sha256=" in readme
+    assert "fix=python3 muyan_pilot.py install-units" in readme
+    # No claim while drifted.
+    assert "不领取" in readme
+    # The repo templates are the single source of truth.
+    assert "唯一事实源" in readme
+
+
+def test_readme_documents_the_doctor_command():
+    """Issue #103: the README must document the read-only `doctor`
+    report: repo commit, unit drift, timer/service active state,
+    current Issue, Runner/Pi and recent journal activity."""
+    readme = README_FILE.read_text(encoding="utf-8")
+    assert "muyan_pilot.py doctor" in readme
+    assert "journal" in readme
+    # doctor is read-only.
+    assert "只读" in readme
+
+
+def test_readme_documents_the_full_deployment_sequence():
+    """Issue #103: the README must show the complete sequence from code
+    merge to the next Runner start: merge -> install units ->
+    daemon-reload -> timer next trigger -> ExecStartPre syncs
+    origin/main -> Runner starts one Issue."""
+    readme = README_FILE.read_text(encoding="utf-8")
+    sequence = readme.split("完整部署时序", 1)[-1]
+    assert "git merge 到 main" in sequence
+    assert "install units" in sequence
+    assert "daemon-reload" in sequence
+    assert "timer 下一次触发" in sequence
+    assert "ExecStartPre 同步 origin/main" in sequence
+    assert "Runner 启动并执行一个 Issue" in sequence
+
+
+def test_agents_md_documents_the_deployment_consistency_contract():
+    """Issue #103: AGENTS.md must carry the same contract: repo
+    templates as single source of truth, the idempotent install that
+    never kills/restarts a running Runner, the pre-start drift check
+    (structured `unit_drift`, fail fast, no claim), and the read-only
+    doctor."""
+    text = AGENTS_FILE.read_text(encoding="utf-8")
+    assert "single source of truth" in text
+    assert "install-units" in text
+    assert "unit_drift" in text
+    assert "daemon-reload" in text
+    assert "doctor" in text
+    # The install never touches a running Runner.
+    assert "never" in text
+    assert "restart" in text
+    # Drift blocks the start before any claim.
+    assert "no claim" in text or "no slot" in text


### PR DESCRIPTION
Fixes #103

<!-- muyan-pilot:run=ac7805eb -->

run_id=ac7805eb

## What

Verifiable systemd deployment flow: the repo templates (`systemd/muyan-pilot.service` + `.timer`) are the single source of truth, with an idempotent install, a pre-start drift check that fails fast, and a read-only `doctor` report.

- **`systemd_deploy.py` (new)** — `unit_status` compares BOTH installed units against the repo templates (missing template or missing installed unit is drift); `drift_lines` renders the structured `unit_drift unit=... repo=... installed=... repo_sha256=... installed_sha256=... fix=...` line (quote_value convention); `check_unit_drift` logs each drifted unit and raises `UnitDriftError`; `install_units` is idempotent (overwrite-copy both templates, `systemctl --user daemon-reload`, `systemctl --user enable --now muyan-pilot.timer`) and NEVER starts/stops/restarts the service — a running Runner is untouched, the new config takes effect at the next service start. It returns the deployed commit (deployment checkout HEAD) and unit hashes.
- **`bootstrap_runner.main`** — the drift preflight runs after `validate_config`, BEFORE any slot or claim: drift → structured `unit_drift` log + non-zero exit, no slot, no claim, no label change, until the units are synced. ExecStartPre base-freshness behavior is unchanged.
- **`muyan_pilot.py`** — `install-units` (prints `deployed commit=...` + per-unit sha256) and read-only `doctor` (repo commit, unit drift, timer/service active via `systemctl show -p ActiveState --value`, Runner slots, Pi session, current Issue per source repo, last 20 journal lines; `--installed-dir` override on both).
- **Docs** — README: new「部署一致性（Issue #103）」section (single source of truth, idempotent install with the no-kill guarantee, `unit_drift` fail-fast contract, doctor, and the full sequence `git merge 到 main → install units → daemon-reload → timer 下一次触发 → ExecStartPre 同步 origin/main → 漂移检查 → Runner 启动并执行一个 Issue`); the manual `cp` install block is replaced by `muyan_pilot.py install-units`. AGENTS.md: deployment-consistency bullet in the base-freshness section.

## Tests

- New `tests/test_systemd_deploy.py` (23 tests): status clean/drift/missing-template/missing-installed, drift line format + quoting, check raises/logs, install command sequence (daemon-reload + enable only — never the service), idempotency, deployed commit, fail-fast paths, installed-dir resolution (override/XDG/default).
- `tests/test_bootstrap_runner.py`: preflight wiring — drift blocks the claim before any slot (structured line fields asserted, no slot file, no claim), clean proceeds, preflight receives the configured repo_dir.
- `tests/conftest.py`: autouse default no-op for the preflight so in-process dispatch tests keep their tmp repo_dirs (drift tests re-stub explicitly).
- `tests/test_concurrency_e2e.py`: the clone carries the real templates; `start_runner` points `MUYAN_PILOT_UNIT_DIR` at a simulated deployment; new e2e: drifted unit → runner exits non-zero with `unit_drift`, no claim/slot/Pi; after the idempotent re-install the same start passes and claims.
- `tests/test_muyan_pilot.py`: doctor clean/drift/missing-unit/default-dir/current-issue+session/fail-fast, install-units report, CLI wiring.
- `tests/test_systemd_timer.py`: docs contract (install command + no-kill guarantee, `unit_drift` fields, doctor, full deployment sequence, AGENTS.md).

Full suite: **673 passed, 100% line/branch coverage** (`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`).

## Real-machine smoke (live deployment, recorded in the run's test.log)

- `install-units` (twice): `deployed commit=06780d4...`, identical unit sha256s, `muyan-pilot.service` stayed `active` before/after (the running Runner was never interrupted); the timer kept running since its original start (no restart).
- `doctor` on the live machine: `unit_drift: clean`, timer/service active, slots 1/1, Pi session, current Issue #103, recent journal.
- Drift (temp `MUYAN_PILOT_UNIT_DIR` with a stale timer; real units untouched): `doctor --installed-dir` reports `unit_drift: DRIFT` with repo/installed paths, both sha256s and the fix command; `bootstrap_runner.py` exits 1 with the structured `unit_drift` line BEFORE any gh traffic — Issue labels unchanged, no slot taken.
- Synced units: preflight logs `unit_drift clean`, then the normal flow continues (`capacity_full` — the live Runner holds the only slot), rc=0.

No database, queue, daemon or second state store: installed files + systemd + GitHub only.