### PR TITLE
docs: Chinese docs (Mintlify i18n) + architecture & lifecycle Mermaid diagrams (Issue #116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,13 @@ jobs:
 
       - name: Enforce 100% line/branch coverage (contract)
         run: python3 -m coverage report --fail-under=100 --show-missing
+
+      # Mintlify docs build smoke (Issue #116): the official `mint` CLI
+      # validates the docs/ build (docs.json config, pages, links) in
+      # strict mode — non-zero exit on any warning or error. Same single
+      # job: no second job, no cache, no matrix.
+      - name: Install the Mintlify CLI (docs build smoke)
+        run: npm install -g mint
+
+      - name: Validate the Mintlify docs build (Issue #116)
+        run: cd docs && mint validate

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 
 ## 文档站
 
-面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。Mintlify 默认地址为 <https://muyan-pilot.mintlify.site>（若绑定了自定义域名，以 Mintlify 控制台配置的地址为准）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
+面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。Mintlify 默认地址为 <https://muyan-pilot.mintlify.site>（若绑定了自定义域名，以 Mintlify 控制台配置的地址为准）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
+
+两张总览图（Mintlify 渲染 Mermaid，仓库内保留可读源码）：
+
+- **系统架构总览**（GitHub Issues、systemd timer/service、Runner、Pi、worktree、llama-server、可选 `local-llm-kv-cache` proxy、PR/review/merge）：文档站首页 [index](docs/index.mdx) / [zh/index](docs/zh/index.mdx)；
+- **任务生命周期状态机**（`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked`，标出 Epic/Release task/P0 边界）：[workflow](docs/workflow.mdx) / [zh/workflow](docs/zh/workflow.mdx)。
 
 ## 当前运行
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -6,34 +6,74 @@
     "primary": "#1d76db"
   },
   "navigation": {
-    "groups": [
+    "languages": [
       {
-        "group": "Getting Started",
-        "pages": [
-          "index",
-          "getting-started",
-          "setup"
+        "language": "en",
+        "default": true,
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "index",
+              "getting-started",
+              "setup"
+            ]
+          },
+          {
+            "group": "Core Concepts",
+            "pages": [
+              "workflow",
+              "operations"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "security",
+              "testing",
+              "contributing"
+            ]
+          },
+          {
+            "group": "Optional Components",
+            "pages": [
+              "optional-kv-cache"
+            ]
+          }
         ]
       },
       {
-        "group": "Core Concepts",
-        "pages": [
-          "workflow",
-          "operations"
-        ]
-      },
-      {
-        "group": "Guides",
-        "pages": [
-          "security",
-          "testing",
-          "contributing"
-        ]
-      },
-      {
-        "group": "Optional Components",
-        "pages": [
-          "optional-kv-cache"
+        "language": "zh",
+        "groups": [
+          {
+            "group": "快速开始",
+            "pages": [
+              "zh/index",
+              "zh/getting-started",
+              "zh/setup"
+            ]
+          },
+          {
+            "group": "核心概念",
+            "pages": [
+              "zh/workflow",
+              "zh/operations"
+            ]
+          },
+          {
+            "group": "指南",
+            "pages": [
+              "zh/security",
+              "zh/testing",
+              "zh/contributing"
+            ]
+          },
+          {
+            "group": "可选组件",
+            "pages": [
+              "zh/optional-kv-cache"
+            ]
+          }
         ]
       }
     ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,6 +6,42 @@ isolated worktree, runs the real test suite, opens a PR, then completes an
 independent review (with in-session fixes) and merges a clean PR — with the
 whole delivery recorded in GitHub Issues, comments and the PR itself.
 
+## System architecture overview
+
+```mermaid
+flowchart LR
+  subgraph github["GitHub — task pool + delivery record"]
+    issues["Issues + labels (ai-ready → ai-merged)"]
+    prs["PRs (Fixes #N, run marker) + review/merge"]
+  end
+  subgraph machine["Runner machine (systemd user session)"]
+    timer["muyan-pilot.timer (15-minute tick)"]
+    service["muyan-pilot.service (ExecStartPre: fast-forward main)"]
+    runner["Runner (muyan_pilot.py): claim → worktree → Pi → PR → review → merge"]
+    worktree["task worktree + feature branch (frozen origin/main SHA, run id in the name)"]
+    pi["Pi sessions (implement + independent review)"]
+    model["llama-server (core: any OpenAI-compatible endpoint)"]
+    proxy["local-llm-kv-cache proxy (OPTIONAL: prefix reuse)"]
+  end
+  issues -->|scan + labels| runner
+  timer -->|triggers| service
+  service -->|starts| runner
+  runner -->|creates| worktree
+  runner -->|starts| pi
+  pi -->|reads/writes| worktree
+  pi -->|OpenAI-compatible| model
+  pi -.->|optional| proxy
+  proxy -->|forwards| model
+  runner -->|gh API: PR / review / merge| prs
+  prs -->|merge → ai-merged| issues
+```
+
+The solid arrow `Pi → llama-server` is the core path (any
+OpenAI-compatible endpoint works). The dotted arrow marks the optional
+[`local-llm-kv-cache`](/optional-kv-cache) proxy: it only adds faster
+prefix reuse for local llama.cpp models and is never a core
+prerequisite.
+
 ## The problem it solves
 
 Small and medium development tasks (a bug, a feature, a docs change, a

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -27,6 +27,11 @@ version and runs the identical commands through `python3` on PATH),
 `requirements.txt` installed, then the two contract commands above. No
 lint, no matrix, no cache.
 
+The same single job also runs the Mintlify docs build smoke (Issue #116):
+the official `mint` CLI's `mint validate` (strict build validation of the
+`docs/` site — config, pages, links — non-zero exit on any warning or
+error).
+
 A PR is not mergeable while CI is red — the Runner's merge gate also
 requires a mergeable PR.
 
@@ -40,7 +45,9 @@ requires a mergeable PR.
   files: `AGENTS.md` contract items, the label set, the systemd units
   (15-minute schedule, preflight), the CI workflow, the LICENSE, and the
   documentation site under `docs/` (this page's claims are enforced by
-  `tests/test_docs_site.py`).
+  `tests/test_docs_site.py`; the Chinese pages and the EN/ZH parity by
+  `tests/test_docs_i18n.py`; the Mermaid diagrams by
+  `tests/test_docs_mermaid.py`).
 
 When you change code, update or add tests in the same PR and keep the
 coverage gate green.

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -7,6 +7,26 @@ automatic chain and the project's GitHub workflow vocabulary.
 
 ## The complete chain
 
+State machine (the six delivery states; the review/fix loop stays on the
+same PR — only its head may advance):
+
+```mermaid
+flowchart LR
+  epic["Epic (ai-epic) — coordination only, never claimed"]
+  epic -.splits into.-> ready
+  release["Release task — a regular ai-ready Issue (release reconciliation)"]
+  release -.delivers through.-> ready
+  ready["ai-ready<br/>(pickup order: P0-labeled first, then bug-labeled, then plain)"]
+  ready -->|claim: label + worktree + Pi| progress["ai-in-progress"]
+  progress -->|PR verified: base fresh, run marker, Fixes #N| opened["ai-pr-opened"]
+  opened -->|independent review session, fixes in-session| verdict{REVIEW_VERDICT}
+  verdict -->|clean verdict + merge gate| merged["ai-merged (terminal)"]
+  verdict -->|finding / base conflict / rounds exhausted| blocked["ai-blocked (terminal, human decides)"]
+  opened -->|finding / base conflict| fixneeded["ai-fix-needed"]
+  fixneeded -->|next tick: next review session on the SAME PR| opened
+  progress -->|fail fast| blocked
+```
+
 ```text
 ai-ready                a task is dispatched (muyan_pilot.py add, or a human
                         adds the label)

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -1,0 +1,75 @@
+# 贡献
+
+Muyan Pilot 用和它运行一样的方式开发：任务是 GitHub Issue，交付是
+PR，仓库契约（`AGENTS.md`）同样适用于人类贡献者。
+
+## Issue 粒度
+
+一个 Issue 是**一个 runtime outcome**（当 X，应该 Y，实际 Z）：一个
+可观测行为、一小批相关文件、含测试。标题应该能当测试名用。根因或期望
+行为确定后再开 Issue——不要作为模糊愿望。
+
+- Issue 之间的依赖用 GitHub 原生 `blockedBy` 关系（`gh issue edit N
+  --add-blocked-by M`）；不要在 body 里写 `Depends on #N`——Runner 不
+  解析 body 依赖。
+- 多任务工作组织为 Epic（见[工作流](/zh/workflow)）：Epic 负责协调，
+  子 Issue 负责交付。
+
+## 创建 Issue
+
+通过创建 Issue 并加 `ai-ready` 标签来给 Pilot 派活（CLI 一步完成两
+件事）：
+
+```bash
+python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+```
+
+或手工：
+
+```bash
+gh issue create --repo OWNER/PILOT-REPO --title "task title" --body "task body"
+gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
+```
+
+好的 body 写清背景、期望行为、验收标准，（bug 时）复现步骤。Pilot 在
+改任何东西之前会读 Issue、仓库的 `AGENTS.md`、README 和代码。
+
+## 报告 bug
+
+开一个带 `bug` 标签的 Issue，包含：
+
+- 失败的命令及其返回码 / stdout / stderr；
+- journal 现场（失败前后的 `journalctl --user -u muyan-pilot.service`，
+  或带 run id 的 `run_failed` 行）；
+- Issue/PR 状态（标签）和进度评论里的 run id；
+- 环境：OS、Python 版本、Pi 版本、模型 endpoint 类型。
+
+带 `bug` 标签的 `ai-ready` Issue 先于新 feature 被领取，带 `p0` 标签
+的紧急 Issue 最先被领取（见工作流页），所以坏掉的交付循环——或生产
+故障——最先被修。
+
+## 贡献代码
+
+1. 读 `AGENTS.md`——它是开发契约（TDD、100% 行/分支覆盖、fail fast、
+   无数据库/队列/daemon/fallback、无业务任务 timeout）。
+2. 在 feature branch 上工作；从不直接 push 保护分支。
+3. 先写失败测试，再写最小实现，再重构。外部接口（CLI flag、HTTP
+   path、配置字段）对照官方文档或一次真实调用断言——从不对照猜出来的
+   形状。
+4. 本地跑完整契约：
+
+   ```bash
+   /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+   /usr/bin/python3 -m coverage report --fail-under=100 --show-missing
+   ```
+
+5. 一个 Issue 一个 PR。PR 描述必须包含 `Fixes #<issue-number>`（可以
+   放在首行），merge 时 GitHub 原生关闭 Issue。
+6. CI 必须绿（与本地同一契约）。Pilot 派发的任务由 Runner 执行独立
+   审查和合并；人类 PR 的 review 和 merge 走仓库正常的 GitHub 流程。
+
+## 不要加什么
+
+MVP 边界是刻意的：无数据库、无消息队列、无 daemon 循环、无 Web UI、
+无任务 DAG、无风险模型、无 fallback 路径、无业务任务 timeout。想加
+其中任何一项的提案，应先解释为什么某个真实、重复出现的失败需要它。

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -1,0 +1,161 @@
+# 快速开始
+
+这一页带你从全新 clone 走到第一个验证过的 tick。这里的所有命令在任何
+clone 路径下都能工作——不依赖任何特定机器布局。
+
+## 前提
+
+| 要求 | 用途 | 检查 |
+|---|---|---|
+| Python 3.14 | Runner 和测试契约（CI 固定同一 minor 版本） | `python3 --version` |
+| [Pi](https://github.com/earendil-works/pi) CLI | 开发 agent；每个任务一个完整 session | `pi --version` |
+| Git | worktree、分支、base 新鲜度 | `git --version` |
+| GitHub CLI（`gh`） | Issue、标签、PR、merge | `gh auth status` |
+| systemd（user session） | 每刻钟触发一个 tick 的 timer | `systemctl --user status` |
+| 可用的 OpenAI-compatible 模型 endpoint | Pi 的模型 provider——本地 llama.cpp server 或任意 OpenAI-compatible API | 一次真实 `pi --print` 调用（见下） |
+
+Pi 必须配置一个能稳定服务 coding agent 的 provider（system prompt +
+tool schemas + 长 session）。派活之前先用一次真实调用验证 endpoint——
+不要假设 key 或模型服务可用：
+
+```bash
+pi --print "reply with the single word: ok"
+```
+
+如果失败，先修模型 endpoint；否则 Runner 会在每个任务上 fail fast。
+
+<Note>
+`local-llm-kv-cache` proxy 是**可选**增强（本地 llama.cpp 模型更快的
+prefix 复用），不是核心前提——见[可选组件](/zh/optional-kv-cache)。
+</Note>
+
+## 1. Clone 仓库
+
+```bash
+git clone https://github.com/xqliu/muyan-pilot.git
+cd muyan-pilot
+```
+
+## 2. 创建配置
+
+仓库带一份提交的 example；真实配置是本地状态（gitignored）。复制并编辑：
+
+```bash
+cp .muyan-pilot.example.toml muyan-pilot.toml
+```
+
+全部字段（TOML，相对路径相对配置文件所在目录解析）：
+
+| 字段 | 必填 | 默认 | 含义 |
+|---|---|---|---|
+| `source_repos` | 是 | — | 每个 tick 按顺序扫描的 `owner/repo` 任务池列表（例如先你的 pilot 仓库，再你的 backlog 仓库） |
+| `repo_dir` | 否 | `.` | service 启动的 Runner checkout（`bootstrap_runner.py` 所在目录） |
+| `workspace_root` | 否 | `..` | 包含任务 worktree 和 agent 可修改仓库的目录 |
+| `prompt` | 否 | `prompt.md` | 实现者 prompt 模板（`{{SOURCE_REPO}}` 等占位符由 Runner 渲染） |
+| `prompt_review` | 否 | `prompt_review.md` | PR 后独立审查 session 的 review prompt 模板 |
+| `base_branch` | 否 | `main` | 交付 base 分支；每个任务 worktree 都从冻结的 `origin/<base_branch>` SHA 创建 |
+| `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数（正整数；本地模型/GPU 通常只稳定服务一个任务） |
+| `skills` | 否 | `[]` | 可选 Pi skill 路径（绝对、`~`，或相对配置文件） |
+| `context_files` | 否 | `[]` | 可选 Markdown 上下文文件，以路径形式注入 prompt |
+
+最小示例：
+
+```toml
+source_repos = [
+  "OWNER/PILOT-REPO",
+  "OWNER/BACKLOG-REPO",
+]
+
+repo_dir = "."
+workspace_root = ".."
+prompt = "prompt.md"
+prompt_review = "prompt_review.md"
+base_branch = "main"
+max_concurrency = 1
+skills = []
+context_files = []
+```
+
+## 3. 运行一次性 setup
+
+setup 入口用一条命令完成全部初始化：验证 `gh auth status` 和仓库权限、
+从仓库管理的 `labels.toml`（标签名/颜色/描述的唯一事实源——commit 从不
+创建标签，缺标签会让扫描静默漏掉对应状态）声明式对齐平台标签、安装
+systemd user units 并 enable timer、检查 checkout、报告可选模型 proxy：
+
+```bash
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
+它幂等（重复运行从不创建重复的标签、units 或 timer）且 fail-fast（仓库
+错误、权限不足、checkout 不干净或缺 systemd user bus 都会带具体原因
+停下）。完整输出契约、成功和失败示例见[一次性 setup](/zh/setup)。
+
+## 4. 手工运行一个 tick
+
+手工命令只用于首次验证和排查——正常运行由 timer 调度（第 6 步）：
+
+```bash
+python3 bootstrap_runner.py --config muyan-pilot.toml
+```
+
+一个 tick 最多做一件事：恢复一个已打开的 PR（review/fix/merge），或
+领取一个 `ai-ready` Issue（带 `p0` 标签的 Issue 最先被领取，然后是
+`bug` 标签的，最后是普通 feature），然后退出。ready 队列为空时干净
+退出，不领取任何东西。
+
+## 5. Smoke walkthrough（从零）
+
+验证环境可用的最小端到端证明。在第 1 步的 clone 目录里运行；每条命令
+都相对该目录。
+
+```bash
+# a. 向第一个配置的 source repo 派一个极小任务。
+#    `add` 一步完成创建 Issue 并加 ai-ready 标签。
+python3 muyan_pilot.py add "Docs: verify smoke walkthrough" \
+  --body "Read README.md and confirm the smoke walkthrough commands exist." \
+  --config muyan-pilot.toml
+
+# b. 看队列：新 Issue 已 ready。
+python3 muyan_pilot.py status --config muyan-pilot.toml
+
+# c. 跑一个 tick：Runner 领取 Issue，在全新 worktree 里启动 Pi，
+#    朝 PR 推进。
+python3 bootstrap_runner.py --config muyan-pilot.toml
+
+# d. tick 运行期间跟实时活动（第二个终端）：
+journalctl --user -u muyan-pilot.service -f
+# 或者对手工 tick 直接跟 session JSONL：
+python3 muyan_pilot.py session --follow --config muyan-pilot.toml
+
+# e. PR 打开后，Issue 带 ai-pr-opened，交付在后续 tick 继续
+#    （独立审查、会话内修复、merge）。在 GitHub 上看 Issue 和 PR。
+gh issue list --repo OWNER/PILOT-REPO --label ai-pr-opened
+```
+
+完成标志：Issue 走完 `ai-ready → ai-in-progress → ai-pr-opened →
+ai-merged`，存在一个 body 带 `Fixes #<issue>` 的 PR，journal 显示
+`run_end ... result=pr_opened`。任何一步失败，Issue 会被标记
+`ai-blocked` 并留下现场——恢复方法见[运维](/zh/operations)。
+
+## 6. 验证 timer
+
+setup 已经安装 units 并 enable 了 timer；验证一下：
+
+```bash
+systemctl --user list-timers muyan-pilot.timer
+```
+
+setup 输出带 `timer=enabled active=true next=...`（下次触发时间）。
+timer 每刻钟触发一次，全天 24 小时（00:00–23:45）。任务运行期间，
+后续 timer 启动请求被 systemd 忽略；下一次真正启动会取到最新代码
+（service 启动前先 fast-forward `main`——见[运维](/zh/operations)）。
+
+<Note>
+提交的 unit 模板通过 `%h` 占位符引用作者的 clone 布局
+（`%h/Documents/muyan/muyan-pilot`）。如果你的 clone 在别处，编辑你
+user unit 目录（`~/.config/systemd/user/`）里**已安装**的 units，把
+`WorkingDirectory`、`MUYAN_PILOT_CONFIG` 和 `ExecStart` 指向**你的**
+clone 路径，然后 `systemctl --user daemon-reload`。仓库模板仍是其余
+一切的唯一事实源——漂移检测见[运维](/zh/operations)。
+</Note>

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -1,0 +1,92 @@
+# Muyan Pilot
+
+Muyan Pilot 是一个本地 AI 开发 Worker：把任务放进 GitHub Issue，它自动领取
+`ai-ready` Issue，在隔离 worktree 中开发、运行真实测试套件、创建 PR，随后
+完成独立审查（会话内修复）并合并干净的 PR——整个交付过程记录在 GitHub
+Issue、评论和 PR 本身中。
+
+## 系统架构总览
+
+```mermaid
+flowchart LR
+  subgraph github["GitHub — 任务池 + 交付记录"]
+    issues["Issues + 标签（ai-ready → ai-merged）"]
+    prs["PR（Fixes #N、run marker）+ review/merge"]
+  end
+  subgraph machine["Runner 机器（systemd user session）"]
+    timer["muyan-pilot.timer（每刻钟 tick）"]
+    service["muyan-pilot.service（ExecStartPre：fast-forward main）"]
+    runner["Runner（muyan_pilot.py）：领取 → worktree → Pi → PR → review → merge"]
+    worktree["任务 worktree + feature branch（冻结 origin/main SHA，名字带 run id）"]
+    pi["Pi session（implement + 独立 review）"]
+    model["llama-server（核心：任意 OpenAI-compatible endpoint）"]
+    proxy["local-llm-kv-cache proxy（可选：prefix 复用）"]
+  end
+  issues -->|扫描 + 标签| runner
+  timer -->|触发| service
+  service -->|启动| runner
+  runner -->|创建| worktree
+  runner -->|启动| pi
+  pi -->|读写| worktree
+  pi -->|OpenAI-compatible| model
+  pi -.->|可选| proxy
+  proxy -->|转发| model
+  runner -->|gh API：PR / review / merge| prs
+  prs -->|merge → ai-merged| issues
+```
+
+实线 `Pi → llama-server` 是核心链路（任意 OpenAI-compatible endpoint
+都可以）。虚线标记可选的 [local-llm-kv-cache](/zh/optional-kv-cache)
+proxy：它只为本地 llama.cpp 模型增加更快的 prefix 复用，**不是**核心
+前提。
+
+## 它解决的问题
+
+中小型开发任务（bug、feature、文档修改、workflow 修复）通常走同一个
+循环：读上下文、规划、实现、测试、开 PR、review、修复、合并。Muyan
+Pilot 在本地无人值守地跑完这个循环：
+
+- **GitHub Issue 就是任务池。** 没有 Web Kanban、没有数据库、没有第二套
+  任务系统——Issue、它的标签、评论和 PR 就是完整的交付记录。
+- **Pi 是开发者。** 每个任务运行一个完整 Pi session（plan → implement →
+  test → verify → PR），在隔离的 git worktree 中；第二个独立的 Pi
+  session 审查 PR 并在会话内修复 findings。
+- **Runner 是薄连接器。** 一个小的 Python 进程（`gh` + `git` + `pi` +
+  `systemd`）负责领取 Issue、把交付推到 merge、发布进度、从重启中恢复。
+  它自己从不实现业务逻辑。
+
+## 什么时候用它
+
+- 你有一个 GitHub 仓库（或一小批固定仓库），希望任务在夜间或无人值守时
+  被领取并交付为 PR。
+- 你希望交付证据（plan、测试、review verdict、PR）留在 GitHub，而不是
+  某个私有工具里。
+- 你运行自己的模型 endpoint（本地 llama.cpp server 或任意
+  OpenAI-compatible API），能稳定服务 coding agent。
+
+## MVP 边界
+
+Muyan Pilot 刻意是一个 MVP，边界是设计的一部分：
+
+- GitHub Issue 和标签是**唯一**状态存储——没有数据库、没有消息队列、
+  没有 Web UI。
+- Python Runner **不是 daemon**：systemd user timer 每刻钟触发一个
+  tick；每个 tick 最多处理一个 Issue（或恢复一个已打开的 PR）然后退出。
+- 没有任务 DAG、没有多 Agent 并行、没有风险模型、没有 policy engine、
+  没有 fallback 路径——命令错误立即失败（fail fast），现场留在 journal
+  和 Issue 评论里。
+- 没有业务任务 timeout：慢模型不是失败。只有命令错误、环境不可用、或
+  无法解决的 review 才会 fail fast。
+
+它**不**做的事：不自动发现仓库、不自己 merge 或 push 保护分支（Runner
+是唯一 merge actor，且只通过已审查的 PR）、没有可用模型 endpoint 时
+不运行。
+
+## 下一步
+
+- [快速开始](/zh/getting-started)：前提、配置、首次启动和从零 smoke
+  walkthrough。
+- [工作流](/zh/workflow)：完整的 Issue → PR → review → merge 链路、
+  标签、run marker、Epic、Release task 和 P0 优先级。
+- [运维](/zh/operations)：timer、日志、CLI、worktree 和故障恢复。
+- [安全](/zh/security)：让 AI 碰不到保护分支、不泄漏密钥的边界。

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -1,0 +1,135 @@
+# 运维
+
+正常运行完全自动：timer 触发 tick，tick 最多做一件事，进度自己发布到
+journal 和 GitHub。正常路径永远不需要 status 命令、轮询或督工——下面的
+命令只用于首次验证、排查和恢复。
+
+## Timer
+
+`systemd/muyan-pilot.timer` 每刻钟触发一次，全天 24 小时
+（`OnCalendar=*-*-* *:00/15`、`AccuracySec=30s`、`Persistent=false`——
+错过的 tick 被丢弃，从不排队）。每个 tick 启动
+`muyan-pilot.service`，它：
+
+1. **先 fast-forward 代码**（`ExecStartPre`，在 Python 进程外）：
+   `git fetch origin main && git merge --ff-only origin/main`。checkout
+   不干净、fetch 失败或无法 fast-forward 时 preflight 失败：service 不
+   启动，原因写入 systemd journal（fail fast）。正在运行的长任务从不被
+   热更新或杀掉——service active 时 systemd 忽略 timer 的 start 请求，
+   下一次真正启动取到最新代码。
+2. **运行一个 tick**：恢复一个已打开的 PR（review/fix/merge），或领取
+   一个 `ai-ready` Issue，然后退出。在任何 slot 或领取之前，tick 还
+   运行启动前 **git transport 检查**（Issue #114）：部署 checkout 的
+   **配置的** `origin` remote 必须是第一个配置 source repo 的 SSH
+   形式，且 `git ls-remote <ssh-url>` 退出 0（SSH 可达且已认证）。
+   传输损坏记录结构化 `transport_check_failed ... reason=...` 行并让
+   启动失败——不取 slot、不领取、不改标签，**没有 HTTPS 回退**（git
+   数据操作，包括 `.github/workflows/*.yml` 推送，永远走 SSH；GitHub
+   API 操作留在 `gh` token 上）。
+
+```bash
+systemctl --user list-timers muyan-pilot.timer
+systemctl --user status muyan-pilot.service
+```
+
+## 日志（journal）
+
+journal 是本地记录。一个 run 的每行都以 run id 前缀 `[<run_id>]` 开头，
+一条 grep 还原完整时间线：
+
+```bash
+journalctl --user -u muyan-pilot.service -f
+journalctl --user -u muyan-pilot.service | grep e07383c2
+```
+
+你会看到的稳定 `key=value` 行：
+
+- `run_start` / `run_end` — 开始时的完整现场（branch、worktree、
+  session 文件），结束时的结果（PR URL、commit）；
+- `activity` / `heartbeat` / `model_wait` / `resumed` — session 运行
+  期间的实时 Pi 活动（phase、最近动作、elapsed、idle）；
+- `pi_idle` — 超过 300 秒（`PI_IDLE_WARN_SECONDS=300`）没有
+  model/session 活动且模型不期望回复时的一次 WARNING；活跃的慢模型
+  （`model_wait`）从不告警；
+- `run_failed` — 完整现场加原因（`pi_exit_N`、`timeout_...s`，或
+  `upstream_dead_stale_...s`——冻结的 `model_wait` 超过
+  `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）判定上游模型已死，Runner
+  杀掉 Pi）。
+
+idle 告警和上游已死 kill 是日志/健康阈值——它们不是每刻钟调度，也
+不是业务任务 timeout。
+
+## CLI（`muyan_pilot.py`）
+
+```bash
+# 在配置的 source repo 创建 Issue 并加 ai-ready 标签
+python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+python3 muyan_pilot.py add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
+
+# 只读队列视图：当前（ai-in-progress）任务带实时 Pi 活动、下一个 ready
+# Issue、每个 source repo 的最近结果（ai-pr-opened / ai-fix-needed /
+# ai-merged / ai-blocked）
+python3 muyan_pilot.py status --config muyan-pilot.toml
+
+# 只读部署/健康报告：repo commit、unit drift、git transport（配置的
+# origin URL、protocol、期望 SSH URL、SSH 探测——传输失败报告为
+# `transport: FAILED ...`，不抛出）、timer/service 状态、slots、Pi
+# session、当前 Issue、最近 journal
+python3 muyan_pilot.py doctor --config muyan-pilot.toml
+
+# 一次性、幂等初始化（新机器/新仓库）：gh auth + 仓库权限、平台 labels、
+# systemd user units、checkout 检查（含 git transport：已有 HTTPS
+# `origin` 迁移为 `git@github.com:owner/repo.git`（人工授权的迁移路径；
+# Runner 本身从不改写 remote），并探测 SSH 连通性（fail fast，没有
+# HTTPS 回退））
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
+```bash
+# 打印当前 run 的 Pi session JSONL 路径（没有 session 时 fail fast）
+python3 muyan_pilot.py session --config muyan-pilot.toml
+python3 muyan_pilot.py session --follow --config muyan-pilot.toml   # tail -f
+python3 muyan_pilot.py session --pretty --config muyan-pilot.toml   # 一行摘要
+```
+
+所有命令通过 `--config` 或 `MUYAN_PILOT_CONFIG` 环境变量接收配置
+（默认 `muyan-pilot.toml`）。`status` 和 `session` 是调试附件——
+journal 和 GitHub 仍是正常可观测路径。
+
+## Worktree 与 base 新鲜度
+
+每次领取先 fetch 并冻结 `origin/<base_branch>`，任务 worktree 和
+feature branch 都从那个精确 SHA 创建——绝不来自主工作区当前 HEAD。
+branch 和 worktree 名带 run id（例如
+`.worktrees/<...>-issue-14-e07383c2`），所以重试的 Issue 得到新的独立
+run，旧现场保留。`.worktrees/` 已 gitignore。
+
+任务 worktree 共享部署 checkout 的单一 `origin` remote（`git worktree
+add` 创建的 worktree 继承主仓库的 remote 配置），所以 git transport 只
+在 checkout 上配置一次，所有 worktree 继承：新 bootstrap worktree
+天然有 SSH `git remote -v`，它们的 fetch/push——包括
+`.github/workflows/*.yml`——走 SSH（Issue #114）。
+
+创建 PR 前，实现者重新 fetch base：如果 `origin/<base_branch>` 前进了，
+它把最新 base 合入 task branch、手工解决冲突、重跑完整测试，然后才
+推送。Runner 用 `git merge-base --is-ancestor origin/<base_branch>
+HEAD` 验证，拒绝 head 不包含最新远端 base 的交付。
+
+## 故障恢复
+
+| 状态 | 发生了什么 | 怎么办 |
+|---|---|---|
+| `ai-blocked` | Runner fail fast（命令错误、现场无法恢复、审查超轮） | 读 Issue 评论（现场 + 原因）和 journal。修环境或修任务，然后把同一 PR 路径重新标为 `ai-fix-needed`（同一 run 继续），或移除标签重新派发为全新 `ai-ready`（新 run）。它从不自动恢复。 |
+| `ai-fix-needed` | PR head 尚不可合并（review finding 或 base 冲突） | 什么都不用做——下一 tick 在同一 PR 上启动下一个审查会话，会话内吸收最新 base。 |
+| 被杀后残留的 `ai-in-progress` | Runner 在任务中途被 SIGKILL | 下一 tick 的重启扫描接回（仅当没有其他 Runner 活着时）：同一 run id、同一 worktree、同一条进度评论——不新建 run。 |
+
+run 产物（plan、test log、session JSONL）留在任务 worktree 作为本地
+记录；GitHub 承载交付记录。
+
+## 并发
+
+`max_concurrency`（默认 1）限定本机并发交付数。slot 是
+`<repo_dir>/.muyan-pilot/slots/slot-N` 上的排他 `flock(2)` 锁，在任何
+领取之前取得，整个交付生命周期（implement → review → merge）持有；
+进程无论如何退出，内核都会释放它。拿不到 slot 的 Runner 记录
+`capacity_full` 后退出，不领取 Issue。

--- a/docs/zh/optional-kv-cache.mdx
+++ b/docs/zh/optional-kv-cache.mdx
@@ -1,0 +1,68 @@
+# 可选：local-llm-kv-cache proxy
+
+[local-llm-kv-cache](https://github.com/xqliu/local-llm-kv-cache) proxy
+是本地 llama.cpp 配置的**可选增强**：它加了两级 KV cache（内存热
+session cache + 磁盘冷 prefix cache），让 coding agent 不必在每个新
+session 重新 prefill 稳定的 system prompt 和 tool schemas。它是独立项
+目，有自己的仓库、测试和 README——这一页只记录它如何接入 Muyan
+Pilot。它**不是**核心前提：没有它，Pilot 直接对接任意
+OpenAI-compatible endpoint 就能工作。
+
+## 它改变了 Pilot 的什么
+
+- proxy 用提交的 systemd unit 安装时监听 `127.0.0.1:18082`（proxy 自己
+  代码的默认端口是 `8081`），转发到 llama.cpp server（默认 upstream
+  `127.0.0.1:8080`）。
+- 把 Pi（和任何其他 agent）的 provider URL 指向 proxy
+  （`http://127.0.0.1:18082/v1`），而不是直接指向 llama server。
+- Pilot 本身不变：它永远只和配置的 OpenAI-compatible endpoint 说话。
+
+## 安装
+
+完整说明见上游仓库的 README；简版（它自己的 clone 路径，例如在你的
+home 目录下）：
+
+```bash
+git clone https://github.com/xqliu/local-llm-kv-cache.git
+cd local-llm-kv-cache
+mkdir -p ~/.config/systemd/user
+cp local-llm-kv-cache.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now local-llm-kv-cache.service
+curl -fsS http://127.0.0.1:18082/health
+```
+
+要求：Python 3.10+ 和启用了 slot save/restore 的 llama.cpp server。
+hybrid/recurrent 模型（例如 Qwen3.8）需要带 checkpoint 持久化修复的
+llama.cpp 构建——精确 branch/commit 和上游 PR 引用见上游 README。
+
+## 配置
+
+user unit 用环境变量承载设置：
+
+| 变量 | 默认 | 含义 |
+|---|---|---|
+| `PI_LLAMA_UPSTREAM` | `http://127.0.0.1:8080` | proxy 转发到的 llama.cpp server |
+| `PI_LLAMA_CACHE_HOST` | `127.0.0.1` | proxy 绑定地址 |
+| `PI_LLAMA_CACHE_PORT` | `8081` (代码默认；提交的 unit 设为 `18082`) | proxy 端口（agent 指向这里） |
+| `PI_LLAMA_CACHE_DIR` | `~/.llama-slot-cache` | 磁盘 KV 状态目录 |
+| `PI_LLAMA_CACHE_MAX_GIB` | `12` | 磁盘缓存大小上限 |
+| `PI_LLAMA_CACHE_WAIT_SECONDS` | `120` | slot restore 最大等待 |
+| `PI_LLAMA_CACHE_PREFIX_SEED_DELAY` | `2` | prefix 播种延迟 |
+
+编辑 unit 后 `systemctl --user daemon-reload &&
+systemctl --user restart local-llm-kv-cache.service`。
+
+## 排障
+
+- `curl -fsS http://127.0.0.1:18082/health` 失败 → proxy 没运行：
+  `systemctl --user status local-llm-kv-cache.service` 和该 unit 的
+  journal。
+- 请求超时 → 检查 `PI_LLAMA_UPSTREAM` 能否到达存活的 llama.cpp
+  server；proxy 自己从不产出模型输出。
+- cache 从不命中 → proxy 不伪造命中；验证你的 llama.cpp 构建支持你的
+  模型类型的 checkpoint 持久化（上游 README），以及 agent 的稳定
+  prefix（system prompt + tool schemas）在 session 之间确实稳定。
+- 停止使用：disable unit，把 agent 的 provider URL 指回 llama
+  server，如果不想让缓存的 prompt 状态留在本地就删除 KV cache 目录
+  （为什么该目录敏感见[安全](/zh/security)）。

--- a/docs/zh/security.mdx
+++ b/docs/zh/security.mdx
@@ -1,0 +1,60 @@
+# 安全
+
+Muyan Pilot 在你的机器上运行一个带 GitHub token 的自主 coding agent。
+安全模型刻意简单：交付契约里的硬边界、本地密钥、没有远端状态存储。
+
+## AI 从不 merge 或 push 保护分支
+
+- 实现者 Pi **只 push 自己的 feature branch** 并开一个 PR。不 merge、
+  不 push `main`/`master`、不 force push、从不自动解决冲突。
+- **Runner 是唯一 merge actor**，且只通过已审查的 PR merge：clean
+  `REVIEW_VERDICT`、merge 门禁（PR head 包含最新远端 base、PR
+  mergeable、远端 head 仍是被审查的 head）、`gh pr merge
+  --match-head-commit` 保证只有被审查的 head 落地。
+- 默认分支上的 GitHub branch protection 是最终边界：把保护分支的
+  权限限定在运行 Runner 的账号（或谁都不给——由 Runner 的 token 执行
+  merge）。
+- 交付状态是推导出来的，从不信任公开文本：恢复现场只从 trusted
+  maintainer（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的评论读取；
+  branch/worktree 路径由配置的 repo、Issue 编号和 run id 推导——公开
+  评论永远无法把 Runner 指向任意本地路径。
+
+## GitHub token（API）与 SSH（git 数据）——两条通道
+
+- **GitHub API 操作**（Issue、PR、label、comment、merge）用 `gh`
+  认证（`gh auth status` 必须成功）。使用**细粒度 personal access
+  token**，限定在 Pilot 实际工作的仓库，最小权限：contents
+  （read/write）、pull requests（read/write）、issues（read/write）、
+  metadata（read）。避免组织级或经典宽 scope token。
+- **Git 数据操作**（fetch、push——包括 `.github/workflows/*.yml`）用
+  机器的 **SSH key** 走 `git@github.com:owner/repo.git`（Issue #114）。
+  workflow 推送从不依赖 OAuth App 的 `workflow` scope——那是阻塞
+  Issue #106 的 HTTPS/OAuth 传输。启动前检查验证 SSH 传输，损坏时
+  fail fast（没有 HTTPS 回退）。
+- 两条通道从不混用：SSH 不是 API 认证，`gh` token 不是 git 数据凭据。
+  token 存在 Runner 机器上 `gh` 的本地凭据存储；SSH key 在用户的 SSH
+  agent/config 里。两者都不写入仓库、配置文件、journal 或 GitHub
+  评论。
+- 日志按构造脱敏：带密钥的命令日志固定为 `<redacted>`，工具摘要截断
+  并屏蔽。完整 prompt、Issue body 和 token 永远不进 journal 或进度
+  评论。
+- 按正常周期轮换 token；泄露的 token 被限制在它可见的仓库内。
+
+## 本地状态文件
+
+Pilot 保留从不出机的本地状态：
+
+- **配置**（`muyan-pilot.toml`）：本地、gitignored。仓库只提交
+  example（`.muyan-pilot.example.toml`）。
+- **Run 产物**：plan、test log、session JSONL 和 review 证据在任务
+  worktree（`.worktrees/...`，gitignored）。
+- **Slots**：`<repo_dir>/.muyan-pilot/slots/slot-N` 锁文件（通过
+  checkout 的 `.muyan-pilot/` 目录约定 gitignore）。
+- **KV cache 文件**（仅当你运行可选的
+  [local-llm-kv-cache](/zh/optional-kv-cache) proxy）：磁盘上的 prefix
+  和 session KV 状态（例如 `~/.llama-slot-cache/*.bin`）包含从你的
+  prompt 派生的序列化模型状态——当作敏感本地数据处理，留在同一台
+  机器，不再需要缓存的 session 时删除。
+
+如果你在共享机器上运行 Pilot，给 Runner 用户独立的 home 目录，让
+配置、worktree 和 KV 文件只属于该用户。

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -1,0 +1,130 @@
+# 一次性 setup
+
+`muyan_pilot.py setup` 是新机器或新任务池仓库的一次性、配置驱动的初始化
+入口。它验证本地前提、对齐平台标签、安装 systemd user units、检查
+checkout、报告可选模型 proxy——一条命令，稳定的机器可读结果。
+
+```bash
+python3 muyan_pilot.py setup --config muyan-pilot.toml
+```
+
+每台机器运行一次（每个新任务池仓库再各运行一次）。它**幂等**：重复运行
+从不创建重复的标签、units 或 timer，也从不碰业务 Issue 或业务标签。
+
+## 按顺序做什么
+
+setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下，stderr
+给出具体原因，退出码非零。
+
+1. **命令** — PATH 上有 `git`、`gh`、`python3`，且 `systemctl --user`
+   user bus 可达（没有 user bus 的容器或 headless session 会以 bus 错误
+   失败）。
+2. **认证** — `gh auth status`（已登录且 token 可用）。
+3. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
+   OWNER/REPO` 时恰好一个）：
+   - 仓库存在且 viewer 有写权限（`gh repo view` → `viewerPermission`
+     必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）；
+   - 七个平台标签从仓库根目录的 `labels.toml` **声明式**对齐——标签
+     名/颜色/描述的唯一事实源：缺的创建、漂移的更新、从不删除，业务
+     标签（`bug`、`enhancement`、...）从不被碰。
+4. **Systemd units** — 仓库模板（`systemd/muyan-pilot.service`、
+   `systemd/muyan-pilot.timer`）幂等安装到 user unit 目录（与
+   `install-units` 相同的安装：复制、`daemon-reload`、enable timer——
+   从不启动、停止或重启 service），然后报告 timer 的
+   enabled/active 状态和下次触发时间。
+5. **Checkout + git transport** — 检查配置的 `repo_dir`：`origin`
+   remote 的**传输协议**（Issue #114）：git 数据操作（fetch、push——
+   包括 `.github/workflows/*.yml`）必须走 SSH
+   （`git@github.com:owner/repo.git`），所以已有的 HTTPS `origin` 在这里
+   用普通的 `git remote set-url origin git@github.com:owner/repo.git`
+   迁移（setup 是人工授权的迁移路径——Runner 本身从不改写 remote）；
+   SSH URL 必须匹配第一个配置的 source repo——指向**另一个**仓库的
+   remote 从不被迁移（改写会把 checkout 指向另一个仓库），直接以
+   `setup_failed reason=... origin remote repo mismatch ...` 失败；
+   `git ls-remote <ssh-url>` 必须退出 0（SSH 可达且已认证——失败是
+   `setup_failed reason=... ssh_unreachable ...`，**没有 HTTPS 回退**）。
+   然后是只读部分：当前分支、干净 worktree（checkout 不干净会失败：
+   timer 的 `ExecStartPre` fast-forward 拒绝脏 worktree，Runner 就永远
+   无法启动）、base 新鲜度（本地 `HEAD` 对比刚 fetch 的
+   `origin/<base_branch>`——只报告，不失败：timer 每次启动都会把干净
+   checkout fast-forward）。
+6. **可选模型 proxy** — 检查 `local-llm-kv-cache` proxy 的 health
+   endpoint（`http://127.0.0.1:18082/health`），报告为**可选**：它的
+   缺失或不健康只是输出里的 warning，从不阻塞核心 GitHub/Pilot setup。
+
+setup 从不创建业务 Issue、从不领取任务、从不启动 Pi、从不修改保护分支。
+
+## 选项
+
+| 选项 | 含义 |
+|---|---|
+| `--config PATH` | `muyan-pilot.toml` 配置（默认：`$MUYAN_PILOT_CONFIG` 或 `muyan-pilot.toml`） |
+| `--repo OWNER/REPO` | 只初始化这个配置的 source repo（默认：每个配置的 source repo） |
+| `--installed-dir PATH` | user unit 目录（默认：标准 `~/.config/systemd/user`） |
+| `--json` | 以 JSON 而不是 `key=value` 行输出结果 |
+
+## 输出
+
+默认输出是稳定的 `key=value` 行（每个关注点一行；含空格的值加引号），
+agent 和脚本可以解析：
+
+```text
+setup=ok version=1 base_branch=main
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
+timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
+```
+
+`labels=7/7` 表示七个平台标签都与 `labels.toml` 一致；`next` 是 timer
+的下次触发时间（没有时为 `-`）；`optional_proxy` 是 `healthy`、
+`unhealthy` 或 `unavailable`，从不改变退出码。`migrated=true` 表示
+setup 把 HTTPS `origin` 改写成了 SSH URL（重跑后报告 `migrated=false`）；
+`ssh_reachable` 是 `git ls-remote` 探测结果。
+
+`--json` 输出等价的 JSON 文档：
+
+```bash
+python3 muyan_pilot.py setup --config muyan-pilot.toml --json
+```
+
+## 成功与失败示例
+
+成功（退出码 `0`）：
+
+```bash
+$ python3 muyan_pilot.py setup --config muyan-pilot.toml
+setup=ok version=1 base_branch=main
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
+timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
+```
+
+（这里可选 proxy 没运行——注意 `optional_proxy=unhealthy`——但核心
+setup 仍以退出码 `0` 成功。）
+
+失败（退出码非零，stderr 输出 `setup_failed reason=...`）：
+
+```text
+setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
+setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
+setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
+setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)
+setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted changes: ' M bootstrap_runner.py') — commit or stash them first: ...
+setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry
+```
+
+仓库错误、无法创建的缺失标签（权限）、脏 checkout、SSH 不可达（没有
+HTTPS 回退）或缺 systemd user bus 都会带具体原因停下——不会半初始化
+而没有明确信号。
+
+## 幂等性
+
+在已初始化的机器上重跑 setup，对外部状态是 no-op：已一致的标签不重写，
+unit 模板从仓库重新复制（漂移修复），timer 保持 enabled，不创建或修改
+任何 Issue 或业务数据。报告的 hash 和状态跨运行稳定。HTTPS→SSH 迁移
+是一次性的：第一次运行后 `origin` remote 已是 SSH，重跑只重新验证
+（`migrated=false`）。

--- a/docs/zh/testing.mdx
+++ b/docs/zh/testing.mdx
@@ -1,0 +1,46 @@
+# 测试
+
+仓库契约（见 `AGENTS.md`）：Python 代码的完整 pytest 套件，
+**100% 行和分支覆盖**。同一契约在 Runner 机器本地和 GitHub 远端
+运行。
+
+## 本地契约命令
+
+从仓库根目录运行（生产解释器 `/usr/bin/python3`，Python 3.14）：
+
+```bash
+/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+/usr/bin/python3 -m coverage report --fail-under=100 --show-missing
+```
+
+第二条命令在任何行或分支低于 100% 时退出非零，所以这对命令是门禁，
+不是报告。
+
+## 远端 CI（GitHub Actions）
+
+`.github/workflows/ci.yml` 在每次 `pull_request` 和每次 push 到
+`main` 时运行同一契约：单个 job，`actions/setup-python` 固定 Python
+3.14（GitHub-hosted runner 没有生产路径上的生产解释器，所以 workflow
+固定同一 minor 版本，通过 PATH 上的 `python3` 运行相同命令），安装
+`requirements.txt`，然后运行上面两条契约命令。没有 lint、没有矩阵、
+没有缓存。
+
+CI 里还运行 Mintlify 文档构建 smoke（Issue #116）：官方 `mint` CLI
+的 `mint validate`（严格构建校验，任何 warning 或 error 都退出非零）
+——文档配置、页面和链接在远端同样被门禁。
+
+CI 红的时候 PR 不可合并——Runner 的 merge 门禁也要求 PR mergeable。
+
+## 测试覆盖什么
+
+- **行为测试**：runner、CLI、slots、进度发布、活动流、
+  resume/review/merge 逻辑（套件主体，包括针对真实 `git` 和 `gh`
+  fixture 的端到端测试）。
+- **静态契约测试**：把仓库钉在它自己的文档和文件上：`AGENTS.md`
+  契约项、标签集、systemd units（每刻钟调度、preflight）、CI
+  workflow、LICENSE、`docs/` 下的文档站（本页的声明由
+  `tests/test_docs_site.py` 强制执行；中文页面和 EN/ZH 同一事实源由
+  `tests/test_docs_i18n.py` 强制执行；Mermaid 图由
+  `tests/test_docs_mermaid.py` 强制执行）。
+
+改代码时，在同一个 PR 里更新或新增测试，保持覆盖率门禁绿。

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -1,0 +1,137 @@
+# 工作流
+
+一个 Muyan Pilot 任务是一个 runtime outcome：当 X，应该 Y，实际 Z。
+任务从一个 GitHub Issue 开始，以一个已合并的 PR 结束（或一个需要人工
+的 `ai-blocked` 现场）。这一页覆盖完整的自动链路和项目的 GitHub 工作流
+词汇。
+
+## 完整链路
+
+状态机（六个交付状态；review/fix 循环留在同一个 PR 上——只有它的 head
+可以前进）：
+
+```mermaid
+flowchart LR
+  epic["Epic（ai-epic）— 只协调，从不被领取"]
+  epic -.拆分为.-> ready
+  release["Release task — 普通 ai-ready Issue（release 对账）"]
+  release -.交付于.-> ready
+  ready["ai-ready<br/>（领取顺序：P0 标签最先，然后 bug 标签，最后普通）"]
+  ready -->|领取：加标签 + 建 worktree + 启动 Pi| progress["ai-in-progress"]
+  progress -->|PR 验收：base 新鲜、run marker、Fixes #N| opened["ai-pr-opened"]
+  opened -->|独立审查会话（会话内修复）| verdict{"REVIEW_VERDICT"}
+  verdict -->|clean verdict + merge 门禁| merged["ai-merged（终态）"]
+  verdict -->|finding / base 冲突 / 超轮| blocked["ai-blocked（终态，人工决策）"]
+  opened -->|finding / base 冲突| fixneeded["ai-fix-needed"]
+  fixneeded -->|下一 tick：同一 PR 的下一个审查会话| opened
+  progress -->|fail fast| blocked
+```
+
+```text
+ai-ready                任务被派发（muyan_pilot.py add，或人工加标签）
+  -> ai-in-progress     Runner 领取：加标签，从冻结的 origin/<base> SHA
+                        创建 worktree，启动 Pi session
+  -> ai-pr-opened       PR 验收通过（base 新鲜度、run marker、Fixes #N）；
+                        交付现在等待 review
+  -> review             独立 Pi session 审查精确的 base/head SHA，并
+                        在会话内修复 findings（代码、完整测试、100%
+                        覆盖率、只 push task branch），然后输出
+                        REVIEW_VERDICT
+  -> ai-fix-needed      会话内未能修复 finding，或 PR 落后最新 base /
+                        有 merge conflict：下一个 tick 在同一 run、
+                        同一 branch、同一 PR 上启动下一个审查会话
+  -> merge              clean verdict + merge 门禁（head 包含最新 base、
+                        PR mergeable、远端 head 未变）
+  -> ai-merged          成功终态；PR body 的 Fixes #N 原生关闭 Issue
+```
+
+任何一点失败都 fail fast：Issue 被标记 `ai-blocked` 并留下具体现场
+（命令、返回码、stdout/stderr、branch、worktree、session 文件），自动
+循环从此不再碰它——人工决定下一步。
+
+链路规则：
+
+- 一个任务 = 一个 run = 一个 feature branch = 一个 worktree = 一个 PR。
+  review/fix 循环期间 PR 编号永远不变；只有它的 head 可以前进。
+- 只有两个 opened-PR 状态会被自动拾取：`ai-pr-opened`（等待 review）
+  和 `ai-fix-needed`（等待下一个审查会话）。`ai-ready` 作为新工作被
+  领取；`ai-blocked` 从不自动恢复。
+- review/fix 循环有界（5 轮）。超轮仍有 findings，或 review 无法验证，
+  Issue 标记 `ai-blocked`；PR、branch 和 worktree 原样保留。
+- base 前进由 task branch 上对最新 `origin/<base>` 的普通 `git merge`
+  吸收（冲突手工解决），然后重跑完整测试。不 force push、不自动解决
+  冲突、不 push 保护分支。
+- Git transport（Issue #114）：git 数据操作（fetch、push——包括
+  `.github/workflows/*.yml`）走 SSH（`git@github.com:owner/repo.git`）；
+  GitHub API 操作（Issue、PR、label、comment、merge）留在 `gh` token 上。
+  任务 worktree 继承部署 checkout 的单一 `origin` remote，所以新
+  bootstrap worktree 天然有 SSH `git remote -v`；传输损坏会让启动前
+  检查失败（没有 HTTPS 回退）。
+
+## 交付标签
+
+GitHub 标签是外部状态机。它们不是 commit 创建的——每个仓库要初始化
+（见[快速开始](/zh/getting-started)）：
+
+| 标签 | 含义 |
+|---|---|
+| `ai-ready` | 明确派发给 Pilot；可以被领取 |
+| `ai-in-progress` | 已领取、正在执行（被杀后的残留由下一 tick 接回） |
+| `ai-pr-opened` | PR 已创建并验收；等待独立审查 |
+| `ai-fix-needed` | PR head 尚不可合并；下一 tick 在同一 PR 上运行下一个审查会话 |
+| `ai-merged` | 成功终态；Runner 已合并 PR 并确认 merge commit 落在保护分支 |
+| `ai-blocked` | Runner fail fast；人工必须决定下一步 |
+
+## Run marker 与 run_id
+
+每个任务 attempt 生成一个 `run_id`（8 位 hex，例如 `e07383c2`），该
+attempt 的每一步复用同一个值；同一 Issue 的 retry 生成新的。同一个 id
+出现在：
+
+- 该 attempt 的每条 journal 行（前缀 `[e07383c2]`）；
+- Issue/PR 评论：可见字段 `run_id=e07383c2` + 隐藏机器可读 marker
+  `<!-- muyan-pilot:run=e07383c2 -->`；
+- feature branch 和 worktree 名（`.worktrees/<...>-issue-<n>-e07383c2`）；
+- PR body——稳定 marker `<!-- muyan-pilot:run=e07383c2 -->` 是 PR 契约
+  的一部分；Runner 拒绝没有它的 PR。
+
+一条 grep 还原完整时间线：
+
+```bash
+journalctl --user -u muyan-pilot.service | grep e07383c2
+gh search issues "e07383c2" --repo OWNER/PILOT-REPO
+```
+
+## PR body 契约：`Fixes #N`
+
+PR 描述必须包含 `Fixes #<issue-number>`（可以放在首行）。GitHub 读的是
+body（不是 PR title），PR merge 到默认分支时原生关闭 Issue。Runner 在
+PR 验收时校验该关键词，缺失即 fail fast。
+
+## Epic、Release task 与 P0 优先级
+
+项目用普通 GitHub 原语组织多任务工作——没有 DAG、没有优先级数字、没有
+独立队列：
+
+- **Epic**：协调 Issue，把一组相关任务归在一起（例如 v0.1 release
+  checklist）。它带 `ai-epic` 标签。Epic 本身不是可直接执行的任务：
+  实际工作拆成独立的 `ai-ready` Issue，每个一个 runtime outcome、一个
+  PR、一次 review、一次 merge。只有当子 Issue 完成且 release 证据
+  （tag、已合并 PR）在远端存在后 Epic 才关闭——通常伴随最后一个
+  `Fixes #<epic>` commit/PR。
+- **Release task**：一个普通 `ai-ready` Issue，职责是 release 对账——
+  检查子 Issue 已合并、版本 tag 在远端存在、release 证据完整。和任何
+  任务一样通过一个 PR 交付（或当证据已在远端时直接关闭 Epic）。
+- **P0 优先级**：普通 `p0` GitHub 标签标记紧急 Issue（生产故障）。它
+  **不是**交付状态——只决定 ready 领取顺序，从不改变 Issue 粒度、任何
+  交付状态或终态语义，Runner 也从不增删它。ready 领取顺序固定：
+  `ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`（三次
+  `gh issue list` 扫描，共享完全相同的排除条件和 blockedBy 语义）。
+  P0 遵守所有现有排除规则和单 slot 约束：被阻塞的 P0 被跳过（回退到
+  bug/普通扫描），在途的 P0 由重启扫描接回。P0 运行失败单独进入
+  `ai-blocked`（领取标签被移除；`ai-ready` 残留被所有 ready 扫描排除），
+  所以没有任何 tick 重新领取——没有无限重试。没有优先级数字或加权队列。
+
+Issue 之间的任务依赖用 GitHub 原生 `blockedBy` 关系（`gh issue edit N
+--add-blocked-by M`）；Runner 读该字段并跳过有未关闭 blocker 的 Issue。
+Issue body 里的 `Depends on #N` 行不被解析。

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -134,6 +134,27 @@ def test_ci_workflow_enforces_full_line_and_branch_coverage():
     )
 
 
+def test_ci_workflow_runs_the_mintlify_docs_build_smoke():
+    """Issue #116: the docs build smoke runs in CI with the official
+    Mintlify CLI — `mint validate` (strict build validation, non-zero
+    exit on any warning or error) in the SAME single job (KISS: no
+    second job, no cache, no matrix)."""
+    commands = step_commands(steps_of(load_workflow()))
+    assert any(
+        re.search(r"npm (i|install)( -g)? mint\b", command) for command in commands
+    ), (
+        "CI must install the official Mintlify CLI (mint), "
+        f"steps run: {commands!r}"
+    )
+    assert any(
+        re.search(r"^mint validate$|\bmint validate\b", command) and "--" not in command
+        for command in commands
+    ), (
+        "CI must run the Mintlify build smoke `mint validate`, "
+        f"steps run: {commands!r}"
+    )
+
+
 def test_readme_documents_remote_ci():
     readme = README_FILE.read_text(encoding="utf-8")
     assert "GitHub Actions" in readme, "README must name the remote CI"

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -1,0 +1,318 @@
+"""Chinese documentation contract (Issue #116).
+
+The Chinese docs live in `docs/zh/` (the verified Mintlify i18n layout:
+same structure as the default English pages at the `docs/` root) and keep
+the SAME single source of truth as the English pages — the implementation
+facts (labels, config fields, commands, ports, the 15-minute timer, the
+P0 pickup order, the PR body contract, the git transport boundary, the
+optional KV cache proxy) are asserted in the Chinese pages exactly as the
+English pages carry them. These tests fail when the Chinese entry or a
+required topic page is missing, when the EN/ZH page sets drift (one
+language documents a topic the other does not), when a Chinese page
+references a label or config field the implementation does not have, or
+when the README stops pointing at the Chinese docs entry.
+"""
+import re
+from pathlib import Path
+
+import bootstrap_runner as runner
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+ZH_DIR = DOCS_DIR / "zh"
+README = REPO_ROOT / "README.md"
+EXAMPLE_CONFIG = REPO_ROOT / ".muyan-pilot.example.toml"
+
+# One page per English topic page (same structure, same slugs).
+REQUIRED_ZH_PAGES = (
+    "index",
+    "getting-started",
+    "setup",
+    "workflow",
+    "operations",
+    "security",
+    "testing",
+    "contributing",
+    "optional-kv-cache",
+)
+
+# Every `ai-*` label the Chinese docs may mention must exist in the
+# runner's label set (same contract as the English pages).
+KNOWN_LABELS = frozenset({
+    "ai-ready",
+    "ai-epic",
+    runner.IN_PROGRESS_LABEL,
+    runner.PR_OPENED_LABEL,
+    runner.FIX_NEEDED_LABEL,
+    runner.MERGED_LABEL,
+    runner.BLOCKED_LABEL,
+})
+
+LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")
+
+# Config fields the implementation understands (bootstrap_runner.load_config
+# plus the committed example) — the Chinese field table may document
+# exactly this set, no invented field.
+KNOWN_CONFIG_FIELDS = frozenset({
+    "source_repos",
+    "repo_dir",
+    "workspace_root",
+    "prompt",
+    "prompt_review",
+    "base_branch",
+    "max_concurrency",
+    "skills",
+    "context_files",
+})
+
+CONFIG_FIELD_PATTERN = re.compile(r"^\s*([a-z][a-z_]+)\s*=", re.MULTILINE)
+
+
+def zh_page_text(slug: str) -> str:
+    path = ZH_DIR / f"{slug}.mdx"
+    assert path.is_file(), f"missing Chinese docs page: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def zh_page_stems() -> set[str]:
+    assert ZH_DIR.is_dir(), f"missing Chinese docs directory: {ZH_DIR}"
+    return {path.stem for path in ZH_DIR.glob("*.mdx")}
+
+
+def en_page_stems() -> set[str]:
+    return {
+        path.stem
+        for path in DOCS_DIR.iterdir()
+        if path.is_file() and path.suffix in (".md", ".mdx")
+    }
+
+
+def test_chinese_docs_entry_and_every_required_topic_page_exist():
+    """A Chinese user starting from the docs home must find the entry
+    (index) and every core topic (Issue #116 requirement list)."""
+    for slug in REQUIRED_ZH_PAGES:
+        assert (ZH_DIR / f"{slug}.mdx").is_file(), (
+            f"missing Chinese docs page: zh/{slug}.mdx"
+        )
+
+
+def test_chinese_and_english_page_sets_stay_the_same_source_of_truth():
+    """No topic may exist in only one language: the page sets must be
+    identical, so a reader in either language sees the same coverage and
+    the two versions cannot drift apart silently."""
+    assert zh_page_stems() == en_page_stems(), (
+        f"EN/ZH page sets differ: only-en={sorted(en_page_stems() - zh_page_stems())} "
+        f"only-zh={sorted(zh_page_stems() - en_page_stems())}"
+    )
+
+
+def test_chinese_overview_names_the_task_pool_and_mvp_boundary():
+    """The Chinese overview (index) must say what the project is (GitHub
+    Issue task pool) and the explicit MVP boundary (no database/queue/
+    daemon) — same facts as the English overview."""
+    text = zh_page_text("index")
+    assert "GitHub Issue" in text, "overview must name the GitHub Issue task pool"
+    assert "MVP" in text, "overview must state the MVP boundary"
+    for forbidden in ("数据库", "队列", "daemon"):
+        assert forbidden in text, (
+            f"overview must name the MVP boundary (no {forbidden})"
+        )
+
+
+def test_chinese_getting_started_documents_prerequisites_and_smoke():
+    """A Chinese user must be able to complete the install-prerequisite
+    check, configuration, first start and the minimal smoke from the
+    docs home (acceptance): the same facts as the English page —
+    production Python minor version, Pi, git + gh, systemd, the
+    OpenAI-compatible endpoint, the optional (not core) KV proxy, and the
+    smoke walkthrough with the real commands."""
+    text = zh_page_text("getting-started")
+    assert "Python" in text
+    assert "3.14" in text, "prerequisites must pin the production Python minor version"
+    assert "Pi" in text
+    assert "git" in text.lower()
+    assert "gh" in text, "prerequisites must name the GitHub CLI (gh)"
+    assert "systemd" in text.lower()
+    assert "OpenAI-compatible" in text, (
+        "prerequisites must name the OpenAI-compatible model endpoint"
+    )
+    assert "local-llm-kv-cache" not in text or "可选" in text, (
+        "the KV cache proxy must not be presented as a core prerequisite"
+    )
+    assert "smoke" in text.lower(), "getting-started must contain the smoke walkthrough"
+    assert "muyan_pilot.py add" in text, "smoke must use the real add command"
+    assert "bootstrap_runner.py" in text, "smoke must run the real one-tick command"
+    assert "journalctl --user -u muyan-pilot.service" in text, (
+        "smoke must show the real journal command"
+    )
+
+
+def test_chinese_config_field_table_matches_the_implementation():
+    """Every config field the Chinese docs document must exist in the
+    committed example (and therefore in load_config); no invented field,
+    and every example field must be documented."""
+    text = zh_page_text("getting-started")
+    documented = set(CONFIG_FIELD_PATTERN.findall(text))
+    unknown = documented - KNOWN_CONFIG_FIELDS
+    assert not unknown, f"Chinese docs document unknown config fields: {sorted(unknown)}"
+    example = EXAMPLE_CONFIG.read_text(encoding="utf-8")
+    example_fields = set(CONFIG_FIELD_PATTERN.findall(example))
+    missing = example_fields - documented
+    assert not missing, (
+        f"Chinese docs field table misses fields of the committed example: {sorted(missing)}"
+    )
+
+
+def test_chinese_workflow_documents_the_full_issue_to_merge_chain():
+    """The Chinese workflow page must cover the complete automatic chain
+    and the project's GitHub workflow vocabulary: all six delivery
+    states, the review verdict, the PR body contract, the run marker,
+    Epic (ai-epic), Release tasks, the P0 pickup order, and the SSH git
+    transport — same facts as the English page."""
+    text = zh_page_text("workflow")
+    for state in (
+        "ai-ready", "ai-in-progress", "ai-pr-opened",
+        "ai-fix-needed", "ai-merged", "ai-blocked",
+    ):
+        assert state in text, f"Chinese workflow page misses the {state} state"
+    assert "REVIEW_VERDICT" in text, "workflow must document the review verdict"
+    assert "Fixes #" in text, "workflow must document the PR body Fixes #N contract"
+    assert "muyan-pilot:run=" in text, "workflow must document the run marker"
+    assert "ai-epic" in text, "workflow must explain Epic issues (ai-epic)"
+    assert "Release" in text, "workflow must explain Release tasks"
+    assert "P0" in text, "workflow must explain the P0 priority"
+    assert "`p0`" in text, "P0 explanation must name the p0 label"
+    assert "`ai-ready`+`p0`" in text, "P0 explanation must show the order"
+    assert "bug" in text.lower(), "P0 explanation must name the bug label"
+    assert "SSH" in text, "workflow must document the SSH git transport"
+    # The Chinese docs only reference labels that exist in the runner's
+    # label set.
+    mentioned = set(LABEL_PATTERN.findall(text))
+    unknown = mentioned - KNOWN_LABELS
+    assert not unknown, f"Chinese workflow references unknown labels: {sorted(unknown)}"
+
+
+def test_chinese_operations_documents_the_real_commands_and_recovery():
+    """The Chinese operations page must carry the real operations facts:
+    the 15-minute timer, the journal, the CLI commands, the worktree and
+    base freshness, the failure recovery (ai-blocked), the ExecStartPre
+    code-update preflight, and the transport check without an HTTPS
+    fallback — same facts as the English page."""
+    text = zh_page_text("operations")
+    assert "muyan-pilot.timer" in text
+    assert "15" in text, "operations must document the 15-minute idle polling interval"
+    assert "journalctl" in text, "operations must show the journal command"
+    assert "muyan_pilot.py" in text, "operations must name the CLI"
+    for command in ("status", "session", "add"):
+        assert command in text, f"operations must document the {command} command"
+    assert "worktree" in text.lower(), "operations must explain the task worktree"
+    assert "ai-blocked" in text, "operations must document failure recovery (ai-blocked)"
+    assert "ExecStartPre" in text, "operations must document the code-update preflight"
+    assert "transport_check_failed" in text, (
+        "operations must document the pre-start transport check"
+    )
+    assert "HTTPS" in text, (
+        "operations must state that a broken transport never falls back to HTTPS"
+    )
+
+
+def test_chinese_security_documents_the_boundaries():
+    """The Chinese security page must carry the same boundaries: the AI
+    never merges or pushes the protected branch, the GitHub token is a
+    local secret, the SSH key is the git-data credential, and the local
+    KV/session files never leave the machine."""
+    text = zh_page_text("security")
+    assert "merge" in text.lower()
+    assert "保护分支" in text, "security must name the protected branch boundary"
+    assert "token" in text.lower(), "security must cover the GitHub token"
+    assert "SSH key" in text, "security must document the SSH key as the git-data credential"
+    assert "KV" in text, "security must cover the local KV/session files"
+
+
+def test_chinese_testing_documents_the_contract_commands():
+    """The Chinese testing page must show the exact contract commands
+    (full pytest with branch coverage + 100% report) and the remote CI
+    gate — same facts as the English page."""
+    text = zh_page_text("testing")
+    assert "coverage run --branch -m pytest tests/" in text, (
+        "testing must show the contract coverage-run command"
+    )
+    assert "coverage report" in text, "testing must show the coverage report command"
+    assert "100%" in text, "testing must state the 100% line/branch coverage requirement"
+    assert "GitHub Actions" in text, "testing must name the remote CI gate"
+
+
+def test_chinese_contributing_documents_issue_bug_and_pr_paths():
+    """The Chinese contributing page must show how to create an Issue
+    (with ai-ready), report a bug, and submit a PR (feature branch,
+    Fixes #N, one PR) — same facts as the English page."""
+    text = zh_page_text("contributing")
+    assert "ai-ready" in text, "contributing must show how to dispatch an Issue"
+    assert "bug" in text.lower(), "contributing must show how to report a bug"
+    assert "PR" in text, "contributing must show how to submit a PR"
+    assert "Fixes #" in text, "contributing must document the PR body contract"
+
+
+def test_chinese_kv_cache_page_matches_the_upstream_port_contract():
+    """Same port contract as the English page: the agent-facing port
+    18082 (the committed unit's value) stays documented, but the
+    Configuration table must not claim 18082 as the env var's code
+    default (8081)."""
+    text = zh_page_text("optional-kv-cache")
+    assert "18082" in text, (
+        "the Chinese docs must keep the unit's agent-facing port 18082"
+    )
+    row = next(
+        (line for line in text.splitlines()
+         if line.startswith("| `PI_LLAMA_CACHE_PORT`")),
+        None,
+    )
+    assert row is not None, "missing the PI_LLAMA_CACHE_PORT row"
+    default_cell = row.strip("|").split("|")[1].strip()
+    assert "18082" not in default_cell.split("(")[0], (
+        f"the Chinese docs claim 18082 as the proxy code default: {row!r}"
+    )
+
+
+def test_chinese_setup_documents_the_migration_and_ssh_failure():
+    """Same setup facts as the English page: the HTTPS-to-SSH migration
+    command and the SSH connectivity failure."""
+    text = zh_page_text("setup")
+    assert "git remote set-url origin" in text, (
+        "setup must document the HTTPS-to-SSH migration command"
+    )
+    assert "ssh_unreachable" in text, (
+        "setup must document the SSH connectivity failure"
+    )
+
+
+def zh_docs_files() -> list[Path]:
+    """All committed MDX pages under docs/zh/ (sorted, stable). The
+    Chinese pages are flat (same structure as the English pages at the
+    docs root), so a flat glob is the whole set."""
+    files = sorted(ZH_DIR.glob("*.mdx"))
+    assert files, "docs/zh/ contains no MDX pages"
+    return files
+
+
+def test_chinese_docs_only_reference_existing_labels_everywhere():
+    for path in zh_docs_files():
+        content = path.read_text(encoding="utf-8")
+        mentioned = set(LABEL_PATTERN.findall(content))
+        unknown = mentioned - KNOWN_LABELS
+        assert not unknown, (
+            f"{path.name} references unknown labels: {sorted(unknown)}"
+        )
+
+
+def test_readme_points_at_the_chinese_docs_entry():
+    """The README keeps the project home and the documentation site
+    entry; since Issue #116 it must also point at the Chinese docs
+    (docs/zh/) so Chinese users find the entry from GitHub too."""
+    text = README.read_text(encoding="utf-8")
+    assert "docs/zh/" in text, (
+        "README must point at the Chinese docs entry (docs/zh/)"
+    )
+    assert "muyan-pilot.mintlify.site" in text, (
+        "README must keep the Mintlify documentation site entry"
+    )

--- a/tests/test_docs_mermaid.py
+++ b/tests/test_docs_mermaid.py
@@ -1,0 +1,144 @@
+"""Mermaid diagram contract (Issue #116).
+
+The docs must ship two diagrams, in BOTH languages (English at the
+`docs/` root, Chinese under `docs/zh/`):
+
+1. the system architecture overview (index page): GitHub Issues/PRs,
+   the systemd timer/service, the Runner, the Pi sessions, the task
+   worktree, the core llama-server path and the OPTIONAL
+   `local-llm-kv-cache` proxy clearly distinguished from it;
+2. the task lifecycle / state machine (workflow page): all six delivery
+   states plus the Epic / Release task / P0 boundary.
+
+Mintlify renders Mermaid from fenced `mermaid` code blocks (verified
+against the official component docs); the fenced source stays readable
+in GitHub Markdown. These tests fail when a diagram is missing in either
+language, when a required node/state disappears, when the optional proxy
+is not marked optional, or when the Mermaid syntax is broken (unbalanced
+subgraphs/brackets, a diagram that does not start with a supported
+type keyword).
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+# The diagram types Mermaid (and therefore Mintlify) supports for these
+# diagrams; a block that starts with anything else is a broken diagram.
+DIAGRAM_START_PATTERN = re.compile(
+    r"^\s*(flowchart|graph|sequenceDiagram|stateDiagram-v2|classDiagram|erDiagram|gantt|pie|journey|gitGraph|mindmap|timeline|quadrantChart|sankey-beta|xychart-beta|block)\b"
+)
+
+
+def mermaid_blocks(text: str) -> list[str]:
+    """Every fenced ```mermaid block of a page (the Mintlify contract)."""
+    return re.findall(r"```mermaid\n(.*?)```", text, flags=re.DOTALL)
+
+
+def page_text(rel_path: str) -> str:
+    path = DOCS_DIR / rel_path
+    assert path.is_file(), f"missing docs page: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def check_syntax(blocks: list[str], where: str) -> None:
+    """Fail fast on a broken diagram: every block must start with a
+    supported diagram type, keep balanced subgraph/end and
+    brackets/parens, and keep ASCII parens out of `|...|` edge labels
+    (verified against the real mermaid v11 parser: an unquoted `(` in an
+    edge label breaks the flowchart grammar, while quoted node labels
+    may contain parens)."""
+    assert blocks, f"{where}: no ```mermaid block found"
+    for block in blocks:
+        assert DIAGRAM_START_PATTERN.search(block), (
+            f"{where}: mermaid block does not start with a supported "
+            f"diagram type: {block.splitlines()[0] if block.strip() else '<empty>'!r}"
+        )
+        subgraphs = len(re.findall(r"^\s*subgraph\b", block, flags=re.MULTILINE))
+        ends = len(re.findall(r"^\s*end\b", block, flags=re.MULTILINE))
+        assert subgraphs == ends, (
+            f"{where}: unbalanced subgraph/end ({subgraphs} subgraphs, {ends} ends)"
+        )
+        for open_ch, close_ch in (("[", "]"), ("(", ")")):
+            assert block.count(open_ch) == block.count(close_ch), (
+                f"{where}: unbalanced {open_ch}{close_ch} in the diagram"
+            )
+        for line in block.splitlines():
+            for label in re.findall(r"\|([^|]*)\|", line):
+                assert label.count("(") == label.count(")"), (
+                    f"{where}: unbalanced parens inside an edge label "
+                    f"break the mermaid flowchart grammar: {line.strip()!r}"
+                )
+
+
+def test_state_machine_diagram_exists_in_both_languages():
+    for rel in ("workflow.mdx", "zh/workflow.mdx"):
+        blocks = mermaid_blocks(page_text(rel))
+        check_syntax(blocks, f"{rel}")
+        diagram = "\n".join(blocks)
+        for state in (
+            "ai-ready", "ai-in-progress", "ai-pr-opened",
+            "ai-fix-needed", "ai-merged", "ai-blocked",
+        ):
+            assert state in diagram, (
+                f"{rel}: state machine diagram misses the {state} state"
+            )
+        # The diagram must mark the Epic / Release task / P0 boundary
+        # (Issue #116: 标出 Epic/Release task/P0 的边界).
+        assert "Epic" in diagram, f"{rel}: diagram misses the Epic boundary"
+        assert "Release" in diagram, f"{rel}: diagram misses the Release task boundary"
+        assert "P0" in diagram, f"{rel}: diagram misses the P0 boundary"
+
+
+def test_architecture_diagram_exists_in_both_languages():
+    for rel in ("index.mdx", "zh/index.mdx"):
+        blocks = mermaid_blocks(page_text(rel))
+        check_syntax(blocks, f"{rel}")
+        diagram = "\n".join(blocks)
+        # The required actors (Issue #116 requirement list).
+        assert "GitHub" in diagram, f"{rel}: diagram misses GitHub (Issues/PRs)"
+        assert "timer" in diagram.lower(), f"{rel}: diagram misses the systemd timer"
+        assert "Runner" in diagram, f"{rel}: diagram misses the Runner"
+        assert "Pi" in diagram, f"{rel}: diagram misses the Pi sessions"
+        assert "worktree" in diagram.lower(), f"{rel}: diagram misses the task worktree"
+        assert "llama" in diagram.lower(), (
+            f"{rel}: diagram misses the core llama-server path"
+        )
+        assert "local-llm-kv-cache" in diagram, (
+            f"{rel}: diagram misses the optional KV proxy"
+        )
+        assert "PR" in diagram, f"{rel}: diagram misses the PR/review/merge chain"
+
+
+def test_architecture_diagram_marks_the_proxy_as_optional():
+    """Acceptance: the diagrams must clearly distinguish the core
+    llama-server path from the OPTIONAL `local-llm-kv-cache` proxy — the
+    proxy node/label must carry an optional marker in both languages."""
+    for rel in ("index.mdx", "zh/index.mdx"):
+        diagram = "\n".join(mermaid_blocks(page_text(rel)))
+        proxy_lines = [
+            line for line in diagram.splitlines()
+            if "local-llm-kv-cache" in line
+        ]
+        assert proxy_lines, f"{rel}: no proxy line in the architecture diagram"
+        marked = any(
+            "optional" in line.lower() or "可选" in line
+            for line in proxy_lines
+        )
+        assert marked, (
+            f"{rel}: the KV proxy node must be marked optional/可选 in the diagram: "
+            f"{proxy_lines!r}"
+        )
+        # The core path must not be marked optional.
+        core_lines = [
+            line for line in diagram.splitlines()
+            if "llama" in line.lower() and "local-llm-kv-cache" not in line
+        ]
+        assert core_lines, f"{rel}: no core llama-server line in the diagram"
+        assert not any(
+            "optional" in line.lower() or "可选" in line for line in core_lines
+        ), (
+            f"{rel}: the core llama-server path must not be marked optional: "
+            f"{core_lines!r}"
+        )

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -1,16 +1,21 @@
-"""Documentation site contract for the v0.1.0 open-source release (Issue #104).
+"""Documentation site contract for the v0.1.0 open-source release (Issue #104
++ Issue #116).
 
-The minimal open-source docs live in `docs/` (Mintlify config `docs.json`
-plus `*.mdx` pages) and are the single source of truth: Mintlify only
-builds, searches and hosts them (repository default branch, documentation
-path `/docs`). These tests fail when the docs are missing, when the
-Mintlify navigation drifts from the actual pages, when a required topic
-disappears (problem/scenarios/MVP boundary, install prerequisites, config
-fields, Issue→PR workflow, operations commands, labels/run marker/Epic/
-Release task/P0, security boundary, test+coverage commands, contributing,
-smoke walkthrough), when a doc references a label or config field the
-implementation does not have, or when a doc carries a personal absolute
-path, an unimplemented feature, or the stale 5-minute timer.
+The open-source docs live in `docs/` (Mintlify config `docs.json` plus
+`*.mdx` pages) and are the single source of truth: Mintlify only builds,
+searches and hosts them (repository default branch, documentation path
+`/docs`). The English pages sit at the `docs/` root and the Chinese
+translation lives in `docs/zh/` (the verified Mintlify i18n layout: the
+`navigation.languages` array, default language unprefixed, translated page
+paths prefixed with the language directory). These tests fail when the
+docs are missing, when the Mintlify navigation drifts from the actual
+pages, when a required topic disappears (problem/scenarios/MVP boundary,
+install prerequisites, config fields, Issue→PR workflow, operations
+commands, labels/run marker/Epic/Release task/P0, security boundary,
+test+coverage commands, contributing, smoke walkthrough), when a doc
+references a label or config field the implementation does not have, or
+when a doc (in any language) carries a personal absolute path, an
+unimplemented feature, or the stale 5-minute timer.
 """
 import json
 import re
@@ -75,10 +80,15 @@ PERSONAL_PATH_PATTERN = re.compile(r"/home/[a-z0-9_]+|/Users/[a-z0-9_]+")
 
 
 def docs_files() -> list[Path]:
-    """All committed Markdown/MDX pages under docs/ (sorted, stable)."""
+    """All committed Markdown/MDX pages under docs/ (sorted, stable).
+
+    Includes the language subdirectories (Issue #116: `docs/zh/`), so
+    every global content check (labels, personal paths, stale timer,
+    unimplemented features) covers every language.
+    """
     assert DOCS_DIR.is_dir(), f"missing docs directory: {DOCS_DIR}"
     files = sorted(
-        path for path in DOCS_DIR.iterdir()
+        path for path in DOCS_DIR.rglob("*")
         if path.is_file() and path.suffix in (".md", ".mdx")
     )
     assert files, "docs/ contains no Markdown/MDX pages"
@@ -98,27 +108,50 @@ def load_docs_config() -> dict:
     return config
 
 
-def navigation_pages(config: dict) -> list[str]:
-    """Every page slug referenced by the Mintlify navigation."""
+def navigation_languages(config: dict) -> list[dict]:
+    """The Mintlify i18n navigation (Issue #116, verified against the
+    official i18n guide + docs.json schema reference): the `languages`
+    array, one entry per language, each with its own groups."""
     navigation = config.get("navigation")
     assert isinstance(navigation, dict) and navigation, (
         "docs.json has no navigation section"
     )
-    pages: list[str] = []
-    groups = navigation.get("groups")
-    assert isinstance(groups, list) and groups, (
-        "docs.json navigation has no groups"
+    languages = navigation.get("languages")
+    assert isinstance(languages, list) and languages, (
+        "docs.json navigation must use the languages array (Mintlify i18n)"
     )
-    for group in groups:
-        assert isinstance(group, dict) and group.get("group"), (
-            f"navigation group without a name: {group!r}"
+    return languages
+
+
+def language_page_entries(config: dict) -> list[tuple[str, list[str]]]:
+    """(language code, page paths) for every navigation language entry.
+
+    The default language lists its pages without a prefix (files at the
+    docs root); every other language prefixes its page paths with the
+    language directory (e.g. `zh/index` -> `docs/zh/index.mdx`).
+    """
+    entries: list[tuple[str, list[str]]] = []
+    for lang in navigation_languages(config):
+        assert isinstance(lang, dict) and lang.get("language"), (
+            f"navigation language entry without a code: {lang!r}"
         )
-        group_pages = group.get("pages")
-        assert isinstance(group_pages, list) and group_pages, (
-            f"navigation group {group.get('group')!r} has no pages"
+        code = str(lang["language"])
+        pages: list[str] = []
+        groups = lang.get("groups")
+        assert isinstance(groups, list) and groups, (
+            f"navigation language {code!r} has no groups"
         )
-        pages.extend(group_pages)
-    return pages
+        for group in groups:
+            assert isinstance(group, dict) and group.get("group"), (
+                f"navigation group without a name: {group!r}"
+            )
+            group_pages = group.get("pages")
+            assert isinstance(group_pages, list) and group_pages, (
+                f"navigation group {group.get('group')!r} has no pages"
+            )
+            pages.extend(group_pages)
+        entries.append((code, pages))
+    return entries
 
 
 def test_docs_config_is_a_mintlify_config_named_muyan_pilot():
@@ -140,15 +173,51 @@ def test_docs_config_is_a_mintlify_config_named_muyan_pilot():
     )
 
 
-def test_docs_navigation_matches_the_actual_pages_exactly():
-    """KISS: one group per topic, every page listed once, no orphan page
-    outside the navigation and no navigation entry without a file."""
+def test_docs_navigation_uses_the_verified_i18n_languages_layout():
+    """Issue #116: the navigation is the Mintlify i18n `languages` array
+    (verified against the official i18n guide + docs.json schema
+    reference): English is the default language (listed first, its pages
+    unprefixed at the docs root), Chinese is `zh` (a supported code) with
+    its pages prefixed `zh/` (files under `docs/zh/`), and no page path
+    appears in more than one language (the official warning: duplicating
+    paths across languages is undefined behavior)."""
     config = load_docs_config()
-    listed = navigation_pages(config)
-    actual = {path.stem for path in docs_files()}
+    entries = language_page_entries(config)
+    codes = [code for code, _pages in entries]
+    assert codes[0] == "en", (
+        f"the default language must be English (first entry), got: {codes!r}"
+    )
+    assert "zh" in codes, (
+        f"the Chinese language must be `zh` (Mintlify supported code), got: {codes!r}"
+    )
+    assert len(codes) == len(set(codes)), f"duplicate language codes: {codes!r}"
+    en_pages = dict(entries)["en"]
+    zh_pages = dict(entries)["zh"]
+    assert all(not page.startswith("en/") for page in en_pages), (
+        f"default-language pages must be unprefixed (docs root), got: {en_pages!r}"
+    )
+    assert zh_pages, "the Chinese navigation lists no pages"
+    assert all(page.startswith("zh/") for page in zh_pages), (
+        f"translated pages must be prefixed with the language directory, got: {zh_pages!r}"
+    )
+    overlap = set(en_pages) & set(zh_pages)
+    assert not overlap, f"page paths duplicated across languages: {sorted(overlap)}"
+
+
+def test_docs_navigation_matches_the_actual_pages_exactly():
+    """KISS: one group per topic per language, every page listed once, no
+    orphan page outside the navigation and no navigation entry without a
+    file (Issue #116: the i18n `languages` layout)."""
+    config = load_docs_config()
+    entries = language_page_entries(config)
+    listed: list[str] = []
+    for _code, pages in entries:
+        listed.extend(pages)
     assert len(listed) == len(set(listed)), (
         f"navigation lists a page twice: {sorted(set(p for p in listed if listed.count(p) > 1))}"
     )
+    actual = {str(path.relative_to(DOCS_DIR)).removesuffix(".mdx").removesuffix(".md")
+              for path in docs_files()}
     missing = set(listed) - actual
     assert not missing, f"navigation references missing pages: {sorted(missing)}"
     orphans = actual - set(listed)


### PR DESCRIPTION
Fixes #116

<!-- muyan-pilot:run=4df4ef9a -->
run_id=4df4ef9a

## 交付内容

完善 v0.1.0 开源文档：中文版本 + 系统架构 Mermaid 总览图 + 任务生命周期状态机图。

- **中文文档**：`docs/zh/` 下 9 个核心页面（index / getting-started / setup / workflow / operations / security / testing / contributing / optional-kv-cache），与英文页面同一结构、同一事实源——同一套命令、标签、配置字段、端口、15 分钟 timer、P0 领取顺序、git transport 边界、KV cache 端口契约，不复制出互相漂移的实现说明。中文用户从文档首页可以完成安装前提确认、配置、启动和最小 smoke。
- **Mintlify i18n**：`docs/docs.json` 导航改为官方 i18n `languages` 数组（已对官方 i18n 指南 + docs.json schema reference 验证）：`en` 为默认语言（页面在 docs 根目录、路径无前缀），`zh` 页面路径带 `zh/` 前缀（文件在 `docs/zh/`）；无页面路径跨语言重复。文档配置仍在 `docs/docs.json`（Mintlify documentation path `/docs`），仓库根目录没有第二份配置。
- **系统架构总览图**（`docs/index.mdx` + `docs/zh/index.mdx`）：GitHub Issues/PRs、systemd timer/service（含 ExecStartPre fast-forward）、Runner、Pi（implement + 独立 review）、任务 worktree、核心 llama-server 链路（实线，任意 OpenAI-compatible endpoint）与可选 `local-llm-kv-cache` proxy（虚线 + OPTIONAL/可选标记）明确区分、PR/review/merge。
- **任务生命周期状态机图**（`docs/workflow.mdx` + `docs/zh/workflow.mdx`）：`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked` 六个交付状态、同一 PR 的 review/fix 循环、REVIEW_VERDICT 分叉，并标出 Epic（ai-epic，只协调从不领取）/ Release task（普通 ai-ready Issue）/ P0（领取顺序，不是交付状态）的边界。
- **Mermaid 契约**：Mintlify 支持的 fenced mermaid code block（已对官方组件文档验证），GitHub Markdown 中保留可读源码；4 张图全部通过真实 mermaid v11 parser 验证（flowchart-v2）。
- **README**：保留项目首页与文档站入口，新增中文文档入口（`docs/zh/`）指针和两张总览图指针。

### 变更

- `docs/docs.json`：`navigation.languages`（en 默认 + zh）；
- `docs/zh/*.mdx`（9 个新页面）：中文入口与核心页面；
- `docs/index.mdx` / `docs/zh/index.mdx`：系统架构总览 Mermaid 图；
- `docs/workflow.mdx` / `docs/zh/workflow.mdx`：任务生命周期状态机 Mermaid 图；
- `docs/testing.mdx` / `docs/zh/testing.mdx`：CI 文档构建 smoke 说明；
- `README.md`：文档站节（中文入口 + 两张图指针）；
- `tests/test_docs_site.py`：`docs_files()` 覆盖 `docs/zh/`（全局检查——标签、个人绝对路径、5 分钟 timer、未实现功能——自动覆盖中文页面）；导航检查改为已验证的 i18n `languages` 布局（en 无前缀、zh 带前缀、无跨语言重复路径、zh 代码 + en 默认）；
- `tests/test_docs_i18n.py`（新）：中文入口与 9 个主题页存在、EN/ZH 页面集同一事实源（双向 parity）、中文页面携带实现事实（六个交付状态、REVIEW_VERDICT、`Fixes #`、run marker、Epic/Release/P0、配置字段表、15 分钟 timer、transport 检查、KV 端口契约、smoke walkthrough 真实命令）、README 指向中文入口；
- `tests/test_docs_mermaid.py`（新）：两张图在两种语言都存在、状态图含六个状态 + Epic/Release/P0 边界、架构图含全部必需 actor 且 proxy 标记 optional/可选（核心 llama 链路不标记）、Mermaid 语法结构检查（图类型关键字、subgraph/end 与括号平衡、`|...|` edge label 内 ASCII 括号平衡——该检查类由真实 mermaid v11 parser 验证时抓到的真实 bug 固定）；
- `tests/test_ci_workflow.py`：CI 必须安装官方 `mint` CLI 并运行 `mint validate`（同一 job）；
- `.github/workflows/ci.yml`：同一 job 追加 Mintlify 构建 smoke（`npm install -g mint` + `cd docs && mint validate`，严格模式，任何 warning/error 退出非零）——仍是一个 job，无 lint/矩阵/缓存。

### 测试（832 passed，line/branch coverage 100%）

- 新增 19 个测试（i18n 布局、中文页面契约、EN/ZH parity、Mermaid 图契约、CI smoke 步骤）；TDD：先红（19 failed）后绿；
- 既有 813 个测试全部保持通过（docs 全局检查现在同时覆盖 `docs/zh/`）。

### 验证

```text
/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q   # 832 passed
/usr/bin/python3 -m coverage report --fail-under=100            # TOTAL 100%
cd docs && mint validate                                       # success build validation passed（0 warning）
cd docs && mint broken-links                                   # success no broken links found
node mermaid.parse() x 4 张图（mermaid@11.17.2）               # 全部 OK (flowchart-v2)
```

本地 `mint dev` 预览 smoke（真实构建 + i18n 路由）：`/` 返回英文首页、`/zh/` 返回中文首页、`/zh/workflow` 与 `/workflow` 均含状态机内容、`/zh/getting-started` 200 且含 smoke walkthrough、服务页嵌入 mermaid `flowchart` 源码。CLI 契约抽查：`muyan_pilot.py --help` / `session --help` / `setup --help` 与文档命令一致。

### 边界

不修改保护分支、不 force-push、不 merge；不新增数据库/队列/daemon/fallback，文档不引入未实现功能；CI 保持单 job（无 lint/矩阵/缓存）；`plan.md` / `test.log` 为 run 产物（gitignored），不进版本库。
