### PR TITLE
Progress comment issue line shows number and title (Issue #100)

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1408,6 +1408,7 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
                         f"{scene['pr_url']} failed: {exc}",
                         "fix the resume verification failure above "
                         "and resume the delivery of this same PR",
+                        title=issue["title"],
                         role=ROLE_REVIEW,
                         review_round=review_rounds_so_far(
                             issue_comments(number, repo=source_repo),
@@ -1763,8 +1764,12 @@ def sync_base_checkout(repo_dir: Path, base_branch: str) -> None:
 
 def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
                               config: dict, source_repo: str,
-                              number: int, priority: str) -> bool:
+                              number: int, title: str, priority: str) -> bool:
     """Run one independent review round; merge when the verdict is clean.
+
+    `title` is the issue's GitHub title (Issue #100): the review
+    progress scenes (ensure, findings, merged) show `#<number> <title>`
+    like every other scene; it is required, never fabricated.
 
     The delivery wait loop (which holds the slot) calls this while the
     PR is open and the Issue awaits review (`ai-pr-opened`) or awaits the
@@ -1815,18 +1820,19 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
         run_id=config["run_id"], issue=number,
         source_repo=source_repo, role=ROLE_REVIEW,
         action=lambda: publisher.ensure(_progress_body(_progress_state(
-            issue=number, run_id=config["run_id"], role=ROLE_REVIEW,
-            branch=branch, worktree=worktree, started=started,
-            pr_url=pr["url"], review_round=round, priority=priority,
+            issue=number, title=title, run_id=config["run_id"],
+            role=ROLE_REVIEW, branch=branch, worktree=worktree,
+            started=started, pr_url=pr["url"], review_round=round,
+            priority=priority,
         ))),
     )
     output = run_review(
         worktree, pr, config, source_repo, number, branch, round,
         progress=LiveProgressThrottle(
-            publisher, issue=number, run_id=config["run_id"],
-            role=ROLE_REVIEW, branch=branch, worktree=worktree,
-            started=started, pr_url=pr["url"], review_round=round,
-            priority=priority,
+            publisher, issue=number, title=title,
+            run_id=config["run_id"], role=ROLE_REVIEW, branch=branch,
+            worktree=worktree, started=started, pr_url=pr["url"],
+            review_round=round, priority=priority,
         ),
     )
     verdict = parse_review_verdict(output)
@@ -1873,7 +1879,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             source_repo=source_repo, role=ROLE_REVIEW,
             action=lambda: publisher.finish(_progress_body(
                 _progress_state(
-                    issue=number, run_id=config["run_id"],
+                    issue=number, title=title, run_id=config["run_id"],
                     role=ROLE_REVIEW, branch=branch,
                     worktree=worktree, started=started,
                     pr_url=pr["url"], review_round=round,
@@ -1948,7 +1954,7 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
         source_repo=source_repo, role=ROLE_REVIEW,
         action=lambda: publisher.finish(_progress_body(
             _progress_state(
-                issue=number, run_id=config["run_id"],
+                issue=number, title=title, run_id=config["run_id"],
                 role=ROLE_REVIEW, branch=branch,
                 worktree=worktree, started=started,
                 pr_url=merged["url"], review_round=round,
@@ -2104,12 +2110,18 @@ def delivery_head_advanced(worktree: Path, base_sha: str) -> bool:
     return head != base_sha
 
 
-def _progress_state(*, issue: int, run_id: str, role: str, branch: str,
-                    worktree: Path, started: float, pr_url: str | None,
-                    review_round: int, priority: str,
+def _progress_state(*, issue: int, title: str, run_id: str, role: str,
+                    branch: str, worktree: Path, started: float,
+                    pr_url: str | None, review_round: int, priority: str,
                     activity: dict | None = None) -> dict:
     """Collect the current run state for the GitHub progress comment.
 
