### PR TITLE
docs: blocking-command contract — timeout wrap + loop-test termination guard (Issue #95)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,13 @@ is **one runtime outcome** (when X, should Y, actually Z).
   refactor.
 - External APIs, CLI flags, and HTTP paths are asserted against official docs
   or one real call.
+- Blocking commands (Issue #95): any shell command that can block (running
+  tests, generator/polling verification, network waits, interactive tools)
+  is wrapped in `timeout <seconds> ...` — a timeout is the signal that the
+  path needs a fix, never ignorable noise. Testing an unbounded-loop
+  function (`while True` poller) requires a termination guard (monkeypatched
+  `time.sleep` raising on the Nth call, an injected iteration cap, or
+  pytest-timeout): the red phase must fail fast and never hang.
 - Python code keeps 100% line and branch coverage:
 
   ```bash

--- a/prompt.md
+++ b/prompt.md
@@ -49,6 +49,20 @@ Hard rules for external behavior (Issue #73):
   log on failure: a bypass failure must never decide whether the main delivery
   succeeded (Issue #79 makes the progress path a pure bypass).
 
+Hard rules for blocking commands (Issue #95):
+
+- Any shell command that can block — running tests, generator or polling
+  verification, network waits, interactive tools — must be wrapped in
+  `timeout <seconds> ...`. A timeout is the signal that the path needs a
+  fix (a missing termination guard, a wrong mock); it is never ignorable
+  noise and never a reason to rerun the same command unchanged.
+- Testing an unbounded-loop function (a `while True` poller such as
+  `wait_for_delivery`) requires a termination guard: monkeypatch
+  `time.sleep` to raise on the Nth call, inject an iteration cap
+  parameter, or use pytest-timeout. The TDD red phase must fail fast —
+  a hung test (a 99% CPU spin or a forever `next(g)` wait) is a broken
+  test, not a red test.
+
 Use the configured skills for implementation. Use TDD, 100% line and branch
 coverage for Python code. Do NOT run a review-fix loop or any independent
 review before opening the PR (Issue #78): the independent review happens

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -41,6 +41,14 @@ build files, and the changed code plus its callers before judging.
 - Bypass failures must only log (Issue #73/#79): a bypass (progress comments,
   notifications, log enhancements) whose failure can decide the main delivery
   outcome is a finding.
+- Blocking commands (Issue #95): a diff that drives a shell command which can
+  block (running tests, generator/polling verification, network waits,
+  interactive tools) without a `timeout <seconds>` wrapper, or that tests an
+  unbounded-loop function (`while True` poller) without a termination guard
+  (monkeypatched `time.sleep` raising on the Nth call, an injected iteration
+  cap, or pytest-timeout), is a **Blocker** — the red phase must fail fast,
+  never hang (the 99% CPU spin / forever `next(g)` class of hang must be
+  caught here, not shipped).
 - Verify the run evidence: the real test/build commands were run and pass in
   the repository's declared runtime; Python business code keeps 100% line and
   branch coverage when Python changed.

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -1,0 +1,108 @@
+"""Guard the prompt contract for blocking commands (Issue #95).
+
+Two real hangs (run cd855188 review session, run 9240f1e4 implement
+session) had the same pattern: a TDD red test driving a `while True`
+loop function spun at 99% CPU instead of failing fast, and an ad-hoc
+verification generator waited forever on `next(g)`. The model learns to
+wrap commands in `timeout` after a failure, but the contract must say
+it up front. These tests fail when the rule text is removed from
+`prompt.md`, `prompt_review.md` or the `AGENTS.md` TDD section, so the
+contract cannot silently drift away.
+"""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPT = REPO_ROOT / "prompt.md"
+PROMPT_REVIEW = REPO_ROOT / "prompt_review.md"
+CONTRACT = REPO_ROOT / "AGENTS.md"
+
+
+def _text(path: Path) -> str:
+    assert path.is_file(), f"missing contract file: {path}"
+    # Collapse whitespace so prose re-wrapping (a line break inside a
+    # sentence) can never break a needle match.
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+def _missing(text: str, items: tuple) -> list:
+    return [name for name, needle in items if needle.lower() not in text]
+
+
+# --- prompt.md (implementer) -------------------------------------------------
+
+PROMPT_ITEMS = (
+    # 1. Blocking shell commands must be wrapped in `timeout <seconds>`.
+    ("blocking-section", "hard rules for blocking commands"),
+    ("timeout-wrap", "timeout <seconds>"),
+    ("timeout-tests", "running tests"),
+    ("timeout-polling", "polling"),
+    ("timeout-network", "network waits"),
+    ("timeout-interactive", "interactive tools"),
+    # 2. A timeout is a fix-needed signal, never ignorable noise.
+    ("timeout-signal", "signal that the path needs a fix"),
+    ("timeout-noise", "ignorable noise"),
+    # 3. Unbounded-loop tests need a termination guard.
+    ("loop-unbounded", "unbounded-loop"),
+    ("loop-while-true", "while true"),
+    ("loop-guard-sleep", "time.sleep"),
+    ("loop-guard-cap", "iteration cap"),
+    ("loop-guard-pytest-timeout", "pytest-timeout"),
+    # 4. The TDD red phase must fail fast, never hang.
+    ("red-fail-fast", "fail fast"),
+    ("red-no-hang", "hung test"),
+)
+
+
+def test_prompt_md_exists_at_repository_root():
+    assert PROMPT.is_file(), f"missing implementer prompt: {PROMPT}"
+
+
+def test_prompt_md_keeps_the_blocking_command_rules():
+    missing = _missing(_text(PROMPT), PROMPT_ITEMS)
+    assert not missing, f"prompt.md is missing blocking-command rules: {missing}"
+
+
+# --- prompt_review.md (reviewer) ----------------------------------------------
+
+REVIEW_ITEMS = (
+    # The review check names the rule and its severity.
+    ("review-blocking", "blocking commands"),
+    ("review-issue", "issue #95"),
+    ("review-timeout", "timeout"),
+    ("review-loop-guard", "termination guard"),
+    ("review-blocker", "blocker"),
+)
+
+
+def test_prompt_review_md_exists_at_repository_root():
+    assert PROMPT_REVIEW.is_file(), f"missing reviewer prompt: {PROMPT_REVIEW}"
+
+
+def test_prompt_review_md_keeps_the_blocking_command_check():
+    missing = _missing(_text(PROMPT_REVIEW), REVIEW_ITEMS)
+    assert not missing, (
+        f"prompt_review.md is missing the blocking-command check: {missing}"
+    )
+
+
+# --- AGENTS.md (TDD section) ---------------------------------------------------
+
+AGENTS_TDD_ITEMS = (
+    ("tdd-timeout", "timeout <seconds>"),
+    ("tdd-blocking", "blocking"),
+    ("tdd-loop-guard", "termination guard"),
+    ("tdd-while-true", "while true"),
+    ("tdd-fail-fast", "fail fast"),
+)
+
+
+def test_agents_md_tdd_section_keeps_the_blocking_command_rule():
+    text = _text(CONTRACT)
+    # The rule must live in the TDD section itself, not just somewhere.
+    tdd = text.split("## tdd and coverage", 1)
+    assert len(tdd) == 2, "AGENTS.md is missing the TDD section"
+    section = tdd[1].split("## ui work", 1)[0]
+    missing = _missing(section, AGENTS_TDD_ITEMS)
+    assert not missing, (
+        f"AGENTS.md TDD section is missing the blocking-command rule: {missing}"
+    )


### PR DESCRIPTION
Fixes #95

run_id=0cd88c37

## What

Prompt contract for blocking commands (the other half of the Issue #94
root cause): two real hangs (run cd855188 review session, run 9240f1e4
implement session) came from a TDD red test spinning a `while True`
loop function at 99% CPU and from an ad-hoc verification generator
waiting forever on `next(g)`. The model learns to wrap commands in
`timeout` after a failure, but the contract now says it up front.

Hard rules added to all three contract files:

1. **Any shell command that can block** (running tests, generator or
   polling verification, network waits, interactive tools) must be
   wrapped in `timeout <seconds> ...`. A timeout is the signal that the
   path needs a fix — never ignorable noise, never a reason to rerun
   the same command unchanged.
2. **Testing an unbounded-loop function** (`while True` poller such as
   `wait_for_delivery`) requires a termination guard: monkeypatch
   `time.sleep` to raise on the Nth call, inject an iteration cap
   parameter, or use pytest-timeout. The TDD red phase must fail fast —
   a hung test is a broken test, not a red test.
3. **Violation is a review Blocker** (new check in `prompt_review.md`,
   alongside the existing R1–R9 issue-specific checks).

## Files

- `prompt.md` — new "Hard rules for blocking commands (Issue #95)"
  section (rules 1 + 2).
- `prompt_review.md` — new "Blocking commands (Issue #95)" check in
  "Checks (code-review R1–R9)": a diff driving a blocking command
  without the `timeout` wrapper, or testing an unbounded-loop function
  without a termination guard, is a **Blocker** (rule 3).
- `AGENTS.md` — the same rule in the "TDD and coverage" section.
- `tests/test_prompt_contract.py` — new prompt-content contract test
  (same style as `tests/test_agents_md.py`): fails when the rule text
  drifts out of any of the three files; whitespace-normalized so prose
  re-wrapping cannot break a needle match.

## Verification

```
$ timeout 300 /usr/bin/python3 -m pytest tests/test_prompt_contract.py -q   # red
3 failed, 2 passed   (rule text not present yet)
$ timeout 300 /usr/bin/python3 -m pytest tests/test_prompt_contract.py -q   # green
5 passed
$ timeout 600 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
769 passed   (3 consecutive green full runs)
$ /usr/bin/python3 -m coverage report --fail-under=100
TOTAL  9839  0  1370  0  100%
```

No Python business code changed (prompt/contract text only); no UI
work. Full record: `.muyan-pilot/runs/issue-95-0cd88c37/test.log` in
the task worktree.

<!-- muyan-pilot:run=0cd88c37 -->
