### PR TITLE
Git transport：bootstrap 默认使用 SSH，支持 workflow 文件可靠推送

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,11 @@ is **one runtime outcome** (when X, should Y, actually Z).
   from a comment or Issue body: only the human-run setup entry
   (`muyan_pilot.py setup`) migrates it with the plain
   `git remote set-url origin git@github.com:owner/repo.git`; every
-  other path fails fast with the exact migration command. `muyan_pilot.py
+  other path fails fast with the exact migration command. A remote
+  that does not point at the first configured source repo is never
+  migrated (the rewrite would re-target the checkout at a different
+  repository) — it fails with the mismatch scene whether or not the
+  setup entry authorizes the migration. `muyan_pilot.py
   doctor` reports the transport read-only (protocol, expected URL, SSH
   probe) — a failed transport is REPORTED there, not raised (the
   pre-start check is the fail-fast gate).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,41 @@ is **one runtime outcome** (when X, should Y, actually Z).
   merge to main -> install units -> daemon-reload -> timer next trigger ->
   ExecStartPre syncs origin/main -> drift check -> Runner starts one Issue.
 
+## Git transport (Issue #114)
+
+- Two authentication channels with distinct responsibilities: **Git
+  data operations** (fetch, push — including pushing
+  `.github/workflows/*.yml`) go over **SSH**
+  (`git@github.com:owner/repo.git`, the machine's SSH key); **GitHub
+  API operations** (Issue, PR, label, comment, merge) stay on the
+  existing `gh` token. SSH is never used as API authentication and the
+  `gh` token is never used for git data. A workflow push must never
+  depend on the OAuth App `workflow` scope (the HTTPS/OAuth transport
+  that blocked Issue #106).
+- The deployment checkout's single `origin` remote is the transport:
+  a task worktree created with `git worktree add` shares the main
+  repository's remote configuration (verified against real git), so
+  the transport is configured once on the checkout and every worktree
+  inherits it. New bootstrap worktrees therefore have an SSH
+  `git remote -v` by construction.
+- Pre-start check: BEFORE any slot or claim (right after the unit-drift
+  preflight) the Runner verifies the checkout's transport — the
+  CONFIGURED `origin` URL (`git config remote.origin.url`, never the
+  insteadOf-rewritten data-plane URL) is SSH for the first configured
+  source repo, and `git ls-remote <ssh-url>` exits 0 (SSH reachable and
+  authenticated — verified against the real CLI). A failure logs the
+  structured `transport_check_failed ... reason=...` line and fails the
+  start: no slot, no claim, no label change, **no HTTPS fallback, no
+  silent skip**.
+- An existing HTTPS remote is never rewritten silently and never read
+  from a comment or Issue body: only the human-run setup entry
+  (`muyan_pilot.py setup`) migrates it with the plain
+  `git remote set-url origin git@github.com:owner/repo.git`; every
+  other path fails fast with the exact migration command. `muyan_pilot.py
+  doctor` reports the transport read-only (protocol, expected URL, SSH
+  probe) — a failed transport is REPORTED there, not raised (the
+  pre-start check is the fail-fast gate).
+
 ## Task dependencies (blockedBy)
 
 - Task dependencies use GitHub's native `blockedBy` relation

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ git merge 到 main
 transport_check_failed repo_dir=<repo path> source_repos=<...> reason=ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — ...
 ```
 
-**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`python3 muyan_pilot.py setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。手工等价命令：
+**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`python3 muyan_pilot.py setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。指向其他仓库的 remote 从不被迁移（改写会把 checkout 指向另一个仓库），无论 setup 是否授权迁移都直接以 mismatch 现场 fail fast。手工等价命令：
 
 ```bash
 git remote set-url origin git@github.com:OWNER/REPO.git

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git fetch origin main && git merge --ff-only origin/main
 unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=python3 muyan_pilot.py install-units
 ```
 
-**只读诊断**：`python3 muyan_pilot.py doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
+**只读诊断**：`python3 muyan_pilot.py doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
 
 **完整部署时序**（从代码合并到下一次 Runner 启动）：
 
@@ -58,8 +58,32 @@ git merge 到 main
   -> timer 下一次触发
   -> ExecStartPre 同步 origin/main（fetch + fast-forward）
   -> 启动前 unit 漂移检查（一致才继续）
+  -> 启动前 Git transport 检查（SSH 且可达才继续，见下节）
   -> Runner 启动并执行一个 Issue
 ```
+
+## Git transport（Issue #114）
+
+两条认证通道，职责边界清晰：
+
+- **Git 数据操作**（fetch、push——包括推送 `.github/workflows/*.yml`）走 **SSH**（`git@github.com:owner/repo.git`，用本机 SSH key 认证）。workflow 文件推送不再依赖 OAuth App 的 `workflow` scope（#106 被 HTTPS/OAuth 通道阻塞的根因）；
+- **GitHub API 操作**（Issue、PR、label、comment、merge）继续走现有 `gh` token。SSH 从不作为 API 认证，`gh` token 也从不用于 git 数据。
+
+部署 checkout 的单一 `origin` remote 就是 transport：`git worktree add` 创建的任务 worktree 共享主仓库的 remote 配置（已对真实 git 验证），所以 transport 只在 checkout 上配置一次，所有 worktree 天然继承——**新 bootstrap worktree 的 `git remote -v` 默认就是 SSH**。
+
+**启动前检查**：Runner 每次启动时（unit 漂移检查之后、取 slot/领取任何 Issue 之前）校验 checkout 的 transport——**配置的** `origin` URL（`git config remote.origin.url`，不是 insteadOf 重写后的数据面 URL）必须是第一个配置 source repo 的 SSH 形式，且 `git ls-remote <ssh-url>` 退出码 0（SSH 可达且已认证，已对真实 CLI 验证）。失败时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签），**不自动降级到 HTTPS，也不静默跳过 workflow 文件**：
+
+```text
+transport_check_failed repo_dir=<repo path> source_repos=<...> reason=ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — ...
+```
+
+**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`python3 muyan_pilot.py setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。手工等价命令：
+
+```bash
+git remote set-url origin git@github.com:OWNER/REPO.git
+```
+
+**只读诊断**：`python3 muyan_pilot.py doctor` 报告 transport 行（remote、配置的 URL、protocol、期望 URL、SSH 探测结果）；SSH 不可用时 doctor 把失败现场写进报告（`transport: FAILED ...`），不中断其余报告——fail-fast 门禁是启动前检查，doctor 是诊断报告。
 
 ## 远程 CI（GitHub Actions）
 
@@ -103,14 +127,15 @@ python3 muyan_pilot.py install-units --config muyan-pilot.toml
 python3 muyan_pilot.py doctor --config muyan-pilot.toml
 
 # 一次性 setup（新机器/新仓库）：gh auth + 仓库权限、平台 labels
-# （labels.toml 为唯一事实源）、systemd user units、checkout 检查、
+# （labels.toml 为唯一事实源）、systemd user units、checkout 检查
+# （含 Git transport：HTTPS origin 迁移为 SSH + SSH 连通性探测）、
 # 可选模型 proxy（warning only）；幂等、fail-fast，--json 输出等价 JSON
 python3 muyan_pilot.py setup --config muyan-pilot.toml
 ```
 
 ## GitHub Issue 标签（外部状态）
 
-GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的 label 只做声明式对齐，业务 label 从不被改动）：
+GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的 label 只做声明式对齐，业务 label 从不被改动；同时完成 Git transport 初始化：HTTPS `origin` 迁移为 SSH 并探测 SSH 连通性，见「Git transport」）：
 
 ```bash
 # 一次性 setup：gh auth + 仓库权限、平台 labels、systemd user units、
@@ -315,7 +340,7 @@ grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
 
 ## 任务 base 与 worktree
 
-每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。
+每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。任务 worktree 共享部署 checkout 的单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree 内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
 
 ### 重启恢复（kill 后自动续跑）
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -36,6 +36,7 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
+from git_transport import TransportError, check_transport
 from pilot_slots import acquire_slot, slot_dir_for, slot_occupancy
 from pi_activity import (
     SessionWatcher,
@@ -2915,6 +2916,31 @@ def main(argv: list[str] | None = None) -> int:
     # (`muyan_pilot.py install-units`). A currently RUNNING task is
     # never interrupted — only the next start is blocked.
     check_unit_drift(config["repo_dir"])
+    # Git transport preflight (Issue #114): BEFORE any slot or claim
+    # the deployment checkout's git transport must be SSH and reachable
+    # (the task worktrees share the checkout's single `origin` remote,
+    # so the worktree's fetch/push — including `.github/workflows/*.yml`
+    # — uses it). A broken transport fails the start with the
+    # structured reason: no slot, no claim, no label change, no HTTPS
+    # fallback. The `gh` token (GitHub API) is untouched.
+    try:
+        transport = check_transport(
+            config["repo_dir"], config["source_repos"],
+            run_command=run_command, migrate=False,
+        )
+    except TransportError as exc:
+        LOGGER.error(
+            "transport_check_failed repo_dir=%s source_repos=%s "
+            "reason=%s",
+            config["repo_dir"], config["source_repos"], exc,
+        )
+        raise
+    LOGGER.info(
+        "transport clean remote=%s protocol=%s url=%s "
+        "ssh_reachable=%s",
+        transport.get("remote", "-"), transport.get("protocol", "-"),
+        transport.get("url", "-"), transport.get("ssh_reachable", "-"),
+    )
     # Concurrency cap (Issue #39): take one slot BEFORE claiming anything.
     # The slot is held for the whole delivery lifecycle (implement ->
     # review -> fix -> merge) and released only after the delivery is

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -22,7 +22,15 @@ missed tick is dropped, never queued). Each tick starts
    the timer's start request, and the next real start picks up the latest
    code.
 2. **Runs one tick**: resume an opened PR (review/fix/merge) or claim one
-   `ai-ready` Issue, then exit.
+   `ai-ready` Issue, then exit. Before any slot or claim the tick also
+   runs the pre-start **git transport check** (Issue #114): the
+   deployment checkout's configured `origin` remote must be SSH for the
+   first configured source repo and `git ls-remote <ssh-url>` must exit
+   0 (SSH reachable and authenticated). A broken transport logs the
+   structured `transport_check_failed ... reason=...` line and fails the
+   start — no slot, no claim, no label change, **no HTTPS fallback**
+   (git data operations, including `.github/workflows/*.yml` pushes,
+   always go over SSH; GitHub API operations stay on the `gh` token).
 
 ```bash
 systemctl --user list-timers muyan-pilot.timer
@@ -68,6 +76,23 @@ python3 muyan_pilot.py add "task title" --repo OWNER/BACKLOG-REPO --config muyan
 # repo (ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked)
 python3 muyan_pilot.py status --config muyan-pilot.toml
 
+# Read-only deployment/health report: repo commit, unit drift, git
+# transport (configured origin URL, protocol, expected SSH URL, SSH
+# probe — a failed transport is reported as `transport: FAILED ...`,
+# not raised), timer/service state, slots, Pi session, current Issue,
+# recent journal
+python3 muyan_pilot.py doctor --config muyan-pilot.toml
+
+# One-time, idempotent initialization (new machine / new repo): gh
+# auth + repo permissions, platform labels, systemd user units, and
+# the checkout check INCLUDING the git transport — an existing HTTPS
+# `origin` is migrated to `git@github.com:owner/repo.git` (the
+# human-authorized migration path; the Runner itself never rewrites a
+# remote) and the SSH connectivity is probed (fail fast, no HTTPS
+# fallback)
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
 # Print the live Pi session JSONL path (fail fast when no session exists)
 python3 muyan_pilot.py session --config muyan-pilot.toml
 python3 muyan_pilot.py session --follow --config muyan-pilot.toml   # tail -f
@@ -87,6 +112,13 @@ main worktree's current HEAD. Branch and worktree names carry the run id
 (e.g. `.worktrees/<...>-issue-14-e07383c2`), so a retried Issue gets a
 new independent run and the old scene is preserved. `.worktrees/` is
 gitignored.
+
+The task worktree shares the deployment checkout's single `origin`
+remote (a `git worktree add` worktree inherits the main repository's
+remote configuration), so the git transport is configured once on the
+checkout and every worktree inherits it: new bootstrap worktrees have
+an SSH `git remote -v` by construction, and their fetch/push —
+including `.github/workflows/*.yml` — go over SSH (Issue #114).
 
 Before creating the PR, the implementer re-fetches the base: if
 `origin/<base_branch>` advanced, it merges the latest base into the task

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -23,16 +23,26 @@ the delivery contract, local-only secrets, and no remote state store.
   derived from the configured repo, Issue number and run id — a public
   comment can never steer the Runner into an arbitrary local path.
 
-## GitHub token
+## GitHub token (API) and SSH (git data) — two channels
 
-- The Runner authenticates with `gh` (`gh auth status` must succeed). Use
-  a **fine-grained personal access token** scoped to the repositories the
+- **GitHub API operations** (Issue, PR, label, comment, merge)
+  authenticate with `gh` (`gh auth status` must succeed). Use a
+  **fine-grained personal access token** scoped to the repositories the
   Pilot actually works on, with the minimum permissions: contents
   (read/write), pull requests (read/write), issues (read/write), and
   metadata (read). Avoid organization-wide or classic broad-scope tokens.
-- The token lives in `gh`'s local credential store on the Runner machine.
-  It is never written into the repository, the config file, the journal,
-  or a GitHub comment.
+- **Git data operations** (fetch, push — including
+  `.github/workflows/*.yml`) authenticate with the machine's **SSH key**
+  over `git@github.com:owner/repo.git` (Issue #114). A workflow push
+  must never depend on the OAuth App `workflow` scope — the
+  HTTPS/OAuth transport that blocked Issue #106. The pre-start check
+  verifies the SSH transport and fails fast when it is broken (no
+  HTTPS fallback).
+- The channels are never mixed: SSH is not an API authentication and
+  the `gh` token is not a git-data credential. The token lives in `gh`'s
+  local credential store on the Runner machine; the SSH key lives in the
+  user's SSH agent/config. Neither is written into the repository, the
+  config file, the journal, or a GitHub comment.
 - Logs are redacted by construction: command lines carrying secrets are
   logged as `<redacted>`, and tool summaries are truncated and masked.
   The full prompt, Issue body and token never reach the journal or the

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -49,8 +49,11 @@ non-zero exit code.
    `git remote set-url origin git@github.com:owner/repo.git` (setup is
    the human-authorized migration path — the Runner itself never
    rewrites a remote), the SSH URL must match the first configured
-   source repo, and `git ls-remote <ssh-url>` must exit 0 (SSH
-   reachable and authenticated — a failure is `setup_failed
+   source repo — a remote pointing at a DIFFERENT repo is never
+   migrated (the rewrite would re-target the checkout at another
+   repository) and fails with `setup_failed reason=... origin remote
+   repo mismatch ...` — and `git ls-remote <ssh-url>` must exit 0
+   (SSH reachable and authenticated — a failure is `setup_failed
    reason=... ssh_unreachable ...`, no HTTPS fallback). Then the
    read-only parts: current branch, clean worktree (a dirty checkout
    fails: the timer's `ExecStartPre` fast-forward refuses a dirty

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -41,13 +41,23 @@ non-zero exit code.
    timer — the service is never started, stopped or restarted), then
    the timer's enabled/active state and next trigger time are
    reported.
-5. **Checkout** — read-only check of the configured `repo_dir`:
-   `origin` remote present, current branch, clean worktree (a dirty
-   checkout fails: the timer's `ExecStartPre` fast-forward refuses a
-   dirty worktree, so the Runner could never start), and base
-   freshness (local `HEAD` vs freshly fetched
-   `origin/<base_branch>` — reported, not a failure: the timer
-   fast-forwards a clean checkout at each start).
+5. **Checkout + git transport** — check of the configured `repo_dir`:
+   the `origin` remote's **transport** (Issue #114): git data
+   operations (fetch, push — including `.github/workflows/*.yml`) must
+   go over SSH (`git@github.com:owner/repo.git`), so an existing
+   HTTPS `origin` is migrated here with the plain
+   `git remote set-url origin git@github.com:owner/repo.git` (setup is
+   the human-authorized migration path — the Runner itself never
+   rewrites a remote), the SSH URL must match the first configured
+   source repo, and `git ls-remote <ssh-url>` must exit 0 (SSH
+   reachable and authenticated — a failure is `setup_failed
+   reason=... ssh_unreachable ...`, no HTTPS fallback). Then the
+   read-only parts: current branch, clean worktree (a dirty checkout
+   fails: the timer's `ExecStartPre` fast-forward refuses a dirty
+   worktree, so the Runner could never start), and base freshness
+   (local `HEAD` vs freshly fetched `origin/<base_branch>` —
+   reported, not a failure: the timer fast-forwards a clean checkout
+   at each start).
 6. **Optional model proxy** — the `local-llm-kv-cache` proxy health
    endpoint (`http://127.0.0.1:18082/health`) is checked and reported
    as **optional**: its absence or unhealthiness is a warning in the
@@ -75,14 +85,16 @@ setup=ok version=1 base_branch=main
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-checkout=remote=origin branch=main clean=true base_fresh=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
 `labels=7/7` means all seven platform labels match `labels.toml`;
 `next` is the timer's next trigger time (`-` when it has none);
 `optional_proxy` is `healthy`, `unhealthy` or `unavailable` and never
-changes the exit code.
+changes the exit code. `migrated=true` means setup rewrote an HTTPS
+`origin` to the SSH URL (a re-run then reports `migrated=false`);
+`ssh_reachable` is the `git ls-remote` probe result.
 
 `--json` prints the equivalent JSON document:
 
@@ -100,7 +112,7 @@ setup=ok version=1 base_branch=main
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-checkout=remote=origin branch=main clean=true base_fresh=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
 ```
 
@@ -115,12 +127,13 @@ setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ..
 setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
 setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)
 setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted changes: ' M bootstrap_runner.py') — commit or stash them first: ...
+setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry
 ```
 
 A wrong repo, missing labels that cannot be created (permission), a
-dirty checkout or a missing systemd user bus all stop the setup with
-the concrete reason — nothing is half-initialized without a clear
-signal.
+dirty checkout, an unreachable SSH (no HTTPS fallback) or a missing
+systemd user bus all stop the setup with the concrete reason —
+nothing is half-initialized without a clear signal.
 
 ## Idempotency
 
@@ -128,4 +141,6 @@ Re-running setup on an already-initialized machine is a no-op for the
 external state: labels that already match are not rewritten, the unit
 templates are re-copied from the repo (drift repair), the timer stays
 enabled, and no Issues or business data are created or modified. The
-reported hashes and states are stable across runs.
+reported hashes and states are stable across runs. The HTTPS→SSH
+migration is one-shot: after the first run the `origin` remote is SSH
+and re-runs only re-verify it (`migrated=false`).

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -49,6 +49,13 @@ Rules of the chain:
   `origin/<base>` on the task branch (conflicts resolved manually),
   followed by a full test rerun. No force push, no auto conflict
   resolution, no push of the protected branch.
+- Git transport (Issue #114): git data operations (fetch, push —
+  including `.github/workflows/*.yml`) go over SSH
+  (`git@github.com:owner/repo.git`); GitHub API operations (Issue, PR,
+  label, comment, merge) stay on the `gh` token. The task worktree
+  inherits the deployment checkout's single `origin` remote, so a new
+  bootstrap worktree has an SSH `git remote -v` by construction; a
+  broken transport fails the pre-start check (no HTTPS fallback).
 
 ## Delivery labels
 

--- a/git_transport.py
+++ b/git_transport.py
@@ -1,0 +1,213 @@
+"""Git transport contract (Issue #114).
+
+Two authentication channels with distinct responsibilities:
+
+- **Git data operations** (fetch, push — including pushing
+  `.github/workflows/*.yml`) go over **SSH**
+  (`git@github.com:owner/repo.git`), authenticated by the machine's
+  SSH key. A workflow push must never depend on the OAuth App
+  `workflow` scope — the HTTPS/OAuth transport that blocked Issue #106.
+- **GitHub API operations** (Issue, PR, label, comment, merge) stay on
+  the existing `gh` token. SSH is never used as API authentication and
+  the `gh` token is never used for git data.
+
+The deployment checkout's single `origin` remote is the transport: a
+task worktree created with `git worktree add` shares the main
+repository's remote configuration (verified against real git — the
+worktree's `git remote -v` and `git config remote.origin.url` are the
+main checkout's), so the transport is configured once on the checkout
+and every worktree inherits it.
+
+An existing HTTPS remote is never rewritten silently and never read
+from a comment or Issue body: only the human-run setup entry
+(`muyan_pilot.py setup`, `migrate=True`) migrates it with the plain
+`git remote set-url origin <ssh-url>`; every other path fails fast
+with the exact migration command. A failed SSH probe (`git ls-remote`,
+verified against the real CLI: exit 0 = reachable and authenticated,
+refs listed) fails fast with the structured reason — no HTTPS
+fallback, no silent skip.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+GITHUB_HOST = "github.com"
+SSH_USER = "git"
+# The plain migration command the failure message reports and the
+# human-run setup entry performs (verified against the real CLI:
+# `git remote set-url origin <url>` rewrites the fetch URL; no
+# separate pushurl is set).
+MIGRATION_COMMAND = "git remote set-url origin {url}"
+# The human-run entry that is authorized to perform the migration.
+MIGRATION_ENTRY = "muyan_pilot.py setup"
+
+
+class TransportError(RuntimeError):
+    """The git transport check failed (fail fast, no HTTPS fallback)."""
+
+
+def ssh_url_for(repo: str) -> str:
+    """The SSH URL of one configured `owner/name` source repo.
+
+    `owner/name` → `git@github.com:owner/name.git`. A malformed repo
+    name (missing/extra slash, empty segment) fails fast: a guessed
+    URL must never be probed.
+    """
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise TransportError(
+            f"malformed source repo name: {repo!r} "
+            "(expected 'owner/name')"
+        )
+    return f"{SSH_USER}@{GITHUB_HOST}:{repo}.git"
+
+
+def remote_protocol(url: str) -> str:
+    """The protocol family of one git remote URL.
+
+    `ssh` for the GitHub SCP-style form (`git@github.com:...`) and the
+    `ssh://` scheme, `https`/`http` for the web forms, `other` for
+    everything else (local paths, unknown hosts).
+    """
+    if url.startswith("https://"):
+        return "https"
+    if url.startswith("http://"):
+        return "http"
+    if (
+        url.startswith(f"{SSH_USER}@{GITHUB_HOST}:")
+        or url.startswith(f"ssh://{SSH_USER}@{GITHUB_HOST}/")
+    ):
+        return "ssh"
+    return "other"
+
+
+def _ssh_repo_path(url: str) -> str | None:
+    """The `owner/name` path of one SSH remote URL, or None.
+
+    Accepts both the SCP-style form (`git@github.com:owner/name[.git]`)
+    and the `ssh://` scheme; the optional `.git` suffix is stripped so
+    a remote configured without it still matches the expected URL.
+    """
+    scp_prefix = f"{SSH_USER}@{GITHUB_HOST}:"
+    scheme_prefix = f"ssh://{SSH_USER}@{GITHUB_HOST}/"
+    if url.startswith(scp_prefix):
+        path = url[len(scp_prefix):]
+    elif url.startswith(scheme_prefix):
+        path = url[len(scheme_prefix):]
+    else:
+        return None
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    return path or None
+
+
+def check_transport(
+    repo_dir: Path,
+    source_repos: list[str],
+    *,
+    run_command,
+    migrate: bool = False,
+    probe: bool = True,
+) -> dict:
+    """Check (and only when authorized, migrate) the git transport.
+
+    Checks, in order: the `origin` remote exists; its protocol is SSH;
+    the SSH URL matches the FIRST configured source repo (the
+    deployment checkout is that repo's clone — the worktrees share the
+    single remote); when `probe` is on, `git ls-remote <ssh-url>`
+    exits 0 (SSH reachable and authenticated). An HTTPS remote is
+    migrated with `git remote set-url origin <ssh-url>` ONLY when
+    `migrate` is True (the human-run setup entry); otherwise the
+    failure carries the exact migration command and the setup entry.
+    Any failure raises :class:`TransportError` with the concrete
+    reason — no HTTPS fallback, no silent skip.
+    """
+    expected = ssh_url_for(source_repos[0])
+    # The CONFIGURED URL is the transport (verified against the real
+    # CLI: `git remote get-url` applies `url.<base>.insteadOf`
+    # rewrites and would report the effective data-plane URL; `git
+    # config remote.origin.url` returns the configured URL, exit 1
+    # when the remote is missing). A local insteadOf rewrite (e.g. in
+    # an offline e2e world) stays a data-plane detail, never the
+    # transport.
+    try:
+        url = run_command(["git", "config", "remote.origin.url"],
+                          cwd=repo_dir)
+    except subprocess.CalledProcessError as exc:
+        detail = str(exc)
+        if exc.stderr:
+            detail += f" stderr={exc.stderr.strip()}"
+        raise TransportError(
+            f"checkout has no origin remote: {repo_dir} "
+            f"({detail})"
+        ) from exc
+    except Exception as exc:
+        raise TransportError(
+            f"checkout has no origin remote: {repo_dir} ({exc})"
+        ) from exc
+    protocol = remote_protocol(url)
+    if protocol == "https":
+        if not migrate:
+            raise TransportError(
+                f"origin remote is HTTPS ({url}); git data operations "
+                f"must use SSH ({expected}). Migrate with: "
+                f"{MIGRATION_COMMAND.format(url=expected)} — or run "
+                f"`python3 {MIGRATION_ENTRY}` (the human-run setup "
+                "entry performs the migration). No automatic rewrite "
+                "and no HTTPS fallback."
+            )
+        run_command(
+            ["git", "remote", "set-url", "origin", expected],
+            cwd=repo_dir,
+        )
+        url = expected
+        migrated = True
+    elif protocol != "ssh":
+        raise TransportError(
+            f"origin remote protocol is {protocol} ({url}); git data "
+            f"operations require SSH ({expected}). Fix the remote "
+            f"with: {MIGRATION_COMMAND.format(url=expected)}"
+        )
+    else:
+        migrated = False
+    repo_path = _ssh_repo_path(url)
+    if repo_path != source_repos[0]:
+        raise TransportError(
+            f"origin remote repo mismatch: actual={url} "
+            f"(repo={repo_path!r}) expected={expected} "
+            f"(repo={source_repos[0]!r}); the deployment checkout "
+            "must be a clone of the first configured source repo"
+        )
+    ssh_reachable: bool | None
+    if probe:
+        try:
+            run_command(["git", "ls-remote", expected], cwd=repo_dir)
+        except subprocess.CalledProcessError as exc:
+            detail = str(exc)
+            if exc.stderr:
+                detail += f" stderr={exc.stderr.strip()}"
+            raise TransportError(
+                f"ssh_unreachable: git ls-remote {expected} failed: "
+                f"{detail} — SSH is unavailable (check the SSH key / "
+                "agent / network). No HTTPS fallback and no silent "
+                "skip: fix SSH and retry."
+            ) from exc
+        except Exception as exc:
+            raise TransportError(
+                f"ssh_unreachable: git ls-remote {expected} failed: "
+                f"{exc} — SSH is unavailable (check the SSH key / "
+                "agent / network). No HTTPS fallback and no silent "
+                "skip: fix SSH and retry."
+            ) from exc
+        ssh_reachable = True
+    else:
+        ssh_reachable = None
+    return {
+        "remote": "origin",
+        "protocol": "ssh",
+        "url": url,
+        "expected": expected,
+        "migrated": migrated,
+        "ssh_reachable": ssh_reachable,
+    }

--- a/git_transport.py
+++ b/git_transport.py
@@ -82,24 +82,30 @@ def remote_protocol(url: str) -> str:
     return "other"
 
 
-def _ssh_repo_path(url: str) -> str | None:
-    """The `owner/name` path of one SSH remote URL, or None.
+def _remote_repo_path(url: str) -> str | None:
+    """The `owner/name` path of one GitHub remote URL, or None.
 
-    Accepts both the SCP-style form (`git@github.com:owner/name[.git]`)
-    and the `ssh://` scheme; the optional `.git` suffix is stripped so
-    a remote configured without it still matches the expected URL.
+    Accepts the SCP-style SSH form (`git@github.com:owner/name[.git]`),
+    the `ssh://` scheme and the `https://`/`http://` web forms; the
+    optional `.git` suffix is stripped so a remote configured without
+    it still matches the expected repo. A URL on any other host (or a
+    local path) has no GitHub repo path: it can never be migrated, a
+    rewrite of such a remote would re-target the checkout at a
+    guessed destination.
     """
-    scp_prefix = f"{SSH_USER}@{GITHUB_HOST}:"
-    scheme_prefix = f"ssh://{SSH_USER}@{GITHUB_HOST}/"
-    if url.startswith(scp_prefix):
-        path = url[len(scp_prefix):]
-    elif url.startswith(scheme_prefix):
-        path = url[len(scheme_prefix):]
-    else:
-        return None
-    if path.endswith(".git"):
-        path = path[: -len(".git")]
-    return path or None
+    prefixes = (
+        f"{SSH_USER}@{GITHUB_HOST}:",
+        f"ssh://{SSH_USER}@{GITHUB_HOST}/",
+        f"https://{GITHUB_HOST}/",
+        f"http://{GITHUB_HOST}/",
+    )
+    for prefix in prefixes:
+        if url.startswith(prefix):
+            path = url[len(prefix):]
+            if path.endswith(".git"):
+                path = path[: -len(".git")]
+            return path or None
+    return None
 
 
 def check_transport(
@@ -112,16 +118,19 @@ def check_transport(
 ) -> dict:
     """Check (and only when authorized, migrate) the git transport.
 
-    Checks, in order: the `origin` remote exists; its protocol is SSH;
-    the SSH URL matches the FIRST configured source repo (the
-    deployment checkout is that repo's clone — the worktrees share the
-    single remote); when `probe` is on, `git ls-remote <ssh-url>`
-    exits 0 (SSH reachable and authenticated). An HTTPS remote is
-    migrated with `git remote set-url origin <ssh-url>` ONLY when
-    `migrate` is True (the human-run setup entry); otherwise the
-    failure carries the exact migration command and the setup entry.
-    Any failure raises :class:`TransportError` with the concrete
-    reason — no HTTPS fallback, no silent skip.
+    Checks, in order: the `origin` remote exists; it points at the
+    FIRST configured source repo (the deployment checkout is that
+    repo's clone — the worktrees share the single remote); its
+    protocol is SSH; when `probe` is on, `git ls-remote <ssh-url>`
+    exits 0 (SSH reachable and authenticated). An HTTPS remote of the
+    SAME repo is migrated with `git remote set-url origin <ssh-url>`
+    ONLY when `migrate` is True (the human-run setup entry); a remote
+    pointing at a DIFFERENT repo is never rewritten (the migration
+    would re-target the checkout) — it fails with the mismatch scene
+    whether or not `migrate` is set. Every other failure carries the
+    exact migration command and the setup entry. Any failure raises
+    :class:`TransportError` with the concrete reason — no HTTPS
+    fallback, no silent skip.
     """
     expected = ssh_url_for(source_repos[0])
     # The CONFIGURED URL is the transport (verified against the real
@@ -146,6 +155,19 @@ def check_transport(
         raise TransportError(
             f"checkout has no origin remote: {repo_dir} ({exc})"
         ) from exc
+    # The repo the remote points at is verified BEFORE any protocol
+    # decision or rewrite: a remote that does not point at the first
+    # configured source repo is never migrated (the migration would
+    # re-target the checkout at a different repository), whether or
+    # not `migrate` is authorized.
+    repo_path = _remote_repo_path(url)
+    if repo_path != source_repos[0]:
+        raise TransportError(
+            f"origin remote repo mismatch: actual={url} "
+            f"(repo={repo_path!r}) expected={expected} "
+            f"(repo={source_repos[0]!r}); the deployment checkout "
+            "must be a clone of the first configured source repo"
+        )
     protocol = remote_protocol(url)
     if protocol == "https":
         if not migrate:
@@ -171,14 +193,6 @@ def check_transport(
         )
     else:
         migrated = False
-    repo_path = _ssh_repo_path(url)
-    if repo_path != source_repos[0]:
-        raise TransportError(
-            f"origin remote repo mismatch: actual={url} "
-            f"(repo={repo_path!r}) expected={expected} "
-            f"(repo={source_repos[0]!r}); the deployment checkout "
-            "must be a clone of the first configured source repo"
-        )
     ssh_reachable: bool | None
     if probe:
         try:

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -24,6 +24,7 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
+import git_transport
 import systemd_deploy
 
 from bootstrap_runner import (
@@ -363,6 +364,28 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
     lines.append(
         f"commit: {run_command(['git', 'rev-parse', 'HEAD'], cwd=repo_dir)}"
     )
+    # Git transport (Issue #114): the checkout's origin protocol, the
+    # expected SSH URL of the first configured source repo and the SSH
+    # probe. doctor is the diagnostic report: a failed transport is
+    # REPORTED with the structured reason (the rest of the report stays
+    # readable) — the fail-fast gate is the pre-start check.
+    try:
+        transport = git_transport.check_transport(
+            repo_dir, config["source_repos"],
+            run_command=run_command, migrate=False,
+        )
+        reachable = transport["ssh_reachable"]
+        reachable_text = "-" if reachable is None else (
+            "true" if reachable else "false"
+        )
+        lines.append(
+            f"transport: remote={transport['remote']} "
+            f"url={transport['url']} protocol={transport['protocol']} "
+            f"expected={transport['expected']} "
+            f"ssh_reachable={reachable_text}"
+        )
+    except git_transport.TransportError as exc:
+        lines.append(f"transport: FAILED {exc}")
     status = systemd_deploy.unit_status(repo_dir, installed_dir)
     drifted = [entry for entry in status if entry["drifted"]]
     if drifted:

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -37,6 +37,7 @@ import shutil
 import tomllib
 from pathlib import Path
 
+import git_transport
 import systemd_deploy
 from pi_activity import quote_value
 
@@ -364,24 +365,31 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     }
 
 
-def check_checkout(repo_dir: Path, base_branch: str, *,
+def check_checkout(repo_dir: Path, base_branch: str,
+                   source_repos: list[str], *,
                    run_command) -> dict:
-    """Read-only local checkout check (no git mutation).
+    """Local checkout check including the git transport (Issue #114).
 
-    Reports the ``origin`` remote, the current branch and whether the
-    local HEAD equals the freshly fetched ``origin/<base_branch>``
-    (base freshness — the same comparison the delivery gate uses,
-    read-only). A missing remote, a dirty worktree (the timer's
-    ``ExecStartPre`` fast-forward would refuse it) or any git error
-    fails fast with the concrete reason.
+    Reports the ``origin`` remote, its transport, the current branch
+    and whether the local HEAD equals the freshly fetched
+    ``origin/<base_branch>`` (base freshness — the same comparison
+    the delivery gate uses). The git transport step (``git_transport``
+    contract): the remote must be SSH for the first configured source
+    repo (the worktrees share the checkout's single remote) and SSH
+    must be reachable (``git ls-remote`` exits 0 — verified against
+    the real CLI). The setup entry is the human-authorized migration
+    path: an existing HTTPS ``origin`` is migrated with the plain
+    ``git remote set-url origin <ssh-url>`` (never a remote read from
+    a comment or Issue, never a silent rewrite outside setup). A
+    missing remote, an unreachable SSH (no HTTPS fallback), a dirty
+    worktree (the timer's ``ExecStartPre`` fast-forward would refuse
+    it) or any git error fails fast with the concrete reason.
     """
     try:
-        remote = run_command(["git", "remote"], cwd=repo_dir)
-        if "origin" not in remote.splitlines():
-            raise SetupError(
-                f"checkout has no origin remote: {repo_dir} "
-                f"(remotes: {remote!r})"
-            )
+        transport = git_transport.check_transport(
+            repo_dir, source_repos, run_command=run_command,
+            migrate=True,
+        )
         branch = run_command(
             ["git", "branch", "--show-current"], cwd=repo_dir,
         )
@@ -402,15 +410,23 @@ def check_checkout(repo_dir: Path, base_branch: str, *,
         )
     except SetupError:
         raise
+    except git_transport.TransportError as exc:
+        raise SetupError(
+            f"checkout check failed for {repo_dir}: {exc}"
+        ) from exc
     except Exception as exc:
         raise SetupError(
             f"checkout check failed for {repo_dir}: {exc}"
         ) from exc
     return {
-        "remote": "origin",
+        "remote": transport["remote"],
         "branch": branch,
         "clean": True,
         "base_fresh": head == base,
+        "remote_url": transport["url"],
+        "remote_protocol": transport["protocol"],
+        "migrated": transport["migrated"],
+        "ssh_reachable": transport["ssh_reachable"],
     }
 
 
@@ -478,7 +494,8 @@ def run_setup(config: dict, installed_dir: Path | None, *,
         })
     units = install_units_step(repo_dir, installed_dir, run_command=run_command)
     checkout = check_checkout(
-        repo_dir, config["base_branch"], run_command=run_command,
+        repo_dir, config["base_branch"], config["source_repos"],
+        run_command=run_command,
     )
     optional_proxy = check_optional_proxy(run_command)
     return {
@@ -524,11 +541,19 @@ def format_setup(result: dict) -> list[str]:
         f"next={quote_value(timer['next'])}"
     )
     checkout = result["checkout"]
+    reachable = checkout["ssh_reachable"]
+    reachable_text = "-" if reachable is None else (
+        "true" if reachable else "false"
+    )
     lines.append(
         f"checkout=remote={checkout['remote']} "
         f"branch={quote_value(checkout['branch'])} "
         f"clean={'true' if checkout['clean'] else 'false'} "
-        f"base_fresh={'true' if checkout['base_fresh'] else 'false'}"
+        f"base_fresh={'true' if checkout['base_fresh'] else 'false'} "
+        f"remote_url={checkout['remote_url']} "
+        f"protocol={checkout['remote_protocol']} "
+        f"migrated={'true' if checkout['migrated'] else 'false'} "
+        f"ssh_reachable={reachable_text}"
     )
     proxy = result["optional_proxy"]
     lines.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 """Shared test fixtures for the Muyan Pilot suite.
 
-The deployment preflight (Issue #103) reads the REAL user unit
-directory on this machine; the in-process dispatch tests use tmp
-repo_dirs that carry no ``systemd/`` templates, so they run with the
-preflight stubbed to a no-op by default. The drift-wiring tests and
-the e2e suites stub or exercise the real check explicitly (a
-``monkeypatch`` always wins over this default).
+The deployment preflights (Issue #103 unit drift, Issue #114 git
+transport) read the REAL machine state (the user unit directory, the
+checkout's ``origin`` remote, SSH connectivity); the in-process
+dispatch tests use tmp repo_dirs that carry no ``systemd/`` templates
+and no git checkout, so they run with both preflights stubbed to a
+passing no-op by default. The wiring tests and the e2e suites stub or
+exercise the real checks explicitly (a ``monkeypatch`` always wins
+over this default).
 """
 import pytest
 
@@ -16,3 +18,9 @@ import bootstrap_runner as runner
 def _default_unit_drift_preflight(monkeypatch):
     """Default: the unit drift preflight passes (no-op)."""
     monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
+
+
+@pytest.fixture(autouse=True)
+def _default_transport_preflight(monkeypatch):
+    """Default: the git transport preflight passes (no-op)."""
+    monkeypatch.setattr(runner, "check_transport", lambda *a, **k: {})

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -59,6 +59,20 @@ REQUIRED_ITEMS = (
     ("base-refetch", "re-fetch"),
     ("base-contains-latest", "contains the latest remote base"),
     ("base-plain-merge", "plain `git merge`"),
+    # 6b2. Git transport (Issue #114): git data operations go over SSH,
+    #      GitHub API operations stay on the gh token; the pre-start
+    #      check fails fast without an HTTPS fallback; only the
+    #      human-run setup entry migrates an HTTPS remote.
+    ("git-transport", "git transport"),
+    ("git-transport-ssh-url", "git@github.com:owner/repo.git"),
+    ("git-transport-workflow", ".github/workflows/*.yml"),
+    ("git-transport-gh-token", "`gh` token"),
+    ("git-transport-no-mix", "ssh is never used as api authentication"),
+    ("git-transport-preflight", "transport_check_failed"),
+    ("git-transport-no-fallback", "no https fallback"),
+    ("git-transport-probe", "git ls-remote"),
+    ("git-transport-migration-entry", "muyan_pilot.py setup"),
+    ("git-transport-migration-command", "git remote set-url origin"),
     # 6c. Run correlation: one run_id per attempt is the single
     #     end-to-end correlation id; every journal line and GitHub text of
     #     the run carries it; a run-scoped event includes a valid run id.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4186,6 +4186,121 @@ def test_main_preflight_receives_the_configured_repo_dir(
     assert seen == [tmp_path]
 
 
+# --- git transport preflight (Issue #114) ------------------------------------
+
+
+def test_main_transport_check_blocks_claim_before_slot(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #114: an unusable git transport fails the start BEFORE any
+    slot or claim: the structured transport reason is raised (non-zero
+    exit), no slot is taken and nothing is claimed — no HTTPS fallback,
+    no silent skip."""
+    import git_transport
+
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\n', encoding="utf-8",
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError(
+            "pick_next_delivery must not run on transport failure"
+        )
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fail_if_called)
+    # The guard itself must fail loudly if it is ever reached.
+    with pytest.raises(
+        AssertionError, match="must not run on transport failure",
+    ):
+        fail_if_called()
+    monkeypatch.setattr(
+        runner, "check_transport",
+        lambda *a, **k: (_ for _ in ()).throw(
+            git_transport.TransportError(
+                "ssh_unreachable: git ls-remote "
+                "git@github.com:owner/repo.git failed: "
+                "Permission denied (publickey)"
+            ),
+        ),
+    )
+    with caplog.at_level("ERROR"):
+        with pytest.raises(
+            git_transport.TransportError, match="ssh_unreachable",
+        ):
+            runner.main(["--config", str(config)])
+    # The structured reason is logged with the run-free preflight scene.
+    assert "transport_check_failed" in caplog.text
+    assert "ssh_unreachable" in caplog.text
+    # No slot was taken and nothing was claimed.
+    assert not (tmp_path / ".muyan-pilot" / "slots").exists()
+
+
+def test_main_transport_check_clean_proceeds_to_claim(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #114: a passing transport check logs `transport clean` and
+    the tick proceeds to the normal claim flow (slot taken, queue
+    scanned)."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\n', encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "check_transport",
+        lambda *a, **k: {
+            "remote": "origin", "protocol": "ssh",
+            "url": "git@github.com:owner/repo.git",
+            "expected": "git@github.com:owner/repo.git",
+            "migrated": False, "ssh_reachable": True,
+        },
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency: None,
+    )
+    with caplog.at_level("INFO"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert "transport clean" in caplog.text
+    # The slot was taken AFTER the preflight passed.
+    assert (tmp_path / ".muyan-pilot" / "slots" / "slot-1").exists()
+
+
+def test_main_transport_preflight_receives_the_configured_args(
+    monkeypatch, tmp_path,
+):
+    """Issue #114: the preflight checks the configured repo_dir and
+    source repos with the real run_command, and never migrates (the
+    migration is the human-run setup entry's job)."""
+    seen: dict = {}
+
+    def fake_check(repo_dir, source_repos, **kwargs):
+        seen["repo_dir"] = Path(repo_dir)
+        seen["source_repos"] = list(source_repos)
+        seen["migrate"] = kwargs.get("migrate")
+        seen["run_command"] = kwargs.get("run_command")
+        return {}
+
+    monkeypatch.setattr(runner, "check_transport", fake_check)
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo", "owner/backlog"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency: None,
+    )
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen["repo_dir"] == tmp_path
+    assert seen["source_repos"] == ["owner/repo", "owner/backlog"]
+    assert seen["migrate"] is False
+    assert seen["run_command"] is runner.run_command
+
+
 # --- delivery lifecycle: slot held until merge or terminal failure ----------
 
 PR_URL = "https://github.com/owner/repo/pull/46"

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -345,7 +345,15 @@ def git(repo: Path, *args: str) -> str:
 
 @pytest.fixture()
 def clone(tmp_path: Path) -> Path:
-    """Local bare origin plus a clone with one commit on main."""
+    """Local bare origin plus a clone with one commit on main.
+
+    The clone's `origin` remote is the SSH URL of the task repo
+    (Issue #114: the pre-start transport check requires the checkout's
+    remote to be SSH for the configured source repo); a
+    `url.<base>.insteadOf` rewrite (git-config(1)) keeps the git data
+    plane local: fetch/ls-remote of the SSH URL resolve to the bare
+    origin without any network.
+    """
     origin = tmp_path / "origin.git"
     origin.mkdir()
     git(origin, "init", "--bare", "-b", "main")
@@ -356,6 +364,13 @@ def clone(tmp_path: Path) -> Path:
     )
     git(clone, "config", "user.email", "pilot@test.local")
     git(clone, "config", "user.name", "Pilot")
+    # The deployment checkout's transport (Issue #114): the origin
+    # remote is the SSH URL of the task repo; the insteadOf rewrite
+    # keeps the data plane local (no network in the e2e world).
+    git(clone, "remote", "set-url", "origin",
+        f"git@github.com:{REPO}.git")
+    git(clone, "config", f"url.{origin}.insteadOf",
+        f"git@github.com:{REPO}.git")
     # The deployment checkout carries the unit templates (Issue #103):
     # the pre-start drift check compares them against the installed
     # units, so a synthetic clone without them could never pass it.

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -298,6 +298,37 @@ def test_docs_document_contributing_paths():
     assert "Fixes #" in text, "contributing must document the PR body contract"
 
 
+def test_docs_document_the_git_transport_boundary():
+    """Issue #114: the docs must document the two-channel boundary —
+    git data operations over SSH (including workflow file pushes),
+    GitHub API operations on the gh token, the pre-start transport
+    check without an HTTPS fallback, and the human-run setup migration
+    of an existing HTTPS remote."""
+    operations = page_text("operations")
+    assert "transport_check_failed" in operations, (
+        "operations must document the pre-start transport check"
+    )
+    assert "no HTTPS fallback" in operations, (
+        "operations must state that a broken transport never falls back "
+        "to HTTPS"
+    )
+    setup = page_text("setup")
+    assert "git remote set-url origin" in setup, (
+        "setup must document the HTTPS-to-SSH migration command"
+    )
+    assert "ssh_unreachable" in setup, (
+        "setup must document the SSH connectivity failure"
+    )
+    workflow = page_text("workflow")
+    assert "SSH" in workflow, (
+        "workflow must document the SSH git transport"
+    )
+    security = page_text("security")
+    assert "SSH key" in security, (
+        "security must document the SSH key as the git-data credential"
+    )
+
+
 def test_docs_smoke_walkthrough_is_clone_path_independent():
     """The smoke walkthrough must use only relative paths / clone-local
     paths so it works at any clone location — no personal absolute path

--- a/tests/test_git_transport.py
+++ b/tests/test_git_transport.py
@@ -353,19 +353,81 @@ def test_ok_run_factory_rejects_an_unexpected_command():
         fake_run(["definitely", "not", "a", "known", "command"])
 
 
-def test_ssh_repo_path_returns_none_for_a_non_ssh_url():
-    """The defensive branch: a URL that is neither the SCP form nor
-    the `ssh://` scheme has no repo path (check_transport only calls
-    this for SSH URLs, so the branch is unit-tested directly)."""
-    assert git_transport._ssh_repo_path(
-        "https://github.com/xqliu/muyan-pilot.git"
-    ) is None
-    assert git_transport._ssh_repo_path(
+def test_remote_repo_path_extracts_the_repo_from_every_github_form():
+    """All four GitHub URL forms (SCP SSH, `ssh://` scheme, https,
+    http) yield the `owner/name` path; the optional `.git` suffix is
+    stripped."""
+    assert git_transport._remote_repo_path(
         "git@github.com:xqliu/muyan-pilot"
     ) == "xqliu/muyan-pilot"
-    assert git_transport._ssh_repo_path(
+    assert git_transport._remote_repo_path(
         "ssh://git@github.com/xqliu/muyan-pilot.git"
     ) == "xqliu/muyan-pilot"
+    assert git_transport._remote_repo_path(
+        "https://github.com/xqliu/muyan-pilot.git"
+    ) == "xqliu/muyan-pilot"
+    assert git_transport._remote_repo_path(
+        "http://github.com/xqliu/muyan-pilot"
+    ) == "xqliu/muyan-pilot"
+
+
+def test_remote_repo_path_returns_none_for_a_non_github_url():
+    """A URL on any other host (or a local path) has no GitHub repo
+    path: such a remote can never be migrated (a rewrite would
+    re-target the checkout at a guessed destination)."""
+    assert git_transport._remote_repo_path(
+        "git@gitlab.com:other/repo.git"
+    ) is None
+    assert git_transport._remote_repo_path(
+        "/home/u/repos/muyan-pilot"
+    ) is None
+
+
+def test_check_transport_never_migrates_a_remote_pointing_at_a_different_repo(
+    tmp_path,
+):
+    """Issue #114: the migration rewrites the checkout's single
+    `origin` remote — pointing it at a DIFFERENT repository would
+    re-target the whole checkout (subsequent fetches/pulls hit the
+    wrong repo). A remote that does not point at the first configured
+    source repo therefore fails with the mismatch scene even when
+    `migrate` is authorized (the human-run setup entry): no
+    `set-url`, no probe, the remote is left untouched."""
+    state = {
+        "origin_url": "https://github.com/other/repo.git",
+    }
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(
+        git_transport.TransportError, match="mismatch",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"],
+            run_command=fake_run, migrate=True,
+        )
+    message = str(exc.value)
+    assert "https://github.com/other/repo.git" in message
+    assert "git@github.com:xqliu/muyan-pilot.git" in message
+    # No rewrite of the mismatching remote, no probe.
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+    assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []
+    assert state["origin_url"] == "https://github.com/other/repo.git"
+
+
+def test_check_transport_never_migrates_a_non_github_remote(tmp_path):
+    """A remote on a non-GitHub host (or a local path) has no
+    recognizable repo: it fails with the mismatch scene (repo=None)
+    even when `migrate` is authorized — never a guessed rewrite."""
+    state = {"origin_url": "git@gitlab.com:other/repo.git"}
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(
+        git_transport.TransportError, match="mismatch",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"],
+            run_command=fake_run, migrate=True,
+        )
+    assert "repo=None" in str(exc.value)
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
 
 
 # --- real git: the worktree inherits the checkout's transport -----------------

--- a/tests/test_git_transport.py
+++ b/tests/test_git_transport.py
@@ -1,0 +1,496 @@
+"""Git transport contract tests (Issue #114).
+
+Git data operations (fetch, push — including `.github/workflows/*.yml`)
+go over SSH (`git@github.com:owner/repo.git`); GitHub API operations
+stay on the `gh` token. The deployment checkout's single `origin`
+remote is the transport: task worktrees created with `git worktree
+add` share it (verified against real git). An existing HTTPS remote is
+never rewritten silently — only the human-run setup entry migrates it
+(`migrate=True`); every other path fails fast with the exact
+migration command. A failed SSH probe (`git ls-remote`, verified
+against the real CLI: exit 0 = reachable + authenticated) fails fast
+with the structured reason — no HTTPS fallback, no silent skip.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import git_transport
+
+
+# --- ssh_url_for -------------------------------------------------------------
+
+
+def test_ssh_url_for_builds_the_github_ssh_url():
+    assert git_transport.ssh_url_for("xqliu/muyan-pilot") == (
+        "git@github.com:xqliu/muyan-pilot.git"
+    )
+
+
+def test_ssh_url_for_rejects_a_repo_without_a_slash():
+    with pytest.raises(git_transport.TransportError, match="malformed"):
+        git_transport.ssh_url_for("muyan-pilot")
+
+
+def test_ssh_url_for_rejects_an_empty_segment():
+    with pytest.raises(git_transport.TransportError, match="malformed"):
+        git_transport.ssh_url_for("/muyan-pilot")
+    with pytest.raises(git_transport.TransportError, match="malformed"):
+        git_transport.ssh_url_for("xqliu/")
+
+
+def test_ssh_url_for_rejects_an_extra_slash():
+    with pytest.raises(git_transport.TransportError, match="malformed"):
+        git_transport.ssh_url_for("xqliu/muyan/pilot")
+
+
+# --- remote_protocol ---------------------------------------------------------
+
+
+def test_remote_protocol_classifies_ssh_scp_style():
+    assert git_transport.remote_protocol(
+        "git@github.com:xqliu/muyan-pilot.git"
+    ) == "ssh"
+
+
+def test_remote_protocol_classifies_ssh_scheme():
+    assert git_transport.remote_protocol(
+        "ssh://git@github.com/xqliu/muyan-pilot.git"
+    ) == "ssh"
+
+
+def test_remote_protocol_classifies_https():
+    assert git_transport.remote_protocol(
+        "https://github.com/xqliu/muyan-pilot.git"
+    ) == "https"
+
+
+def test_remote_protocol_classifies_http():
+    assert git_transport.remote_protocol(
+        "http://github.com/xqliu/muyan-pilot.git"
+    ) == "http"
+
+
+def test_remote_protocol_classifies_everything_else_other():
+    assert git_transport.remote_protocol("origin") == "other"
+    assert git_transport.remote_protocol(
+        "/home/u/repos/muyan-pilot"
+    ) == "other"
+
+
+# --- check_transport ----------------------------------------------------------
+
+
+def ok_run_factory(state: dict):
+    """A run_command double driven by `state` (counters + canned output)."""
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:2] == ["git", "config"]:
+            if state.get("no_origin"):
+                raise subprocess.CalledProcessError(
+                    1, command, stderr="",
+                )
+            return state.get("origin_url",
+                             "git@github.com:xqliu/muyan-pilot.git")
+        if command[:2] == ["git", "ls-remote"]:
+            if state.get("ssh_down"):
+                raise subprocess.CalledProcessError(
+                    128, command,
+                    stderr="git@github.com: Permission denied (publickey).",
+                )
+            return "abc123\tHEAD"
+        if command[:3] == ["git", "remote", "set-url"]:
+            state["origin_url"] = command[4]
+            state.setdefault("migrations", []).append(command[4])
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    return fake_run, calls, state
+
+
+def test_check_transport_passes_for_a_matching_ssh_remote(tmp_path):
+    state = {}
+    fake_run, calls, _ = ok_run_factory(state)
+    result = git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+    )
+    assert result == {
+        "remote": "origin",
+        "protocol": "ssh",
+        "url": "git@github.com:xqliu/muyan-pilot.git",
+        "expected": "git@github.com:xqliu/muyan-pilot.git",
+        "migrated": False,
+        "ssh_reachable": True,
+    }
+    # Read-only: no set-url, one probe of the exact SSH URL.
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+    assert [
+        "git", "ls-remote", "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
+
+
+def test_check_transport_accepts_an_ssh_url_without_the_dot_git_suffix(
+    tmp_path,
+):
+    state = {"origin_url": "git@github.com:xqliu/muyan-pilot"}
+    fake_run, calls, _ = ok_run_factory(state)
+    result = git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+    )
+    assert result["protocol"] == "ssh"
+    assert result["ssh_reachable"] is True
+    # The probe uses the normalized .git form.
+    assert [
+        "git", "ls-remote", "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
+
+
+def test_check_transport_fails_fast_on_a_missing_origin(tmp_path):
+    state = {"no_origin": True}
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(
+        git_transport.TransportError, match="no origin remote",
+    ):
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    # No probe, no migration after the missing remote.
+    assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []
+
+
+def test_check_transport_diagnoses_an_https_remote_without_migrating(
+    tmp_path,
+):
+    state = {
+        "origin_url": "https://github.com/xqliu/muyan-pilot.git",
+    }
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(git_transport.TransportError, match="HTTPS") as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    message = str(exc.value)
+    # The failure carries the exact migration command and the setup
+    # entry that performs it — never a silent rewrite, never a remote
+    # read from a comment or Issue.
+    assert "git remote set-url origin git@github.com:xqliu/muyan-pilot.git" in message
+    assert "muyan_pilot.py setup" in message
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+    # No HTTPS fallback: no ls-remote of the HTTPS URL either.
+    assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []
+
+
+def test_check_transport_migrates_an_https_remote_when_authorized(tmp_path):
+    state = {"origin_url": "https://github.com/xqliu/muyan-pilot.git"}
+    fake_run, calls, _ = ok_run_factory(state)
+    result = git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot"],
+        run_command=fake_run, migrate=True,
+    )
+    assert result["protocol"] == "ssh"
+    assert result["migrated"] is True
+    assert result["url"] == "git@github.com:xqliu/muyan-pilot.git"
+    assert result["ssh_reachable"] is True
+    assert state["migrations"] == [
+        "git@github.com:xqliu/muyan-pilot.git",
+    ]
+
+
+def test_check_transport_fails_fast_on_an_ssh_repo_mismatch(tmp_path):
+    state = {"origin_url": "git@github.com:other/repo.git"}
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(
+        git_transport.TransportError, match="mismatch",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    message = str(exc.value)
+    assert "git@github.com:other/repo.git" in message
+    assert "git@github.com:xqliu/muyan-pilot.git" in message
+    # A mismatching remote is not probed and not migrated.
+    assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+
+
+def test_check_transport_fails_fast_on_an_unsupported_protocol(tmp_path):
+    state = {"origin_url": "http://github.com/xqliu/muyan-pilot.git"}
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(git_transport.TransportError, match="http"):
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+
+
+def test_check_transport_fails_fast_when_ssh_is_unreachable(tmp_path):
+    state = {"ssh_down": True}
+    fake_run, calls, _ = ok_run_factory(state)
+    with pytest.raises(
+        git_transport.TransportError, match="ssh_unreachable",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    message = str(exc.value)
+    # The structured scene: the exact probe command and the git stderr.
+    assert "git ls-remote git@github.com:xqliu/muyan-pilot.git" in message
+    assert "Permission denied (publickey)" in message
+    # No HTTPS fallback: the probe is never retried over HTTPS.
+    probes = [c for c in calls if c[:2] == ["git", "ls-remote"]]
+    assert len(probes) == 1
+    assert probes[0][2].startswith("git@github.com:")
+
+
+def test_check_transport_skips_the_probe_when_disabled(tmp_path):
+    state = {}
+    fake_run, calls, _ = ok_run_factory(state)
+    result = git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot"],
+        run_command=fake_run, probe=False,
+    )
+    assert result["ssh_reachable"] is None
+    assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []
+
+
+def test_check_transport_fails_fast_on_a_malformed_source_repo(tmp_path):
+    fake_run, calls, _ = ok_run_factory({})
+    with pytest.raises(
+        git_transport.TransportError, match="malformed",
+    ):
+        git_transport.check_transport(
+            tmp_path, ["not-a-repo"], run_command=fake_run,
+        )
+    assert calls == []
+
+
+def test_check_transport_uses_the_first_configured_source_repo(tmp_path):
+    state = {}
+    fake_run, calls, _ = ok_run_factory(state)
+    git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot", "xqliu/muyan-ceo"],
+        run_command=fake_run,
+    )
+    assert [
+        "git", "ls-remote", "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
+
+
+def test_check_transport_accepts_an_ssh_scheme_url(tmp_path):
+    """Both SSH forms are the same transport: the `ssh://` scheme URL
+    matches the expected repo and is probed in the normalized SCP form."""
+    state = {
+        "origin_url": "ssh://git@github.com/xqliu/muyan-pilot.git",
+    }
+    fake_run, calls, _ = ok_run_factory(state)
+    result = git_transport.check_transport(
+        tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+    )
+    assert result["protocol"] == "ssh"
+    assert result["ssh_reachable"] is True
+    assert [
+        "git", "ls-remote", "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
+
+
+def test_check_transport_fails_fast_on_a_generic_config_error(tmp_path):
+    """A non-git failure reading the configured URL (e.g. a spawn
+    error) still fails fast as a missing/unknown origin — never a
+    guessed transport."""
+    def fake_run(command, **kwargs):
+        raise OSError("spawn failed")
+
+    with pytest.raises(
+        git_transport.TransportError, match="no origin remote",
+    ):
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+
+
+def test_check_transport_reports_a_probe_failure_without_stderr(tmp_path):
+    """A probe failure without captured stderr (e.g. the error went to
+    the terminal) still carries the exact probe command — the scene is
+    never incomplete."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        raise subprocess.CalledProcessError(128, command)
+
+    with pytest.raises(
+        git_transport.TransportError, match="ssh_unreachable",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    message = str(exc.value)
+    assert "git ls-remote git@github.com:xqliu/muyan-pilot.git" in message
+    assert "stderr=" not in message
+
+
+def test_check_transport_fails_fast_on_a_generic_probe_error(tmp_path):
+    """A non-git failure of the SSH probe (e.g. a spawn error) fails
+    fast as ssh_unreachable — no HTTPS fallback."""
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        raise OSError("spawn failed")
+
+    with pytest.raises(
+        git_transport.TransportError, match="ssh_unreachable",
+    ) as exc:
+        git_transport.check_transport(
+            tmp_path, ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    assert "spawn failed" in str(exc.value)
+
+
+def test_ok_run_factory_rejects_an_unexpected_command():
+    fake_run, _, _ = ok_run_factory({})
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["definitely", "not", "a", "known", "command"])
+
+
+def test_ssh_repo_path_returns_none_for_a_non_ssh_url():
+    """The defensive branch: a URL that is neither the SCP form nor
+    the `ssh://` scheme has no repo path (check_transport only calls
+    this for SSH URLs, so the branch is unit-tested directly)."""
+    assert git_transport._ssh_repo_path(
+        "https://github.com/xqliu/muyan-pilot.git"
+    ) is None
+    assert git_transport._ssh_repo_path(
+        "git@github.com:xqliu/muyan-pilot"
+    ) == "xqliu/muyan-pilot"
+    assert git_transport._ssh_repo_path(
+        "ssh://git@github.com/xqliu/muyan-pilot.git"
+    ) == "xqliu/muyan-pilot"
+
+
+# --- real git: the worktree inherits the checkout's transport -----------------
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def test_git_helper_fails_fast_on_nonzero_exit(tmp_path):
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git(tmp_path, "rev-parse", "no-such-ref")
+
+
+def test_real_worktree_inherits_the_checkout_origin_remote(tmp_path):
+    """A `git worktree add` worktree shares the deployment checkout's
+    single `origin` remote (verified against real git): configuring the
+    transport once on the checkout makes every task worktree's
+    `git remote -v` carry it."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    git(clone, "commit", "--allow-empty", "-m", "first")
+    # The checkout's origin is a local path (the stand-in for the
+    # remote); the transport is configured by rewriting it.
+    ssh_style = "git@github.com:xqliu/muyan-pilot.git"
+    git(clone, "remote", "set-url", "origin", ssh_style)
+    assert git(clone, "remote", "get-url", "origin") == ssh_style
+    worktree = tmp_path / "wt"
+    git(clone, "worktree", "add", "-b", "task", str(worktree), "HEAD")
+    # The worktree's `git remote -v` shows the checkout's transport.
+    assert git(worktree, "remote", "get-url", "origin") == ssh_style
+    remote_v = git(worktree, "remote", "-v")
+    assert f"origin\t{ssh_style} (fetch)" in remote_v
+    assert f"origin\t{ssh_style} (push)" in remote_v
+    git(clone, "worktree", "remove", "--force", str(worktree))
+
+
+def test_real_workflow_file_push_goes_over_the_ssh_transport(tmp_path):
+    """The Issue #106 scenario: pushing a `.github/workflows/*.yml`
+    file from the task worktree. The worktree's `origin` is the SSH
+    URL (a `url.<base>.insteadOf` rewrite keeps the data plane local,
+    the same mechanism the e2e world uses): the push of the workflow
+    file succeeds over the configured SSH transport — it never depends
+    on the OAuth App `workflow` scope (the HTTPS/OAuth transport that
+    blocked Issue #106)."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    git(clone, "commit", "--allow-empty", "-m", "first")
+    # The transport: SSH URL on the remote, local data plane (the
+    # e2e mechanism, git-config(1) `url.<base>.insteadOf`).
+    ssh_style = "git@github.com:xqliu/muyan-pilot.git"
+    git(clone, "remote", "set-url", "origin", ssh_style)
+    git(clone, "config", f"url.{origin}.insteadOf", ssh_style)
+    worktree = tmp_path / "wt"
+    git(clone, "worktree", "add", "-b", "task", str(worktree), "HEAD")
+    # The delivery: a GitHub workflow file committed in the worktree.
+    workflows = worktree / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(
+        "name: CI\njobs:\n  tests:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    git(worktree, "add", ".")
+    git(worktree, "commit", "-m", "feat: workflow file (Issue #106 scene)")
+    # The push of the workflow file goes over the worktree's origin
+    # (the checkout's single SSH remote).
+    git(worktree, "push", "origin", "HEAD:refs/heads/task")
+    # The workflow file is on the remote branch.
+    refs = git(origin, "ls-tree", "-r", "refs/heads/task")
+    assert ".github/workflows/ci.yml" in refs
+    git(clone, "worktree", "remove", "--force", str(worktree))
+
+
+def test_real_set_url_migration_rewrites_only_the_origin_remote(tmp_path):
+    """The migration command the check reports (and setup runs) is a
+    plain `git remote set-url origin <ssh-url>`: it rewrites the fetch
+    URL of `origin` only and leaves the worktree-visible transport
+    consistent."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    git(clone, "commit", "--allow-empty", "-m", "first")
+    https_style = "https://github.com/xqliu/muyan-pilot.git"
+    git(clone, "remote", "set-url", "origin", https_style)
+    assert git(clone, "remote", "get-url", "origin") == https_style
+    assert git_transport.remote_protocol(
+        git(clone, "remote", "get-url", "origin")
+    ) == "https"
+    # The migration (the exact command the failure message reports).
+    git(clone, "remote", "set-url", "origin",
+        "git@github.com:xqliu/muyan-pilot.git")
+    assert git(clone, "remote", "get-url", "origin") == (
+        "git@github.com:xqliu/muyan-pilot.git"
+    )
+    assert git_transport.remote_protocol(
+        git(clone, "remote", "get-url", "origin")
+    ) == "ssh"

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -1102,13 +1103,22 @@ def _deploy_world(tmp_path, drift: bool = False) -> tuple[dict, Path]:
     return config, installed
 
 
-def _fake_doctor_commands(monkeypatch) -> list:
+def _fake_doctor_commands(monkeypatch, ssh_down: bool = False) -> list:
     calls: list = []
 
     def fake_run(command, **kwargs):
         calls.append(command)
         if command[:3] == ["git", "rev-parse", "HEAD"]:
             return "0123456789abcdef0123456789abcdef01234567"
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            if ssh_down:
+                raise subprocess.CalledProcessError(
+                    128, command,
+                    stderr="git@github.com: Permission denied (publickey).",
+                )
+            return "abc\tHEAD"
         if command[:2] == ["systemctl", "--user"]:
             assert command[2:5] == ["show", "-p", "ActiveState"]
             return "active"
@@ -1208,6 +1218,10 @@ def _setup_result() -> dict:
             "branch": "main",
             "clean": True,
             "base_fresh": True,
+            "remote_url": "git@github.com:xqliu/muyan-pilot.git",
+            "remote_protocol": "ssh",
+            "migrated": False,
+            "ssh_reachable": True,
         },
         "optional_proxy": {
             "optional": True,
@@ -1317,6 +1331,18 @@ def test_doctor_report_clean(tmp_path, monkeypatch):
         assert (
             f"  {entry['unit']}: sha256={entry['installed_sha256']}"
         ) in lines
+    # The git transport (Issue #114): the checkout's origin is SSH for
+    # the configured source repo and the SSH probe succeeded.
+    assert (
+        "transport: remote=origin "
+        "url=git@github.com:xqliu/muyan-pilot.git protocol=ssh "
+        "expected=git@github.com:xqliu/muyan-pilot.git ssh_reachable=true"
+    ) in lines
+    # The probe is the real read-only command (verified against the
+    # live CLI: exit 0 = reachable + authenticated).
+    assert [
+        "git", "ls-remote", "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
     assert "muyan-pilot.timer: active" in lines
     assert "muyan-pilot.service: active" in lines
     assert "slots: 0/1" in lines
@@ -1339,6 +1365,25 @@ def test_doctor_report_clean(tmp_path, monkeypatch):
         "journalctl", "--user", "-u", "muyan-pilot.service",
         "-n", "20", "--no-pager",
     ] in calls
+
+
+def test_doctor_report_reports_a_failed_transport(tmp_path, monkeypatch):
+    """Issue #114: doctor is the diagnostic report — a failed transport
+    (SSH unreachable) is REPORTED with the structured reason, not
+    raised: the rest of the health report stays readable. The
+    fail-fast gate is the pre-start check, not doctor."""
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch, ssh_down=True)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, installed)
+    lines = report.splitlines()
+    failed = [line for line in lines if line.startswith("transport: FAILED")]
+    assert len(failed) == 1
+    assert "ssh_unreachable" in failed[0]
+    assert "Permission denied (publickey)" in failed[0]
+    # The report continues past the transport failure.
+    assert "slots: 0/1" in lines
+    assert "journal:" in lines
 
 
 def test_doctor_report_drift_carries_paths_hashes_and_fix(

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -79,6 +79,17 @@ def fake_run_factory(state: dict):
         head = list(command)
         if head[:3] == ["git", "rev-parse", "HEAD"]:
             return "0123456789abcdef0123456789abcdef01234567"
+        if head[:2] == ["git", "config"]:
+            return state.get(
+                "origin_url", "git@github.com:xqliu/muyan-pilot.git",
+            )
+        if head[:2] == ["git", "ls-remote"]:
+            if state.get("ssh_down"):
+                raise subprocess.CalledProcessError(
+                    128, command,
+                    stderr="git@github.com: Permission denied (publickey).",
+                )
+            return "abc\tHEAD"
         if head[:2] == ["git", "remote"]:
             return "origin"
         if head[:3] == ["git", "branch", "--show-current"]:
@@ -520,24 +531,32 @@ def test_timer_next_trigger_ignores_other_timers():
 def test_check_checkout_reports_remote_branch_clean_and_fresh(tmp_path):
     repo = tmp_path / "checkout"
     repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            return "abc\tHEAD"
+        if command[:3] == ["git", "rev-parse", "origin/main"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return "main"
+        return ""
+
     result = pilot_setup.check_checkout(
-        repo, "main", run_command=lambda command, **kwargs: (
-            "0123456789abcdef0123456789abcdef01234567"
-            if command[:3] == ["git", "rev-parse", "origin/main"]
-            else "0123456789abcdef0123456789abcdef01234567"
-            if command[:3] == ["git", "rev-parse", "HEAD"]
-            else "origin"
-            if command[:2] == ["git", "remote"]
-            else "main"
-            if command[:3] == ["git", "branch", "--show-current"]
-            else ""
-        ),
+        repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
     )
     assert result == {
         "remote": "origin",
         "branch": "main",
         "clean": True,
         "base_fresh": True,
+        "remote_url": "git@github.com:xqliu/muyan-pilot.git",
+        "remote_protocol": "ssh",
+        "migrated": False,
+        "ssh_reachable": True,
     }
 
 
@@ -546,15 +565,17 @@ def test_check_checkout_fails_fast_on_a_dirty_checkout(tmp_path):
     repo.mkdir()
 
     def fake_run(command, **kwargs):
-        if command[:2] == ["git", "remote"]:
-            return "origin"
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            return "abc\tHEAD"
         if command[:2] == ["git", "status"]:
             return " M bootstrap_runner.py"
         return ""
 
     with pytest.raises(pilot_setup.SetupError, match="not clean"):
         pilot_setup.check_checkout(
-            repo, "main", run_command=fake_run,
+            repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
         )
 
 
@@ -563,8 +584,10 @@ def test_check_checkout_reports_a_stale_base(tmp_path):
     repo.mkdir()
 
     def fake_run(command, **kwargs):
-        if command[:2] == ["git", "remote"]:
-            return "origin"
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            return "abc\tHEAD"
         if command[:3] == ["git", "rev-parse", "origin/main"]:
             return "1111111111111111111111111111111111111111"
         if command[:3] == ["git", "rev-parse", "HEAD"]:
@@ -572,7 +595,7 @@ def test_check_checkout_reports_a_stale_base(tmp_path):
         return ""
 
     result = pilot_setup.check_checkout(
-        repo, "main", run_command=fake_run,
+        repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
     )
     assert result["base_fresh"] is False
 
@@ -582,7 +605,7 @@ def test_check_checkout_fails_fast_without_an_origin_remote(tmp_path):
     repo.mkdir()
     with pytest.raises(pilot_setup.SetupError, match="remote"):
         pilot_setup.check_checkout(
-            repo, "main",
+            repo, "main", ["xqliu/muyan-pilot"],
             run_command=lambda command, **kwargs: (
                 (_ for _ in ()).throw(
                     subprocess.CalledProcessError(1, command, stderr="no remote")
@@ -596,13 +619,124 @@ def test_check_checkout_fails_fast_on_a_git_error(tmp_path):
     repo.mkdir()
     with pytest.raises(pilot_setup.SetupError, match="checkout"):
         pilot_setup.check_checkout(
-            repo, "main",
+            repo, "main", ["xqliu/muyan-pilot"],
             run_command=lambda command, **kwargs: (
                 (_ for _ in ()).throw(
                     subprocess.CalledProcessError(1, command, stderr="boom")
                 )
             ),
         )
+
+
+# --- git transport in the checkout check (Issue #114) -------------------------
+
+
+def test_check_checkout_migrates_an_https_remote_to_ssh(tmp_path):
+    """Issue #114: the setup entry is the human-authorized migration
+    path: an existing HTTPS `origin` is rewritten to the SSH URL of
+    the first configured source repo with the plain
+    `git remote set-url origin <ssh-url>` (never a remote read from a
+    comment or Issue)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    state = {"url": "https://github.com/xqliu/muyan-pilot.git"}
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return state["url"]
+        if command[:3] == ["git", "remote", "set-url"]:
+            state["url"] = command[4]
+            return ""
+        if command[:2] == ["git", "ls-remote"]:
+            return "abc\tHEAD"
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return "main"
+        return ""
+
+    result = pilot_setup.check_checkout(
+        repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
+    )
+    assert state["url"] == "git@github.com:xqliu/muyan-pilot.git"
+    assert result["remote_url"] == "git@github.com:xqliu/muyan-pilot.git"
+    assert result["remote_protocol"] == "ssh"
+    assert result["migrated"] is True
+    assert result["ssh_reachable"] is True
+
+
+def test_check_checkout_fails_fast_when_ssh_is_unreachable(tmp_path):
+    """Issue #114: a failed SSH probe fails the setup with the
+    structured reason (the exact probe command and git stderr) — no
+    HTTPS fallback, no silent skip."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            raise subprocess.CalledProcessError(
+                128, command,
+                stderr="git@github.com: Permission denied (publickey).",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(
+        pilot_setup.SetupError, match="ssh_unreachable",
+    ) as exc:
+        pilot_setup.check_checkout(
+            repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    message = str(exc.value)
+    assert "git ls-remote git@github.com:xqliu/muyan-pilot.git" in message
+    assert "Permission denied (publickey)" in message
+    # The fake is strict: an unexpected command fails loudly.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["git", "worktree", "add"])
+
+
+def test_check_checkout_fails_fast_on_a_generic_git_error(tmp_path):
+    """A non-git failure of a checkout command (e.g. a spawn error)
+    fails the setup with the checkout reason — never a guessed state."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:xqliu/muyan-pilot.git"
+        if command[:2] == ["git", "ls-remote"]:
+            return "abc\tHEAD"
+        if command[:3] == ["git", "branch", "--show-current"]:
+            raise OSError("spawn failed")
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(pilot_setup.SetupError, match="checkout"):
+        pilot_setup.check_checkout(
+            repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    # The fake is strict: an unexpected command fails loudly.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["git", "worktree", "add"])
+
+
+def test_check_checkout_fails_fast_on_a_remote_repo_mismatch(tmp_path):
+    """Issue #114: the checkout's remote must match the configured
+    source repo — a clone of a different repo fails fast with both
+    URLs (no migration of a mismatching remote)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "config"]:
+            return "git@github.com:other/repo.git"
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(pilot_setup.SetupError, match="mismatch"):
+        pilot_setup.check_checkout(
+            repo, "main", ["xqliu/muyan-pilot"], run_command=fake_run,
+        )
+    # The fake is strict: an unexpected command fails loudly.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["git", "worktree", "add"])
 
 
 # --- optional model proxy (never blocks) --------------------------------------
@@ -761,6 +895,44 @@ def test_run_setup_optional_proxy_failure_never_blocks(tmp_path):
     assert result["optional_proxy"]["proxy"] == "unhealthy"
 
 
+def test_run_setup_migrates_an_https_checkout_remote(tmp_path):
+    """Issue #114: the full setup entry migrates the deployment
+    checkout's HTTPS `origin` to SSH (the human-authorized path) and
+    reports it in the checkout result."""
+    repo, installed, state = make_run_state(tmp_path)
+    state["origin_url"] = "https://github.com/xqliu/muyan-pilot.git"
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo))
+    result = pilot_setup.run_setup(
+        config, installed, run_command=fake_run,
+    )
+    assert result["checkout"]["remote_url"] == (
+        "git@github.com:xqliu/muyan-pilot.git"
+    )
+    assert result["checkout"]["remote_protocol"] == "ssh"
+    assert result["checkout"]["migrated"] is True
+    assert result["checkout"]["ssh_reachable"] is True
+    assert [
+        "git", "remote", "set-url", "origin",
+        "git@github.com:xqliu/muyan-pilot.git",
+    ] in calls
+
+
+def test_run_setup_fails_fast_when_ssh_is_unreachable(tmp_path):
+    """Issue #114: a failed SSH probe fails the setup (structured
+    reason) — no HTTPS fallback, no silent skip."""
+    repo, installed, state = make_run_state(tmp_path)
+    state["ssh_down"] = True
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="ssh_unreachable"):
+        pilot_setup.run_setup(
+            config, installed, run_command=fake_run,
+        )
+    # No migration happened (the remote was already SSH).
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+
+
 def test_run_setup_missing_labels_file_fails_fast(tmp_path):
     repo = make_repo(tmp_path)
     (repo / "labels.toml").unlink()
@@ -803,6 +975,10 @@ def sample_result() -> dict:
             "branch": "main",
             "clean": True,
             "base_fresh": True,
+            "remote_url": "git@github.com:xqliu/muyan-pilot.git",
+            "remote_protocol": "ssh",
+            "migrated": False,
+            "ssh_reachable": True,
         },
         "optional_proxy": {
             "optional": True,
@@ -828,7 +1004,9 @@ def test_format_setup_renders_stable_key_value_lines():
         'timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"'
     ) in lines
     assert (
-        "checkout=remote=origin branch=main clean=true base_fresh=true"
+        "checkout=remote=origin branch=main clean=true base_fresh=true "
+        "remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh "
+        "migrated=false ssh_reachable=true"
     ) in lines
     assert (
         "model_endpoint=optional optional_proxy=healthy "
@@ -983,8 +1161,14 @@ def test_check_checkout_fails_fast_when_origin_is_missing(tmp_path):
     repo.mkdir()
     with pytest.raises(pilot_setup.SetupError, match="origin remote"):
         pilot_setup.check_checkout(
-            repo, "main",
-            run_command=lambda command, **kwargs: "upstream",
+            repo, "main", ["xqliu/muyan-pilot"],
+            run_command=lambda command, **kwargs: (
+                (_ for _ in ()).throw(
+                    subprocess.CalledProcessError(
+                        128, command, stderr="No remote configured",
+                    )
+                )
+            ),
         )
 
 


### PR DESCRIPTION
Fixes #114

<!-- muyan-pilot:run=517abad2 -->
run_id=517abad2

## 交付内容

两条认证通道职责边界清晰：

- **Git 数据操作**（fetch、push——包括 `.github/workflows/*.yml`）走 **SSH**（`git@github.com:owner/repo.git`，本机 SSH key）；workflow 推送不再依赖 OAuth App `workflow` scope（#106 被阻塞的根因）。
- **GitHub API 操作**（Issue、PR、label、comment、merge）继续走现有 `gh` token；SSH 从不作为 API 认证。

### 变更

- `git_transport.py`（新）：transport 契约——`ssh_url_for` / `remote_protocol` / `check_transport`（配置的 `origin` URL 必须为第一个 source repo 的 SSH 形式；`git ls-remote` 探测 SSH 连通性，已对真实 CLI 验证 exit 0 = 可达且已认证；失败 fail fast，**无 HTTPS 降级、不静默跳过**）。
- `bootstrap_runner.py`：启动前检查（unit 漂移检查之后、取 slot/领取之前）——失败记录结构化 `transport_check_failed ... reason=...` 并 fail fast；worktree 创建不变（`git worktree add` 共享 checkout 的单一 `origin`，新 worktree 的 `git remote -v` 默认即 SSH）。
- `pilot_setup.py`：setup（人工执行的一次性入口）是 HTTPS→SSH 的授权迁移路径（`git remote set-url origin <ssh-url>`，从不从评论/Issue 读取 remote）；checkout 结果新增 `remote_url/remote_protocol/migrated/ssh_reachable`。
- `muyan_pilot.py doctor`：只读 transport 行（`transport: remote=... url=... protocol=... expected=... ssh_reachable=...`；失败时 `transport: FAILED ...`，报告不中断）。
- 文档：`AGENTS.md`（Git transport 契约节）、`README.md`（Git transport 节 + setup/doctor/worktree 说明）、`docs/setup.mdx`、`docs/operations.mdx`、`docs/workflow.mdx`、`docs/security.mdx`（双通道边界）。

### 测试（810 passed，line/branch coverage 100%）

- 新 worktree SSH remote（真实 git：worktree 共享 checkout 的单一 origin）；
- workflow 文件 push 场景（真实 git：worktree 内提交并 push `.github/workflows/ci.yml`，走 SSH remote）；
- 已有 HTTPS remote 诊断（fail fast + 确切迁移命令，不静默改写）与 setup 迁移；
- SSH 失败（结构化现场：命令 + stderr；无 HTTPS 降级）；
- API 操作仍走 `gh`（e2e 假 `gh` 应答全部 API 调用，transport 检查只触碰 git 数据命令）；
- 启动前检查接线（失败在取 slot/领取之前；通过则 `transport clean`）。

### 验证

```text
/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q   # 810 passed
/usr/bin/python3 -m coverage report --fail-under=100            # TOTAL 100%
```

真实机器只读抽查：部署 checkout（HTTPS origin）的诊断信息携带确切迁移命令；`git ls-remote git@github.com:xqliu/muyan-pilot.git` exit 0；`doctor` 输出 `transport: FAILED ...`（迁移前预期现场）且报告继续。

### 边界

不修改保护分支、不 force-push；#106 的 PR/branch/scene 未做任何改动（issue 仍 `ai-blocked`，PR #108 原样 OPEN/MERGEABLE）——合并本 PR 后由人工运行 `python3 muyan_pilot.py setup` 迁移部署 checkout 的 remote 为 SSH，再恢复 #106 的交付流程（同一 branch/worktree/PR，不创建替代 PR）。
