### PR TITLE
Setup: one-time config-driven initialization of GitHub, labels and local prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,26 @@ python3 muyan_pilot.py install-units --config muyan-pilot.toml
 # 只读部署/健康报告：repo commit、unit drift、timer/service active、
 # Runner slot、Pi session、当前 Issue、最近 journal 活动
 python3 muyan_pilot.py doctor --config muyan-pilot.toml
+
+# 一次性 setup（新机器/新仓库）：gh auth + 仓库权限、平台 labels
+# （labels.toml 为唯一事实源）、systemd user units、checkout 检查、
+# 可选模型 proxy（warning only）；幂等、fail-fast，--json 输出等价 JSON
+python3 muyan_pilot.py setup --config muyan-pilot.toml
 ```
 
 ## GitHub Issue 标签（外部状态）
 
-GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默漏掉对应状态的 Issue。新仓库初始化时必须先创建这些 label，再用 `gh label list` 检查：
+GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的 label 只做声明式对齐，业务 label 从不被改动）：
 
 ```bash
-# 仓库初始化：创建全部 label（已存在时 gh 会报错，可忽略或先 gh label list 检查）
+# 一次性 setup：gh auth + 仓库权限、平台 labels、systemd user units、
+# checkout 检查、可选模型 proxy（warning only）；输出 key=value（--json 等价 JSON）
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
+setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略或先 `gh label list` 检查）：
+
+```bash
 for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
   gh label create "$l" --repo xqliu/muyan-pilot --force
   gh label edit "$l" --repo xqliu/muyan-pilot \

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,8 @@
         "group": "Getting Started",
         "pages": [
           "index",
-          "getting-started"
+          "getting-started",
+          "setup"
         ]
       },
       {

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -82,24 +82,25 @@ skills = []
 context_files = []
 ```
 
-## 3. Initialize the delivery labels
+## 3. Run the one-time setup
 
-GitHub labels are **external state**: a commit never creates them, and a
-missing label makes the scan silently skip that state. Create them once
-per task-pool repository:
+The setup entry does the whole initialization in one command: it
+verifies `gh auth status` and the repo permissions, aligns the platform
+labels from the repo-managed `labels.toml` (the single source of truth
+for label name, color and description — a commit never creates labels,
+and a missing label makes the scan silently skip that state), installs
+the systemd user units and enables the timer, checks the checkout, and
+reports the optional model proxy:
 
 ```bash
-for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
-  gh label create "$l" --repo OWNER/PILOT-REPO --force
-  gh label edit "$l" --repo OWNER/PILOT-REPO \
-    --description "Muyan Pilot delivery state (see docs)"
-done
-# p0 is the urgent-priority label (not a delivery state, see the
-# workflow page): picked up before bugs and features.
-gh label create p0 --repo OWNER/PILOT-REPO --force --color "fbca04" \
-  --description "Muyan Pilot urgent priority: picked up before bugs and features"
-gh label list --repo OWNER/PILOT-REPO
+python3 muyan_pilot.py setup --config muyan-pilot.toml
 ```
+
+It is idempotent (re-running it never creates duplicate labels, units
+or timers) and fail-fast (a wrong repo, insufficient permission, a
+dirty checkout or a missing systemd user bus stops it with the concrete
+reason). See [One-time setup](/setup) for the full output contract,
+success and failure examples.
 
 ## 4. Run one tick manually
 
@@ -151,24 +152,28 @@ and the journal shows `run_end ... result=pr_opened`. If any step fails,
 the Issue is marked `ai-blocked` with the scene — see
 [Operations](/operations) for recovery.
 
-## 6. Enable the timer
+## 6. Verify the timer
+
+The setup step already installed the units and enabled the timer; verify
+it:
 
 ```bash
-mkdir -p ~/.config/systemd/user
-cp systemd/muyan-pilot.service systemd/muyan-pilot.timer ~/.config/systemd/user/
-```
-
-The committed units reference the author's clone layout via `%h`
-specifiers (`%h/Documents/muyan/muyan-pilot`). Point `WorkingDirectory`,
-`MUYAN_PILOT_CONFIG` and `ExecStart` at **your** clone path, then:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now muyan-pilot.timer
 systemctl --user list-timers muyan-pilot.timer
 ```
 
-The timer fires every 15 minutes, 24 hours a day (00:00–23:45). While a
-task is running, further timer starts are ignored by systemd; the next
-real start picks up the latest code (the service fast-forwards `main`
-before starting — see [Operations](/operations)).
+The setup output carries `timer=enabled active=true next=...` (the next
+trigger time). The timer fires every 15 minutes, 24 hours a day
+(00:00–23:45). While a task is running, further timer starts are ignored
+by systemd; the next real start picks up the latest code (the service
+fast-forwards `main` before starting — see [Operations](/operations)).
+
+<Note>
+The committed unit templates reference the author's clone layout via
+`%h` specifiers (`%h/Documents/muyan/muyan-pilot`). If your clone lives
+elsewhere, edit the **installed** units in your user unit directory
+(`~/.config/systemd/user/`) to point `WorkingDirectory`,
+`MUYAN_PILOT_CONFIG` and `ExecStart` at **your** clone path, then
+`systemctl --user daemon-reload`. The repo templates stay the single
+source of truth for everything else — see [Operations](/operations) on
+drift detection.
+</Note>

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -1,0 +1,131 @@
+# One-time setup
+
+`muyan_pilot.py setup` is the one-time, config-driven initialization
+entry for a new machine or a new task-pool repository. It verifies the
+local prerequisites, aligns the platform labels, installs the systemd
+user units, checks the checkout, and reports the optional model proxy —
+in one command, with a stable machine-readable result.
+
+```bash
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
+Run it once per machine (and once per new task-pool repository). It is
+**idempotent**: re-running it never creates duplicate labels, units or
+timers, and never touches business Issues or business labels.
+
+## What it does, in order
+
+Setup is **fail-fast**: a core prerequisite failure stops the run
+before any later mutation, with the concrete reason on stderr and a
+non-zero exit code.
+
+1. **Commands** — `git`, `gh`, `python3` on the PATH, and a reachable
+   `systemctl --user` user bus (a container or headless session without
+   a user bus fails with the bus error).
+2. **Auth** — `gh auth status` (logged in with a usable token).
+3. **Per target repository** (every configured `source_repos` entry by
+   default; exactly one with `--repo OWNER/REPO`):
+   - the repo exists and the viewer has write permission
+     (`gh repo view` → `viewerPermission` must be `WRITE`, `MAINTAIN`
+     or `ADMIN`);
+   - the seven platform labels are aligned **declaratively** from the
+     repo-managed `labels.toml` (repo root) — the single source of
+     truth for label name, color and description: a missing label is
+     created, a drifted label is updated, nothing is deleted, and
+     business labels (`bug`, `enhancement`, ...) are never touched.
+4. **Systemd units** — the repo templates
+   (`systemd/muyan-pilot.service`, `systemd/muyan-pilot.timer`) are
+   installed idempotently into the user unit directory (the same
+   install `install-units` performs: copy, `daemon-reload`, enable the
+   timer — the service is never started, stopped or restarted), then
+   the timer's enabled/active state and next trigger time are
+   reported.
+5. **Checkout** — read-only check of the configured `repo_dir`:
+   `origin` remote present, current branch, clean worktree (a dirty
+   checkout fails: the timer's `ExecStartPre` fast-forward refuses a
+   dirty worktree, so the Runner could never start), and base
+   freshness (local `HEAD` vs freshly fetched
+   `origin/<base_branch>` — reported, not a failure: the timer
+   fast-forwards a clean checkout at each start).
+6. **Optional model proxy** — the `local-llm-kv-cache` proxy health
+   endpoint (`http://127.0.0.1:18082/health`) is checked and reported
+   as **optional**: its absence or unhealthiness is a warning in the
+   output and never blocks the core GitHub/Pilot setup.
+
+Setup never creates business Issues, never claims a task, never starts
+Pi, and never modifies a protected branch.
+
+## Options
+
+| Option | Meaning |
+|---|---|
+| `--config PATH` | The `muyan-pilot.toml` configuration (default: `$MUYAN_PILOT_CONFIG` or `muyan-pilot.toml`) |
+| `--repo OWNER/REPO` | Initialize exactly this configured source repo (default: every configured source repo) |
+| `--installed-dir PATH` | User unit directory (default: the standard `~/.config/systemd/user`) |
+| `--json` | Print the result as JSON instead of `key=value` lines |
+
+## Output
+
+The default output is stable `key=value` lines (one per concern; values
+containing spaces are quoted), so agents and scripts can parse it:
+
+```text
+setup=ok version=1 base_branch=main
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
+timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
+checkout=remote=origin branch=main clean=true base_fresh=true
+model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
+```
+
+`labels=7/7` means all seven platform labels match `labels.toml`;
+`next` is the timer's next trigger time (`-` when it has none);
+`optional_proxy` is `healthy`, `unhealthy` or `unavailable` and never
+changes the exit code.
+
+`--json` prints the equivalent JSON document:
+
+```bash
+python3 muyan_pilot.py setup --config muyan-pilot.toml --json
+```
+
+## Success and failure examples
+
+Success (exit code `0`):
+
+```bash
+$ python3 muyan_pilot.py setup --config muyan-pilot.toml
+setup=ok version=1 base_branch=main
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
+timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
+checkout=remote=origin branch=main clean=true base_fresh=true
+model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
+```
+
+(The optional proxy is down here — note `optional_proxy=unhealthy` —
+but the core setup still succeeds with exit code `0`.)
+
+Failures (non-zero exit code, `setup_failed reason=...` on stderr):
+
+```text
+setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
+setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
+setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
+setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)
+setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted changes: ' M bootstrap_runner.py') — commit or stash them first: ...
+```
+
+A wrong repo, missing labels that cannot be created (permission), a
+dirty checkout or a missing systemd user bus all stop the setup with
+the concrete reason — nothing is half-initialized without a clear
+signal.
+
+## Idempotency
+
+Re-running setup on an already-initialized machine is a no-op for the
+external state: labels that already match are not rewritten, the unit
+templates are re-copied from the repo (drift repair), the timer stays
+enabled, and no Issues or business data are created or modified. The
+reported hashes and states are stable across runs.

