### PR TITLE
feat: P0 urgent pickup priority — p0 label first, ai-blocked terminal, priority in logs/progress (Issue #101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,32 @@ is **one runtime outcome** (when X, should Y, actually Z).
 - No DAG, topological sort, or multi-worker scheduling: single-slot
   serial execution only reads the field, skips, and waits.
 
+## Pickup priority (P0)
+
+- Emergency priority is the plain GitHub label `p0` — NOT a delivery
+  state: it only orders the ready pickup, never changes the Issue
+  granularity (one Issue = one runtime outcome), any delivery state, or
+  the terminal-state semantics. The Runner never adds or removes it.
+- The ready pickup order is fixed: `ai-ready`+`p0` → `ai-ready`+`bug`
+  → plain `ai-ready` (three `gh issue list` scans sharing the exact
+  same exclusions and blockedBy semantics). P0 obeys every existing
+  exclusion rule (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`,
+  `ai-merged`, `ai-blocked`) and the single-slot constraint: a blocked
+  P0 is skipped (falling back to the bug/plain scans) and an in-flight
+  P0 is resumed by the restart scan (which fetches `labels` too, so the
+  progress comment keeps showing `p0`).
+- The pickup log line carries the explicit `priority=p0` /
+  `priority=normal` field; the GitHub progress comment shows the
+  `priority` field; the run scene (`run_info`) and the started
+  milestone carry `priority=...`.
+- A failed P0 run enters `ai-blocked` ALONE (the claim label is
+  removed; the `ai-ready` residue is excluded by every ready scan) —
+  no tick re-claims it, so there is no infinite retry; the failure
+  comment and blocked scene keep the concrete reason and the
+  recoverable scene.
+- review/merge failures of a P0 PR follow the existing same-PR, bounded
+  review-round mechanism (no new loop).
+
 ## Review, in-session fix and merge (same PR)
 
 - The review session is independent (a new Pi process, `prompt_review.md`,

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked
   gh label edit "$l" --repo xqliu/muyan-pilot \
     --description "Muyan Pilot delivery state (see README)"
 done
+# p0 是紧急优先级 label（不是交付状态，见「领取优先级（P0）」）
+gh label create p0 --repo xqliu/muyan-pilot --force --color "fbca04" \
+  --description "Muyan Pilot urgent priority: picked up before bugs and features"
 gh label list --repo xqliu/muyan-pilot
 ```
 
@@ -125,6 +128,7 @@ gh label list --repo xqliu/muyan-pilot
 | `ai-fix-needed` | 已有 PR 需要在原 branch/worktree/PR 上继续修复；定时 Runner 自动拾取 | 审查会话未能修复的 finding，或 PR 落后最新 base / merge conflict | 下一个审查会话（同一 PR）clean verdict 合并后移除（转 `ai-merged`）；超轮 / 无法修复时移除（转 `ai-blocked`） |
 | `ai-merged` | 成功终态：Runner 已合并 PR 并确认 merge commit 落在保护分支 | Runner 合并并确认后添加（替代 `ai-pr-opened`） | 终态，不再自动变更；PR body 的 `Fixes #N` 在 merge 时自动关闭 Issue |
 | `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | 命令失败、现场无法恢复、审查超轮等 fail fast 场景 | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
+| `p0` | 紧急优先级（**不是交付状态**）：只改变领取顺序，不改变 Issue 粒度、交付状态或终态语义 | 人工加 label（生产链路出现高优先级故障时） | 人工移除；Runner 从不增删该 label |
 
 ## 任务依赖（blockedBy）
 
@@ -143,6 +147,16 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 - 存在未关闭 blocker（blocker 节点 `state=OPEN`）→ **不领取**：不加 `ai-in-progress`、不改任何标签、不建 worktree，记录结构化日志 `blocked_by issue=N repo=... blockers=M1,M2`，继续检查同 repo 后面的 ready Issue；
 - blocker 关闭后不再阻塞：GitHub 会把该关系保留在列表中（节点 `state=CLOSED`，惰性，已对真实 API 验证），Runner 只统计未关闭 blocker——无需人工操作，下一 tick 该 Issue 自然可领；
 - `blockedBy` 查询失败 → **fail open**（视为未阻塞：本 tick 不从该 repo 领取，记录 `blocked_by_check_failed`，下一 tick 重试查询），API 异常不会死锁队列。
+
+## 领取优先级（P0）
+
+紧急优先级用普通 GitHub label `p0` 表示（**不是交付状态**）：它只表达处理优先级，不改变 Issue 粒度（仍要求一个 Issue 对应一个 runtime outcome），不改变任何交付状态或终态语义，Runner 也从不增删该 label。
+
+- ready 领取顺序固定为：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`（三次 `gh issue list` 扫描，共享同一组排除条件和 `blockedBy` 语义）；
+- P0 仍遵守全部现有排除规则（`ai-in-progress`、`ai-pr-opened`、`ai-fix-needed`、`ai-merged`、`ai-blocked`）和单 slot 约束：P0 被阻塞（open blocker）时跳过并回退到 bug/普通扫描，P0 已在途（`ai-in-progress`）时由重启恢复扫描接回（扫描同样携带 `labels`，恢复后进度评论继续显示 `p0`）；
+- 领取日志行携带明确的 `priority=p0` / `priority=normal` 字段；GitHub 进度评论显示 `priority` 字段；run 现场（`run_info`）与 started milestone 携带 `priority=...`；
+- P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；失败评论和 blocked 现场保留具体失败原因和可恢复现场；
+- P0 的 review/merge 失败沿用现有同一 PR、有限 review round（`MAX_REVIEW_ROUNDS=5`）机制，不引入新的循环。
 
 ## 自动可观测（正常运行不需要执行任何命令）
 
@@ -197,7 +211,8 @@ elapsed、last activity、last action、session、branch。implementer、reviewe
 **Pi 运行期间就是活的**：implementer、reviewer 两种 session 的每次
 活动变化/心跳都会渲染当前状态并 PATCH 同一条评论（不是等 Pi 退出后才
 回写），手机用户看到的始终是进行中的进展，而不是一条静态的 starting
-评论。评论始终显示：当前阶段、role、已运行时间、最近活动时间、最近动作、
+评论。评论始终显示：当前阶段、role、优先级（`p0`/`normal`，见「领取
+优先级（P0）」）、已运行时间、最近活动时间、最近动作、
 测试状态、review/fix round、branch、PR/merge 状态。进程重启后按 run marker
 找回同一条评论继续更新，不需要数据库。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -114,6 +114,13 @@ PR_OPENED_LABEL = "ai-pr-opened"
 FIX_NEEDED_LABEL = "ai-fix-needed"
 MERGED_LABEL = "ai-merged"
 BLOCKED_LABEL = "ai-blocked"
+# P0 urgent priority (Issue #101): a plain GitHub label, not a delivery
+# state. It only orders the ready pickup (`ai-ready`+`p0` first); it
+# never changes the delivery states, the blockedBy semantics or the
+# terminal states. A failed P0 run enters `ai-blocked` like every other
+# failed run — the ready scans exclude `ai-blocked`, so the `ai-ready`
+# residue never re-enters the queue (no infinite retry).
+P0_LABEL = "p0"
 
 # Only comments posted by a repo maintainer are trusted to carry the
 # recovery scene: a public comment (authorAssociation=NONE) must never
@@ -313,20 +320,44 @@ def open_blocker_numbers(issue: dict) -> list[int]:
     return numbers
 
 
-# Ready scans (Issue #71): bugs are claimed before new features — if
-# the delivery loop is broken, claiming enhancements only piles up
-# unreviewed PRs. The bug scan runs first with the exact same
-# exclusions; the plain ready scan only runs when the bug scan found
-# nothing claimable. No priority numbers, no separate queue, no new
-# state machine: two `gh issue list` searches with the same blockedBy
-# semantics (Issue #54).
+# Ready scans (Issue #71/#101): P0 urgent Issues are claimed before
+# bugs, bugs before new features — if the delivery loop is broken,
+# claiming enhancements only piles up unreviewed PRs, and a production
+# outage (P0) must not wait behind ordinary work. The P0 scan runs
+# first, then the bug scan, then the plain ready scan — each with the
+# exact same exclusions. No priority numbers, no separate queue, no
+# new state machine: three `gh issue list` searches with the same
+# blockedBy semantics (Issue #54). `p0` is a plain label, not a
+# delivery state: it only orders the pickup (Issue #101).
 READY_SCAN_EXCLUSIONS = (
     f"-label:{IN_PROGRESS_LABEL} -label:{PR_OPENED_LABEL} "
     f"-label:{FIX_NEEDED_LABEL} -label:{MERGED_LABEL} "
     f"-label:{BLOCKED_LABEL}"
 )
+P0_READY_SEARCH = f"label:ai-ready label:{P0_LABEL} {READY_SCAN_EXCLUSIONS}"
 BUG_READY_SEARCH = f"label:ai-ready label:bug {READY_SCAN_EXCLUSIONS}"
 READY_SEARCH = f"label:ai-ready {READY_SCAN_EXCLUSIONS}"
+
+
+def issue_priority(issue: dict) -> str:
+    """Return the pickup priority of one issue (Issue #101).
+
+    `p0` when the issue carries the `p0` label, `normal` otherwise.
+    The ready/in-flight/resumable scans fetch `labels` (verified
+    against `gh issue list --help`: `labels` is a supported JSON
+    field, an array of `{name, ...}` nodes), so this is a pure
+    function of the scanned issue — no extra gh call. A missing or
+    malformed `labels` field fails to `normal` (like the blockedBy
+    field fails open): a P0 misread as normal only loses its ordering
+    for one run, never the delivery.
+    """
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return "normal"
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") == P0_LABEL:
+            return "p0"
+    return "normal"
 
 
 def pick_issue(repo: str) -> dict | None:
@@ -337,14 +368,17 @@ def pick_issue(repo: str) -> dict | None:
     # reads the native GitHub dependency per Issue (Issue #54): an
     # Issue with open blockers is skipped — no claim, no label change,
     # no worktree — and the next ready Issue is considered instead.
-    # Issue #71: the bug scan runs first; a bug with open blockers is
-    # skipped there and the plain ready scan still decides.
-    for search in (BUG_READY_SEARCH, READY_SEARCH):
+    # Issue #71/#101: the P0 scan runs first, then the bug scan; a P0
+    # or bug with open blockers is skipped there and the next scan
+    # still decides. The scan also fetches `labels` so the picked
+    # issue's priority is visible without an extra gh call.
+    for search in (P0_READY_SEARCH, BUG_READY_SEARCH, READY_SEARCH):
         try:
             raw = run_command([
                 "gh", "issue", "list", "--repo", repo, "--state", "open",
                 "--search", search,
-                "--json", "number,title,body,blockedBy", "--limit", "200",
+                "--json", "number,title,body,labels,blockedBy",
+                "--limit", "200",
             ])
             issues = parse_issue_array(raw)
         except Exception as exc:
@@ -366,6 +400,12 @@ def pick_issue(repo: str) -> dict | None:
                     ",".join(str(number) for number in blockers),
                 )
                 continue
+            # The pickup log carries the explicit priority field
+            # (Issue #101): `p0` for urgent Issues, `normal` otherwise.
+            LOGGER.info(
+                "picked issue=%s repo=%s priority=%s",
+                issue.get("number"), repo, issue_priority(issue),
+            )
             return issue
     return None
 
@@ -404,7 +444,9 @@ def pick_in_progress_issue(
         "label:ai-ready label:ai-in-progress "
         f"-label:{PR_OPENED_LABEL} -label:{FIX_NEEDED_LABEL} "
         f"-label:{MERGED_LABEL} -label:{BLOCKED_LABEL}",
-        "--json", "number,title,body", "--limit", "1",
+        # `labels` (Issue #101): a P0 a killed runner left behind
+        # keeps its priority in the progress comment on resume.
+        "--json", "number,title,body,labels", "--limit", "1",
     ])
     return parse_issue_list(raw)
 