+    `title` is the issue's GitHub title (Issue #100): the progress
+    comment's issue line shows `#<number> <title>` in every scene. It
+    is required — the GitHub issue data contract guarantees a
+    non-empty string title (every runner scan fetches it), and a
+    missing title fails fast in `progress.issue_field` instead of
+    fabricating one.
     `priority` is the pickup priority of the issue (`p0` or `normal`,
     Issue #101), derived from the issue's labels at claim/resume time.
     `activity` is the live state from the `stream_pi` watcher while a Pi
@@ -2127,6 +2139,7 @@ def _progress_state(*, issue: int, run_id: str, role: str, branch: str,
     return {
         "run_id": run_id,
         "issue": issue,
+        "issue_title": title,
         "role": role,
         "priority": priority,
         "phase": (activity or {}).get("phase") or "starting",
@@ -2205,9 +2218,10 @@ def _safe_publish(*, run_id: str, issue: int, source_repo: str,
         )
 
 
-def _live_progress(publisher: ProgressPublisher, *, issue: int, run_id: str,
-                   role: str, branch: str, worktree: Path, started: float,
-                   pr_url: str | None, review_round: int, priority: str,
+def _live_progress(publisher: ProgressPublisher, *, issue: int,
+                   title: str, run_id: str, role: str, branch: str,
+                   worktree: Path, started: float, pr_url: str | None,
+                   review_round: int, priority: str,
                    activity: dict | None = None) -> None:
     """One live GitHub progress update while a Pi session is running.
 
@@ -2221,9 +2235,9 @@ def _live_progress(publisher: ProgressPublisher, *, issue: int, run_id: str,
     ensures first.
     """
     state = _progress_state(
-        issue=issue, run_id=run_id, role=role, branch=branch,
-        worktree=worktree, started=started, pr_url=pr_url,
-        review_round=review_round, priority=priority,
+        issue=issue, title=title, run_id=run_id, role=role,
+        branch=branch, worktree=worktree, started=started,
+        pr_url=pr_url, review_round=review_round, priority=priority,
         activity=activity,
     )
     publisher.patch(_progress_body(state))
@@ -2240,13 +2254,14 @@ class LiveProgressThrottle:
     """
 
     def __init__(self, publisher: ProgressPublisher, *, issue: int,
-                 run_id: str, role: str, branch: str, worktree: Path,
-                 started: float, pr_url: str | None, review_round: int,
-                 priority: str) -> None:
+                 title: str, run_id: str, role: str, branch: str,
+                 worktree: Path, started: float, pr_url: str | None,
+                 review_round: int, priority: str) -> None:
         def publish(activity: dict) -> None:
             _live_progress(
-                publisher, issue=issue, run_id=run_id, role=role,
-                branch=branch, worktree=worktree, started=started,
+                publisher, issue=issue, title=title, run_id=run_id,
+                role=role, branch=branch, worktree=worktree,
+                started=started,
                 pr_url=pr_url, review_round=review_round,
                 priority=priority, activity=activity,
             )
@@ -2271,6 +2286,12 @@ class LiveProgressThrottle:
 
 def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
+    # Issue #100: the progress comment's issue line shows the number
+    # AND the title in every scene. The scanned issue dict always
+    # carries the GitHub title (every scan fetches `title`); a missing
+    # or non-string title fails fast here (KeyError / ValueError in
+    # `progress.issue_field`) — it is never fabricated.
+    title = issue["title"]
     base_branch = config["base_branch"]
     # The run id is generated once per attempt and bound BEFORE any
     # other step is logged, so every journal line of the attempt
@@ -2342,8 +2363,9 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             role=ROLE_IMPLEMENT,
             action=lambda: publisher.ensure(_progress_body(
                 _progress_state(
-                    issue=number, run_id=run_id, role=ROLE_IMPLEMENT,
-                    branch=branch, worktree=worktree, started=started,
+                    issue=number, title=title, run_id=run_id,
+                    role=ROLE_IMPLEMENT, branch=branch,
+                    worktree=worktree, started=started,
                     pr_url=None, review_round=0, priority=priority,
                 ),
             )),
@@ -2358,7 +2380,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         run_pi(
             issue, worktree, config, source_repo, branch=branch,
             progress=LiveProgressThrottle(
-                publisher, issue=number, run_id=run_id,
+                publisher, issue=number, title=title, run_id=run_id,
                 role=ROLE_IMPLEMENT, branch=branch, worktree=worktree,
                 started=started, pr_url=None, review_round=0,
                 priority=priority,
@@ -2415,8 +2437,9 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_IMPLEMENT,
             action=lambda: publisher.finish(_progress_body(_progress_state(
-                issue=number, run_id=run_id, role=ROLE_IMPLEMENT,
-                branch=branch, worktree=worktree, started=started,
+                issue=number, title=title, run_id=run_id,
+                role=ROLE_IMPLEMENT, branch=branch,
+                worktree=worktree, started=started,
                 pr_url=pr_url, review_round=0, priority=priority,
             ), outcome="**Muyan Pilot delivered**")),
         )
@@ -2491,7 +2514,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
                     source_repo=source_repo, role=ROLE_IMPLEMENT,
                     action=lambda: publisher.finish(_progress_body(
                         _progress_state(
-                            issue=number, run_id=run_id,
+                            issue=number, title=title, run_id=run_id,
                             role=ROLE_IMPLEMENT, branch=branch,
                             worktree=worktree, started=started,
                             pr_url=None, review_round=0,
@@ -2553,11 +2576,15 @@ def issue_labels(number: int, repo: str) -> list[str]:
 def _finish_blocked_progress(
     number: int, run_id: str | None, source_repo: str,
     worktree: Path | None, branch: str | None, pr_url: str,
-    detail: str, next_step: str,
+    detail: str, next_step: str, title: str,
     role: str = ROLE_REVIEW, review_round: int = 0,
     priority: str = "normal",
 ) -> None:
     """Finish the tracked progress comment with the blocked scene.
+
+    `title` is the issue's GitHub title (Issue #100): the blocked scene
+    shows `#<number> <title>` like every other progress scene; it is
+    required, never fabricated.
 
     The contract (Issue #18): on failure the progress comment becomes
     the blocked scene with the next-step reason — the same terminal
@@ -2578,7 +2605,7 @@ def _finish_blocked_progress(
         number, source_repo, run_id, run_command=run_command,
     )
     publisher.ensure(_progress_body(_progress_state(
-        issue=number, run_id=run_id, role=role,
+        issue=number, title=title, run_id=run_id, role=role,
         branch=branch or "-", worktree=worktree or Path("-"),
         started=time.monotonic(), pr_url=pr_url,
         review_round=review_round, priority=priority,
@@ -2626,6 +2653,11 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
     the open descriptor). No polling shim, no daemon loop, no queue.
     """
     number = int(issue["number"])
+    # Issue #100: the progress comment's issue line shows the number
+    # AND the title in every scene; the scanned issue dict always
+    # carries the GitHub title (every scan fetches `title`) — a
+    # missing or non-string title fails fast, never fabricated.
+    title = issue["title"]
     run_id = current_run_id()
     marker = run_marker(run_id) if run_id else ""
     # Pickup priority (Issue #101): derived from the scanned issue's
@@ -2710,6 +2742,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                         "investigate why the PR was closed and re-open "
                         "the delivery or start a fresh run on the "
                         "Issue",
+                        title=title,
                         role=ROLE_REVIEW, review_round=blocked_round,
                         priority=priority,
                     ),
@@ -2780,7 +2813,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 merged = review_and_merge_if_clean(
                     worktree, branch, config["base_branch"],
                     review_config, source_repo, number,
-                    priority=priority,
+                    title=title, priority=priority,
                 )
             except Exception as exc:
                 LOGGER.exception(
@@ -2838,6 +2871,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                             f"failed: {exc}",
                             "fix the review failure above and resume "
                             "the delivery of this same PR",
+                            title=title,
                             role=ROLE_REVIEW,
                             review_round=review_rounds_so_far(
                                 issue_comments(number, repo=source_repo),

--- a/progress.py
+++ b/progress.py
@@ -63,6 +63,27 @@ def find_progress_comment(
     return None
 
 
+def issue_field(issue: int, title: str) -> str:
+    """Render the progress comment's issue value: `#<number> <title>`.
+
+    Issue #100: the issue line shows the number AND the title so a
+    mobile user sees what the agent works on without opening GitHub.
+    The `#<number>` prefix is preserved so existing log/scene parsing
+    keeps working. The title is flattened to a single line (whitespace
+    collapsed) so spaces, Markdown and long titles stay readable.
+    A missing or non-string title violates the GitHub issue data
+    contract (issues always carry a non-empty string title) and fails
+    fast — a title is never fabricated.
+    """
+    if not isinstance(issue, int) or isinstance(issue, bool):
+        raise ValueError(f"issue number must be an int, got {issue!r}")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError(
+            f"issue title must be a non-empty string, got {title!r}",
+        )
+    return f"#{issue} {' '.join(title.split())}"
+
+
 def format_elapsed(seconds: float) -> str:
     """Format seconds as `45s`, `3m 12s` or `1h 2m 3s` (zero units omitted)."""
     total = max(0, int(seconds))
@@ -89,7 +110,10 @@ def progress_body(state: dict) -> str:
         "",
         PROGRESS_HEADER,
         "",
-        f"- issue: #{state['issue']}",
+        # Issue #100: number AND title, one consistent format in every
+        # scene; both state keys are required (a state without the
+        # title fails fast, never a fabricated or bare number).
+        f"- issue: {issue_field(state['issue'], state['issue_title'])}",
         # The visible run_id field is `run_id=<id>` (key=value, Issue
         # #41 contract), so a grep for the value finds every comment
         # of the run.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3632,9 +3632,10 @@ def test_stream_pi_live_progress_patches_github_before_child_exits(
 
     publisher = FakePublisher()
     throttle = runner.LiveProgressThrottle(
-        publisher, issue=24, run_id="run1", role="implement",
-        branch="b", worktree=tmp_path, started=time.monotonic(),
-        pr_url=None, review_round=0, priority="normal",
+        publisher, issue=24, title="Live progress", run_id="run1",
+        role="implement", branch="b", worktree=tmp_path,
+        started=time.monotonic(), pr_url=None, review_round=0,
+        priority="normal",
     )
     result = runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
@@ -3692,9 +3693,10 @@ def test_live_progress_throttle_patches_on_change_and_cadence():
 
     publisher = FakePublisher()
     throttle = runner.LiveProgressThrottle(
-        publisher, issue=1, run_id="run1", role="implement",
-        branch="b", worktree=Path("/w"), started=time.monotonic(),
-        pr_url=None, review_round=0, priority="normal",
+        publisher, issue=1, title="Throttle task", run_id="run1",
+        role="implement", branch="b", worktree=Path("/w"),
+        started=time.monotonic(), pr_url=None, review_round=0,
+        priority="normal",
     )
     first = {
         "phase": "starting", "action": None, "result": None,
@@ -4248,7 +4250,7 @@ def test_finish_blocked_progress_is_a_noop_without_run_id(monkeypatch):
     )
     runner._finish_blocked_progress(
         39, None, "owner/repo", None, None, "https://x/pull/46",
-        "failure", "next step",
+        "failure", "next step", title="Blocked task",
     )
     assert calls == []
 
@@ -4274,7 +4276,7 @@ def test_finish_blocked_progress_creates_the_comment_when_missing(
     monkeypatch.setattr(runner, "run_command", fake_run)
     runner._finish_blocked_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
-        "the failure", "the next step",
+        "the failure", "the next step", title="Blocked task",
     )
     posts = [
         command for command in api_calls
@@ -4286,6 +4288,8 @@ def test_finish_blocked_progress_creates_the_comment_when_missing(
     assert "the failure" in body
     assert "the next step" in body
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in body
+    # Issue #100: the blocked scene shows the number AND the title.
+    assert "- issue: #39 Blocked task" in body
 
 
 def test_finish_blocked_progress_carries_the_actual_role_and_round(
@@ -4308,7 +4312,7 @@ def test_finish_blocked_progress_carries_the_actual_role_and_round(
     monkeypatch.setattr(runner, "run_command", fake_run)
     runner._finish_blocked_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
-        "the failure", "the next step",
+        "the failure", "the next step", title="Blocked task",
         role=runner.ROLE_REVIEW, review_round=2,
     )
     posts = [
@@ -4338,7 +4342,7 @@ def test_finish_blocked_progress_defaults_to_review_round_zero(monkeypatch):
     monkeypatch.setattr(runner, "run_command", fake_run)
     runner._finish_blocked_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
-        "the failure", "the next step",
+        "the failure", "the next step", title="Blocked task",
     )
     posts = [
         command for command in api_calls
@@ -4528,7 +4532,7 @@ def test_wait_for_delivery_passes_p0_priority_to_the_review(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
         "owner/repo",
     )
-    assert review_calls == [{"priority": "p0"}]
+    assert review_calls == [{"title": "p0 task", "priority": "p0"}]
     # The awaiting log line carries the explicit priority field.
     awaiting = [m for m in caplog.messages if "delivery_awaiting" in m]
     assert any("priority=p0" in m for m in awaiting)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -65,10 +65,142 @@ def test_format_elapsed_omits_zero_units(seconds, expected):
     assert progress.format_elapsed(seconds) == expected
 
 
+def test_issue_field_renders_number_and_title():
+    # Issue #100: the progress comment's issue line shows the number
+    # AND the title; the `#<number>` prefix is preserved so existing
+    # log/scene parsing keeps working.
+    assert progress.issue_field(89, "ship it") == "#89 ship it"
+    assert progress.issue_field(18, "Publish progress") == \
+        "#18 Publish progress"
+
+
+def test_issue_field_keeps_the_hash_number_prefix():
+    # A grep for `#18` (the existing journal/scene convention) must
+    # still find the issue line.
+    field = progress.issue_field(18, "Publish progress")
+    assert field.startswith("#18")
+
+
+def test_issue_field_flattens_spaces_and_newlines_to_one_line():
+    # Titles with spaces, internal newlines and repeated whitespace
+    # stay single-line and readable (Issue #100 requirement).
+    assert progress.issue_field(7, "a  b\n\nc\t\td") == "#7 a b c d"
+
+
+def test_issue_field_keeps_markdown_characters_readable():
+    # Markdown in the title is not escaped or stripped: the comment is
+    # Markdown too, so the title renders as-is on one line.
+    title = "Bug: `resume` uses **PR URL**, no more verify_pr (#45)"
+    assert progress.issue_field(7, title) == f"#7 {title}"
+
+
+def test_issue_field_handles_a_long_title():
+    # A long title is kept in full (no silent truncation): the field
+    # stays one line and readable.
+    title = "x" * 300
+    field = progress.issue_field(7, title)
+    assert field == f"#7 {title}"
+    assert "\n" not in field
+
+
+def test_issue_field_fails_fast_on_missing_or_empty_title():
+    # A missing or blank title violates the GitHub issue data contract
+    # (issues always carry a non-empty string title): fail fast, never
+    # fabricate one (Issue #100 requirement).
+    with pytest.raises(ValueError, match="title"):
+        progress.issue_field(7, None)
+    with pytest.raises(ValueError, match="title"):
+        progress.issue_field(7, "")
+    with pytest.raises(ValueError, match="title"):
+        progress.issue_field(7, "   \n  ")
+
+
+def test_issue_field_fails_fast_on_non_string_title():
+    with pytest.raises(ValueError, match="title"):
+        progress.issue_field(7, 123)
+
+
+def test_issue_field_fails_fast_on_non_int_issue():
+    with pytest.raises(ValueError, match="issue"):
+        progress.issue_field("7", "t")
+    # bool is an int subclass but not an issue number.
+    with pytest.raises(ValueError, match="issue"):
+        progress.issue_field(True, "t")
+
+
+def test_progress_body_issue_line_carries_number_and_title():
+    # Issue #100: every progress scene renders `#<number> <title>`.
+    body = progress.progress_body({
+        "run_id": "abc123",
+        "issue": 89,
+        "issue_title": "Bug: resume 使用评论里的 PR URL，不再 verify_pr",
+        "role": "implement",
+        "phase": "test",
+        "elapsed": "3m 12s",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 0,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    })
+    assert (
+        "- issue: #89 Bug: resume 使用评论里的 PR URL，不再 verify_pr"
+        in body
+    )
+    # The `#89` prefix is preserved for existing parsing.
+    assert "- issue: #89" in body
+
+
+def test_progress_body_issue_line_is_single_line_for_any_title():
+    state = {
+        "run_id": "abc123",
+        "issue": 7,
+        "issue_title": "a\n\nb  c",
+        "role": "review",
+        "phase": "test",
+        "elapsed": "1s",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 2,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    }
+    body = progress.progress_body(state)
+    lines = body.splitlines()
+    issue_lines = [line for line in lines if line.startswith("- issue:")]
+    assert issue_lines == ["- issue: #7 a b c"]
+
+
+def test_progress_body_fails_fast_without_issue_title():
+    # A state without the title is a contract violation: fail fast,
+    # never render a bare `#<number>` (that would hide the violation).
+    state = {
+        "run_id": "abc123",
+        "issue": 18,
+        "role": "implement",
+        "phase": "starting",
+        "elapsed": "0s",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 0,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    }
+    with pytest.raises(KeyError):
+        progress.progress_body(state)
+
+
 def test_progress_body_starts_with_hidden_run_marker():
     body = progress.progress_body({
         "run_id": "abc123",
         "issue": 18,
+        "issue_title": "Publish progress",
         "role": "implement",
         "phase": "test",
         "elapsed": "3m 12s",
@@ -83,7 +215,7 @@ def test_progress_body_starts_with_hidden_run_marker():
     lines = body.splitlines()
     assert lines[0] == "<!-- muyan-pilot:run=abc123 -->"
     assert "**Muyan Pilot progress**" in body
-    assert "- issue: #18" in body
+    assert "- issue: #18 Publish progress" in body
     assert "- role: implement" in body
     assert "- phase: test" in body
     assert "- elapsed: 3m 12s" in body
@@ -100,6 +232,7 @@ def test_progress_body_marks_missing_values_as_dash():
     body = progress.progress_body({
         "run_id": "abc123",
         "issue": 18,
+        "issue_title": "Publish progress",
         "role": "implement",
         "phase": "starting",
         "elapsed": "0s",
@@ -121,6 +254,7 @@ def test_progress_body_shows_pr_url_when_present():
     body = progress.progress_body({
         "run_id": "abc123",
         "issue": 18,
+        "issue_title": "Publish progress",
         "role": "implement",
         "phase": "pr",
         "elapsed": "1h 0m",
@@ -145,6 +279,7 @@ def test_progress_body_shows_priority_field():
     state = {
         "run_id": "abc123",
         "issue": 7,
+        "issue_title": "p0 outage",
         "role": "implement",
         "phase": "test",
         "elapsed": "3m 12s",

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -311,7 +311,8 @@ def test_failure_detail_without_stderr_uses_message():
 
 def test_progress_body_outcome_header_prepends_outcome():
     state = {
-        "run_id": "a1b2c3d4", "issue": 18, "role": "implement",
+        "run_id": "a1b2c3d4", "issue": 18,
+        "issue_title": "Publish progress", "role": "implement",
         "phase": "test", "elapsed": "1s", "last_activity": None,
         "last_action": None, "tests": None, "review_round": 0,
         "branch": "b", "pr": None, "session": None,
@@ -409,7 +410,8 @@ def test_process_issue_creates_progress_comment_with_marker(monkeypatch, tmp_pat
         f"expected exactly one progress comment, got: {posted}"
     )
     body = progress_posts[0]
-    assert "- issue: #18" in body
+    # Issue #100: the issue line shows the number AND the title.
+    assert "- issue: #18 Publish progress" in body
     assert "- role: implement" in body
     assert "- branch: muyan-pilot/xqliu-muyan-pilot-issue-18-a1b2c3d4" in body
     assert "- PR: -" in body
@@ -506,6 +508,22 @@ def test_process_issue_p0_failure_enters_ai_blocked_terminal_state(
     assert "Muyan Pilot blocked" in last_body
     assert "- priority: p0" in last_body
     assert "pi exploded" in last_body
+    # Issue #100: the P0 blocked scene shows the number AND the title.
+    assert "- issue: #18 Publish progress" in last_body
+
+
+def test_process_issue_fails_fast_on_missing_issue_title(
+    monkeypatch, tmp_path,
+):
+    """Issue #100: a scanned issue without a title violates the GitHub
+    issue data contract: `process_issue` fails fast (KeyError) instead
+    of fabricating a title or publishing a bare `#<number>` line."""
+    make_fake_gh(monkeypatch)
+    patch_process_deps(monkeypatch, tmp_path)
+    issue = {"number": 18, "body": "body"}  # no "title"
+    with pytest.raises(KeyError):
+        runner.process_issue(issue, make_config(tmp_path),
+                             "xqliu/muyan-pilot")
 
 
 def test_process_issue_passes_issue_number_to_verify_pr(
@@ -1358,7 +1376,8 @@ def _run_review_and_merge(monkeypatch, tmp_path, *, verdict,
         tmp_path, "branch", "main",
         {"repo_dir": tmp_path, "base_branch": "main", "base_sha": "b1",
          "run_id": "a1b2c3d4"},
-        "xqliu/muyan-pilot", 18, priority="normal",
+        "xqliu/muyan-pilot", 18, title="Publish progress",
+        priority="normal",
     )
     return merged, edits, calls, posted
 
@@ -1551,6 +1570,9 @@ def test_wait_for_delivery_closed_unmerged_posts_blocked_milestone(
     assert "closed without a merge" in blocked
     assert "next step:" in blocked
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked
+    # Issue #100: the wait-loop blocked scene shows the number AND
+    # the title, consistent with the other scenes.
+    assert "- issue: #39 t" in blocked
     # The blocked scene carries the actual role (Issue #82: both
     # opened-PR states are review states, so always `review`) and the
     # completed review rounds (review round 2, PR #42).

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -486,6 +486,7 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     }
     merged = runner.review_and_merge_if_clean(
         worktree, branch, "main", review_config, REPO, ISSUE_NUMBER,
+        title=issue()["title"],
         # Issue #101: the wait loop derives the priority from the
         # scanned issue's labels (no extra gh call).
         priority=runner.issue_priority(issue()),

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -642,7 +642,7 @@ def test_review_and_merge_clean_verdict_merges_and_labels_merged(
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is True
@@ -697,7 +697,7 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is True
@@ -737,7 +737,7 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is True
@@ -774,7 +774,7 @@ def test_review_and_merge_keeps_merged_when_checkout_sync_fails(
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is True
@@ -814,7 +814,7 @@ def test_review_and_merge_findings_labels_fix_needed_and_comments(
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is False
@@ -859,7 +859,7 @@ def test_review_and_merge_behind_base_labels_fix_needed(monkeypatch, tmp_path):
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is False
@@ -899,7 +899,7 @@ def test_review_and_merge_conflict_labels_fix_needed(monkeypatch, tmp_path):
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
         tmp_path, "branch", "main", _review_merge_config(tmp_path),
-        "owner/repo", 4,
+        "owner/repo", 4, title="Review task",
         priority="normal",
     )
     assert merged is False
@@ -925,7 +925,7 @@ def test_review_and_merge_reraises_non_fixable_gate_error(monkeypatch, tmp_path)
         make_fake_gh(monkeypatch)
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
-            "owner/repo", 4,
+            "owner/repo", 4, title="Review task",
             priority="normal",
         )
 
@@ -940,7 +940,7 @@ def test_review_and_merge_missing_verdict_raises(monkeypatch, tmp_path):
         make_fake_gh(monkeypatch)
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
-            "owner/repo", 4,
+            "owner/repo", 4, title="Review task",
             priority="normal",
         )
 
@@ -960,7 +960,7 @@ def test_review_and_merge_exhausted_rounds_raises(monkeypatch, tmp_path, caplog)
         make_fake_gh(monkeypatch)
         runner.review_and_merge_if_clean(
             tmp_path, "branch", "main", _review_merge_config(tmp_path),
-            "owner/repo", 4,
+            "owner/repo", 4, title="Review task",
             priority="normal",
         )
     assert "review_rounds_exhausted" in caplog.text


### PR DESCRIPTION
Fixes #100

<!-- muyan-pilot:run=32051729 -->

run_id=32051729

## Change

The GitHub progress comment's issue line now shows the Issue number AND
title, e.g.

```text
- issue: #89 Bug: resume 使用评论里的 PR URL，不再 verify_pr
```

One consistent format in every progress scene (implement, review,
blocked, merged). The `#<number>` prefix is preserved so existing
log/scene parsing and tests keep working; the title is flattened to a
single line (whitespace collapsed) so spaces, Markdown characters and
long titles stay readable. A missing or non-string title violates the
GitHub issue data contract (issues always carry a non-empty string
title; every runner scan already fetches `title`) and fails fast — a
title is never fabricated, and no extra gh call is made.

## Files

- `progress.py`: new `issue_field(issue, title)` (int issue, required
  non-empty string title, fail fast otherwise); `progress_body` renders
  `- issue: <issue_field(...)>` from the required `issue` +
  `issue_title` state keys.
- `bootstrap_runner.py`: threads the scanned issue's title through
  `_progress_state`, `_live_progress`, `LiveProgressThrottle`,
  `process_issue`, `review_and_merge_if_clean`,
  `_finish_blocked_progress`, `wait_for_delivery` and
  `verify_resumed_pr` (required keywords, no default, no fallback).
- Tests: `issue_field` unit tests (normal/long/Markdown titles,
  single-line contract, fail-fast on missing/empty/non-string title
  and non-int/bool issue), `progress_body` scene tests, wiring
  assertions that the implement/review/blocked/merged scenes all carry
  `#<number> <title>`, and a fail-fast test for a title-less issue dict
  in `process_issue`.

## Verification

- Full suite: `698 passed` (`/usr/bin/python3 -m pytest tests/ -q`).
- Coverage: 100% line and branch on every module
  (`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q &&
  /usr/bin/python3 -m coverage report --show-missing` — TOTAL
  9118 stmts / 1252 branches, 0 missed).
- Commands and results recorded in the worktree `test.log`.