--- a/labels.toml
+++ b/labels.toml
@@ -1,0 +1,46 @@
+# Muyan Pilot platform labels — the single source of truth (Issue #117).
+#
+# `muyan_pilot.py setup` aligns every configured source repo with this
+# file declaratively: a missing label is created and a drifted label is
+# updated (name, color, description); nothing is ever deleted and no
+# business label (bug, enhancement, ...) is touched. The values below
+# match the live xqliu/muyan-pilot labels (verified against the GitHub
+# API); a commit never creates labels — only the setup entry does.
+#
+# Color: 6-character hex (GitHub normalizes case). Description: one
+# short line per label.
+
+[[label]]
+name = "ai-ready"
+color = "1d76db"
+description = "Issue is explicitly dispatched to Muyan Pilot"
+
+[[label]]
+name = "ai-in-progress"
+color = "fbca04"
+description = "Issue currently being handled by Muyan Pilot"
+
+[[label]]
+name = "ai-pr-opened"
+color = "0e8a16"
+description = "A PR has been opened for this issue"
+
+[[label]]
+name = "ai-fix-needed"
+color = "fbca04"
+description = "Existing PR needs automatic review/fix continuation"
+
+[[label]]
+name = "ai-merged"
+color = "0e8a16"
+description = "Muyan Pilot automatically reviewed and merged the task PR"
+
+[[label]]
+name = "ai-blocked"
+color = "d73a4a"
+description = "Muyan Pilot stopped and needs human attention"
+
+[[label]]
+name = "p0"
+color = "fbca04"
+description = "Muyan Pilot urgent priority: picked up before bugs and features"

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -35,6 +35,7 @@ from bootstrap_runner import (
     run_command,
     validate_config,
 )
+import pilot_setup
 from pilot_slots import slot_occupancy
 from pi_activity import activity_snapshot
 
@@ -479,6 +480,25 @@ def main(argv: list[str] | None = None) -> int:
         "--installed-dir", type=Path, default=None,
         help="user unit directory to check (default: the standard dir)",
     )
+    setup_parser = subparsers.add_parser(
+        "setup", parents=[common],
+        help="one-time, idempotent initialization: gh auth + repo "
+             "permissions, platform labels, systemd user units, checkout "
+             "check and the optional model proxy (Issue #117)",
+    )
+    setup_parser.add_argument(
+        "--repo", default=None,
+        help="initialize exactly this source repo (default: every "
+             "configured source repo)",
+    )
+    setup_parser.add_argument(
+        "--installed-dir", type=Path, default=None,
+        help="user unit directory (default: the standard user dir)",
+    )
+    setup_parser.add_argument(
+        "--json", action="store_true",
+        help="print the result as JSON instead of key=value lines",
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format=log_format())
 
@@ -534,6 +554,23 @@ def main(argv: list[str] | None = None) -> int:
         print(install_units_command(config, args.installed_dir))
     elif args.command == "doctor":
         print(doctor_report(config, args.installed_dir))