@@ -624,7 +666,9 @@ def pick_resumable_delivery(
         f"label:{FIX_NEEDED_LABEL},{PR_OPENED_LABEL} "
         f"-label:{BLOCKED_LABEL} -label:{MERGED_LABEL} "
         f"-label:{IN_PROGRESS_LABEL}",
-        "--json", "number,title,state,url", "--limit", "1",
+        # `labels` (Issue #101): a resumed P0 delivery keeps its
+        # priority in the progress comment through review/merge.
+        "--json", "number,title,state,url,labels", "--limit", "1",
     ])
     issues = parse_issue_array(raw)
     if not issues:
@@ -1368,6 +1412,7 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
                         review_round=review_rounds_so_far(
                             issue_comments(number, repo=source_repo),
                         ),
+                        priority=issue_priority(issue),
                     ),
                 )
         except Exception:
@@ -1718,7 +1763,7 @@ def sync_base_checkout(repo_dir: Path, base_branch: str) -> None:
 
 def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
                               config: dict, source_repo: str,
-                              number: int) -> bool:
+                              number: int, priority: str) -> bool:
     """Run one independent review round; merge when the verdict is clean.
 
     The delivery wait loop (which holds the slot) calls this while the
@@ -1772,7 +1817,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
         action=lambda: publisher.ensure(_progress_body(_progress_state(
             issue=number, run_id=config["run_id"], role=ROLE_REVIEW,
             branch=branch, worktree=worktree, started=started,
-            pr_url=pr["url"], review_round=round,
+            pr_url=pr["url"], review_round=round, priority=priority,
         ))),
     )
     output = run_review(
@@ -1781,6 +1826,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             publisher, issue=number, run_id=config["run_id"],
             role=ROLE_REVIEW, branch=branch, worktree=worktree,
             started=started, pr_url=pr["url"], review_round=round,
+            priority=priority,
         ),
     )
     verdict = parse_review_verdict(output)
@@ -1831,6 +1877,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
                     role=ROLE_REVIEW, branch=branch,
                     worktree=worktree, started=started,
                     pr_url=pr["url"], review_round=round,
+                    priority=priority,
                 ), outcome=(
                     "**Muyan Pilot review findings**\n\n"
                     f"round {round}: {verdict['blockers']} blocker(s), "
@@ -1905,6 +1952,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
                 role=ROLE_REVIEW, branch=branch,
                 worktree=worktree, started=started,
                 pr_url=merged["url"], review_round=round,
+                priority=priority,
             ), outcome=(
                 "**Muyan Pilot delivered**\n\n"
                 f"PR {merged['url']} merged "
@@ -2058,10 +2106,12 @@ def delivery_head_advanced(worktree: Path, base_sha: str) -> bool:
 
 def _progress_state(*, issue: int, run_id: str, role: str, branch: str,
                     worktree: Path, started: float, pr_url: str | None,
-                    review_round: int,
+                    review_round: int, priority: str,
                     activity: dict | None = None) -> dict:
     """Collect the current run state for the GitHub progress comment.
 
