### PR TITLE
feat: pi_idle 超时后自动清理挂死的 Pi 子进程，让工具失败信号回到模型 (Issue #94)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,14 +73,29 @@ is **one runtime outcome** (when X, should Y, actually Z).
   carries issue, run id, role (implement/review/merge), phase, elapsed,
   last activity, last action, session and branch. No model/session activity
   for 5 minutes logs an idle warning; the first new activity after it logs
-  a resumed event. A session frozen in `model_wait` (the newest event is a
-  tool result) past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s) declares
-  the upstream (llama/proxy) dead — the HTTP timeout or connection drop
-  left Pi in epoll_wait and it will never exit on its own: the Runner
-  kills Pi, logs `run_failed ... reason=upstream_dead_stale_...`, and fails
-  fast through the normal failure path (the Issue is marked `ai-blocked`
-  with the scene in the Issue comment, the slot is released by the kernel
-  when the process exits, and the next tick can resume or claim the next
+  a resumed event. A stalled (non-`model_wait`) session is recovered
+  automatically, not only warned (Issue #94): one step per idle window of
+  `PI_IDLE_WARN_SECONDS` since the stall was first seen — window 1
+  SIGTERMs the Pi descendants that already existed before the window
+  (the hung tools: ppid chain + start time from `/proc/<pid>/stat`, never
+  a name guess; only Pi descendants, never other system processes, never
+  a process spawned after the window began), so the tool gets a non-zero
+  exit and the failure signal reaches the model; window 2 SIGKILLs a
+  target that survived; after `PI_IDLE_RECOVERY_CYCLES` (default 3)
+  consecutive idle windows the Runner kills the Pi session itself and
+  fails fast through the normal failure path (the slot is never held
+  forever). Every step logs a `pi_idle_term` / `pi_idle_kill` line (run
+  id, pid, cmdline, TERM/KILL, result) and the progress comment shows the
+  recovery state via its `recovery` field; the first new activity resets
+  the whole recovery state. A session frozen in `model_wait` (the newest
+  event is a tool result) past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s)
+  declares the upstream (llama/proxy) dead — the HTTP timeout or
+  connection drop left Pi in epoll_wait and it will never exit on its
+  own: the Runner kills Pi, logs
+  `run_failed ... reason=upstream_dead_stale_...`, and fails fast through
+  the normal failure path (the Issue is marked `ai-blocked` with the
+  scene in the Issue comment, the slot is released by the kernel when the
+  process exits, and the next tick can resume or claim the next
   `ai-fix-needed`) (Issue #75). It never fires while events keep arriving
   (a slow model is not a dead upstream) and it is NOT a business task
   timeout.

--- a/README.md
+++ b/README.md
@@ -213,13 +213,17 @@ Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`boo
 - `model_wait issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；
 - `resumed issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
 - `pi_idle issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
-- `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed）。
-- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|upstream_dead_stale_...s`——进程异常退出、超时或上游已死（Issue #75）时先记录完整现场再抛出错误；
+- `pi_idle_term run=... issue=... role=... pid=... cmdline=... result=sent|failed: ...`（或无 pid 的 `result=no_target`）——idle 告警后第一个 idle 窗口内，对 idle 窗口开始前就已存在、仍在运行的 Pi 后代（挂死的 bash/pytest 等工具）逐个发 SIGTERM（保留现场），让工具拿到非零退出、失败信号回到模型（Issue #94）；找不到挂死后代时记 `no_target`（Pi 自身卡住）；
+- `pi_idle_kill run=... issue=... role=... pid=... cmdline=... result=sent|already_dead|failed: ...`——再过一个 idle 窗口仍无新活动且被 TERM 的后代仍存活时发 SIGKILL；TERM 已生效（进程已退出）时记 `already_dead`，不再发信号；
+- `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed），整个 idle 恢复状态同时复位；
+- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|upstream_dead_stale_...s|idle_recovery_stale_...s`——进程异常退出、超时、上游已死（Issue #75）或连续 3 个 idle 窗口（`PI_IDLE_RECOVERY_CYCLES=3`）仍无新活动（Issue #94，Runner 杀掉 Pi 会话本身）时先记录完整现场再抛出错误；
 - `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
 
 上游已死检测（Issue #75）：`model_wait` 期间 session JSONL 冻结超过 `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）判定上游（llama/proxy）已死——HTTP 超时或连接断开后 Pi 停在 epoll_wait 永不退出：Runner 杀掉 Pi 进程，记录 `run_failed ... reason=upstream_dead_stale_...s` 后 fail fast（Issue 标记 `ai-blocked`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍可 resume 或领取下一个 `ai-fix-needed`）。事件持续到达时永不触发（慢模型不是死上游），它也不是业务任务 timeout。
 
-所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`。默认 tail 示例（仅用于查看，不是产品步骤）：
+idle 卡死自动恢复（Issue #94）：非 `model_wait` 的卡死（Pi 的 bash 工具子进程永久阻塞，如 TDD red 阶段的死循环测试、`next(generator)` 永久等待）不再只告警。Runner 在现有轮询循环里按 idle 窗口（`idle_warn_seconds`，默认 5 分钟）逐级恢复：第一个窗口对 idle 窗口开始前就已存在、仍在运行的 Pi 后代逐个 SIGTERM（判定依据是 `/proc/<pid>/stat` 的 ppid 链 + 进程启动时间早于 idle 起点，不靠猜；只动 Pi 的后代，不碰系统其他进程，也不碰窗口开始后新起的进程）——工具拿到非零退出，失败信号回到模型，会话自行继续；第二个窗口对被 TERM 后仍存活的后代 SIGKILL；连续 `PI_IDLE_RECOVERY_CYCLES`（默认 3）个窗口仍无新活动时杀掉 Pi 会话本身，按现有 `ai-blocked`/可恢复流程收尾（Issue 标记 `ai-blocked`，slot 随进程退出释放）——slot 绝不被无限占用。每一步写 `pi_idle_term` / `pi_idle_kill` journal 行（带 run_id、pid、cmdline、TERM/KILL、结果），GitHub 进度评论通过 `recovery` 字段（`term` / `kill`）同步现场；第一条新 session 事件到达时整个恢复状态复位（`pi_resumed`）。不引入常驻进程/守护线程。
+
+所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end` / `pi_idle_term` / `pi_idle_kill`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`。默认 tail 示例（仅用于查看，不是产品步骤）：
 
 ```bash
 journalctl --user -u muyan-pilot.service -f

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -29,6 +29,7 @@ import logging
 import os
 import re
 import select
+import signal
 import subprocess
 import time
 import tomllib
@@ -38,6 +39,7 @@ from pathlib import Path
 
 from git_transport import TransportError, check_transport
 from pilot_slots import acquire_slot, slot_dir_for, slot_occupancy
+from pi_recovery import find_idle_descendants, pid_alive, signal_pid
 from pi_activity import (
     SessionWatcher,
     activity_snapshot,
@@ -83,6 +85,15 @@ PI_IDLE_WARN_SECONDS = 300.0
 # it only fires while the session file is frozen (stale seconds), never
 # while events keep arriving — a slow generation survives.
 PI_MODEL_WAIT_DEAD_SECONDS = 600.0
+# Idle-stall recovery (Issue #94): a stalled (non-model_wait) session
+# is recovered automatically instead of only warning. Measured in idle
+# windows of `idle_warn_seconds`: at the first window the pre-idle
+# descendants (the hung tools) get SIGTERM (the failure signal reaches
+# the model), at the second window a target that survived gets
+# SIGKILL, and after `PI_IDLE_RECOVERY_CYCLES` consecutive idle windows
+# the Pi session itself is killed and the run fails fast through the
+# normal `ai-blocked` path — the slot is never held forever.
+PI_IDLE_RECOVERY_CYCLES = 3
 
 # The bootstrap runner streams every Pi session of a run through the same
 # live activity pipeline (Issue #24/#40); implement/review share the same
@@ -917,6 +928,24 @@ def stream_pi(
     model_wait, ONE `pi_idle` WARNING carries `stale_seconds`; the
     first new session event after it logs `pi_resumed`. A slow active
     model (model_wait) is never reported idle (Issue #40).
+
+    Idle-stall recovery (Issue #94): the warning is no longer the end
+    of the story. While the session stays stalled (no new activity,
+    not model_wait) the runner recovers it, one step per idle window
+    of `idle_warn_seconds` since the stall was first seen:
+    window 1 SIGTERMs the Pi descendants that already existed before
+    the window (the hung tools — found by the ppid chain in
+    `/proc/<pid>/stat` plus their start time, never a name guess) so
+    the tool gets a non-zero exit and the failure signal reaches the
+    model; window 2 SIGKILLs a target that survived; after
+    `PI_IDLE_RECOVERY_CYCLES` (default 3) consecutive idle windows the
+    Pi session itself is killed and the run fails fast through the
+    normal failure path (`ai-blocked`, the slot released) — the slot
+    is never held forever. Every step logs a `pi_idle_term` /
+    `pi_idle_kill` line (run id, pid, cmdline, result) and the live
+    progress comment shows the recovery state via the `recovery`
+    activity field. The first new session event resets the whole
+    recovery state (`pi_resumed`).
     """
     # The raw pi command embeds the full prompt and Issue body; only the
     # redacted form may ever reach the journal or an exception message.
@@ -962,6 +991,25 @@ def stream_pi(
     # Idle warning state (Issue #18): at most one `pi_idle` warning per
     # stall; the first new session event after it logs `pi_resumed`.
     idle_warned = False
+    # Idle-stall recovery state (Issue #94): `idle_start_epoch` marks
+    # the start of the current idle window (only descendants that
+    # started no later than it are targets — a process spawned after
+    # the window began is a new tool call, never a target); `recovery`
+    # is the live state shown in the GitHub progress comment (None /
+    # `term` / `kill`); `recovery_targets` are the TERMed descendants
+    # tracked for the KILL escalation; `recovery_step` is the highest
+    # escalation step already executed (0 none, 1 TERM, 2 KILL).
+    idle_start_epoch: float | None = None
+    # The monotonic moment the idle window opened: escalation is
+    # measured in idle windows of NEW silence since the runner first
+    # saw the stall (never in absolute stale seconds — a session that
+    # is already stale when the window opens, e.g. old record
+    # timestamps, starts at step one, not at the session kill).
+    idle_start_monotonic: float | None = None
+    recovery: str | None = None
+    recovery_targets: list[dict] = []
+    recovery_step = 0
+    idle_recovery_failed = False
     try:
         while True:
             if deadline is not None and time.monotonic() >= deadline:
@@ -979,14 +1027,6 @@ def stream_pi(
                     else:
                         stderr_chunks.append(data)
             activity = watcher.poll()
-            if progress is not None:
-                try:
-                    progress(activity)
-                except Exception:
-                    LOGGER.exception(
-                        "progress_publish_failed run=%s issue=%s role=%s",
-                        run_id, issue_ref, role,
-                    )
             visible = (
                 activity["phase"], activity["action"], activity["result"],
             )
@@ -1033,6 +1073,13 @@ def stream_pi(
                     issue_ref, role, activity["phase"],
                 )
                 idle_warned = False
+                # The stall is over: the whole recovery state resets
+                # (Issue #94) — a later stall starts a fresh window.
+                idle_start_epoch = None
+                idle_start_monotonic = None
+                recovery = None
+                recovery_targets = []
+                recovery_step = 0
             elif (
                 not activity["model_wait"]
                 and not idle_warned
@@ -1047,6 +1094,107 @@ def stream_pi(
                     format_duration(activity["stale_seconds"]),
                 )
                 idle_warned = True
+                # The idle window starts now (Issue #94): only
+                # descendants that already existed before this moment
+                # are recovery targets.
+                idle_start_epoch = time.time()
+                idle_start_monotonic = time.monotonic()
+            # Idle-stall recovery (Issue #94): a stalled session (no
+            # model/session activity for idle windows, and the model is
+            # NOT expected to reply next) is recovered instead of only
+            # warning. Escalation, one step per idle window:
+            #   window 1: SIGTERM the pre-idle descendants (the hung
+            #             tools) — the tool gets a non-zero exit, the
+            #             failure signal reaches the model, the session
+            #             continues on its own;
+            #   window 2: SIGKILL a TERMed target that is still alive;
+            #   window N (PI_IDLE_RECOVERY_CYCLES, default 3): kill the
+            #             Pi session itself and fail fast through the
+            #             normal `ai-blocked` path (the slot is never
+            #             held forever). Only pi descendants (ppid
+            #             chain) that started no later than the idle
+            #             start are ever signaled — never other system
+            #             processes, never a process spawned after the
+            #             window began. The progress comment is synced
+            #             via the `recovery` activity field.
+            if (
+                idle_warned
+                and not activity["model_wait"]
+                and activity["stale_seconds"] >= idle_warn_seconds
+                and idle_start_epoch is not None
+            ):
+                # Escalation is measured in idle windows of NEW silence
+                # since the window opened (never in absolute stale
+                # seconds): a session that is already stale when the
+                # window opens (e.g. old record timestamps) starts at
+                # step one, not at the session kill.
+                silence = time.monotonic() - idle_start_monotonic
+                cycle = int(silence // idle_warn_seconds) + 1
+                if cycle >= 1 and recovery_step == 0:
+                    targets = find_idle_descendants(
+                        process.pid, idle_start_epoch,
+                    )
+                    if targets:
+                        recovery_targets = targets
+                        for target in targets:
+                            result = signal_pid(
+                                target["pid"], signal.SIGTERM,
+                            )
+                            LOGGER.warning(
+                                "pi_idle_term run=%s issue=%s role=%s "
+                                "pid=%s cmdline=%s result=%s",
+                                run_id, issue_ref, role, target["pid"],
+                                quote_value(target["cmdline"] or "-"),
+                                result,
+                            )
+                        recovery = "term"
+                    else:
+                        # No hung tool found (Pi itself is stuck): the
+                        # escalation continues, nothing is signaled.
+                        LOGGER.warning(
+                            "pi_idle_term run=%s issue=%s role=%s "
+                            "result=no_target",
+                            run_id, issue_ref, role,
+                        )
+                    recovery_step = 1
+                elif cycle >= 2 and recovery_step == 1:
+                    for target in recovery_targets:
+                        if not pid_alive(target["pid"]):
+                            # The TERM worked between polls: record it,
+                            # signal nothing.
+                            LOGGER.warning(
+                                "pi_idle_kill run=%s issue=%s role=%s "
+                                "pid=%s cmdline=%s result=already_dead",
+                                run_id, issue_ref, role, target["pid"],
+                                quote_value(target["cmdline"] or "-"),
+                            )
+                            continue
+                        result = signal_pid(target["pid"], signal.SIGKILL)
+                        LOGGER.warning(
+                            "pi_idle_kill run=%s issue=%s role=%s "
+                            "pid=%s cmdline=%s result=%s",
+                            run_id, issue_ref, role, target["pid"],
+                            quote_value(target["cmdline"] or "-"),
+                            result,
+                        )
+                    recovery = "kill"
+                    recovery_step = 2
+                if cycle >= PI_IDLE_RECOVERY_CYCLES:
+                    process.kill()
+                    idle_recovery_failed = True
+                    break
+            # The live progress comment shows the recovery state while
+            # it is active (Issue #94); the watcher state is a fresh
+            # dict per poll, so the field never leaks into other polls.
+            activity["recovery"] = recovery
+            if progress is not None:
+                try:
+                    progress(activity)
+                except Exception:
+                    LOGGER.exception(
+                        "progress_publish_failed run=%s issue=%s role=%s",
+                        run_id, issue_ref, role,
+                    )
             # Upstream-dead detection (Issue #75): the model is
             # expected to reply next (model_wait) but the session file
             # has been frozen for the dead threshold — the upstream
@@ -1069,6 +1217,21 @@ def stream_pi(
         _drain_stream(process.stderr, stderr_chunks)
     stdout = _decode_chunks(stdout_chunks)
     stderr = _decode_chunks(stderr_chunks)
+    if idle_recovery_failed:
+        stale = format_duration(activity["stale_seconds"])
+        LOGGER.error(
+            "run_failed %s reason=idle_recovery_stale_%s",
+            format_run_scene(
+                activity, run_id=run_id, issue=issue_ref,
+                role=role, branch=branch, worktree=str(cwd),
+            ),
+            stale,
+        )
+        raise RuntimeError(
+            f"Pi session stayed idle for {stale} after idle recovery "
+            f"(TERM/KILL of pre-idle descendants); Pi was killed "
+            "(Issue #94)"
+        )
     if upstream_dead:
         stale = format_duration(activity["stale_seconds"])
         LOGGER.error(
@@ -2152,6 +2315,10 @@ def _progress_state(*, issue: int, title: str, run_id: str, role: str,
         "branch": branch,
         "pr": pr_url,
         "session": (activity or {}).get("session_id"),
+        # Idle-stall recovery state (Issue #94): `term` / `kill` while
+        # the runner recovers a stalled session, absent/None otherwise
+        # (the body renders the line only while it is active).
+        "recovery": (activity or {}).get("recovery"),
     }
 
 
@@ -2275,6 +2442,9 @@ class LiveProgressThrottle:
         visible = (
             activity["phase"], activity["action"], activity["result"],
             activity["model_wait"],
+            # The idle-recovery state is visible progress (Issue #94):
+            # entering/leaving it PATCHes the live comment immediately.
+            activity.get("recovery"),
         )
         now = time.monotonic()
         if visible == self._last_visible and \

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -56,13 +56,26 @@ Stable `key=value` lines you will see:
 - `pi_idle` — one WARNING when there is no model/session activity for
   more than 5 minutes (`PI_IDLE_WARN_SECONDS=300`) and the model is not
   expected to reply; a slow active model (`model_wait`) never warns;
+- `pi_idle_term` / `pi_idle_kill` — the idle-stall recovery (Issue
+  #94): while the session stays stalled the Runner SIGTERMs the Pi
+  descendants that already existed before the idle window (the hung
+  tools — ppid chain + start time from `/proc/<pid>/stat`, never a
+  name guess; only Pi descendants are ever signaled), then SIGKILLs a
+  target that survived; each line carries run id, pid, cmdline and
+  result (`sent` / `already_dead` / `no_target` / `failed: ...`);
 - `run_failed` — the full scene plus the reason
-  (`pi_exit_N`, `timeout_...s`, or `upstream_dead_stale_...s` when a
+  (`pi_exit_N`, `timeout_...s`, `upstream_dead_stale_...s` when a
   frozen `model_wait` past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s)
-  declares the upstream model dead and the Runner kills Pi).
+  declares the upstream model dead, or `idle_recovery_stale_...s` when
+  the session stayed idle for `PI_IDLE_RECOVERY_CYCLES` (default 3)
+  consecutive idle windows and the Runner kills the Pi session itself).
 
-The idle warning and the upstream-dead kill are log/health thresholds —
-they are not the 15-minute schedule and not a business task timeout.
+The idle warning, the idle recovery and the upstream-dead kill are
+log/health thresholds — they are not the 15-minute schedule and not a
+business task timeout. The idle recovery never holds the slot forever:
+a stalled session either resumes (the failure signal reached the model
+and the first new event resets the recovery state) or the run fails
+fast through the normal `ai-blocked` path.
 
 ## The CLI (`muyan_pilot.py`)
 

--- a/pi_recovery.py
+++ b/pi_recovery.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Idle-stall recovery for a running Pi session (Issue #94).
+
+A Pi session can stall while a tool call hangs forever (a `while True`
+test in the TDD red phase, a `next(generator)` that never returns, ...):
+the Pi process waits for its child, the session JSONL freezes, and the
+slot is held forever. The runner's existing poll loop detects the stall
+(`stale_seconds >= idle_warn_seconds`, not `model_wait`) and this module
+gives it the /proc-based primitives to recover instead of only warning:
+
+- `descendant_pids` — the live process tree of the Pi process, built
+  from the ppid chain in `/proc/<pid>/stat` (never a name guess);
+- `find_idle_descendants` — the descendants that already existed before
+  the idle window started (start time from stat field 22 converted with
+  the boot time and CLK_TCK) and are still running: those are the hung
+  tools, and ONLY they may be signaled;
+- `signal_pid` / `pid_alive` — SIGTERM first (the scene is preserved and
+  the tool gets a non-zero exit, so the failure signal reaches the
+  model), SIGKILL only for a target that survived.
+
+This module never spawns anything and owns no background thread: it is
+called from the existing `stream_pi` poll loop.
+"""
+from __future__ import annotations
+
+import os
+import signal
+from pathlib import Path
+
+# The real procfs; the unit tests point this at a fake directory.
+PROC = Path("/proc")
+
+
+def _read_stat(pid: int) -> str | None:
+    """The raw `/proc/<pid>/stat` line; None when the process is gone."""
+    try:
+        return (PROC / str(pid) / "stat").read_text()
+    except OSError:
+        return None
+
+
+def _stat_fields(raw: str) -> list[str] | None:
+    """The fields after the parenthesized comm (index 0 = state).
+
+    comm (field 2) may contain spaces and parentheses, so the split
+    point is the LAST `)` of the line.
+    """
+    end = raw.rfind(")")
+    if end < 0:
+        return None
+    return raw[end + 2:].split()
+
+
+def _comm(raw: str) -> str:
+    """The parenthesized comm name; empty when the line is malformed."""
+    start = raw.find("(")
+    end = raw.rfind(")")
+    if start < 0 or end <= start:
+        return ""
+    return raw[start + 1:end]
+
+
+def process_ppid(pid: int) -> int | None:
+    """The parent pid (stat field 4); None when the process is gone."""
+    raw = _read_stat(pid)
+    if raw is None:
+        return None
+    fields = _stat_fields(raw)
+    if fields is None or len(fields) < 2:
+        return None
+    try:
+        return int(fields[1])
+    except ValueError:
+        return None
+
+
+def process_start_epoch(pid: int, *, btime: float, hz: float) -> float | None:
+    """The process start time in epoch seconds.
+
+    stat field 22 is the start time in clock ticks since boot; the boot
+    time comes from `/proc/stat` (`btime`) and the tick rate from
+    `sysconf(_SC_CLK_TCK)`. None when the process is gone or the line is
+    malformed.
+    """
+    raw = _read_stat(pid)
+    if raw is None:
+        return None
+    fields = _stat_fields(raw)
+    if fields is None or len(fields) < 20:
+        return None
+    try:
+        starttime = int(fields[19])
+    except ValueError:
+        return None
+    return btime + starttime / hz
+
+
+def boot_time() -> float:
+    """The system boot time in epoch seconds (`/proc/stat` `btime`)."""
+    for line in (PROC / "stat").read_text().splitlines():
+        if line.startswith("btime "):
+            return float(line.split()[1])
+    raise RuntimeError("/proc/stat has no btime line")
+
+
+def clk_tck() -> float:
+    """The system clock tick rate (`sysconf(_SC_CLK_TCK)`)."""
+    return float(os.sysconf("SC_CLK_TCK"))
+
+
+def cmdline_of(pid: int) -> str:
+    """The process command line (NUL-separated args joined by spaces).
+
+    A kernel thread or a zombie has an empty cmdline: the comm name is
+    the fallback so the journal line still names the process.
+    """
+    try:
+        raw = (PROC / str(pid) / "cmdline").read_bytes()
+    except OSError:
+        return ""
+    if raw:
+        return raw.decode("utf-8", "replace").replace("\x00", " ").strip()
+    stat = _read_stat(pid)
+    if stat is None:
+        return ""
+    return _comm(stat)
+
+
+def descendant_pids(root_pid: int) -> list[int]:
+    """All live descendants of `root_pid`, sorted by pid.
+
+    The ppid chain from `/proc/<pid>/stat` is the only criterion: a
+    process is a target candidate only when its parent chain reaches
+    `root_pid`. Gone entries (no stat) and malformed lines are skipped.
+    """
+    children: dict[int, list[int]] = {}
+    try:
+        entries = list(PROC.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        raw = _read_stat(pid)
+        if raw is None:
+            continue
+        fields = _stat_fields(raw)
+        if fields is None or len(fields) < 2:
+            continue
+        try:
+            ppid = int(fields[1])
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(pid)
+    found: list[int] = []
+    queue = [root_pid]
+    seen = {root_pid}
+    while queue:
+        current = queue.pop()
+        for child in children.get(current, []):
+            if child in seen:
+                continue
+            seen.add(child)
+            found.append(child)
+            queue.append(child)
+    return sorted(found)
+
+
+def find_idle_descendants(root_pid: int, idle_start_epoch: float,
+                          *, btime: float | None = None,
+                          hz: float | None = None) -> list[dict]:
+    """The descendants of `root_pid` that are still running AND started
+    no later than `idle_start_epoch` — the hung tools of the stalled
+    scene.
+
+    Each result is `{"pid": int, "cmdline": str}`. A process spawned
+    after the idle window began (a new tool call) is never a target, and
+    a process that is not a descendant (checked by the ppid chain) is
+    never a target. `btime`/`hz` default to the real clock constants.
+    """
+    if btime is None:
+        btime = boot_time()
+    if hz is None:
+        hz = clk_tck()
+    targets: list[dict] = []
+    for pid in descendant_pids(root_pid):
+        start = process_start_epoch(pid, btime=btime, hz=hz)
+        if start is None:
+            continue
+        if start <= idle_start_epoch:
+            targets.append({"pid": pid, "cmdline": cmdline_of(pid)})
+    return targets
+
+
+def pid_alive(pid: int) -> bool:
+    """True when a signal-0 reachability check finds the process."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists but is owned by another user: alive.
+        return True
+
+
+def signal_pid(pid: int, sig: int) -> str:
+    """Send `sig` to `pid`; return the outcome for the journal.
+
+    `sent` (delivered), `already_dead` (ESRCH: it exited between the
+    discovery and the signal) or `failed: <error>` (any other OS error —
+    logged, never raised: the recovery must not take the delivery down).
+    """
+    try:
+        os.kill(pid, sig)
+        return "sent"
+    except ProcessLookupError:
+        return "already_dead"
+    except OSError as exc:
+        return f"failed: {exc}"

--- a/progress.py
+++ b/progress.py
@@ -132,6 +132,11 @@ def progress_body(state: dict) -> str:
         f"- PR: {value('pr')}",
         f"- session: {value('session')}",
     ]
+    # Idle-stall recovery (Issue #94): the recovery state is shown only
+    # while it is active (`term` / `kill`); an idle run keeps the
+    # pre-#94 body shape exactly.
+    if state.get("recovery"):
+        lines.append(f"- recovery: {state['recovery']}")
     return "\n".join(lines)
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2369,6 +2369,87 @@ def test_process_issue_upstream_dead_failure_marks_blocked(
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked[0]
 
 
+def test_process_issue_idle_recovery_failure_marks_blocked(
+    monkeypatch, tmp_path,
+):
+    """Issue #94 acceptance: the idle-recovery escalation of the
+    implementer session (three idle cycles without any new activity,
+    stream_pi killed Pi and raised) flows through the EXISTING
+    `ai-blocked`/recoverable failure path exactly like the Issue #75
+    upstream-dead failure: the Issue is marked `ai-blocked` (removing
+    `ai-in-progress`), the `Muyan Pilot failed` comment carries the
+    idle-recovery reason and the run marker, and the error re-raises
+    so the tick exits and the kernel releases the slot — the slot is
+    never held forever. No special handling, no fallback."""
+    calls = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    )
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(
+        runner, "create_worktree", Mock(return_value=tmp_path),
+    )
+    idle_recovery = RuntimeError(
+        "Pi session stayed idle for 15m after idle recovery (TERM/KILL "
+        "of pre-idle descendants); Pi was killed (Issue #94)"
+    )
+
+    def dead_run_pi(*args, **kwargs):
+        raise idle_recovery
+
+    monkeypatch.setattr(runner, "run_pi", dead_run_pi)
+    monkeypatch.setattr(
+        runner, "activity_snapshot", lambda session_dir: None,
+    )
+    posted = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "list"]:
+            # Restart-resume scan (Issue #18): fresh claim, no label.
+            return "[]"
+        calls.append(("comment", (), {"body": command[-1]}))
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="idle recovery"):
+        runner.process_issue(
+            {"number": 94, "title": "Idle recovery", "body": ""},
+            {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+             "base_branch": "main"},
+            "xqliu/muyan-pilot",
+        )
+    edits = [entry for entry in calls if isinstance(entry, dict)]
+    assert edits == [
+        {"repo": "xqliu/muyan-pilot", "add": "ai-in-progress"},
+        {"repo": "xqliu/muyan-pilot", "add": "ai-blocked",
+         "remove": "ai-in-progress"},
+    ]
+    comment_bodies = [
+        entry[2]["body"] for entry in calls
+        if isinstance(entry, tuple) and entry[0] == "comment"
+    ]
+    failure = [
+        body for body in comment_bodies
+        if "Muyan Pilot failed:" in body
+    ]
+    assert len(failure) == 1
+    # The idle-recovery reason and the run marker stay in the Issue.
+    assert "idle recovery" in failure[0]
+    assert "(Issue #94)" in failure[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure[0]
+    # The blocked milestone notification carries the same scene.
+    blocked = [body for body in posted if "Muyan Pilot: blocked" in body]
+    assert blocked
+    assert "idle recovery" in blocked[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked[0]
+
+
 def test_process_issue_preserves_original_failure_when_reporting_fails(monkeypatch, tmp_path, caplog):
     edit_calls = []
 
@@ -3543,6 +3624,307 @@ def test_stream_pi_no_upstream_kill_before_model_wait(tmp_path, caplog):
     assert "upstream_dead" not in caplog.text
 
 
+def make_hung_pi(tmp_path, *, child_sleep=10.0, ignore_sigterm=False,
+                 react_on_child_death=True, exit_code=0,
+                 model_wait=False):
+    """Build a command that mimics a HUNG Pi (Issue #94): it writes the
+    session toolCall, spawns a long-running child (the hung bash tool)
+    and waits for it. When `react_on_child_death`, the child's death
+    (the runner's TERM/KILL) makes the fake Pi write the toolResult
+    error — the failure signal to the model — and exit with
+    `exit_code` (the session continues on its own). Otherwise it stays
+    silent (Pi itself is stuck). `model_wait` writes a toolResult
+    first (the model is expected to reply next: the Issue #75
+    territory, never the idle-recovery territory).
+
+    The sleeps are short on purpose (Issue #95 termination guard):
+    WITHOUT the recovery implementation the child exits naturally and
+    the run ends, so the red phase fails on the missing recovery
+    lines instead of hanging for the full child sleep."""
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir(exist_ok=True)
+    ignore = (
+        "import signal as _sig\n"
+        "_sig.signal(_sig.SIGTERM, _sig.SIG_IGN)\n"
+        if ignore_sigterm else ""
+    )
+    tool_result = (
+        "write({'type': 'message', 'id': 'r0', 'timestamp': ts(),\n"
+        "       'message': {'role': 'toolResult', 'toolCallId': 't1',\n"
+        "                   'toolName': 'bash', 'isError': False,\n"
+        "                   'content': [{'type': 'text', 'text': 'ok'}]}})\n"
+        if model_wait else ""
+    )
+    react = (
+        "write({'type': 'message', 'id': 'r1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'toolResult', 'toolCallId': 't1',\n"
+        "                   'toolName': 'bash', 'isError': True,\n"
+        "                   'content': [{'type': 'text',\n"
+        "                                  'text': 'killed by runner'}]}})\n"
+        if react_on_child_death else "time.sleep(10)\n"
+    )
+    script = (
+        "import json, subprocess, sys, time\n"
+        "from datetime import datetime, timezone\n"
+        f"session = {str(session_dir / 'sess.jsonl')!r}\n"
+        "def ts():\n"
+        "    return datetime.now(timezone.utc).isoformat()\n"
+        "def write(record):\n"
+        "    with open(session, 'a') as handle:\n"
+        "        handle.write(json.dumps(record) + '\\n')\n"
+        "write({'type': 'session', 'id': 'sess-hung', 'timestamp': ts(),\n"
+        "       'cwd': '/w'})\n"
+        "write({'type': 'message', 'id': 'a1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'assistant', 'content': [\n"
+        "           {'type': 'toolCall', 'id': 't1', 'name': 'bash',\n"
+        "            'arguments': {'command': 'sleep 300'}}]}})\n"
+        f"{tool_result}"
+        f"{ignore}"
+        "child = subprocess.Popen([sys.executable, '-c',\n"
+        f"     'import time; time.sleep({child_sleep!r})'])\n"
+        "while child.poll() is None:\n"
+        "    time.sleep(0.05)\n"
+        f"{react}"
+        f"sys.exit({exit_code!r})\n"
+    )
+    return [sys.executable, "-c", script]
+
+
+def test_stream_pi_idle_recovery_terms_hung_descendant_and_resumes(
+    tmp_path, caplog,
+):
+    """Issue #94 acceptance 1 (TERM 成功恢复): a stalled session
+    (no model/session activity past `idle_warn_seconds`, not
+    model_wait) with a hung descendant that existed before the idle
+    window gets SIGTERM'd — the journal line carries run_id, pid,
+    cmdline and result — the fake Pi gets the non-zero exit, writes
+    the failure toolResult and the run RESUMES and SUCCEEDS (the
+    failure signal reached the model)."""
+    command = make_hung_pi(tmp_path)
+    with caplog.at_level("INFO"):
+        result = runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    assert result == ""
+    lines = caplog.text.splitlines()
+    idles = [line for line in lines if " pi_idle " in line]
+    assert len(idles) == 1  # the existing warning, once
+    terms = [line for line in lines if " pi_idle_term " in line]
+    assert len(terms) == 1, f"exactly one TERM step: {lines}"
+    term = terms[0]
+    assert "run=run1" in term
+    assert "issue=xqliu/muyan-pilot#94" in term
+    assert "role=implement" in term
+    assert "pid=" in term
+    assert "cmdline=" in term
+    assert "result=sent" in term
+    # The TERM came after the warning...
+    assert lines.index(term) > lines.index(idles[0])
+    # ...and the model got the failure signal: the fake Pi wrote the
+    # error toolResult (visible as result=error) and resumed.
+    resumed = [line for line in lines if " pi_resumed " in line]
+    assert len(resumed) == 1
+    assert lines.index(resumed[0]) > lines.index(term)
+    assert "result=error" in caplog.text
+    # The run SUCCEEDED: no failure, no session kill.
+    assert "run_failed" not in caplog.text
+    # No KILL escalation: the TERM worked within one idle cycle.
+    assert " pi_idle_kill " not in caplog.text
+
+
+def test_stream_pi_idle_recovery_kills_descendant_that_ignores_term(
+    tmp_path, caplog,
+):
+    """Issue #94 acceptance 2 (TERM 后仍存活升级 KILL): a descendant
+    that ignores SIGTERM is still alive one idle cycle later — the
+    runner SIGKILLs it (journal line with pid, cmdline, result), the
+    fake Pi reacts to the death and the run resumes."""
+    command = make_hung_pi(
+        tmp_path, ignore_sigterm=True, react_on_child_death=True,
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    terms = [line for line in lines if " pi_idle_term " in line]
+    kills = [line for line in lines if " pi_idle_kill " in line]
+    assert len(terms) == 1 and "result=sent" in terms[0]
+    assert len(kills) == 1, f"exactly one KILL step: {lines}"
+    kill = kills[0]
+    assert "run=run1" in kill
+    assert "pid=" in kill
+    assert "cmdline=" in kill
+    assert "result=sent" in kill  # the SIGKILL was delivered
+    # The KILL came one idle cycle after the TERM...
+    assert lines.index(kill) > lines.index(terms[0])
+    # ...and the run still recovered (the fake Pi reacted to the death).
+    resumed = [line for line in lines if " pi_resumed " in line]
+    assert len(resumed) == 1
+    assert "run_failed" not in caplog.text
+
+
+def test_stream_pi_idle_recovery_kills_pi_session_after_three_idle_cycles(
+    tmp_path, caplog,
+):
+    """Issue #94 acceptance 3 (连续 idle 升级终止会话): the hung tool
+    died from the TERM but the session NEVER resumes (Pi itself is
+    stuck) — after three idle cycles the runner kills the Pi session
+    itself and fails fast: `run_failed` carries the full scene and
+    `reason=idle_recovery_stale_...`, the error names the idle
+    recovery, and the normal `ai-blocked` flow takes over (the slot is
+    never held forever)."""
+    command = make_hung_pi(tmp_path, react_on_child_death=False)
+    with caplog.at_level("INFO"), pytest.raises(
+        RuntimeError, match="idle recovery",
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    terms = [line for line in lines if " pi_idle_term " in line]
+    kills = [line for line in lines if " pi_idle_kill " in line]
+    assert len(terms) == 1 and "result=sent" in terms[0]
+    # The TERM worked (the child died) — the KILL step reports the
+    # target as already dead instead of signaling again.
+    assert len(kills) == 1
+    assert "result=already_dead" in kills[0]
+    failures = [line for line in lines if " run_failed " in line]
+    assert len(failures) == 1
+    failure = failures[0]
+    assert "reason=idle_recovery_stale_" in failure
+    assert "run=run1" in failure
+    assert "issue=xqliu/muyan-pilot#94" in failure
+    assert f"worktree={tmp_path}" in failure
+
+
+def test_stream_pi_idle_recovery_without_descendants_still_terminates(
+    tmp_path, caplog,
+):
+    """Issue #94: a stalled session with NO pre-idle descendants (Pi
+    itself is stuck, no hung tool) still escalates: the TERM step logs
+    `result=no_target` (nothing was signaled — no pid), there is no
+    KILL step, and after three idle cycles the session is killed and
+    the run fails fast."""
+    records = [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+        (0.1, {"type": "message", "id": "a1",
+               "timestamp": fresh_timestamp(1),
+               "message": {"role": "assistant", "content": [
+                   {"type": "text", "text": "stuck thinking"}]}}),
+    ]
+    command = make_fake_pi(tmp_path, session_records=records, sleep=10.0)
+    with caplog.at_level("INFO"), pytest.raises(
+        RuntimeError, match="idle recovery",
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    terms = [line for line in lines if " pi_idle_term " in line]
+    assert len(terms) == 1
+    assert "result=no_target" in terms[0]
+    assert " pid=" not in terms[0]
+    assert " pi_idle_kill " not in caplog.text
+    failures = [line for line in lines if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=idle_recovery_stale_" in failures[0]
+
+
+def test_stream_pi_idle_recovery_never_signals_non_descendants(
+    tmp_path, caplog,
+):
+    """Issue #94 constraint (非 pi 后代不被误杀): a long-running
+    process that is NOT a descendant of the Pi process (parented by
+    the test itself) is never signaled — the ppid chain is the only
+    target criterion."""
+    bystander = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+    )
+    try:
+        command = make_hung_pi(tmp_path)
+        with caplog.at_level("INFO"):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                idle_warn_seconds=0.3,
+                run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+        # The bystander is untouched: still running, and its pid never
+        # appears on a recovery line.
+        assert bystander.poll() is None
+        for line in caplog.text.splitlines():
+            if " pi_idle_term " in line or " pi_idle_kill " in line:
+                assert f"pid={bystander.pid}" not in line
+    finally:
+        bystander.kill()
+        bystander.wait()
+
+
+def test_stream_pi_idle_recovery_never_fires_during_model_wait(
+    tmp_path, caplog,
+):
+    """Issue #94: the recovery is the non-model_wait territory (same
+    gate as the `pi_idle` warning). A frozen model_wait with a hung
+    descendant is the Issue #75 upstream-dead case: the runner kills
+    Pi via that path and never TERMs the descendant."""
+    command = make_hung_pi(tmp_path, model_wait=True)
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError, match="upstream",
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            model_wait_dead_seconds=0.5,
+            run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    assert " pi_idle_term " not in caplog.text
+    assert " pi_idle_kill " not in caplog.text
+    failures = [line for line in caplog.text.splitlines()
+                if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=upstream_dead_stale_" in failures[0]
+
+
+def test_stream_pi_idle_recovery_state_visible_in_progress_callback(
+    tmp_path,
+):
+    """Issue #94: the live GitHub progress comment is synced with the
+    recovery — the activity state passed to the progress callback
+    carries `recovery` (None -> `term` while the TERMed tool is being
+    waited on -> back to None when the session resumes)."""
+    command = make_hung_pi(tmp_path)
+    seen = []
+
+    def progress(activity):
+        seen.append(activity.get("recovery"))
+
+    runner.stream_pi(
+        command, cwd=tmp_path, poll_interval=0.1,
+        idle_warn_seconds=0.3,
+        run_id="run1", issue=94, source_repo="xqliu/muyan-pilot",
+        branch="b", progress=progress,
+    )
+    assert "term" in seen
+    # Before the stall and after the resume the state is None again.
+    assert seen[0] is None
+    assert seen[-1] is None
+    assert seen.index("term") > 0
+
+
 def test_stream_pi_times_out_and_kills_process(tmp_path, caplog):
     command = make_fake_pi(tmp_path, session_records=[], sleep=10.0)
     with caplog.at_level("ERROR"), pytest.raises(
@@ -3723,6 +4105,50 @@ def test_live_progress_throttle_patches_on_change_and_cadence():
     # The rendered body carries the live state.
     assert "- phase: test" in calls[-1]
     assert "- last action: bash pytest tests/" in calls[-1]
+
+
+def test_live_progress_throttle_patches_on_recovery_change():
+    """Issue #94: the recovery state is part of the visible progress —
+    entering idle recovery (None -> `term`) PATCHes the live comment
+    immediately even though phase/action/result did not change, and
+    the rendered body carries the `recovery` line."""
+    calls = []
+
+    class FakePublisher:
+        comment_id = 1
+
+        def patch(self, body):
+            calls.append(body)
+
+    publisher = FakePublisher()
+    throttle = runner.LiveProgressThrottle(
+        publisher, issue=94, title="Idle recovery", run_id="run1",
+        role="implement", branch="b", worktree=Path("/w"),
+        started=time.monotonic(), pr_url=None, review_round=0,
+        priority="normal",
+    )
+    first = {
+        "phase": "test", "action": "bash pytest tests/", "result": None,
+        "model_wait": False, "session_id": None,
+        "last_activity": None, "stale_seconds": 0.0,
+        "session_file": None, "events": 0, "changed": False,
+        "recovery": None,
+    }
+    throttle(first)
+    assert len(calls) == 1
+    assert "- recovery" not in calls[0]  # no recovery line when idle-recovery is off
+    # Entering recovery: visible change -> immediate PATCH with the line.
+    throttle(dict(first, recovery="term"))
+    assert len(calls) == 2
+    assert "- recovery: term" in calls[1]
+    # Escalating to KILL: another visible change -> another PATCH.
+    throttle(dict(first, recovery="kill"))
+    assert len(calls) == 3
+    assert "- recovery: kill" in calls[2]
+    # Back to None after the resume: visible change -> PATCH without the line.
+    throttle(first)
+    assert len(calls) == 4
+    assert "- recovery" not in calls[3]
 
 
 def test_run_pi_passes_progress_callback_to_stream_pi(monkeypatch, tmp_path):

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -1,0 +1,439 @@
+"""Unit tests for the idle-stall recovery helpers (Issue #94).
+
+The helpers read the REAL `/proc` in production (ppid chain from
+`/proc/<pid>/stat` + process start time — never a name guess). The unit
+tests build a fake procfs in `tmp_path` and point `pi_recovery.PROC` at
+it, so no real process is ever signaled here.
+"""
+import os
+import signal
+import sys
+
+import pytest
+
+import pi_recovery
+
+
+# Fake clock constants: btime=1_000_000 s, CLK_TCK=100 -> one tick = 0.01 s.
+FAKE_BTIME = 1_000_000.0
+FAKE_HZ = 100.0
+
+
+def make_procfs(tmp_path, processes, btime=FAKE_BTIME):
+    """Build a fake procfs: `processes` is a list of
+    `(pid, comm, ppid, starttime_ticks, cmdline_bytes_or_None)`."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    (proc / "stat").write_text(f"btime {int(btime)}\n", encoding="utf-8")
+    for pid, comm, ppid, starttime, cmdline in processes:
+        entry = proc / str(pid)
+        entry.mkdir()
+        # stat layout: pid (comm) state ppid ... starttime (field 22).
+        # After the LAST ')' the fields start at index 0 (state); ppid is
+        # index 1 and starttime index 19.
+        fields = ["S", str(ppid)] + ["0"] * 17 + [str(starttime)]
+        (entry / "stat").write_text(
+            f"{pid} ({comm}) " + " ".join(fields), encoding="utf-8",
+        )
+        if cmdline is not None:
+            (entry / "cmdline").write_bytes(cmdline)
+    return proc
+
+
+def start_epoch(starttime_ticks):
+    return FAKE_BTIME + starttime_ticks / FAKE_HZ
+
+
+# --- /proc parsing -----------------------------------------------------------
+
+
+def test_process_ppid_reads_field_4(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [(42, "bash", 7, 100, b"bash")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_ppid(42) == 7
+
+
+def test_process_ppid_returns_none_for_gone_process(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_ppid(99) is None
+
+
+def test_process_ppid_returns_none_for_malformed_stat(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    (proc / "5").mkdir()
+    (proc / "5" / "stat").write_text("garbage without parens",
+                                     encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_ppid(5) is None
+
+
+def test_process_ppid_returns_none_for_non_numeric_ppid(tmp_path,
+                                                        monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    (proc / "6").mkdir()
+    (proc / "6" / "stat").write_text(
+        "6 (bad) S x " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_ppid(6) is None
+
+
+def test_process_start_epoch_converts_ticks_to_epoch(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [(42, "bash", 7, 1234, b"bash")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_epoch(
+        42, btime=FAKE_BTIME, hz=FAKE_HZ,
+    ) == start_epoch(1234)
+
+
+def test_process_start_epoch_returns_none_for_gone_process(tmp_path,
+                                                           monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_epoch(
+        99, btime=FAKE_BTIME, hz=FAKE_HZ,
+    ) is None
+
+
+def test_process_start_epoch_returns_none_for_short_stat(tmp_path,
+                                                         monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    (proc / "7").mkdir()
+    (proc / "7" / "stat").write_text("7 (short) S 1", encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_epoch(
+        7, btime=FAKE_BTIME, hz=FAKE_HZ,
+    ) is None
+
+
+def test_process_start_epoch_returns_none_for_bad_starttime(tmp_path,
+                                                            monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    (proc / "8").mkdir()
+    (proc / "8" / "stat").write_text(
+        "8 (bad) S 1 " + " ".join(["0"] * 17) + " x", encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_epoch(
+        8, btime=FAKE_BTIME, hz=FAKE_HZ,
+    ) is None
+
+
+def test_boot_time_reads_btime_from_proc_stat(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [], btime=1234567)
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.boot_time() == 1234567.0
+
+
+def test_boot_time_fails_fast_without_btime(tmp_path, monkeypatch):
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    (proc / "stat").write_text("intr 1\n", encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    with pytest.raises(RuntimeError, match="btime"):
+        pi_recovery.boot_time()
+
+
+def test_cmdline_of_joins_null_separated_arguments(tmp_path, monkeypatch):
+    proc = make_procfs(
+        tmp_path, [(42, "bash", 7, 100, b"/usr/bin/python3\x00-m\x00pytest")],
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(42) == "/usr/bin/python3 -m pytest"
+
+
+def test_cmdline_of_falls_back_to_comm_when_cmdline_empty(tmp_path,
+                                                          monkeypatch):
+    proc = make_procfs(tmp_path, [(42, "kthreadd", 7, 100, b"")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(42) == "kthreadd"
+
+
+def test_cmdline_of_empty_when_process_gone(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(99) == ""
+
+
+def test_cmdline_of_empty_when_stat_malformed(tmp_path, monkeypatch):
+    # Empty cmdline and a stat line without a parenthesized comm: the
+    # comm fallback yields empty, never a crash.
+    proc = make_procfs(tmp_path, [])
+    (proc / "9").mkdir()
+    (proc / "9" / "stat").write_text("garbage", encoding="utf-8")
+    (proc / "9" / "cmdline").write_bytes(b"")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(9) == ""
+
+
+def test_comm_empty_when_parenthesis_unbalanced(tmp_path, monkeypatch):
+    # A `(` with no closing `)` (end <= start): the comm fallback
+    # yields empty, never a crash.
+    proc = make_procfs(tmp_path, [])
+    (proc / "10").mkdir()
+    (proc / "10" / "stat").write_text("10 (unbalanced S 1", encoding="utf-8")
+    (proc / "10" / "cmdline").write_bytes(b"")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(10) == ""
+
+
+def test_cmdline_of_empty_when_stat_gone_after_empty_cmdline(
+    tmp_path, monkeypatch,
+):
+    # The process exits between the empty cmdline read and the stat
+    # fallback read: empty, never a crash.
+    proc = make_procfs(tmp_path, [])
+    (proc / "11").mkdir()
+    (proc / "11" / "cmdline").write_bytes(b"")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(11) == ""
+
+
+def test_cmdline_of_empty_when_cmdline_file_missing(tmp_path, monkeypatch):
+    # No cmdline file at all (the process exited before the read): the
+    # result is empty — the comm fallback only applies to an EMPTY
+    # cmdline (kernel threads), not to a gone process.
+    proc = make_procfs(tmp_path, [(42, "kworker", 2, 100, None)])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.cmdline_of(42) == ""
+
+
+# --- descendant discovery ----------------------------------------------------
+
+
+def test_descendant_pids_follows_ppid_chain_to_all_depths(
+    tmp_path, monkeypatch,
+):
+    # 100 (pi) -> 200 (bash) -> 300 (pytest); 400 is a sibling of 200's
+    # child only via the chain; 500 is unrelated.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 20, b"bash"),
+        (300, "pytest", 200, 30, b"pytest"),
+        (400, "python", 300, 40, b"python"),
+        (500, "unrelated", 1, 50, b"unrelated"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.descendant_pids(100) == [200, 300, 400]
+
+
+def test_descendant_pids_empty_for_leaf_process(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [(100, "pi", 1, 10, b"pi")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.descendant_pids(100) == []
+
+
+def test_descendant_pids_empty_when_procfs_unreadable(tmp_path, monkeypatch):
+    monkeypatch.setattr(pi_recovery, "PROC", tmp_path / "no-such-proc")
+    assert pi_recovery.descendant_pids(100) == []
+
+
+def test_descendant_pids_skips_gone_and_malformed_entries(tmp_path,
+                                                          monkeypatch):
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 20, b"bash"),
+    ])
+    (proc / "999").mkdir()  # a directory without a stat file
+    (proc / "notes").mkdir()  # a non-numeric entry
+    (proc / "300").mkdir()
+    (proc / "300" / "stat").write_text("garbage", encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.descendant_pids(100) == [200]
+
+
+def test_descendant_pids_skips_non_numeric_ppid(tmp_path, monkeypatch):
+    # A corrupted stat line (non-numeric ppid) is skipped, never a
+    # crash — the rest of the tree is still walked.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 20, b"bash"),
+    ])
+    (proc / "300").mkdir()
+    (proc / "300" / "stat").write_text(
+        "300 (bad) S x " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.descendant_pids(100) == [200]
+
+
+def test_descendant_pids_survives_ppid_cycle(tmp_path, monkeypatch):
+    # A corrupted procfs where a process is its own parent (ppid cycle)
+    # must not loop forever: the seen-set breaks the cycle.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 20, b"bash"),
+    ])
+    (proc / "300").mkdir()
+    (proc / "300" / "stat").write_text(
+        "300 (cycle) S 300 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    # The contract: no hang — the cycle is broken by the seen-set (the
+    # process is not its own descendant).
+    assert pi_recovery.descendant_pids(300) == []
+
+
+# --- idle target selection ---------------------------------------------------
+
+
+def test_find_idle_descendants_selects_pre_idle_start_descendants_only(
+    tmp_path, monkeypatch,
+):
+    # 200 started long before the idle window (the hung tool), 300
+    # started AFTER it (a newer tool call): only 200 is a target.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 100, b"/bin/bash\x00-c\x00pytest"),
+        (300, "pytest", 200, 5000, b"pytest"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    idle_start = start_epoch(1000)  # between the two starts
+    targets = pi_recovery.find_idle_descendants(
+        100, idle_start, btime=FAKE_BTIME, hz=FAKE_HZ,
+    )
+    assert targets == [
+        {"pid": 200, "cmdline": "/bin/bash -c pytest"},
+    ]
+
+
+def test_find_idle_descendants_includes_process_started_at_idle_start(
+    tmp_path, monkeypatch,
+):
+    # A process that started exactly at the idle start belongs to the
+    # stalled scene (boundary is inclusive).
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 1000, b"bash"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    targets = pi_recovery.find_idle_descendants(
+        100, start_epoch(1000), btime=FAKE_BTIME, hz=FAKE_HZ,
+    )
+    assert [t["pid"] for t in targets] == [200]
+
+
+def test_find_idle_descendants_skips_targets_that_died_before_read(
+    tmp_path, monkeypatch,
+):
+    # The descendant exists in the tree walk but its stat is unreadable
+    # (it exited between the walk and the start-time read): skipped.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 100, b"bash"),
+    ])
+    (proc / "200" / "stat").unlink()
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.find_idle_descendants(
+        100, start_epoch(1000), btime=FAKE_BTIME, hz=FAKE_HZ,
+    ) == []
+
+
+def test_find_idle_descendants_skips_unreadable_start_time(
+    tmp_path, monkeypatch,
+):
+    # A descendant whose stat vanishes between the tree walk and the
+    # start-time read (it exited in the gap) is skipped, never a
+    # crash; the remaining targets are still reported.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 100, b"bash"),
+        (300, "pytest", 100, 200, b"pytest"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    real_read = pi_recovery._read_stat
+
+    def flaky_read(pid):
+        raw = real_read(pid)
+        if pid == 300 and raw is not None:
+            # First read (the tree walk) sees the process; the second
+            # read (the start time) finds it gone.
+            (proc / "300" / "stat").unlink()
+        return raw
+
+    monkeypatch.setattr(pi_recovery, "_read_stat", flaky_read)
+    targets = pi_recovery.find_idle_descendants(
+        100, start_epoch(1000), btime=FAKE_BTIME, hz=FAKE_HZ,
+    )
+    assert [t["pid"] for t in targets] == [200]
+
+
+def test_find_idle_descendants_uses_real_clock_when_not_given(
+    tmp_path, monkeypatch,
+):
+    # Without explicit btime/hz the real boot time and CLK_TCK are used:
+    # a process that started just now is NOT pre-idle-start for an
+    # idle start in the past.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "bash", 100, 100, b"bash"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    real_btime = pi_recovery.boot_time()
+    real_hz = pi_recovery.clk_tck()
+    # starttime=100 ticks after the real boot: a very old process.
+    targets = pi_recovery.find_idle_descendants(
+        100, real_btime + 10_000,
+    )
+    assert [t["pid"] for t in targets] == [200]
+    # Sanity: the real clock constants are sane (guards the test itself).
+    assert real_btime > 0 and real_hz > 0
+
+
+# --- signaling ---------------------------------------------------------------
+
+
+def test_pid_alive_true_for_running_process():
+    pid = os.getpid()
+    assert pi_recovery.pid_alive(pid) is True
+
+
+def test_pid_alive_true_for_process_owned_by_other_user(monkeypatch):
+    # EPERM means the process EXISTS (owned by another user): alive —
+    # the runner must not signal it, only report it.
+    def deny(pid, sig):
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", deny)
+    assert pi_recovery.pid_alive(42) is True
+
+
+def test_pid_alive_false_for_gone_process(monkeypatch):
+    def raise_esrch(pid, sig):
+        raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", raise_esrch)
+    assert pi_recovery.pid_alive(42) is False
+
+
+def test_pid_alive_false_for_real_exited_process():
+    import subprocess
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    assert pi_recovery.pid_alive(child.pid) is False
+
+
+def test_signal_pid_reports_sent_for_running_process():
+    pid = os.getpid()
+    # Signal 0: no signal is delivered, only the reachability check.
+    assert pi_recovery.signal_pid(pid, 0) == "sent"
+
+
+def test_signal_pid_reports_already_dead_for_gone_process(monkeypatch):
+    def raise_esrch(pid, sig):
+        raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", raise_esrch)
+    assert pi_recovery.signal_pid(42, signal.SIGTERM) == "already_dead"
+
+
+def test_signal_pid_reports_failed_for_unreachable_process(
+    monkeypatch,
+):
+    def deny(pid, sig):
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", deny)
+    assert pi_recovery.signal_pid(42, signal.SIGTERM) == \
+        "failed: [Errno 1] Operation not permitted"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -301,6 +301,36 @@ def test_progress_body_shows_priority_field():
     assert "- priority: normal" in body
 
 
+def test_progress_body_shows_recovery_field_only_when_active():
+    """Issue #94: the live progress comment shows the idle-recovery
+    state (`term` / `kill`) at the end of the body while the runner
+    is recovering a stalled session; without it the body is exactly
+    the pre-#94 shape (no empty recovery line)."""
+    state = {
+        "run_id": "abc123",
+        "issue": 94,
+        "issue_title": "Idle recovery",
+        "role": "implement",
+        "phase": "test",
+        "elapsed": "6m",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 0,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    }
+    body = progress.progress_body(state)
+    assert "- recovery" not in body
+    body = progress.progress_body({**state, "recovery": "term"})
+    assert "- recovery: term" in body
+    # The recovery line is the last line of the body.
+    assert body.splitlines()[-1] == "- recovery: term"
+    body = progress.progress_body({**state, "recovery": "kill"})
+    assert body.splitlines()[-1] == "- recovery: kill"
+
+
 def make_publisher(run_command=None, comments=None, posted=None,
                    post_response=None):
     """Build a ProgressPublisher over a fake gh layer.


### PR DESCRIPTION
Fixes #94

<!-- muyan-pilot:run=7de04e92 -->
run_id=7de04e92

## 交付内容

Pi 会话内的 bash 工具子进程可能永久阻塞（TDD red 阶段的死循环测试、`next(generator)` 永久等待），Pi 等子进程退出、session JSONL 冻结、slot 被永远占住。此前 runner 的 `pi_idle` 检测只打一条 WARNING（`bootstrap_runner.py:993`），只能靠人手工 `kill <pid>` 让失败信号回到模型。现在 runner 自动恢复：

- **窗口 1**（`stale >= idle_warn_seconds` 且无新活动）：找到 Pi 进程树中 **idle 窗口开始前就已存在、仍在运行的后代**（bash/pytest/python 等挂死工具），逐个 **SIGTERM**（保留现场）——工具拿到非零退出，失败信号回到模型，会话自行继续；
- **窗口 2**（再过一个 idle 周期仍无新活动且该后代仍存活）：**SIGKILL**；
- **连续 3 个 idle 窗口**（`PI_IDLE_RECOVERY_CYCLES=3`）仍无新活动：终止本次 Pi 会话，按现有 `ai-blocked`/可恢复流程收尾（`run_failed ... reason=idle_recovery_stale_...` → RuntimeError → 现有失败路径：Issue 标记 `ai-blocked`、slot 随进程退出释放）——slot 绝不被无限占用。

约束全部满足：只动 Pi 的后代（`/proc/<pid>/stat` 的 ppid 链 + 进程启动时间早于 idle 起点，不靠猜；不碰系统其他进程，也不碰窗口开始后新起的进程）；每一步写 journal 行（`pi_idle_term` / `pi_idle_kill`，带 run_id、pid、cmdline、TERM/KILL、结果）；progress comment 通过 `recovery` 字段（`term` / `kill`）同步 milestone；不引入常驻进程/守护线程，逻辑全在现有 `stream_pi` 轮询循环里；第一条新 session 事件到达时整个恢复状态复位（`pi_resumed`）。

### 变更

- `pi_recovery.py`（新）：/proc 助手（stdlib only）——`descendant_pids`（ppid 链，含 ppid 环防护）、`find_idle_descendants`（ppid 链 + 启动时间 ≤ idle 起点）、`cmdline_of`（空 cmdline 回退 comm）、`pid_alive` / `signal_pid`（`sent` / `already_dead` / `failed: ...`，从不抛异常打断交付）。
- `bootstrap_runner.py`：`stream_pi` 轮询循环内的恢复状态机（`PI_IDLE_RECOVERY_CYCLES=3`；升级按"窗口开始后新增的静默时长"计 idle 窗口，已 stale 的 session 从第一步开始而不是直接杀会话）；`pi_idle_term` / `pi_idle_kill` journal 行；`run_failed ... reason=idle_recovery_stale_...` + RuntimeError（复用 #75 的 break-and-raise 模式，走现有 `ai-blocked` 路径）；activity 状态新增 `recovery` 字段（每 poll 新 dict，不泄漏）；`_progress_state` / `LiveProgressThrottle` 同步 recovery（进入/离开恢复立即 PATCH）。
- `progress.py`：`progress_body` 仅在 recovery 活跃时追加 `- recovery: term|kill` 行（非恢复期间 body 形状与之前完全一致）。
- 文档：`README.md`（journal 行 + idle 卡死自动恢复段 + 低频场景行清单）、`docs/operations.mdx`、`AGENTS.md`（自动可观测节）。

### 测试（858 passed，line/branch coverage 100%）

- **TERM 成功恢复**：fake Pi 挂起真实子进程 → runner SIGTERM（journal 行带 run_id/pid/cmdline/result=sent）→ 子进程死亡 → fake Pi 写出 error toolResult（失败信号回到模型）→ `pi_resumed`，run 成功结束，无 KILL、无 run_failed；
- **TERM 后仍存活升级 KILL**：子进程忽略 SIGTERM → 第二个 idle 窗口 SIGKILL（result=sent）→ 恢复成功；
- **连续 idle 升级终止会话**：子进程死于 TERM 但会话永不恢复 → 第三个 idle 窗口杀掉 Pi 会话，`run_failed reason=idle_recovery_stale_...`（完整现场）+ RuntimeError；KILL 步对已死目标记 `result=already_dead`（不再发信号）；
- **非 pi 后代不被误杀**：测试进程自己拉起的长睡进程（父进程不是 fake Pi）全程存活，其 pid 不出现在任何恢复行；
- 无后代（Pi 自身卡住）：`result=no_target`，升级继续，第三个窗口杀会话；
- `model_wait` 期间永不触发恢复（#75 上游已死路径独占，已有 kill 行为不变）；
- 恢复状态可见于 progress callback（None → term → None）与 LiveProgressThrottle（进入/离开立即 PATCH，body 携带 `- recovery: ...` 行）；
- `process_issue` 接线：idle-recovery RuntimeError 走现有 `ai-blocked` 失败路径（同 #75 测试形状：label 转换、失败评论带 run marker、blocked milestone）；
- `pi_recovery` 助手单测：fake procfs（ppid 链、启动时间过滤/边界、cmdline 回退、signal 结果、gone/malformed/cycle 防护、真实时钟默认值）。

### 验证

```text
timeout 900 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q   # 858 passed
timeout 60 /usr/bin/python3 -m coverage report                              # TOTAL 100% (line+branch)
```

Issue #95 终止保护：fake 挂死 Pi 的子进程 sleep 为 10s（非 300s）——无实现时 red 阶段在断言上快速失败（缺恢复行），而不是挂满整个子进程 sleep。

### 边界

- 不 merge、不 push 保护分支；只 push 任务分支 `muyan-pilot/xqliu-muyan-pilot-issue-94-7de04e92`。
- 不引入常驻进程/守护线程/新依赖（requirements 不变，stdlib only）。
- 恢复只作用于非 `model_wait` 的卡死；`model_wait` 仍由 #75 上游已死检测处理。
- 被 TERM/KILL 的只可能是 Pi 后代且启动时间早于 idle 起点；窗口开始后新起的进程（新工具调用）永不被信号。
- 一次 full-suite 运行中 `test_capacity_two_allows_two_runners_and_rejects_third` 在高负载下 flake（60s wait_for 超时）；隔离运行与最终全量运行均通过（e2e fake pi 秒级完成，远低于 300s idle 阈值，不触碰恢复路径）。