+    elif args.command == "setup":
+        try:
+            result = pilot_setup.run_setup(
+                config, args.installed_dir,
+                repos=[args.repo] if args.repo else None,
+                run_command=run_command,
+            )
+        except pilot_setup.SetupError as exc:
+            print(
+                f"setup_failed reason={exc}",
+                file=sys.stderr,
+            )
+            return 1
+        if args.json:
+            print(pilot_setup.to_json(result))
+        else:
+            print("\n".join(pilot_setup.format_setup(result)))
     else:
         print(status_report(config))
     return 0

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -1,0 +1,541 @@
+"""One-time setup for Muyan Pilot (Issue #117).
+
+`muyan_pilot.py setup` is the config-driven, idempotent, fail-fast
+initialization entry for a new machine or new task-pool repository:
+
+- verifies ``gh auth status`` and the viewer's read/write permission on
+  every target repo;
+- verifies the required commands (``git``, ``gh``, ``python3``) and the
+  ``systemctl --user`` user bus;
+- aligns the platform labels (``ai-ready``, ``ai-in-progress``,
+  ``ai-pr-opened``, ``ai-fix-needed``, ``ai-merged``, ``ai-blocked``,
+  ``p0``) declaratively from the repo-managed ``labels.toml`` — the
+  single source of truth for label name, color and description. A
+  missing label is created, a drifted label is updated, nothing is
+  deleted, and no business label (``bug``, ``enhancement``, ...) is
+  ever touched;
+- installs the repo's user systemd service/timer templates idempotently
+  (reusing ``systemd_deploy.install_units``: copy, daemon-reload,
+  enable the timer — never start/stop/restart the service) and reports
+  the enable/active state plus the next trigger time;
+- checks the local checkout read-only (remote, current branch, clean
+  status, base freshness);
+- checks the optional ``local-llm-kv-cache`` proxy health and reports it
+  as a warning only — an optional component never blocks the core
+  GitHub/Pilot setup.
+
+Core failures raise :class:`SetupError` with the concrete reason before
+any later mutation; there is no fallback path. The output is stable
+``key=value`` lines (or an equivalent JSON document with ``--json``) so
+agents and scripts can parse it.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tomllib
+from pathlib import Path
+
+import systemd_deploy
+from pi_activity import quote_value
+
+# Bumped whenever the setup output contract changes shape.
+SETUP_VERSION = 1
+
+# The repo-managed single source of truth for the platform labels.
+LABELS_FILE = "labels.toml"
+REQUIRED_LABELS = (
+    "ai-ready",
+    "ai-in-progress",
+    "ai-pr-opened",
+    "ai-fix-needed",
+    "ai-merged",
+    "ai-blocked",
+    "p0",
+)
+COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")
+
+# Permissions that may create/edit labels (GitHub viewerPermission).
+WRITE_PERMISSIONS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
+
+# Required local commands (checked with shutil.which).
+REQUIRED_COMMANDS = ("git", "gh", "python3")
+
+# The optional local-llm-kv-cache proxy health endpoint (docs/
+# optional-kv-cache.mdx: the committed user unit listens on 18082).
+OPTIONAL_PROXY_URL = "http://127.0.0.1:18082/health"
+OPTIONAL_PROXY_TIMEOUT = 3
+
+
+class SetupError(RuntimeError):
+    """A core setup prerequisite or step failed (fail fast)."""
+
+
+def load_label_defs(path: Path) -> list[dict]:
+    """Parse and validate the repo-managed label definitions.
+
+    The file must define EXACTLY the 7 platform labels (no more, no
+    less, no duplicates), each with a non-empty name, a 6-hex color and
+    a non-empty description. Any deviation is a fail-fast SetupError:
+    a typo'd or missing label would silently skip a delivery state.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise SetupError(
+            f"label definitions missing: {path} (the repo-managed "
+            "single source of truth for the platform labels)"
+        )
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise SetupError(f"malformed {LABELS_FILE}: {path}: {exc}") from exc
+    entries = data.get("label")
+    if not isinstance(entries, list):
+        raise SetupError(
+            f"malformed {LABELS_FILE}: {path}: expected a [[label]] "
+            "array of name/color/description entries"
+        )
+    defs: list[dict] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise SetupError(
+                f"malformed {LABELS_FILE}: {path}: each label entry "
+                "must be a table with name/color/description"
+            )
+        name = entry.get("name")
+        color = entry.get("color")
+        description = entry.get("description")
+        if not isinstance(name, str) or not name:
+            raise SetupError(
+                f"malformed {LABELS_FILE}: {path}: a label entry has "
+                "no non-empty name"
+            )
+        if name in seen:
+            raise SetupError(
+                f"malformed {LABELS_FILE}: {path}: duplicate label "
+                f"name: {name}"
+            )
+        seen.add(name)
+        if not isinstance(color, str) or not COLOR_PATTERN.fullmatch(color):
+            raise SetupError(
+                f"malformed {LABELS_FILE}: {path}: label {name} has an "
+                "invalid color (6-character hex required): "
+                f"{color!r}"
+            )
+        if not isinstance(description, str) or not description:
+            raise SetupError(
+                f"malformed {LABELS_FILE}: {path}: label {name} has no "
+                "non-empty description"
+            )
+        defs.append({
+            "name": name,
+            "color": color,
+            "description": description,
+        })
+    missing = [name for name in REQUIRED_LABELS if name not in seen]
+    unknown = [name for name in seen if name not in REQUIRED_LABELS]
+    if missing or unknown:
+        raise SetupError(
+            f"malformed {LABELS_FILE}: {path}: must define exactly the "
+            f"platform labels {list(REQUIRED_LABELS)}; "
+            f"missing={missing} unknown={unknown}"
+        )
+    return defs
+
+
+def check_commands(run_command) -> dict:
+    """Verify the required commands and the systemctl --user bus.
+
+    ``git``, ``gh`` and ``python3`` must be on the PATH; the systemd
+    user bus must be reachable (a probe ``systemctl --user show`` must
+    succeed — a container or a headless session without a user bus
+    fails fast with the concrete reason). No mutation happens here.
+    """
+    paths: dict[str, str] = {}
+    for name in REQUIRED_COMMANDS:
+        path = shutil.which(name)
+        if path is None:
+            raise SetupError(f"required command missing: {name} (not on PATH)")
+        paths[name] = path
+    probe = [
+        "systemctl", "--user", "show", "-p", "LoadState", "--value",
+        systemd_deploy.TIMER_UNIT,
+    ]
+    try:
+        run_command(probe)
+    except Exception as exc:
+        detail = str(exc)
+        raise SetupError(
+            "systemctl --user user bus unavailable (is a systemd user "
+            f"session running?): {detail}"
+        ) from exc
+    paths["systemctl"] = "user-bus-ok"
+    return paths
+
+
+def check_auth(run_command) -> None:
+    """Verify ``gh auth status`` (logged in with a usable token)."""
+    try:
+        run_command(["gh", "auth", "status"])
+    except Exception as exc:
+        raise SetupError(
+            f"gh auth status failed (log in with `gh auth login`): {exc}"
+        ) from exc
+
+
+def check_repo(repo: str, run_command) -> dict:
+    """Verify the target repo exists and the viewer may write to it.
+
+    ``gh repo view`` (verified against the real CLI: unknown repo exits
+    non-zero, a readable repo returns ``nameWithOwner``,
+    ``viewerPermission`` and ``defaultBranchRef``). The viewer
+    permission must allow label mutation (WRITE/MAINTAIN/ADMIN).
+    """
+    try:
+        raw = run_command([
+            "gh", "repo", "view", repo,
+            "--json", "nameWithOwner,viewerPermission,defaultBranchRef",
+        ])
+    except Exception as exc:
+        raise SetupError(
+            f"repo not accessible: {repo} (gh repo view failed: {exc})"
+        ) from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SetupError(
+            f"cannot parse gh repo view output for {repo}: {raw!r}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise SetupError(
+            f"cannot parse gh repo view output for {repo}: {raw!r}"
+        )
+    permission = data.get("viewerPermission")
+    if permission not in WRITE_PERMISSIONS:
+        raise SetupError(
+            f"insufficient permission for {repo}: viewerPermission="
+            f"{permission!r} (one of {sorted(WRITE_PERMISSIONS)} "
+            "required to manage labels)"
+        )
+    name_with_owner = data.get("nameWithOwner")
+    if not isinstance(name_with_owner, str) or not name_with_owner:
+        raise SetupError(
+            f"cannot parse gh repo view output for {repo}: "
+            "nameWithOwner missing"
+        )
+    default_branch = (data.get("defaultBranchRef") or {}).get("name")
+    if not isinstance(default_branch, str) or not default_branch:
+        raise SetupError(
+            f"cannot parse gh repo view output for {repo}: "
+            "defaultBranchRef.name missing"
+        )
+    return {
+        "repo": name_with_owner,
+        "permission": permission,
+        "default_branch": default_branch,
+    }
+
+
+def align_labels(repo: str, defs: list[dict], run_command) -> dict:
+    """Declaratively align the repo's platform labels with `defs`.
+
+    Reads the current labels (``gh label list --json name,color,
+    description``) and, for every definition, creates the label when
+    missing or updates color/description when drifted (``gh label
+    create NAME --color C --description D --force`` — verified against
+    the CLI help: with ``--force`` the command updates an existing
+    label instead of failing). Existing labels whose name, color and
+    description already match are left untouched, and labels outside
+    the platform set (business labels) are never read-modified or
+    deleted. Returns ``{"repo", "aligned", "total"}``.
+    """
+    raw = run_command([
+        "gh", "label", "list", "--repo", repo,
+        "--json", "name,color,description", "--limit", "100",
+    ])
+    try:
+        existing = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SetupError(
+            f"cannot parse gh label list output for {repo}: {raw!r}"
+        ) from exc
+    if not isinstance(existing, list):
+        raise SetupError(
+            f"cannot parse gh label list output for {repo}: {raw!r}"
+        )
+    by_name = {
+        entry.get("name"): entry
+        for entry in existing
+        if isinstance(entry, dict)
+    }
+    aligned = 0
+    for entry in defs:
+        current = by_name.get(entry["name"])
+        matches = (
+            isinstance(current, dict)
+            and (current.get("color") or "").lower() == entry["color"].lower()
+            and current.get("description") == entry["description"]
+        )
+        if matches:
+            aligned += 1
+            continue
+        try:
+            run_command([
+                "gh", "label", "create", entry["name"],
+                "--repo", repo,
+                "--color", entry["color"],
+                "--description", entry["description"],
+                "--force",
+            ])
+        except Exception as exc:
+            raise SetupError(
+                f"label alignment failed for {repo}: {entry['name']} "
+                f"(gh label create failed: {exc})"
+            ) from exc
+        aligned += 1
+    return {"repo": repo, "aligned": aligned, "total": len(defs)}
+
+
+def timer_next_trigger(list_timers_output: str) -> str:
+    """The NEXT column of the muyan-pilot.timer row, or ``-``.
+
+    ``systemctl --user list-timers --no-pager`` prints a header line
+    (``NEXT  LEFT ...``) followed by one row per timer; the row whose
+    UNIT column is the Pilot timer carries the next trigger time.
+    """
+    for line in list_timers_output.splitlines():
+        columns = line.split()
+        if len(columns) >= 2 and columns[-2] == systemd_deploy.TIMER_UNIT:
+            # NEXT is the first fixed-width column and itself contains
+            # spaces ("Thu 2026-08-27 10:00:00 +08"): it ends where the
+            # all-whitespace column separator begins, so take the line
+            # up to the first run of two or more spaces.
+            match = re.match(r"^(\S+(?: \S+)*?)  ", line)
+            if match:
+                return match.group(1)
+            return columns[0]
+    return "-"
+
+
+def install_units_step(repo_dir: Path, installed_dir: Path | None,
+                       *, run_command) -> dict:
+    """Install the repo's user units and report their live state.
+
+    Reuses the idempotent ``systemd_deploy.install_units`` (copy the
+    repo templates, ``daemon-reload``, enable the timer — never
+    start/stop/restart the service), then reports the timer's enabled
+    state (``systemctl --user is-enabled``), active state (``show -p
+    ActiveState``) and next trigger time (``list-timers``).
+    """
+    try:
+        result = systemd_deploy.install_units(
+            repo_dir, installed_dir, run_command=run_command,
+        )
+    except Exception as exc:
+        raise SetupError(
+            f"systemd units install failed: {exc}"
+        ) from exc
+    enabled = run_command([
+        "systemctl", "--user", "is-enabled", systemd_deploy.TIMER_UNIT,
+    ]) == "enabled"
+    active = run_command([
+        "systemctl", "--user", "show", "-p", "ActiveState", "--value",
+        systemd_deploy.TIMER_UNIT,
+    ]) == "active"
+    next_trigger = timer_next_trigger(run_command([
+        "systemctl", "--user", "list-timers", "--no-pager",
+    ]))
+    service = result["units"][systemd_deploy.SERVICE_UNIT]
+    return {
+        "service": {
+            "installed": True,
+            "installed_path": service["installed_path"],
+            "sha256": service["sha256"],
+        },
+        "timer": {
+            "enabled": enabled,
+            "active": active,
+            "next": next_trigger,
+        },
+    }
+
+
+def check_checkout(repo_dir: Path, base_branch: str, *,
+                   run_command) -> dict:
+    """Read-only local checkout check (no git mutation).
+
+    Reports the ``origin`` remote, the current branch and whether the
+    local HEAD equals the freshly fetched ``origin/<base_branch>``
+    (base freshness — the same comparison the delivery gate uses,
+    read-only). A missing remote, a dirty worktree (the timer's
+    ``ExecStartPre`` fast-forward would refuse it) or any git error
+    fails fast with the concrete reason.
+    """
+    try:
+        remote = run_command(["git", "remote"], cwd=repo_dir)
+        if "origin" not in remote.splitlines():
+            raise SetupError(
+                f"checkout has no origin remote: {repo_dir} "
+                f"(remotes: {remote!r})"
+            )
+        branch = run_command(
+            ["git", "branch", "--show-current"], cwd=repo_dir,
+        )
+        dirty = run_command(
+            ["git", "status", "--porcelain"], cwd=repo_dir,
+        )
+        if dirty:
+            raise SetupError(
+                f"checkout is not clean: {repo_dir} (uncommitted "
+                f"changes: {dirty.strip()!r}) — commit or stash them "
+                "first: the timer's ExecStartPre fast-forward refuses "
+                "a dirty worktree, so the Runner could never start"
+            )
+        run_command(["git", "fetch", "origin", base_branch], cwd=repo_dir)
+        head = run_command(["git", "rev-parse", "HEAD"], cwd=repo_dir)
+        base = run_command(
+            ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,
+        )
+    except SetupError:
+        raise
+    except Exception as exc:
+        raise SetupError(
+            f"checkout check failed for {repo_dir}: {exc}"
+        ) from exc
+    return {
+        "remote": "origin",
+        "branch": branch,
+        "clean": True,
+        "base_fresh": head == base,
+    }
+
+
+def check_optional_proxy(run_command) -> dict:
+    """Health-check the optional local-llm-kv-cache proxy (never raises).
+
+    The proxy (docs/optional-kv-cache.mdx) is an optional enhancement:
+    its absence or unhealthiness is reported as a warning and never
+    blocks the core GitHub/Pilot setup. ``healthy`` on a 2xx health
+    response, ``unhealthy`` on a command/HTTP failure, ``unavailable``
+    when curl itself is missing.
+    """
+    try:
+        run_command([
+            "curl", "-fsS", "-m", str(OPTIONAL_PROXY_TIMEOUT),
+            OPTIONAL_PROXY_URL,
+        ])
+        status = "healthy"
+    except FileNotFoundError:
+        status = "unavailable"
+    except Exception:
+        status = "unhealthy"
+    return {
+        "optional": True,
+        "proxy": status,
+        "url": OPTIONAL_PROXY_URL,
+    }
+
+
+def run_setup(config: dict, installed_dir: Path | None, *,
+              repos: list[str] | None = None,
+              run_command) -> dict:
+    """Run the full one-time setup and return its result document.
+
+    Order (fail fast, no mutation before the prerequisites pass):
+    commands -> auth -> per target repo (permission check, then label
+    alignment) -> unit install -> read-only checkout check -> optional
+    proxy health (warning only). ``repos`` overrides the target set
+    (the ``--repo`` flag); it must be a non-empty subset of the
+    configured ``source_repos``.
+    """
+    if repos is None:
+        targets = list(config["source_repos"])
+    else:
+        if not repos:
+            raise SetupError("--repo requires a non-empty repo list")
+        configured = list(config["source_repos"])
+        for repo in repos:
+            if repo not in configured:
+                raise SetupError(
+                    f"--repo must be one of: {', '.join(configured)}"
+                )
+        targets = list(repos)
+    repo_dir = config["repo_dir"]
+    defs = load_label_defs(repo_dir / LABELS_FILE)
+    check_commands(run_command)
+    check_auth(run_command)
+    repo_results = []
+    for repo in targets:
+        info = check_repo(repo, run_command)
+        labels = align_labels(repo, defs, run_command)
+        repo_results.append({
+            **info,
+            "labels": {"aligned": labels["aligned"], "total": labels["total"]},
+        })
+    units = install_units_step(repo_dir, installed_dir, run_command=run_command)
+    checkout = check_checkout(
+        repo_dir, config["base_branch"], run_command=run_command,
+    )
+    optional_proxy = check_optional_proxy(run_command)
+    return {
+        "setup": "ok",
+        "version": SETUP_VERSION,
+        "base_branch": config["base_branch"],
+        "repos": repo_results,
+        "service": units["service"],
+        "timer": units["timer"],
+        "checkout": checkout,
+        "optional_proxy": optional_proxy,
+    }
+
+
+def format_setup(result: dict) -> list[str]:
+    """Render the result document as stable key=value lines.
+
+    One line per concern; values containing spaces are quoted (the
+    ``pi_activity.quote_value`` convention) so the output stays
+    parseable.
+    """
+    lines = [
+        (
+            f"setup={result['setup']} version={result['version']} "
+            f"base_branch={result['base_branch']}"
+        ),
+    ]
+    for entry in result["repos"]:
+        lines.append(
+            f"repo={entry['repo']} permission={entry['permission']} "
+            f"default_branch={entry['default_branch']} "
+            f"labels={entry['labels']['aligned']}/{entry['labels']['total']}"
+        )
+    service = result["service"]
+    lines.append(
+        f"service=installed path={quote_value(str(service['installed_path']))} "
+        f"sha256={service['sha256']}"
+    )
+    timer = result["timer"]
+    lines.append(
+        f"timer={'enabled' if timer['enabled'] else 'disabled'} "
+        f"active={'true' if timer['active'] else 'false'} "
+        f"next={quote_value(timer['next'])}"
+    )
+    checkout = result["checkout"]
+    lines.append(
+        f"checkout=remote={checkout['remote']} "
+        f"branch={quote_value(checkout['branch'])} "
+        f"clean={'true' if checkout['clean'] else 'false'} "
+        f"base_fresh={'true' if checkout['base_fresh'] else 'false'}"
+    )
+    proxy = result["optional_proxy"]
+    lines.append(
+        f"model_endpoint=optional optional_proxy={proxy['proxy']} "
+        f"url={proxy['url']}"
+    )
+    return lines
+
+
+def to_json(result: dict) -> str:
+    """The result document as JSON (equivalent to the key=value lines)."""
+    return json.dumps(result, indent=2, ensure_ascii=False)

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -351,7 +351,9 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     return {
         "service": {
             "installed": True,
-            "installed_path": service["installed_path"],
+            # str: the result document must stay JSON-serializable
+            # (--json output contract).
+            "installed_path": str(service["installed_path"]),
             "sha256": service["sha256"],
         },
         "timer": {

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1179,6 +1179,128 @@ def test_main_install_units_prints_report_and_returns_zero(
     assert "deployed commit=abc installed_dir=/x" in out
 
 
+# --- setup (Issue #117) -------------------------------------------------------
+
+
+
+def _setup_result() -> dict:
+    """A complete run_setup result document (format_setup contract)."""
+    return {
+        "setup": "ok",
+        "version": 1,
+        "base_branch": "main",
+        "repos": [
+            {
+                "repo": "xqliu/muyan-pilot",
+                "permission": "ADMIN",
+                "default_branch": "main",
+                "labels": {"aligned": 7, "total": 7},
+            },
+        ],
+        "service": {
+            "installed": True,
+            "installed_path": "/u/.config/systemd/user/muyan-pilot.service",
+            "sha256": "ab" * 32,
+        },
+        "timer": {"enabled": True, "active": True, "next": "-"},
+        "checkout": {
+            "remote": "origin",
+            "branch": "main",
+            "clean": True,
+            "base_fresh": True,
+        },
+        "optional_proxy": {
+            "optional": True,
+            "proxy": "healthy",
+            "url": "http://127.0.0.1:18082/health",
+        },
+    }
+
+def _setup_world(tmp_path):
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"xqliu/muyan-pilot\"]\n",
+                      encoding="utf-8")
+    _write_prompts(tmp_path)
+    return config
+
+
+def test_main_setup_prints_key_value_lines_and_returns_zero(
+    monkeypatch, tmp_path, capsys,
+):
+    config = _setup_world(tmp_path)
+    seen = {}
+    result = _setup_result()
+
+    def fake_run_setup(cfg, installed_dir, **kwargs):
+        seen["config"] = cfg
+        seen["installed_dir"] = installed_dir
+        seen.update(kwargs)
+        return result
+
+    monkeypatch.setattr(muyan_pilot.pilot_setup, "run_setup", fake_run_setup)
+    assert muyan_pilot.main([
+        "setup", "--config", str(config),
+        "--installed-dir", str(tmp_path / "u"),
+    ]) == 0
+    assert seen["installed_dir"] == tmp_path / "u"
+    assert seen["repos"] is None
+    assert seen["config"]["source_repos"] == ["xqliu/muyan-pilot"]
+    out = capsys.readouterr().out
+    assert "setup=ok" in out
+
+
+def test_main_setup_json_prints_the_equivalent_document(
+    monkeypatch, tmp_path, capsys,
+):
+    config = _setup_world(tmp_path)
+    result = {"setup": "ok", "version": 1, "base_branch": "main"}
+    monkeypatch.setattr(
+        muyan_pilot.pilot_setup, "run_setup",
+        lambda cfg, installed_dir, **kwargs: result,
+    )
+    assert muyan_pilot.main([
+        "setup", "--json", "--config", str(config),
+    ]) == 0
+    out = capsys.readouterr().out
+    assert json.loads(out) == result
+
+
+def test_main_setup_repo_override_is_passed_through(
+    monkeypatch, tmp_path, capsys,
+):
+    config = _setup_world(tmp_path)
+    seen = {}
+
+    def fake_run_setup(cfg, installed_dir, **kwargs):
+        seen.update(kwargs)
+        return _setup_result()
+
+    monkeypatch.setattr(muyan_pilot.pilot_setup, "run_setup", fake_run_setup)
+    assert muyan_pilot.main([
+        "setup", "--repo", "xqliu/muyan-pilot", "--config", str(config),
+    ]) == 0
+    assert seen["repos"] == ["xqliu/muyan-pilot"]
+
+
+def test_main_setup_failure_prints_the_reason_and_returns_nonzero(
+    monkeypatch, tmp_path, capsys,
+):
+    config = _setup_world(tmp_path)
+
+    def failing(cfg, installed_dir, **kwargs):
+        raise muyan_pilot.pilot_setup.SetupError(
+            "insufficient permission for xqliu/muyan-pilot",
+        )
+
+    monkeypatch.setattr(muyan_pilot.pilot_setup, "run_setup", failing)
+    assert muyan_pilot.main([
+        "setup", "--config", str(config),
+    ]) == 1
+    err = capsys.readouterr().err
+    assert "setup_failed" in err
+    assert "insufficient permission" in err
+
+
 def test_doctor_report_clean(tmp_path, monkeypatch):
     config, installed = _deploy_world(tmp_path, drift=False)
     calls = _fake_doctor_commands(monkeypatch)

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -437,7 +437,9 @@ def test_install_units_step_reports_install_state(tmp_path):
         repo, installed, run_command=fake_run,
     )
     assert result["service"]["installed"] is True
-    assert result["service"]["installed_path"] == installed / "muyan-pilot.service"
+    assert result["service"]["installed_path"] == str(
+        installed / "muyan-pilot.service",
+    )
     assert result["service"]["sha256"] == systemd_deploy.sha256_hex(
         installed / "muyan-pilot.service",
     )
@@ -858,6 +860,20 @@ def test_format_setup_renders_multiple_repos():
     assert len(repo_lines) == 2
     assert repo_lines[1].startswith("repo=xqliu/muyan-ceo ")
     assert "labels=6/7" in repo_lines[1]
+
+
+def test_install_units_step_result_is_json_serializable(tmp_path):
+    """Regression: install_units_step returns a Path for the installed
+    unit; the --json contract requires the result document to stay
+    JSON-serializable."""
+    state = {}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", run_command=fake_run,
+    )
+    assert isinstance(result["service"]["installed_path"], str)
+    json.loads(pilot_setup.to_json(result))
 
 
 def test_json_output_round_trips_the_result():

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -1,0 +1,983 @@
+"""One-time setup tests (Issue #117).
+
+`muyan_pilot.py setup` is the config-driven, idempotent, fail-fast
+initialization entry: it verifies gh auth and repo permissions, aligns
+the platform labels from the repo-managed `labels.toml` (the single
+source of truth for name/color/description), installs the repo's
+systemd user units, checks the local checkout read-only, and reports the
+optional model proxy health as a warning only. Core failures raise
+`SetupError` with a concrete reason before any later mutation; the
+optional proxy never blocks the core setup.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import bootstrap_runner as runner
+import pilot_setup
+import systemd_deploy
+
+VALID_DEFS = [
+    {"name": "ai-ready", "color": "1d76db", "description": "dispatched"},
+    {"name": "ai-in-progress", "color": "fbca04", "description": "work"},
+    {"name": "ai-pr-opened", "color": "0e8a16", "description": "pr"},
+    {"name": "ai-fix-needed", "color": "fbca04", "description": "fix"},
+    {"name": "ai-merged", "color": "0e8a16", "description": "merged"},
+    {"name": "ai-blocked", "color": "d73a4a", "description": "blocked"},
+    {"name": "p0", "color": "fbca04", "description": "urgent"},
+]
+
+
+def write_labels_toml(tmp_path: Path, defs: list[dict]) -> Path:
+    lines = []
+    for entry in defs:
+        lines.append("[[label]]")
+        for key in ("name", "color", "description"):
+            lines.append(f'{key} = "{entry[key]}"')
+        lines.append("")
+    path = tmp_path / "labels.toml"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def make_repo(tmp_path: Path) -> Path:
+    """A deployment checkout carrying unit templates and labels.toml."""
+    repo = tmp_path / "repo"
+    systemd = repo / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "muyan-pilot.service").write_text(
+        "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n",
+        encoding="utf-8",
+    )
+    (systemd / "muyan-pilot.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/15\n", encoding="utf-8",
+    )
+    write_labels_toml(repo, VALID_DEFS)
+    return repo
+
+
+def make_config(tmp_path: Path, repo_dir: Path,
+                source_repos: list[str] | None = None) -> Path:
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        "source_repos = ["
+        + ", ".join(f'"{r}"' for r in (source_repos or ["xqliu/muyan-pilot"]))
+        + f']\nrepo_dir = "{repo_dir}"\nbase_branch = "main"\n',
+        encoding="utf-8",
+    )
+    return config
+
+
+def fake_run_factory(state: dict):
+    """A run_command double driven by `state` (a dict of call counters)."""
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        head = list(command)
+        if head[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        if head[:2] == ["git", "remote"]:
+            return "origin"
+        if head[:3] == ["git", "branch", "--show-current"]:
+            return "main"
+        if head[:2] == ["git", "status"]:
+            return ""
+        if head[:3] == ["git", "fetch", "origin"]:
+            return ""
+        if head[:3] == ["git", "rev-parse", "origin/main"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        if head[:2] == ["gh", "auth"]:
+            return ""
+        if head[:3] == ["gh", "repo", "view"]:
+            return (
+                '{"nameWithOwner":"xqliu/muyan-pilot",'
+                '"viewerPermission":"ADMIN",'
+                '"defaultBranchRef":{"name":"main"}}'
+            )
+        if head[:3] == ["gh", "label", "list"]:
+            return json.dumps(state.get("existing_labels", []))
+        if head[:3] == ["gh", "label", "create"]:
+            return ""
+        if head[:3] == ["systemctl", "--user", "show"]:
+            if "-p" in command and command[command.index("-p") + 1] == "ActiveState":
+                return state.get("active_state", "active")
+            return "loaded"
+        if head[:3] == ["systemctl", "--user", "is-enabled"]:
+            return state.get("is_enabled", "enabled")
+        if head[:3] == ["systemctl", "--user", "list-timers"]:
+            return state.get(
+                "list_timers",
+                "NEXT\n"
+                "Thu 2026-08-27 10:00:00 +08        1min "
+                "Thu 2026-08-27 09:45:00 +08    15min ago "
+                "muyan-pilot.timer                   muyan-pilot.service\n",
+            )
+        if head[:1] == ["curl"]:
+            if state.get("proxy_down"):
+                raise subprocess.CalledProcessError(
+                    7, command, stderr="Connection refused",
+                )
+            return '{"status":"ok"}'
+        if head[:2] == ["systemctl", "--user"] and head[2] in (
+            "daemon-reload", "enable",
+        ):
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    return fake_run, calls
+
+
+def test_fake_run_factory_rejects_an_unexpected_command():
+    fake_run, _ = fake_run_factory({})
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["definitely", "not", "a", "known", "command"])
+
+
+# --- labels.toml: the single source of truth -------------------------------
+
+
+def test_load_label_defs_parses_all_seven_platform_labels(tmp_path):
+    path = write_labels_toml(tmp_path, VALID_DEFS)
+    defs = pilot_setup.load_label_defs(path)
+    assert [entry["name"] for entry in defs] == [
+        "ai-ready", "ai-in-progress", "ai-pr-opened",
+        "ai-fix-needed", "ai-merged", "ai-blocked", "p0",
+    ]
+    assert defs[0] == {
+        "name": "ai-ready", "color": "1d76db", "description": "dispatched",
+    }
+
+
+def test_load_label_defs_rejects_a_missing_platform_label(tmp_path):
+    defs = [entry for entry in VALID_DEFS if entry["name"] != "p0"]
+    path = write_labels_toml(tmp_path, defs)
+    with pytest.raises(pilot_setup.SetupError, match="p0"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_an_unknown_label(tmp_path):
+    defs = VALID_DEFS + [
+        {"name": "ai-epic", "color": "bfdadc", "description": "epic"},
+    ]
+    path = write_labels_toml(tmp_path, defs)
+    with pytest.raises(pilot_setup.SetupError, match="ai-epic"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_duplicate_names(tmp_path):
+    defs = VALID_DEFS + [dict(VALID_DEFS[0])]
+    path = write_labels_toml(tmp_path, defs)
+    with pytest.raises(pilot_setup.SetupError, match="duplicate"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_a_bad_color(tmp_path):
+    defs = [dict(entry) for entry in VALID_DEFS]
+    defs[0]["color"] = "red"
+    path = write_labels_toml(tmp_path, defs)
+    with pytest.raises(pilot_setup.SetupError, match="color"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_an_empty_description(tmp_path):
+    defs = [dict(entry) for entry in VALID_DEFS]
+    defs[0]["description"] = ""
+    path = write_labels_toml(tmp_path, defs)
+    with pytest.raises(pilot_setup.SetupError, match="description"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_a_missing_file(tmp_path):
+    with pytest.raises(pilot_setup.SetupError, match="labels.toml"):
+        pilot_setup.load_label_defs(tmp_path / "labels.toml")
+
+
+def test_load_label_defs_rejects_malformed_toml(tmp_path):
+    path = tmp_path / "labels.toml"
+    path.write_text("label = 3\n", encoding="utf-8")
+    with pytest.raises(pilot_setup.SetupError, match="labels.toml"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_committed_labels_toml_covers_the_seven_platform_labels():
+    """The committed labels.toml (repo root) must define exactly the 7
+    platform labels with valid colors and non-empty descriptions."""
+    path = Path(__file__).resolve().parent.parent / "labels.toml"
+    defs = pilot_setup.load_label_defs(path)
+    assert [entry["name"] for entry in defs] == list(
+        pilot_setup.REQUIRED_LABELS,
+    )
+
+
+# --- prerequisites: commands and auth ---------------------------------------
+
+
+def test_check_commands_reports_the_required_commands(monkeypatch):
+    monkeypatch.setattr(
+        pilot_setup.shutil, "which",
+        lambda name: f"/usr/bin/{name}",
+    )
+    result = pilot_setup.check_commands(
+        run_command=lambda command, **kwargs: "loaded",
+    )
+    assert result == {
+        "git": "/usr/bin/git",
+        "gh": "/usr/bin/gh",
+        "python3": "/usr/bin/python3",
+        "systemctl": "user-bus-ok",
+    }
+
+
+def test_check_commands_fails_fast_on_a_missing_command(monkeypatch):
+    monkeypatch.setattr(
+        pilot_setup.shutil, "which",
+        lambda name: None if name == "gh" else f"/usr/bin/{name}",
+    )
+    with pytest.raises(pilot_setup.SetupError, match="gh"):
+        pilot_setup.check_commands(
+            run_command=lambda command, **kwargs: "loaded",
+        )
+
+
+def test_check_commands_fails_fast_without_a_user_bus(monkeypatch):
+    monkeypatch.setattr(
+        pilot_setup.shutil, "which",
+        lambda name: f"/usr/bin/{name}",
+    )
+    with pytest.raises(
+        pilot_setup.SetupError, match="user bus",
+    ):
+        pilot_setup.check_commands(
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(
+                        1, command,
+                        stderr="Failed to connect to user scope bus",
+                    )
+                )
+            ),
+        )
+
+
+def test_check_auth_passes_when_gh_is_logged_in():
+    pilot_setup.check_auth(run_command=lambda command, **kwargs: "")
+    # no exception: logged in
+
+
+def test_check_auth_fails_fast_when_gh_is_not_logged_in():
+    with pytest.raises(pilot_setup.SetupError, match="gh auth"):
+        pilot_setup.check_auth(
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(
+                        1, command, stderr="not logged in",
+                    )
+                )
+            ),
+        )
+
+
+# --- repo permission check ---------------------------------------------------
+
+
+def test_check_repo_reports_permission_and_default_branch():
+    result = pilot_setup.check_repo(
+        "xqliu/muyan-pilot",
+        run_command=lambda command, **kwargs: (
+            json.dumps({
+                "nameWithOwner": "xqliu/muyan-pilot",
+                "viewerPermission": "WRITE",
+                "defaultBranchRef": {"name": "main"},
+            })
+        ),
+    )
+    assert result == {
+        "repo": "xqliu/muyan-pilot",
+        "permission": "WRITE",
+        "default_branch": "main",
+    }
+
+
+def test_check_repo_fails_fast_on_a_read_only_repo():
+    with pytest.raises(pilot_setup.SetupError, match="permission"):
+        pilot_setup.check_repo(
+            "xqliu/muyan-pilot",
+            run_command=lambda command, **kwargs: (
+                json.dumps({
+                    "nameWithOwner": "xqliu/muyan-pilot",
+                    "viewerPermission": "READ",
+                    "defaultBranchRef": {"name": "main"},
+                })
+            ),
+        )
+
+
+def test_check_repo_fails_fast_when_the_repo_is_missing():
+    with pytest.raises(pilot_setup.SetupError, match="no-such"):
+        pilot_setup.check_repo(
+            "nobody/no-such",
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(
+                        1, command,
+                        stderr="Could not resolve to a Repository",
+                    )
+                )
+            ),
+        )
+
+
+def test_check_repo_fails_fast_on_unparseable_output():
+    with pytest.raises(pilot_setup.SetupError, match="parse"):
+        pilot_setup.check_repo(
+            "xqliu/muyan-pilot",
+            run_command=lambda command, **kwargs: "not-json",
+        )
+
+
+# --- label alignment ---------------------------------------------------------
+
+
+def test_align_labels_creates_missing_and_edits_drifted(tmp_path):
+    state = {"existing_labels": [
+        dict(entry) for entry in VALID_DEFS
+    ] + [
+        {"name": "bug", "color": "d73a4a",
+         "description": "Something isn't working"},
+    ]}
+    # p0 is drifted (color and description), ai-ready already matches.
+    state["existing_labels"] = [
+        entry
+        for entry in state["existing_labels"]
+        if entry["name"] != "p0"
+    ] + [
+        {"name": "p0", "color": "000000", "description": "old"},
+    ]
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.align_labels(
+        "xqliu/muyan-pilot",
+        pilot_setup.load_label_defs(repo / "labels.toml"),
+        run_command=fake_run,
+    )
+    assert result["repo"] == "xqliu/muyan-pilot"
+    assert result["aligned"] == 7
+    assert result["total"] == 7
+    # Only the drifted p0 label is written; ai-ready already matches and
+    # the business label `bug` is never touched.
+    creates = [c for c in calls if c[:3] == ["gh", "label", "create"]]
+    assert len(creates) == 1
+    assert creates[0][:3] == ["gh", "label", "create"]
+    assert creates[0][3] == "p0"
+    assert "--force" in creates[0]
+    assert "--color" in creates[0]
+    assert "--description" in creates[0]
+    assert "--repo" in creates[0]
+
+
+def test_align_labels_is_idempotent_when_everything_matches(tmp_path):
+    state = {"existing_labels": [dict(entry) for entry in VALID_DEFS]}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.align_labels(
+        "xqliu/muyan-pilot",
+        pilot_setup.load_label_defs(repo / "labels.toml"),
+        run_command=fake_run,
+    )
+    assert result["aligned"] == 7
+    assert [c for c in calls if c[:3] == ["gh", "label", "create"]] == []
+
+
+def test_align_labels_reports_partial_alignment(tmp_path):
+    state = {"existing_labels": []}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.align_labels(
+        "xqliu/muyan-pilot",
+        pilot_setup.load_label_defs(repo / "labels.toml"),
+        run_command=fake_run,
+    )
+    assert result["aligned"] == 7
+    assert result["total"] == 7
+    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 7
+
+
+def test_align_labels_fails_fast_on_a_label_write_error(tmp_path):
+    state = {"existing_labels": []}
+    fake_run, calls = fake_run_factory(state)
+
+    def failing(command, **kwargs):
+        if command[:3] == ["gh", "label", "create"]:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="boom",
+            )
+        return fake_run(command, **kwargs)
+
+    repo = make_repo(tmp_path)
+    with pytest.raises(pilot_setup.SetupError, match="label"):
+        pilot_setup.align_labels(
+            "xqliu/muyan-pilot",
+            pilot_setup.load_label_defs(repo / "labels.toml"),
+            run_command=failing,
+        )
+
+
+# --- units -------------------------------------------------------------------
+
+
+def test_install_units_step_reports_install_state(tmp_path):
+    state = {}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "units"
+    result = pilot_setup.install_units_step(
+        repo, installed, run_command=fake_run,
+    )
+    assert result["service"]["installed"] is True
+    assert result["service"]["installed_path"] == installed / "muyan-pilot.service"
+    assert result["service"]["sha256"] == systemd_deploy.sha256_hex(
+        installed / "muyan-pilot.service",
+    )
+    assert result["timer"]["enabled"] is True
+    assert result["timer"]["active"] is True
+    assert result["timer"]["next"] == "Thu 2026-08-27 10:00:00 +08"
+    # The install itself is the systemd_deploy idempotent install.
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot.timer",
+    ] in calls
+
+
+def test_install_units_step_reports_a_disabled_inactive_timer(tmp_path):
+    state = {"is_enabled": "disabled", "active_state": "inactive"}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", run_command=fake_run,
+    )
+    assert result["timer"]["enabled"] is False
+    assert result["timer"]["active"] is False
+
+
+def test_install_units_step_reports_a_missing_next_trigger(tmp_path):
+    state = {"list_timers": "NEXT\n"}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", run_command=fake_run,
+    )
+    assert result["timer"]["next"] == "-"
+
+
+def test_install_units_step_fails_fast_on_an_install_error(tmp_path):
+    repo = make_repo(tmp_path)
+
+    def failing(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "enable"]:
+            raise subprocess.CalledProcessError(1, command, stderr="no bus")
+        return ""
+
+    with pytest.raises(pilot_setup.SetupError, match="units"):
+        pilot_setup.install_units_step(
+            repo, tmp_path / "units", run_command=failing,
+        )
+
+
+def test_timer_next_trigger_parses_the_list_timers_row():
+    raw = (
+        "NEXT                                   LEFT LAST\n"
+        "Thu 2026-08-27 10:00:00 +08        1min 46s "
+        "Thu 2026-08-27 09:18:18 +08    28min ago "
+        "muyan-pilot.timer                   muyan-pilot.service\n"
+    )
+    assert pilot_setup.timer_next_trigger(raw) == (
+        "Thu 2026-08-27 10:00:00 +08"
+    )
+
+
+def test_timer_next_trigger_returns_dash_when_the_timer_is_absent():
+    assert pilot_setup.timer_next_trigger("NEXT\n") == "-"
+
+
+def test_timer_next_trigger_ignores_other_timers():
+    raw = (
+        "NEXT                                   LEFT LAST\n"
+        "Thu 2026-08-27 10:00:00 +08        1min 46s "
+        "Thu 2026-08-27 09:18:18 +08    28min ago "
+        "other.timer                         other.service\n"
+    )
+    assert pilot_setup.timer_next_trigger(raw) == "-"
+
+
+# --- checkout check (read-only) ----------------------------------------------
+
+
+def test_check_checkout_reports_remote_branch_clean_and_fresh(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    result = pilot_setup.check_checkout(
+        repo, "main", run_command=lambda command, **kwargs: (
+            "0123456789abcdef0123456789abcdef01234567"
+            if command[:3] == ["git", "rev-parse", "origin/main"]
+            else "0123456789abcdef0123456789abcdef01234567"
+            if command[:3] == ["git", "rev-parse", "HEAD"]
+            else "origin"
+            if command[:2] == ["git", "remote"]
+            else "main"
+            if command[:3] == ["git", "branch", "--show-current"]
+            else ""
+        ),
+    )
+    assert result == {
+        "remote": "origin",
+        "branch": "main",
+        "clean": True,
+        "base_fresh": True,
+    }
+
+
+def test_check_checkout_fails_fast_on_a_dirty_checkout(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "remote"]:
+            return "origin"
+        if command[:2] == ["git", "status"]:
+            return " M bootstrap_runner.py"
+        return ""
+
+    with pytest.raises(pilot_setup.SetupError, match="not clean"):
+        pilot_setup.check_checkout(
+            repo, "main", run_command=fake_run,
+        )
+
+
+def test_check_checkout_reports_a_stale_base(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "remote"]:
+            return "origin"
+        if command[:3] == ["git", "rev-parse", "origin/main"]:
+            return "1111111111111111111111111111111111111111"
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "2222222222222222222222222222222222222222"
+        return ""
+
+    result = pilot_setup.check_checkout(
+        repo, "main", run_command=fake_run,
+    )
+    assert result["base_fresh"] is False
+
+
+def test_check_checkout_fails_fast_without_an_origin_remote(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    with pytest.raises(pilot_setup.SetupError, match="remote"):
+        pilot_setup.check_checkout(
+            repo, "main",
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(1, command, stderr="no remote")
+                )
+            ),
+        )
+
+
+def test_check_checkout_fails_fast_on_a_git_error(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    with pytest.raises(pilot_setup.SetupError, match="checkout"):
+        pilot_setup.check_checkout(
+            repo, "main",
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(1, command, stderr="boom")
+                )
+            ),
+        )
+
+
+# --- optional model proxy (never blocks) --------------------------------------
+
+
+def test_check_optional_proxy_reports_healthy():
+    result = pilot_setup.check_optional_proxy(
+        run_command=lambda command, **kwargs: '{"status":"ok"}',
+    )
+    assert result == {
+        "optional": True,
+        "proxy": "healthy",
+        "url": pilot_setup.OPTIONAL_PROXY_URL,
+    }
+
+
+def test_check_optional_proxy_reports_unhealthy_without_raising():
+    result = pilot_setup.check_optional_proxy(
+        run_command=lambda command, **kwargs: (
+            (_ for _ in ()).throw(
+                subprocess.CalledProcessError(7, command, stderr="refused")
+            )
+        ),
+    )
+    assert result["proxy"] == "unhealthy"
+    assert result["optional"] is True
+
+
+def test_check_optional_proxy_reports_a_missing_curl_without_raising():
+    result = pilot_setup.check_optional_proxy(
+        run_command=lambda command, **kwargs: (
+            (_ for _ in ()).throw(FileNotFoundError("curl"))
+        ),
+    )
+    assert result["proxy"] == "unavailable"
+    assert result["optional"] is True
+
+
+# --- run_setup orchestration ---------------------------------------------------
+
+
+def make_run_state(tmp_path: Path):
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "units"
+    state = {
+        "existing_labels": [dict(entry) for entry in VALID_DEFS],
+    }
+    return repo, installed, state
+
+
+def test_run_setup_success_reports_all_steps(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo))
+    result = pilot_setup.run_setup(
+        config, installed,
+        run_command=fake_run,
+    )
+    assert result["setup"] == "ok"
+    assert result["version"] == pilot_setup.SETUP_VERSION
+    assert result["base_branch"] == "main"
+    assert result["repos"] == [
+        {
+            "repo": "xqliu/muyan-pilot",
+            "permission": "ADMIN",
+            "default_branch": "main",
+            "labels": {"aligned": 7, "total": 7},
+        },
+    ]
+    assert result["service"]["installed"] is True
+    assert result["timer"]["enabled"] is True
+    assert result["timer"]["active"] is True
+    assert result["checkout"]["clean"] is True
+    assert result["checkout"]["base_fresh"] is True
+    assert result["optional_proxy"]["optional"] is True
+
+
+def test_run_setup_repo_override_limits_the_target(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(
+        tmp_path, repo,
+        source_repos=["xqliu/muyan-pilot", "xqliu/muyan-ceo"],
+    ))
+    result = pilot_setup.run_setup(
+        config, installed,
+        repos=["xqliu/muyan-pilot"],
+        run_command=fake_run,
+    )
+    assert [entry["repo"] for entry in result["repos"]] == [
+        "xqliu/muyan-pilot",
+    ]
+    views = [
+        c for c in calls if c[:3] == ["gh", "repo", "view"]
+    ]
+    assert len(views) == 1
+
+
+def test_run_setup_rejects_a_repo_outside_the_config(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="--repo"):
+        pilot_setup.run_setup(
+            config, installed,
+            repos=["other/repo"],
+            run_command=lambda command, **kwargs: "",
+        )
+
+
+def test_run_setup_fails_fast_on_auth_before_any_mutation(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    fake_run, calls = fake_run_factory(state)
+
+    def failing(command, **kwargs):
+        if command[:2] == ["gh", "auth"]:
+            raise subprocess.CalledProcessError(1, command, stderr="nope")
+        return fake_run(command, **kwargs)
+
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="gh auth"):
+        pilot_setup.run_setup(
+            config, installed, run_command=failing,
+        )
+    # No label mutation, no unit install happened before the failure.
+    assert [c for c in calls if c[:3] == ["gh", "label", "create"]] == []
+    assert [c for c in calls if c[:3] == ["systemctl", "--user", "daemon-reload"]] == []
+
+
+def test_run_setup_fails_fast_on_a_label_error_before_units(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    state["existing_labels"] = []
+    fake_run, calls = fake_run_factory(state)
+
+    def failing(command, **kwargs):
+        if command[:3] == ["gh", "label", "create"]:
+            raise subprocess.CalledProcessError(1, command, stderr="boom")
+        return fake_run(command, **kwargs)
+
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="label"):
+        pilot_setup.run_setup(
+            config, installed, run_command=failing,
+        )
+    assert [c for c in calls if c[:3] == ["systemctl", "--user", "daemon-reload"]] == []
+
+
+def test_run_setup_optional_proxy_failure_never_blocks(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    state["proxy_down"] = True
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo))
+    result = pilot_setup.run_setup(
+        config, installed, run_command=fake_run,
+    )
+    assert result["setup"] == "ok"
+    assert result["optional_proxy"]["proxy"] == "unhealthy"
+
+
+def test_run_setup_missing_labels_file_fails_fast(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / "labels.toml").unlink()
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="labels.toml"):
+        pilot_setup.run_setup(
+            config, tmp_path / "units",
+            run_command=lambda command, **kwargs: "",
+        )
+
+
+# --- output rendering -----------------------------------------------------------
+
+
+def sample_result() -> dict:
+    return {
+        "setup": "ok",
+        "version": 1,
+        "base_branch": "main",
+        "repos": [
+            {
+                "repo": "xqliu/muyan-pilot",
+                "permission": "ADMIN",
+                "default_branch": "main",
+                "labels": {"aligned": 7, "total": 7},
+            },
+        ],
+        "service": {
+            "installed": True,
+            "installed_path": "/home/u/.config/systemd/user/muyan-pilot.service",
+            "sha256": "ab" * 32,
+        },
+        "timer": {
+            "enabled": True,
+            "active": True,
+            "next": "Thu 2026-08-27 10:00:00 +08",
+        },
+        "checkout": {
+            "remote": "origin",
+            "branch": "main",
+            "clean": True,
+            "base_fresh": True,
+        },
+        "optional_proxy": {
+            "optional": True,
+            "proxy": "healthy",
+            "url": "http://127.0.0.1:18082/health",
+        },
+    }
+
+
+def test_format_setup_renders_stable_key_value_lines():
+    lines = pilot_setup.format_setup(sample_result())
+    assert lines[0] == "setup=ok version=1 base_branch=main"
+    assert (
+        "repo=xqliu/muyan-pilot permission=ADMIN "
+        "default_branch=main labels=7/7" in lines
+    )
+    assert (
+        "service=installed path=/home/u/.config/systemd/user/"
+        "muyan-pilot.service sha256=" + "ab" * 32 in lines
+    )
+    # The NEXT field carries spaces, so it is quoted (quote_value).
+    assert (
+        'timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"'
+    ) in lines
+    assert (
+        "checkout=remote=origin branch=main clean=true base_fresh=true"
+    ) in lines
+    assert (
+        "model_endpoint=optional optional_proxy=healthy "
+        "url=http://127.0.0.1:18082/health"
+    ) in lines
+
+
+def test_format_setup_quotes_values_with_spaces():
+    result = sample_result()
+    result["timer"]["next"] = "Thu 2026 08-27 10:00:00"
+    lines = pilot_setup.format_setup(result)
+    assert (
+        'timer=enabled active=true next="Thu 2026 08-27 10:00:00"'
+    ) in lines
+
+
+def test_format_setup_renders_multiple_repos():
+    result = sample_result()
+    result["repos"].append(
+        {
+            "repo": "xqliu/muyan-ceo",
+            "permission": "WRITE",
+            "default_branch": "main",
+            "labels": {"aligned": 6, "total": 7},
+        },
+    )
+    lines = pilot_setup.format_setup(result)
+    repo_lines = [line for line in lines if line.startswith("repo=")]
+    assert len(repo_lines) == 2
+    assert repo_lines[1].startswith("repo=xqliu/muyan-ceo ")
+    assert "labels=6/7" in repo_lines[1]
+
+
+def test_json_output_round_trips_the_result():
+    payload = pilot_setup.to_json(sample_result())
+    assert json.loads(payload) == sample_result()
+
+
+def test_setup_error_is_a_runtime_error():
+    assert issubclass(pilot_setup.SetupError, RuntimeError)
+
+
+# --- remaining defensive branches ---------------------------------------------
+
+
+def test_load_label_defs_rejects_broken_toml_syntax(tmp_path):
+    path = tmp_path / "labels.toml"
+    path.write_text('label = ["\n', encoding="utf-8")
+    with pytest.raises(pilot_setup.SetupError, match="malformed"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_a_non_table_entry(tmp_path):
+    path = tmp_path / "labels.toml"
+    path.write_text("label = [1]\n", encoding="utf-8")
+    with pytest.raises(
+        pilot_setup.SetupError, match="must be a table",
+    ):
+        pilot_setup.load_label_defs(path)
+
+
+def test_load_label_defs_rejects_an_entry_without_a_name(tmp_path):
+    path = tmp_path / "labels.toml"
+    path.write_text(
+        "[[label]]\ncolor = \"1d76db\"\ndescription = \"x\"\n"
+        + "\n".join(
+            f'[[label]]\nname = "{e["name"]}"\ncolor = "{e["color"]}"\n'
+            f'description = "{e["description"]}"'
+            for e in VALID_DEFS[1:]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(pilot_setup.SetupError, match="no non-empty name"):
+        pilot_setup.load_label_defs(path)
+
+
+def test_check_repo_fails_fast_on_non_object_json():
+    with pytest.raises(pilot_setup.SetupError, match="parse"):
+        pilot_setup.check_repo(
+            "xqliu/muyan-pilot",
+            run_command=lambda command, **kwargs: "[1, 2]",
+        )
+
+
+def test_check_repo_fails_fast_without_name_with_owner():
+    with pytest.raises(pilot_setup.SetupError, match="nameWithOwner"):
+        pilot_setup.check_repo(
+            "xqliu/muyan-pilot",
+            run_command=lambda command, **kwargs: (
+                json.dumps({
+                    "viewerPermission": "WRITE",
+                    "defaultBranchRef": {"name": "main"},
+                })
+            ),
+        )
+
+
+def test_check_repo_fails_fast_without_default_branch():
+    with pytest.raises(pilot_setup.SetupError, match="defaultBranchRef"):
+        pilot_setup.check_repo(
+            "xqliu/muyan-pilot",
+            run_command=lambda command, **kwargs: (
+                json.dumps({
+                    "nameWithOwner": "xqliu/muyan-pilot",
+                    "viewerPermission": "WRITE",
+                })
+            ),
+        )
+
+
+def test_align_labels_fails_fast_on_unparseable_label_list():
+    with pytest.raises(pilot_setup.SetupError, match="label list"):
+        pilot_setup.align_labels(
+            "xqliu/muyan-pilot",
+            VALID_DEFS,
+            run_command=lambda command, **kwargs: "not-json",
+        )
+
+
+def test_align_labels_fails_fast_on_non_array_label_list():
+    with pytest.raises(pilot_setup.SetupError, match="label list"):
+        pilot_setup.align_labels(
+            "xqliu/muyan-pilot",
+            VALID_DEFS,
+            run_command=lambda command, **kwargs: '{"name": "bug"}',
+        )
+
+
+def test_timer_next_trigger_falls_back_to_the_first_column():
+    # A timer row without the two-space column separator (defensive
+    # fallback): the first column is reported as-is.
+    raw = "X muyan-pilot.timer muyan-pilot.service\n"
+    assert pilot_setup.timer_next_trigger(raw) == "X"
+
+
+def test_check_checkout_fails_fast_when_origin_is_missing(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    with pytest.raises(pilot_setup.SetupError, match="origin remote"):
+        pilot_setup.check_checkout(
+            repo, "main",
+            run_command=lambda command, **kwargs: "upstream",
+        )
+
+
+def test_run_setup_rejects_an_empty_repo_list(tmp_path):
+    repo = make_repo(tmp_path)
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="--repo"):
+        pilot_setup.run_setup(
+            config, tmp_path / "units",
+            repos=[],
+            run_command=lambda command, **kwargs: "",
+        )


### PR DESCRIPTION
Fixes #117

<!-- muyan-pilot:run=96dfeecc -->

run_id=96dfeecc

## One-time setup entry (config-driven, idempotent, fail-fast)

`python3 muyan_pilot.py setup --config muyan-pilot.toml` is the one-time
initialization entry for a new machine / new task-pool repository:

1. **Commands** — `git`, `gh`, `python3` on PATH + reachable
   `systemctl --user` user bus (probe `systemctl --user show`);
2. **Auth** — `gh auth status`;
3. **Per target repo** (every configured `source_repos`; `--repo
   OWNER/REPO` limits to one configured repo) — repo exists + viewer
   write permission (`gh repo view` → `viewerPermission` ∈
   WRITE/MAINTAIN/ADMIN), then the 7 platform labels aligned
   **declaratively** from `labels.toml` (repo-managed single source of
   truth for name/color/description: create missing, update drifted,
   never delete, business labels untouched);
4. **Systemd units** — idempotent install of the repo templates
   (reuses `systemd_deploy.install_units`: copy + daemon-reload +
   enable timer, never start/stop/restart the service) + enabled/
   active state + next trigger time (`list-timers`);
5. **Checkout** — read-only: `origin` remote, current branch, clean
   worktree (dirty fails: the timer's `ExecStartPre` would refuse it),
   base freshness (HEAD vs freshly fetched `origin/<base_branch>`,
   reported);
6. **Optional model proxy** — `local-llm-kv-cache` health
   (`http://127.0.0.1:18082/health`) reported as optional; never
   blocks core setup.

Output: stable `key=value` lines (space-carrying values quoted, the
`quote_value` convention) or `--json`; success exits 0, any core
failure prints `setup_failed reason=...` on stderr and exits 1 before
any later mutation. No business Issues created, no task claimed, no Pi
started, no protected branch touched.

```text
setup=ok version=1 base_branch=main
repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
service=installed path=... sha256=...
timer=enabled active=true next="Thu 2026-08-27 10:45:00 +08"
checkout=remote=origin branch=main clean=true base_fresh=true
model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
```

## Changed files

- `muyan_pilot.py` — new `setup` subcommand (`--repo`,
  `--installed-dir`, `--json`)
- `pilot_setup.py` (new) — setup steps, `SetupError` fail-fast,
  `format_setup`/`to_json` output
- `labels.toml` (new) — the 7 platform labels (values match the live
  xqliu/muyan-pilot labels, verified against the GitHub API)
- `tests/test_pilot_setup.py` (new, 62 tests) + `tests/test_muyan_pilot.py`
  (subcommand wiring)
- `docs/setup.mdx` (new page) + `docs/docs.json` navigation +
  `docs/getting-started.mdx` (steps 3/6 use the setup command) +
  `README.md` (setup entry + manual fallback)

## Verification

- Full suite: 764 passed, 100% line/branch coverage
  (`coverage run --branch -m pytest tests/ -q` +
  `coverage report --fail-under=100`).
- Real smoke runs on the Runner machine (real gh auth, real GitHub,
  real systemd user bus) — see `test.log` in the task worktree:
  success path, `--json`, `--repo` override, and the failure paths
  (no user bus, wrong repo, `--repo` outside config, dirty checkout),
  plus the label CREATE path on a fresh scratch repo
  (`labels=7/7`, business labels untouched) and idempotency (second
  run: zero label writes).
- External interfaces verified against `--help` / one real call
  (Issue #73): `gh label list/create --force`, `gh repo view --json
  nameWithOwner,viewerPermission,defaultBranchRef`, `gh auth status`,
  `systemctl --user show/is-enabled/list-timers`, `curl -fsS -m`.

## Notes

- Scratch repo `xqliu/muyan-pilot-setup-smoke-96dfeecc` (private,
  single README commit) was used for the live label-create smoke; the
  token lacks the `delete_repo` scope so it could not be deleted from
  this session — please delete it.
- Pre-existing machine observation (not caused by this change):
  `muyan-pilot.timer` can get stuck in `SubState=running` with no next
  elapse after it triggers a still-active service (systemd 261);
  `systemctl --user restart muyan-pilot.timer` restores the schedule.