+    `priority` is the pickup priority of the issue (`p0` or `normal`,
+    Issue #101), derived from the issue's labels at claim/resume time.
     `activity` is the live state from the `stream_pi` watcher while a Pi
     session runs (fresh and already read); without it the newest session
     file is full-scanned. Activity snapshotting is best-effort
@@ -2078,6 +2128,7 @@ def _progress_state(*, issue: int, run_id: str, role: str, branch: str,
         "run_id": run_id,
         "issue": issue,
         "role": role,
+        "priority": priority,
         "phase": (activity or {}).get("phase") or "starting",
         "elapsed": format_elapsed(time.monotonic() - started),
         "last_activity": (activity or {}).get("last_activity"),
@@ -2156,7 +2207,7 @@ def _safe_publish(*, run_id: str, issue: int, source_repo: str,
 
 def _live_progress(publisher: ProgressPublisher, *, issue: int, run_id: str,
                    role: str, branch: str, worktree: Path, started: float,
-                   pr_url: str | None, review_round: int,
+                   pr_url: str | None, review_round: int, priority: str,
                    activity: dict | None = None) -> None:
     """One live GitHub progress update while a Pi session is running.
 
@@ -2172,7 +2223,8 @@ def _live_progress(publisher: ProgressPublisher, *, issue: int, run_id: str,
     state = _progress_state(
         issue=issue, run_id=run_id, role=role, branch=branch,
         worktree=worktree, started=started, pr_url=pr_url,
-        review_round=review_round, activity=activity,
+        review_round=review_round, priority=priority,
+        activity=activity,
     )
     publisher.patch(_progress_body(state))
 
@@ -2189,14 +2241,14 @@ class LiveProgressThrottle:
 
     def __init__(self, publisher: ProgressPublisher, *, issue: int,
                  run_id: str, role: str, branch: str, worktree: Path,
-                 started: float, pr_url: str | None,
-                 review_round: int) -> None:
+                 started: float, pr_url: str | None, review_round: int,
+                 priority: str) -> None:
         def publish(activity: dict) -> None:
             _live_progress(
                 publisher, issue=issue, run_id=run_id, role=role,
                 branch=branch, worktree=worktree, started=started,
                 pr_url=pr_url, review_round=review_round,
-                activity=activity,
+                priority=priority, activity=activity,
             )
 
         self._publish = publish
@@ -2248,8 +2300,13 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             )
     base_sha = freeze_base(config["repo_dir"], base_branch)
     branch = task_branch(source_repo, number, run_id)
+    # Pickup priority (Issue #101): derived from the scanned issue's
+    # labels (no extra gh call) and carried on every journal line and
+    # scene comment of the attempt via `run_info`.
+    priority = issue_priority(issue)
     run_info = (
-        f"base_branch={base_branch} base_sha={base_sha} run_id={run_id}"
+        f"base_branch={base_branch} base_sha={base_sha} run_id={run_id} "
+        f"priority={priority}"
     )
     LOGGER.info(
         "issue=%s %s", number, run_info,
@@ -2287,7 +2344,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
                 _progress_state(
                     issue=number, run_id=run_id, role=ROLE_IMPLEMENT,
                     branch=branch, worktree=worktree, started=started,
-                    pr_url=None, review_round=0,
+                    pr_url=None, review_round=0, priority=priority,
                 ),
             )),
         )
@@ -2304,6 +2361,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
                 publisher, issue=number, run_id=run_id,
                 role=ROLE_IMPLEMENT, branch=branch, worktree=worktree,
                 started=started, pr_url=None, review_round=0,
+                priority=priority,
             ),
         )
         _safe_publish(
@@ -2359,7 +2417,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             action=lambda: publisher.finish(_progress_body(_progress_state(
                 issue=number, run_id=run_id, role=ROLE_IMPLEMENT,
                 branch=branch, worktree=worktree, started=started,
-                pr_url=pr_url, review_round=0,
+                pr_url=pr_url, review_round=0, priority=priority,
             ), outcome="**Muyan Pilot delivered**")),
         )
         LOGGER.info(
@@ -2437,6 +2495,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
                             role=ROLE_IMPLEMENT, branch=branch,
                             worktree=worktree, started=started,
                             pr_url=None, review_round=0,
+                            priority=priority,
                         ), outcome=(
                             "**Muyan Pilot blocked**\n\n"
                             f"failure: {detail}\n"
@@ -2496,6 +2555,7 @@ def _finish_blocked_progress(
     worktree: Path | None, branch: str | None, pr_url: str,
     detail: str, next_step: str,
     role: str = ROLE_REVIEW, review_round: int = 0,
+    priority: str = "normal",
 ) -> None:
     """Finish the tracked progress comment with the blocked scene.
 
@@ -2521,7 +2581,7 @@ def _finish_blocked_progress(
         issue=number, run_id=run_id, role=role,
         branch=branch or "-", worktree=worktree or Path("-"),
         started=time.monotonic(), pr_url=pr_url,
-        review_round=review_round,
+        review_round=review_round, priority=priority,
     ), outcome=(
         "**Muyan Pilot blocked**\n\n"
         f"failure: {detail}\n"
@@ -2568,10 +2628,15 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
     number = int(issue["number"])
     run_id = current_run_id()
     marker = run_marker(run_id) if run_id else ""
+    # Pickup priority (Issue #101): derived from the scanned issue's
+    # labels (the resumable/in-flight scans fetch `labels`), so the
+    # progress comment of a resumed P0 delivery keeps showing `p0`
+    # through review/merge.
+    priority = issue_priority(issue)
     LOGGER.info(
-        "issue=%s delivery_awaiting pr=%s; holding the slot until the "
-        "PR is merged or terminally failed",
-        number, pr_url,
+        "issue=%s delivery_awaiting pr=%s priority=%s; holding the "
+        "slot until the PR is merged or terminally failed",
+        number, pr_url, priority,
     )
     while True:
         state = pr_state(pr_url)
@@ -2646,6 +2711,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                         "the delivery or start a fresh run on the "
                         "Issue",
                         role=ROLE_REVIEW, review_round=blocked_round,
+                        priority=priority,
                     ),
                 )
             return
@@ -2714,6 +2780,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 merged = review_and_merge_if_clean(
                     worktree, branch, config["base_branch"],
                     review_config, source_repo, number,
+                    priority=priority,
                 )
             except Exception as exc:
                 LOGGER.exception(
@@ -2775,6 +2842,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                             review_round=review_rounds_so_far(
                                 issue_comments(number, repo=source_repo),
                             ),
+                            priority=priority,
                         ),
                     )
                 return

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -47,8 +47,10 @@ Open an Issue with the `bug` label and include:
 - the Issue/PR state (labels) and the run id from the progress comment;
 - the environment: OS, Python version, Pi version, model endpoint type.
 
-Bug-labeled `ai-ready` Issues are picked up before new features (P0
-convention), so a broken delivery loop gets fixed first.
+Bug-labeled `ai-ready` Issues are picked up before new features, and
+`p0`-labeled urgent Issues are picked up first of all (see the workflow
+page), so a broken delivery loop — or a production outage — gets fixed
+first.
 
 ## Contributing code
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -94,6 +94,10 @@ for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked
   gh label edit "$l" --repo OWNER/PILOT-REPO \
     --description "Muyan Pilot delivery state (see docs)"
 done
+# p0 is the urgent-priority label (not a delivery state, see the
+# workflow page): picked up before bugs and features.
+gh label create p0 --repo OWNER/PILOT-REPO --force --color "fbca04" \
+  --description "Muyan Pilot urgent priority: picked up before bugs and features"
 gh label list --repo OWNER/PILOT-REPO
 ```
 
@@ -107,9 +111,9 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
 One tick does at most one thing: resume an opened PR (review/fix/merge) or
-claim one `ai-ready` Issue (bug-labeled Issues are picked before new
-features), then it exits. With an empty ready queue it exits cleanly
-without claiming anything.
+claim one `ai-ready` Issue (`p0`-labeled Issues are picked first, then
+bug-labeled Issues, then plain features), then it exits. With an empty
+ready queue it exits cleanly without claiming anything.
 
 ## 5. Smoke walkthrough (from zero)
 

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -111,13 +111,19 @@ DAG, no priority numbers, no separate queues:
   tag exists on the remote, and the release evidence is complete. Like
   any task it delivers through one PR (or closes the Epic when the
   evidence is already on the remote).
-- **P0 priority**: the convention that urgent bug fixes come before new
-  features. The current implementation is deliberately simple: the ready
-  scan picks `bug`-labeled `ai-ready` Issues before plain `ai-ready`
-  Issues (same exclusions, same blockedBy semantics) — if the delivery
-  loop is broken, claiming enhancements only piles up unreviewed PRs.
-  There is no priority number or weighted queue; dispatch order is the
-  only other lever (create the urgent Issue first).
+- **P0 priority**: the plain `p0` GitHub label marks an urgent Issue
+  (a production outage). It is NOT a delivery state — it only orders the
+  ready pickup, never changes the Issue granularity, any delivery state,
+  or the terminal-state semantics, and the Runner never adds or removes
+  it. The ready pickup order is fixed: `ai-ready`+`p0` →
+  `ai-ready`+`bug` → plain `ai-ready` (three `gh issue list` scans
+  sharing the exact same exclusions and blockedBy semantics). P0 obeys
+  every existing exclusion rule and the single-slot constraint: a
+  blocked P0 is skipped (falling back to the bug/plain scans) and an
+  in-flight P0 is resumed by the restart scan. A failed P0 run enters
+  `ai-blocked` ALONE (the claim label is removed; the `ai-ready`
+  residue is excluded by every ready scan), so no tick re-claims it —
+  no infinite retry. There is no priority number or weighted queue.
 
 Task dependencies between Issues use GitHub's native `blockedBy`
 relation (`gh issue edit N --add-blocked-by M`); the Runner reads the

--- a/progress.py
+++ b/progress.py
@@ -95,6 +95,9 @@ def progress_body(state: dict) -> str:
         # of the run.
         f"- run_id={state['run_id']}",
         f"- role: {value('role')}",
+        # Pickup priority (Issue #101): `p0` for urgent Issues,
+        # `normal` otherwise — visible at a glance on mobile.
+        f"- priority: {value('priority')}",
         f"- phase: {value('phase')}",
         f"- elapsed: {value('elapsed')}",
         f"- last activity: {value('last_activity')}",

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -280,6 +280,7 @@ def test_run_command_logs_optional_timeout_and_reraises(tmp_path, caplog):
 def test_pick_issue_uses_github_queue(monkeypatch):
     issue = {
         "number": 9, "title": "task", "body": "body",
+        "labels": [{"name": "ai-ready"}],
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
     calls = []
@@ -287,22 +288,32 @@ def test_pick_issue_uses_github_queue(monkeypatch):
     def fake_run(command, **kwargs):
         calls.append(command)
         search = command[command.index("--search") + 1]
-        if "label:bug" in search:
+        if "label:p0" in search or "label:bug" in search:
             return json.dumps([])
         return json.dumps([issue])
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.pick_issue("xqliu/muyan-ceo") == issue
-    # Issue #71: the bug scan runs first; with no bug in the queue the
-    # plain ready scan decides. Both keep the same exclusions.
+    # Issue #101: the P0 scan runs first, then the bug scan (Issue
+    # #71); with nothing in either queue the plain ready scan decides.
+    # All three keep the same exclusions.
     assert calls == [
+        [
+            "gh", "issue", "list", "--repo", "xqliu/muyan-ceo",
+            "--state", "open", "--search",
+            "label:ai-ready label:p0 -label:ai-in-progress "
+            "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+            "-label:ai-blocked",
+            "--json", "number,title,body,labels,blockedBy",
+            "--limit", "200",
+        ],
         [
             "gh", "issue", "list", "--repo", "xqliu/muyan-ceo",
             "--state", "open", "--search",
             "label:ai-ready label:bug -label:ai-in-progress "
             "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
             "-label:ai-blocked",
-            "--json", "number,title,body,blockedBy",
+            "--json", "number,title,body,labels,blockedBy",
             "--limit", "200",
         ],
         [
@@ -310,7 +321,7 @@ def test_pick_issue_uses_github_queue(monkeypatch):
             "--state", "open", "--search",
             "label:ai-ready -label:ai-in-progress -label:ai-pr-opened "
             "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
-            "--json", "number,title,body,blockedBy",
+            "--json", "number,title,body,labels,blockedBy",
             "--limit", "200",
         ],
     ]
@@ -477,54 +488,12 @@ def test_pick_issue_prefers_bug_labeled_issues(monkeypatch):
     Issue exist at the same time, the runner claims the bug first —
     if the delivery loop is broken, claiming enhancements only piles
     up unreviewed PRs. No priority numbers, no new state: the bug
-    scan runs first with the same exclusions, and the plain ready
-    scan only runs when the bug scan found nothing claimable."""
+    scan runs (after the P0 scan, Issue #101) with the same
+    exclusions, and the plain ready scan only runs when the bug scan
+    found nothing claimable."""
     bug = {
         "number": 11, "title": "bug", "body": "",
-        "blockedBy": {"nodes": [], "totalCount": 0},
-    }
-    searches = []
-
-    def fake_run(command, **kwargs):
-        searches.append(command[command.index("--search") + 1])
-        return json.dumps([bug])
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.pick_issue("xqliu/muyan-pilot") == bug
-    # The bug scan ran first and found the bug: the plain ready scan
-    # never ran.
-    assert len(searches) == 1
-    assert "label:bug" in searches[0]
-    assert "label:ai-ready" in searches[0]
-
-
-def test_pick_issue_bug_scan_keeps_existing_exclusions(monkeypatch):
-    """Issue #71: the bug scan keeps the exact same exclusions as the
-    ready scan (in-flight, opened-PR, fix-needed, merged, blocked)."""
-    bug = {
-        "number": 11, "title": "bug", "body": "",
-        "blockedBy": {"nodes": [], "totalCount": 0},
-    }
-    searches = []
-
-    def fake_run(command, **kwargs):
-        searches.append(command[command.index("--search") + 1])
-        return json.dumps([bug])
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    assert runner.pick_issue("xqliu/muyan-pilot") == bug
-    assert searches[0] == (
-        "label:ai-ready label:bug -label:ai-in-progress "
-        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
-        "-label:ai-blocked"
-    )
-
-
-def test_pick_issue_falls_back_to_ready_scan_when_no_bug(monkeypatch):
-    """Issue #71: with no claimable bug, behavior is exactly as before
-    (the plain ready scan runs second and decides)."""
-    feature = {
-        "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "bug"}, {"name": "ai-ready"}],
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
     searches = []
@@ -532,14 +501,73 @@ def test_pick_issue_falls_back_to_ready_scan_when_no_bug(monkeypatch):
     def fake_run(command, **kwargs):
         searches.append(command[command.index("--search") + 1])
         if "label:bug" in searches[-1]:
+            return json.dumps([bug])
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_issue("xqliu/muyan-pilot") == bug
+    # The P0 scan ran first and found nothing; the bug scan found the
+    # bug: the plain ready scan never ran.
+    assert len(searches) == 2
+    assert "label:p0" in searches[0]
+    assert "label:bug" in searches[1]
+    assert "label:ai-ready" in searches[1]
+
+
+def test_pick_issue_bug_scan_keeps_existing_exclusions(monkeypatch):
+    """Issue #71: the bug scan keeps the exact same exclusions as the
+    ready scan (in-flight, opened-PR, fix-needed, merged, blocked),
+    and runs after the P0 scan (Issue #101)."""
+    bug = {
+        "number": 11, "title": "bug", "body": "",
+        "labels": [{"name": "bug"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    searches = []
+
+    def fake_run(command, **kwargs):
+        searches.append(command[command.index("--search") + 1])
+        if "label:bug" in searches[-1]:
+            return json.dumps([bug])
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_issue("xqliu/muyan-pilot") == bug
+    assert searches[0] == (
+        "label:ai-ready label:p0 -label:ai-in-progress "
+        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+        "-label:ai-blocked"
+    )
+    assert searches[1] == (
+        "label:ai-ready label:bug -label:ai-in-progress "
+        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+        "-label:ai-blocked"
+    )
+
+
+def test_pick_issue_falls_back_to_ready_scan_when_no_bug(monkeypatch):
+    """Issue #71: with no claimable P0 or bug, behavior is exactly as
+    before (the plain ready scan runs last and decides)."""
+    feature = {
+        "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    searches = []
+
+    def fake_run(command, **kwargs):
+        searches.append(command[command.index("--search") + 1])
+        if "label:p0" in searches[-1] or "label:bug" in searches[-1]:
             return json.dumps([])
         return json.dumps([feature])
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.pick_issue("xqliu/muyan-pilot") == feature
-    assert len(searches) == 2
-    assert "label:bug" in searches[0]
-    assert "label:bug" not in searches[1]
+    assert len(searches) == 3
+    assert "label:p0" in searches[0]
+    assert "label:bug" in searches[1]
+    assert "label:bug" not in searches[2]
+    assert "label:p0" not in searches[2]
 
 
 def test_pick_issue_bug_blocked_by_open_blocker_falls_back(monkeypatch):
@@ -548,23 +576,27 @@ def test_pick_issue_bug_blocked_by_open_blocker_falls_back(monkeypatch):
     scan then decides."""
     blocked_bug = {
         "number": 11, "title": "bug", "body": "",
+        "labels": [{"name": "bug"}, {"name": "ai-ready"}],
         "blockedBy": {"nodes": [{"number": 9}], "totalCount": 1},
     }
     feature = {
         "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "ai-ready"}],
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
     searches = []
 
     def fake_run(command, **kwargs):
         searches.append(command[command.index("--search") + 1])
+        if "label:p0" in searches[-1]:
+            return json.dumps([])
         if "label:bug" in searches[-1]:
             return json.dumps([blocked_bug])
         return json.dumps([feature])
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.pick_issue("xqliu/muyan-pilot") == feature
-    assert len(searches) == 2
+    assert len(searches) == 3
 
 
 def test_pick_issue_bug_scan_failure_fails_open(monkeypatch, caplog):
@@ -581,13 +613,186 @@ def test_pick_issue_bug_scan_failure_fails_open(monkeypatch, caplog):
     assert "blocked_by_check_failed" in caplog.text
 
 
-def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):
-    """A killed runner leaves `ai-ready`+`ai-in-progress` behind (Issue
-    #18): the claim scan must recover such in-flight Issues, so the
-    restart resume (run id / worktree / progress comment reuse) is
-    reachable in the production flow — the ready scan alone excludes
-    `ai-in-progress` and would strand the run forever."""
-    issue = {"number": 18, "title": "task", "body": "body"}
+# --- Issue #101: P0 priority ---------------------------------------------------
+
+
+def test_pick_issue_prefers_p0_over_bug_and_plain(monkeypatch, caplog):
+    """Issue #101: when an `ai-ready`+`p0` Issue, an `ai-ready`+`bug`
+    Issue and a plain `ai-ready` Issue exist at the same time, the
+    runner claims the P0 first — the P0 scan runs first with the exact
+    same exclusions, and the bug/plain scans only run when the P0 scan
+    found nothing claimable. The journal line carries `priority=p0`."""
+    p0 = {
+        "number": 7, "title": "p0 outage", "body": "",
+        "labels": [{"name": "p0"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    bug = {
+        "number": 11, "title": "bug", "body": "",
+        "labels": [{"name": "bug"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    feature = {
+        "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    searches = []
+
+    def fake_run(command, **kwargs):
+        searches.append(command[command.index("--search") + 1])
+        # All three Issues exist in the repo; the P0 scan (the only
+        # scan that runs) sees them all and must pick the P0.
+        return json.dumps([p0, bug, feature])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == p0
+    # The P0 scan ran first and found the P0: the bug and plain ready
+    # scans never ran.
+    assert len(searches) == 1
+    assert "label:p0" in searches[0]
+    assert "label:ai-ready" in searches[0]
+    # The pickup log carries the explicit priority field.
+    assert "priority=p0" in caplog.text
+    assert "issue=7" in caplog.text
+
+
+def test_pick_issue_p0_scan_keeps_existing_exclusions(monkeypatch):
+    """Issue #101: the P0 scan keeps the exact same exclusions as the
+    bug and ready scans (in-flight, opened-PR, fix-needed, merged,
+    blocked) — a P0 in any delivery state is never claimed by the
+    ready scan (single-slot and resume semantics are unchanged)."""
+    p0 = {
+        "number": 7, "title": "p0", "body": "",
+        "labels": [{"name": "p0"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    searches = []
+
+    def fake_run(command, **kwargs):
+        searches.append(command[command.index("--search") + 1])
+        # Only the P0 scan runs (it finds the P0): it must carry the
+        # exact exclusions.
+        return json.dumps([p0])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_issue("xqliu/muyan-pilot") == p0
+    assert searches[0] == (
+        "label:ai-ready label:p0 -label:ai-in-progress "
+        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+        "-label:ai-blocked"
+    )
+
+
+def test_pick_issue_p0_blocked_by_open_blocker_falls_back_to_bug(
+    monkeypatch, caplog,
+):
+    """Issue #101: a P0 with open native blockers is skipped by the P0
+    scan (same blockedBy semantics as the other scans — no claim, no
+    label change, no worktree); the bug scan then decides."""
+    blocked_p0 = {
+        "number": 7, "title": "p0 blocked", "body": "",
+        "labels": [{"name": "p0"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [{"number": 3}], "totalCount": 1},
+    }
+    bug = {
+        "number": 11, "title": "bug", "body": "",
+        "labels": [{"name": "bug"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    searches = []
+
+    def fake_run(command, **kwargs):
+        searches.append(command[command.index("--search") + 1])
+        # Only the P0 and bug scans run (the bug scan claims the bug):
+        # the P0 scan sees the blocked P0, the bug scan the bug.
+        if "label:p0" in searches[-1]:
+            return json.dumps([blocked_p0])
+        return json.dumps([bug])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == bug
+    # The blocked P0 was skipped with the structured blocked_by line;
+    # the bug was claimed with priority=normal (it is not a P0).
+    assert "blocked_by" in caplog.text
+    assert "issue=7" in caplog.text
+    assert "3" in caplog.text
+    assert len(searches) == 2
+    assert "priority=normal" in caplog.text
+
+
+def test_pick_issue_p0_scan_failure_fails_open(monkeypatch, caplog):
+    """Issue #101: a failed P0 scan fails open like the other scans
+    (Issue #54) — the tick claims nothing from this repo, the error is
+    logged, never raised."""
+    error = subprocess.CalledProcessError(1, ["gh"], output="boom")
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(error),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") is None
+    assert "blocked_by_check_failed" in caplog.text
+
+
+def test_pick_issue_logs_priority_normal_for_plain_pickup(
+    monkeypatch, caplog,
+):
+    """Issue #101: a non-P0 pickup (bug or plain) logs
+    `priority=normal` — the explicit field is present on every
+    pickup, not only for P0."""
+    feature = {
+        "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+
+    def fake_run(command, **kwargs):
+        search = command[command.index("--search") + 1]
+        if "label:p0" in search or "label:bug" in search:
+            return json.dumps([])
+        return json.dumps([feature])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == feature
+    assert "priority=normal" in caplog.text
+    assert "issue=10" in caplog.text
+
+
+def test_issue_priority_reads_the_p0_label():
+    """Issue #101: `issue_priority` is a pure function of the issue's
+    `labels` (the scans fetch `labels`, so no extra gh call): `p0`
+    when the label is present, `normal` otherwise."""
+    assert runner.issue_priority({
+        "number": 7,
+        "labels": [{"name": "p0"}, {"name": "ai-ready"}],
+    }) == "p0"
+    assert runner.issue_priority({
+        "number": 10,
+        "labels": [{"name": "ai-ready"}, {"name": "bug"}],
+    }) == "normal"
+    assert runner.issue_priority({"number": 10}) == "normal"
+    # Malformed label fields never break the pickup (fail to normal,
+    # like the blockedBy field fails open): a P0 misread as normal
+    # only loses its ordering for one run, never the delivery.
+    assert runner.issue_priority({"number": 10, "labels": "nope"}) \
+        == "normal"
+    assert runner.issue_priority({
+        "number": 10, "labels": ["p0", {"name": 7}],
+    }) == "normal"
+
+
+def test_pick_in_progress_issue_scan_fetches_labels(monkeypatch, tmp_path):
+    """Issue #101: the in-flight restart scan fetches `labels` too, so
+    a P0 a killed runner left behind keeps its priority in the
+    progress comment on resume (the scan's exclusions are unchanged)."""
+    issue = {
+        "number": 18, "title": "task", "body": "body",
+        "labels": [{"name": "p0"}, {"name": "ai-ready"}],
+    }
     calls = []
 
     def fake_run(command, **kwargs):
@@ -604,7 +809,37 @@ def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):
         "--state", "open", "--search",
         "label:ai-ready label:ai-in-progress -label:ai-pr-opened "
         "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
-        "--json", "number,title,body", "--limit", "1",
+        "--json", "number,title,body,labels", "--limit", "1",
+    ]]
+
+
+def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):
+    """A killed runner leaves `ai-ready`+`ai-in-progress` behind (Issue
+    #18): the claim scan must recover such in-flight Issues, so the
+    restart resume (run id / worktree / progress comment reuse) is
+    reachable in the production flow — the ready scan alone excludes
+    `ai-in-progress` and would strand the run forever."""
+    issue = {
+        "number": 18, "title": "task", "body": "body",
+        "labels": [{"name": "ai-ready"}],
+    }
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return json.dumps([issue])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    # No slot dir yet: every slot is free, so the scan runs.
+    assert runner.pick_in_progress_issue(
+        "xqliu/muyan-pilot", tmp_path / "slots", 1,
+    ) == issue
+    assert calls == [[
+        "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
+        "--state", "open", "--search",
+        "label:ai-ready label:ai-in-progress -label:ai-pr-opened "
+        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
+        "--json", "number,title,body,labels", "--limit", "1",
     ]]
 
 
@@ -3399,7 +3634,7 @@ def test_stream_pi_live_progress_patches_github_before_child_exits(
     throttle = runner.LiveProgressThrottle(
         publisher, issue=24, run_id="run1", role="implement",
         branch="b", worktree=tmp_path, started=time.monotonic(),
-        pr_url=None, review_round=0,
+        pr_url=None, review_round=0, priority="normal",
     )
     result = runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
@@ -3459,7 +3694,7 @@ def test_live_progress_throttle_patches_on_change_and_cadence():
     throttle = runner.LiveProgressThrottle(
         publisher, issue=1, run_id="run1", role="implement",
         branch="b", worktree=Path("/w"), started=time.monotonic(),
-        pr_url=None, review_round=0,
+        pr_url=None, review_round=0, priority="normal",
     )
     first = {
         "phase": "starting", "action": None, "result": None,
@@ -4238,6 +4473,65 @@ def test_wait_for_delivery_auto_merges_on_clean_review(
     # PR state poll.
     assert pr_calls["n"] == 1
     assert "delivery_auto_merged" in caplog.text
+
+
+def test_wait_for_delivery_passes_p0_priority_to_the_review(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #101: a P0 delivery in an opened-PR state (the resumable
+    scan fetches `labels`) keeps its priority end to end: the awaiting
+    log line carries `priority=p0` and the independent review receives
+    it, so the review/merge progress comment shows `p0` too."""
+    states = ["OPEN"]
+    review_calls = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"] and command[2] == "view":
+            return json.dumps({"state": "OPEN"})
+        if command[:2] == ["gh", "issue"] and command[2] == "view":
+            if command[-1] == "comments":
+                return json.dumps({"comments": [
+                    {
+                        "body": (
+                            "<!-- muyan-pilot:run=a1b2c3d4 -->\n"
+                            "Muyan Pilot opened PR: "
+                            f"{PR_URL} (base_branch=main "
+                            "base_sha=abc123def456 run_id=a1b2c3d4)"
+                        ),
+                        "authorAssociation": "OWNER",
+                    },
+                ]})
+            return json.dumps({"labels": [
+                {"name": "ai-pr-opened"}, {"name": "p0"},
+            ]})
+        raise AssertionError(f"unexpected command: {command}")
+
+    # The fake rejects anything that is not a pr/issue view.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
+    monkeypatch.setattr(runner, "run_command", fake_run)
+
+    def fake_review(*args, **kwargs):
+        review_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", fake_review)
+    (tmp_path / ".worktrees"
+     / "muyan-pilot-owner-repo-issue-39-a1b2c3d4").mkdir(parents=True)
+    issue = {
+        "number": 39, "title": "p0 task", "body": "",
+        "labels": [{"name": "ai-pr-opened"}, {"name": "p0"}],
+    }
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    caplog.set_level("INFO")
+    runner.wait_for_delivery(
+        PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
+        "owner/repo",
+    )
+    assert review_calls == [{"priority": "p0"}]
+    # The awaiting log line carries the explicit priority field.
+    awaiting = [m for m in caplog.messages if "delivery_awaiting" in m]
+    assert any("priority=p0" in m for m in awaiting)
 
 
 def test_wait_for_delivery_marks_blocked_when_review_fails(

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -143,6 +143,46 @@ def test_readme_documents_upstream_dead_kill():
     assert "业务" in text
 
 
+def test_readme_documents_p0_priority_and_terminal_state():
+    """Issue #101: the README must document the P0 contract: the plain
+    `p0` label (not a delivery state), the fixed pickup order
+    (`ai-ready`+`p0` → `ai-ready`+`bug` → plain `ai-ready`), the
+    unchanged exclusion/single-slot semantics, and the terminal state
+    of a failed P0 (`ai-blocked`, never re-claimed — no infinite
+    retry)."""
+    text = README.read_text(encoding="utf-8")
+    # The label is documented in the table and the initialization.
+    assert "`p0`" in text
+    assert "gh label create p0" in text
+    # It is explicitly NOT a delivery state.
+    assert "不是交付状态" in text
+    # The fixed pickup order is documented.
+    assert "`ai-ready`+`p0`" in text
+    assert "`ai-ready`+`bug`" in text
+    # The existing exclusion rules and single-slot constraint apply.
+    assert "单 slot" in text
+    # The terminal state of a failed P0: ai-blocked, no infinite retry.
+    assert "无限重试" in text
+    assert "ai-blocked" in text
+
+
+def test_agents_md_documents_p0_priority():
+    """Issue #101: the development contract must document the same P0
+    semantics: plain label, fixed pickup order, unchanged exclusions
+    and single-slot constraint, `priority=` log/progress field, and the
+    `ai-blocked` terminal state without infinite retry."""
+    text = AGENTS.read_text(encoding="utf-8")
+    assert "pickup priority (p0)" in text.lower()
+    assert "`p0`" in text
+    assert "`ai-ready`+`p0`" in text
+    assert "`ai-ready`+`bug`" in text
+    # The explicit log/progress field.
+    assert "priority=p0" in text
+    # The terminal state without infinite retry.
+    assert "ai-blocked" in text
+    assert "no infinite retry" in text
+
+
 def test_agents_md_documents_upstream_dead_kill():
     """Issue #75: the development contract (AGENTS.md) must document
     the same upstream-dead behavior in its observability section: a

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -225,14 +225,20 @@ def test_docs_document_the_full_issue_to_merge_workflow():
 def test_docs_document_labels_run_marker_epic_release_task_and_p0():
     """The workflow page must give the basic explanation of the project's
     GitHub workflow vocabulary: the delivery labels, the run marker, Epic
-    coordination issues (ai-epic), Release tasks, and the bug-first (P0)
-    pickup order. Epic/Release task/P0 are workflow concepts — the docs
-    must not claim runner features that are not implemented yet (Issue
-    #93/#98/#101 are still open)."""
+    coordination issues (ai-epic), Release tasks, and the P0 pickup
+    order (the plain `p0` label, Issue #101: `ai-ready`+`p0` before
+    `ai-ready`+`bug` before plain `ai-ready`, failed P0 enters
+    `ai-blocked` with no infinite retry). Epic/Release task/P0 are
+    workflow concepts — the docs must not claim runner features that are
+    not implemented yet (Issue #93/#98 are still open)."""
     text = page_text("workflow")
     assert "ai-epic" in text, "workflow must explain Epic issues (ai-epic)"
     assert "Release" in text, "workflow must explain Release tasks"
-    assert "P0" in text, "workflow must explain the P0 (bug-first) priority"
+    assert "P0" in text, "workflow must explain the P0 priority"
+    # Issue #101: the P0 explanation names the plain `p0` label and the
+    # fixed pickup order (p0 before bug before plain).
+    assert "`p0`" in text, "P0 explanation must name the p0 label"
+    assert "`ai-ready`+`p0`" in text, "P0 explanation must show the order"
     assert "bug" in text.lower(), "P0 explanation must name the bug label"
     # The docs only reference labels that exist in the runner's label set.
     mentioned = set(LABEL_PATTERN.findall(text))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -138,6 +138,34 @@ def test_progress_body_shows_pr_url_when_present():
     assert "- review/fix round: 1" in body
 
 
+def test_progress_body_shows_priority_field():
+    """Issue #101: the live progress comment shows the pickup priority
+    (`p0` for urgent Issues, `normal` otherwise) right after the role,
+    so a mobile user sees at a glance that this run is a P0."""
+    state = {
+        "run_id": "abc123",
+        "issue": 7,
+        "role": "implement",
+        "phase": "test",
+        "elapsed": "3m 12s",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 0,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    }
+    body = progress.progress_body({**state, "priority": "p0"})
+    assert "- priority: p0" in body
+    # The priority line sits between role and phase.
+    lines = body.splitlines()
+    assert lines.index("- priority: p0") == \
+        lines.index("- role: implement") + 1
+    body = progress.progress_body({**state, "priority": "normal"})
+    assert "- priority: normal" in body
+
+
 def make_publisher(run_command=None, comments=None, posted=None,
                    post_response=None):
     """Build a ProgressPublisher over a fake gh layer.

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -9,7 +9,7 @@ summary or the blocked scene — in the same comment.
 import json
 import subprocess
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, call as mock_call
 
 import pytest
 
@@ -413,6 +413,99 @@ def test_process_issue_creates_progress_comment_with_marker(monkeypatch, tmp_pat
     assert "- role: implement" in body
     assert "- branch: muyan-pilot/xqliu-muyan-pilot-issue-18-a1b2c3d4" in body
     assert "- PR: -" in body
+
+
+def test_process_issue_p0_progress_comment_and_milestones_carry_priority(
+    monkeypatch, tmp_path,
+):
+    """Issue #101: a P0 pickup (the scan's issue dict carries `labels`)
+    shows `priority: p0` in the progress comment and `priority=p0` in
+    the journal/scene text (run_info, started milestone, started-Pi
+    scene comment) — the explicit field is visible end to end."""
+    calls, posted = make_fake_gh(monkeypatch)
+    patch_process_deps(monkeypatch, tmp_path)
+    edit = Mock()
+    # AFTER patch_process_deps: it installs its own edit_issue mock.
+    monkeypatch.setattr(runner, "edit_issue", edit)
+    issue = make_issue()
+    issue["labels"] = [{"name": "p0"}, {"name": "ai-ready"}]
+    runner.process_issue(issue, make_config(tmp_path), "xqliu/muyan-pilot")
+    progress_posts = [
+        body for body in posted if "**Muyan Pilot progress**" in body
+    ]
+    assert len(progress_posts) == 1
+    assert "- priority: p0" in progress_posts[0]
+    milestones = [
+        body for body in posted
+        if any(line.startswith(progress.MILESTONE_PREFIX)
+               for line in body.splitlines())
+    ]
+    started = [b for b in milestones if "Muyan Pilot: started" in b]
+    assert started, f"no started milestone: {milestones}"
+    assert "priority=p0" in started[0]
+    # The started-Pi scene comment (run_info) carries the priority too.
+    scene_comments = [
+        call for call in calls
+        if call[:2] == ["gh", "issue"] and "comment" in call
+    ]
+    assert any("priority=p0" in call[-1] for call in scene_comments)
+
+
+def test_process_issue_p0_failure_enters_ai_blocked_terminal_state(
+    monkeypatch, tmp_path,
+):
+    """Issue #101: a failed P0 run enters the terminal state
+    `ai-blocked` ALONE (the claim label is removed, the `ai-ready`
+    residue is excluded by every ready scan) — no tick can re-claim it,
+    so there is no infinite retry; the blocked scene keeps the
+    priority visible and the concrete failure reason."""
+    calls, posted = make_fake_gh(monkeypatch)
+    patch_process_deps(
+        monkeypatch, tmp_path,
+        run_pi_side_effect=subprocess.CalledProcessError(
+            3, ["pi"], stderr="pi exploded",
+        ),
+    )
+    edit = Mock()
+    # AFTER patch_process_deps: it installs its own edit_issue mock.
+    monkeypatch.setattr(runner, "edit_issue", edit)
+    issue = make_issue()
+    issue["labels"] = [{"name": "p0"}, {"name": "ai-ready"}]
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_issue(issue, make_config(tmp_path),
+                             "xqliu/muyan-pilot")
+    # Claim first, then the terminal state: `ai-blocked` added,
+    # `ai-in-progress` removed.
+    assert edit.call_args_list[0] == mock_call(
+        18, repo="xqliu/muyan-pilot", add="ai-in-progress",
+    )
+    assert edit.call_args_list[1] == mock_call(
+        18, repo="xqliu/muyan-pilot", add="ai-blocked",
+        remove="ai-in-progress",
+    )
+    # The failure comment carries the run marker and the reason.
+    failure_comments = [
+        call for call in calls
+        if call[:2] == ["gh", "issue"] and "comment" in call
+        and "Muyan Pilot failed" in call[-1]
+    ]
+    assert failure_comments, f"no failure comment: {calls}"
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure_comments[0][-1]
+    assert "pi exploded" in failure_comments[0][-1]
+    # The blocked progress scene keeps the priority visible.
+    final_patches = [
+        command for command in calls
+        if command[:2] == ["gh", "api"]
+        and command[2] == "repos/xqliu/muyan-pilot/issues/comments/77"
+        and "PATCH" in command
+    ]
+    assert final_patches, "no PATCH of the progress comment"
+    last_body = final_patches[-1][
+        final_patches[-1].index("--field") + 1
+    ][len("body="):] if final_patches else ""
+    assert "Muyan Pilot blocked" in last_body
+    assert "- priority: p0" in last_body
+    assert "pi exploded" in last_body
 
 
 def test_process_issue_passes_issue_number_to_verify_pr(
@@ -1265,7 +1358,7 @@ def _run_review_and_merge(monkeypatch, tmp_path, *, verdict,
         tmp_path, "branch", "main",
         {"repo_dir": tmp_path, "base_branch": "main", "base_sha": "b1",
          "run_id": "a1b2c3d4"},
-        "xqliu/muyan-pilot", 18,
+        "xqliu/muyan-pilot", 18, priority="normal",
     )
     return merged, edits, calls, posted
 

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -486,6 +486,9 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     }
     merged = runner.review_and_merge_if_clean(
         worktree, branch, "main", review_config, REPO, ISSUE_NUMBER,
+        # Issue #101: the wait loop derives the priority from the
+        # scanned issue's labels (no extra gh call).
+        priority=runner.issue_priority(issue()),
     )
     assert merged is True
     assert pr["merged"] is True

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -340,7 +340,9 @@ def test_pick_resumable_delivery_returns_newest_issue_with_scene(
         "--search",
         "label:ai-fix-needed,ai-pr-opened "
         "-label:ai-blocked -label:ai-merged -label:ai-in-progress",
-        "--json", "number,title,state,url", "--limit", "1",
+        # `labels` (Issue #101): a resumed P0 delivery keeps its
+        # priority in the progress comment through review/merge.
+        "--json", "number,title,state,url,labels", "--limit", "1",
     ]
     assert calls[1] == [
         "gh", "issue", "view", "9", "--repo", "owner/repo",
@@ -374,7 +376,9 @@ def test_pick_resumable_delivery_scans_fix_needed_and_awaiting_review(
         "--search",
         "label:ai-fix-needed,ai-pr-opened "
         "-label:ai-blocked -label:ai-merged -label:ai-in-progress",
-        "--json", "number,title,state,url", "--limit", "1",
+        # `labels` (Issue #101): a resumed P0 delivery keeps its
+        # priority in the progress comment through review/merge.
+        "--json", "number,title,state,url,labels", "--limit", "1",
     ]]
 
 

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -643,6 +643,7 @@ def test_review_and_merge_clean_verdict_merges_and_labels_merged(
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is True
     assert "sync" in calls
@@ -697,6 +698,7 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is True
     # The merge gate ran against the RE-FROZEN (fixed) head...
@@ -736,6 +738,7 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is True
     assert calls == [("gate", "h1")]
@@ -772,6 +775,7 @@ def test_review_and_merge_keeps_merged_when_checkout_sync_fails(
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is True
     assert ("edit", {"repo": "owner/repo", "add": "ai-merged",
@@ -811,6 +815,7 @@ def test_review_and_merge_findings_labels_fix_needed_and_comments(
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is False
     # The findings are recorded on Issue and PR with the run marker...
@@ -855,6 +860,7 @@ def test_review_and_merge_behind_base_labels_fix_needed(monkeypatch, tmp_path):
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is False
     # A behind head is never merged: the fixer absorbs the latest base.
@@ -894,6 +900,7 @@ def test_review_and_merge_conflict_labels_fix_needed(monkeypatch, tmp_path):
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
         "owner/repo", 4,
+        priority="normal",
     )
     assert merged is False
     assert "merge conflict" in calls[0][1] or "not mergeable" in calls[0][1]
@@ -919,6 +926,7 @@ def test_review_and_merge_reraises_non_fixable_gate_error(monkeypatch, tmp_path)
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
             "owner/repo", 4,
+            priority="normal",
         )
 
 
@@ -933,6 +941,7 @@ def test_review_and_merge_missing_verdict_raises(monkeypatch, tmp_path):
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
             "owner/repo", 4,
+            priority="normal",
         )
 
 
@@ -952,5 +961,6 @@ def test_review_and_merge_exhausted_rounds_raises(monkeypatch, tmp_path, caplog)
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
             "owner/repo", 4,
+            priority="normal",
         )
     assert "review_rounds_exhausted" in caplog.text


### PR DESCRIPTION
Fixes #101

<!-- muyan-pilot:run=159f66e6 -->

run_id=159f66e6

## 变更

给 Runner 增加最小的 P0 紧急优先级能力（Issue #101）：

- **pickup 顺序固定**：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`
  （`pick_issue` 三次 `gh issue list` 扫描，共享同一组排除条件和
  `blockedBy` 语义；`p0` 是普通 label，不是交付状态）。
- **P0 遵守现有约束**：blockedBy（open blocker 跳过并回退）、
  `ai-in-progress`/`ai-pr-opened`/`ai-fix-needed`/`ai-merged`/`ai-blocked`
  排除规则、单 slot 约束全部不变。
- **P0 失败终态**：执行失败进入 `ai-blocked`（alone，移除领取标签）；
  `ai-ready` 残留被所有 ready 扫描排除，没有任何 tick 重新领取——
  无无限重试；失败评论/blocked 现场保留具体原因和可恢复现场。
- **review/merge 失败**：沿用现有同一 PR + 有限 review round
  （`MAX_REVIEW_ROUNDS=5`）机制，不引入新循环。
- **可观测**：领取日志行 `picked issue=N repo=R priority=p0|normal`、
  `delivery_awaiting ... priority=...`、run 现场 `run_info` 与
  started milestone 携带 `priority=...`；GitHub 进度评论新增
  `- priority: p0|normal` 字段（implement 与 review 两个 role 都显示，
  三个扫描的 `--json` 都带 `labels`，恢复的 P0 在 review/merge 期间
  继续显示 `p0`）。
- **文档**：`AGENTS.md` 新增「Pickup priority (P0)」节；`README.md`
  label 初始化循环 + label 表 + 「领取优先级（P0）」节；docs 站点
  （workflow/getting-started/contributing）同步更新。

## 测试

- 新增 13 个测试（P0 抢占普通 bug、P0 扫描排除条件、P0 与 blockedBy
  回退、P0 扫描失败 fail open、领取日志 `priority=`、`issue_priority`
  纯函数、in-flight 扫描带 labels、P0 进度评论/milestone 携带 priority、
  P0 失败终态 `ai-blocked` alone、review 路径传递 priority、
  进度评论 priority 字段、README/AGENTS 文档契约）。
- 全量 pytest 通过：686 passed；100% line/branch coverage
  （`coverage run --branch -m pytest tests/ -q` +
  `coverage report --fail-under=100`）。
- 外部契约已验证：`gh issue list --help` 的 JSON FIELDS 包含 `labels`，
  真实调用返回 `labels: [{name, ...}]`（与 `issue_labels()` 解析形状一致）。
