### PR TITLE
docs: v0.1.0 release reconciliation record + corrected tag v0.1.1 (Issue #97)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,6 +39,12 @@
             "pages": [
               "optional-kv-cache"
             ]
+          },
+          {
+            "group": "Releases",
+            "pages": [
+              "release-v0.1.0"
+            ]
           }
         ]
       },
@@ -72,6 +78,12 @@
             "group": "可选组件",
             "pages": [
               "zh/optional-kv-cache"
+            ]
+          },
+          {
+            "group": "发布",
+            "pages": [
+              "zh/release-v0.1.0"
             ]
           }
         ]

--- a/docs/release-v0.1.0.mdx
+++ b/docs/release-v0.1.0.mdx
@@ -1,0 +1,91 @@
+# v0.1.0 release reconciliation record (Issue #97)
+
+One-time release-state reconciliation for the v0.1.0 release (Epic #80,
+release PR #92). run_id=5ce476bd. This record is the durable, auditable
+artifact; every GitHub state change it describes is listed with the
+command evidence in the Issue #97 reconciliation comment.
+
+## Tag state (verified against origin, never moved)
+
+| Ref | Object | Points at | Status |
+|---|---|---|---|
+| `v0.1.0` | annotated tag `912631d390b0b1f7039afac52125ecf7e1d92589` | commit `335fa274e4b451a025bc2426b2a9fe7297ce8bb2` ("test: record post-merge verification in test.log (Issue #80)") | **immutable, untouched** |
+| `v0.1.1` (corrected) | annotated tag (created by this run) | commit `f82969e974b17803759493bad7e339bdcd6f463f` ("Fix review round 1 findings: session follow, run artifacts, state chain (Issue #80)") | new, pushed by this run |
+| PR #92 merge commit | `f6c065e8ec7ec53d7e9fb99e6475c1bc16c2dabf` | — | MERGED 2026-08-26T13:21:26Z |
+
+Verified relationship (real `git merge-base --is-ancestor` on this
+repository): `335fa274` (the `v0.1.0` target) IS an ancestor of
+`f82969e9` (the corrected `v0.1.1` head), and `f82969e9` is the PR #92
+branch head at merge time (an ancestor of the merge commit
+`f6c065e8`). The existing `v0.1.0` tag was NOT moved and NOT
+force-pushed (`git ls-remote --tags origin` before and after this run
+shows `v0.1.0` still at `912631d390b0b1f7039afac52125ecf7e1d92589`).
+
+## Why a corrected tag was needed
+
+`v0.1.0` points at `335fa274`, an intermediate commit of the PR #92
+branch. The final head that was reviewed and merged is `f82969e9` —
+the review-round-1 fix commit — which is NOT reachable from the
+`v0.1.0` target. `git diff 335fa274 f82969e9` shows the fixes the
+original tag misses:
+
+- `muyan_pilot.py`: session-follow line handling (the `follow_session_file`
+  contract: only follow the file it was given, no re-discovery mid-follow,
+  no fragmented/dropped lines for the `--pretty` parser);
+- `.gitignore`: run-artifact ignore entries;
+- `README.md`: wording aligned with the session contract;
+- `tests/test_muyan_pilot.py`, `tests/test_run_artifacts.py`: the pinning
+  tests for the above;
+- removal of the run artifacts `plan.md`/`test.log` from the tree.
+
+`v0.1.1` therefore contains everything `v0.1.0` contains plus the
+review-round-1 fixes that actually shipped with PR #92.
+
+## Sub-Issue verdicts (Epic #80 checklist)
+
+Every core item has a conclusive verdict: MERGED (with PR evidence),
+verified incomplete, or excluded.
+
+| Issue | Item | Verdict | Evidence |
+|---|---|---|---|
+| #75 | Pi exits on llama/proxy upstream death and releases the slot | MERGED | PR #110 (merge commit `6e793e54b5cf830f84ce3311e468a62f1210ebf5`); code: `PI_MODEL_WAIT_DEAD_SECONDS` upstream-dead kill path in `bootstrap_runner.py` |
+| #77 | Resume independent review when the process dies at `ai-pr-opened` | MERGED | PR #85 (merge commit `d76045a734de717a1b8edfdd1e26a3f021919fd1`, delivered for #70 covering the same defect); Issue closed with evidence comment |
+| #78 | Implementer does not run the independent review-fix loop before the PR | MERGED | PR #109 (merge commit `678c72f91ffc18f8bf79c09a6ccbec28c1f57d0f`); guard test `tests/test_agents_md.py` |
+| #79 | `ProgressPublisher` is a pure bypass, never blocks the main delivery | MERGED | PR #107 (merge commit `e2cc6dca5b66e5a6b16df38fc9819a2c13a78fa7`); code: `progress_publish_failed` log-only path |
+| #82 | Reviewer fixes findings in the same session before the verdict | MERGED | PR #87 (merge commit `724892763f90eaa166ee20f26157335b51111222`); `prompt_review.md` in-session fix contract |
+| #52 | Start the Runner from the latest `origin/main` | MERGED | PR #92 (ExecStartPre `git fetch origin main && git merge --ff-only origin/main` in `systemd/muyan-pilot.service`); Epic #80's "(PR #112)" reference is inaccurate — PR #112 is #103's deployment consistency; the #52 code landed in PR #92 |
+| #53 | PR body uses `Fixes #N` so GitHub closes the Issue natively | MERGED | PR #69 (merge commit `133786e391a3eec9c23f73c5172f6dedd6faea4c`) |
+| #71 | Pick `ai-ready` bugs before new features | MERGED | PR #92 (`BUG_READY_SEARCH` in `bootstrap_runner.py`; later extended by #101's P0 scan) |
+| #73 | Prompt/skill/harness: verify against docs and reality, do not guess | MERGED | PR #92 (prompt.md "Hard rules for external behavior (Issue #73)", prompt_review.md verification rules, bypass-log-only rule; pinned by `tests/test_bootstrap_runner.py` prompt-contract tests). Issue was still OPEN with no terminal label — closed by this run with an evidence comment and the `ai-merged` label |
+| #74 | `muyan_pilot.py session [--follow] [--pretty]` | MERGED | PR #92 (`session` subcommand in `muyan_pilot.py`); real call `muyan_pilot.py session --help` exits 0 and shows `--follow`/`--pretty` (asserted in `tests/test_release_v01.py`) |
+| #49 | Document GitHub labels, run markers, and recovery state | MERGED | PR #111 (docs site) + contract test `tests/test_docs_labels.py`; closed by the #76 cleanup run |
+| #76 | Close leftover Issues that already have `ai-merged` and a merged PR | MERGED | Cleanup run closed #49/#52/#71/#74 (2026-08-27T01:56Z) and itself, with an evidence comment |
+| #81 | Root-directory LICENSE | MERGED | PR #88 (merge commit `b9a7e1fe9021629bb14f2b36ea1302d818a5981c`) |
+| #83 | Different `--skill` lists for implement vs review Pi | MERGED | PR #86 (merge commit `468fdd4e1251f1b497136ac232d97551d04bdf30`) |
+
+## Verified incomplete (stays OPEN — not closed to tick the checklist)
+
+| Issue | Item | Verdict | Evidence |
+|---|---|---|---|
+| #93 | Runner: identify and correctly handle Epic Issues | verified incomplete, stays OPEN | No implementation evidence in current main (`87ec2c4`): no `ai-epic` skip in the claim scan, no `epic_not_claimed` structured log, no Epic completion gate, no unit tests, and `ai-epic` is absent from `labels.toml`. #80 is excluded from pickup only because it lacks `ai-ready`, not because of an Epic mechanism. An evidence comment was added to #93; no labels changed |
+
+## Out of v0.1 (unchanged, per Epic #80)
+
+#94, #95, #98, #101, #105, #106, #114, #117 — remain in the normal
+backlog; none is a v0.1 blocker. (#95, #101, #114, #117 have since been
+delivered by their own PRs; that does not change the v0.1 scope.)
+
+## GitHub state changes made by this run (all auditable)
+
+1. `gh issue edit 73 --add-label ai-merged` + evidence comment +
+   `gh issue close 73` (run marker in the comment).
+2. Evidence comment on #93 (verified incomplete; stays OPEN).
+3. Annotated tag `v0.1.1` created at `f82969e9` with the release notes
+   above; `git push origin v0.1.1`; verified with
+   `git ls-remote --tags origin` (`v0.1.0` untouched).
+4. GitHub Release `v0.1.1` created at `f82969e9` (release evidence).
+5. Evidence comment on #80 (this reconciliation table + closure items).
+6. Reconciliation result comment on #97 with the full command evidence.
+
+No protected branch was modified, no second business PR was created, and
+the existing `v0.1.0` tag was neither moved nor force-pushed.

--- a/docs/zh/release-v0.1.0.mdx
+++ b/docs/zh/release-v0.1.0.mdx
@@ -1,0 +1,87 @@
+# v0.1.0 发布对账记录（Issue #97）
+
+v0.1.0 发布（Epic #80，发布 PR #92）的一次性发布状态对账。
+run_id=5ce476bd。本记录是持久、可审计的工件；它所描述的每一处 GitHub
+状态变更都列在 Issue #97 的对账结果评论中，并附命令证据。
+
+## Tag 状态（对 origin 验证，从未移动）
+
+| Ref | 对象 | 指向 | 状态 |
+|---|---|---|---|
+| `v0.1.0` | 注解 tag `912631d390b0b1f7039afac52125ecf7e1d92589` | 提交 `335fa274e4b451a025bc2426b2a9fe7297ce8bb2`（"test: record post-merge verification in test.log (Issue #80)"） | **不可变，未动** |
+| `v0.1.1`（修正版） | 注解 tag（本次运行创建） | 提交 `f82969e974b17803759493bad7e339bdcd6f463f`（"Fix review round 1 findings: session follow, run artifacts, state chain (Issue #80)"） | 新建，本次运行推送 |
+| PR #92 合并提交 | `f6c065e8ec7ec53d7e9fb99e6475c1bc16c2dabf` | — | 2026-08-26T13:21:26Z 合并 |
+
+已验证的关系（在本仓库上用真实 `git merge-base --is-ancestor` 验证）：
+`335fa274`（`v0.1.0` 指向）是 `f82969e9`（修正版 `v0.1.1` head）的祖先，
+且 `f82969e9` 是 PR #92 合并时的分支 head（合并提交 `f6c065e8` 的祖先）。
+现有 `v0.1.0` tag 未被移动、未被 force-push（本次运行前后
+`git ls-remote --tags origin` 均显示 `v0.1.0` 仍在
+`912631d390b0b1f7039afac52125ecf7e1d92589`）。
+
+## 为什么需要修正版 tag
+
+`v0.1.0` 指向 `335fa274`，这是 PR #92 分支上的一个中间提交。经过审查
+并合并的最终 head 是 `f82969e9` —— review 第 1 轮的修复提交 —— 它
+**不在** `v0.1.0` 指向的可达范围内。`git diff 335fa274 f82969e9` 显示
+原 tag 缺少的修复：
+
+- `muyan_pilot.py`：session-follow 行处理（`follow_session_file` 契约：
+  只跟随给定文件、中途不重新发现、`--pretty` 解析器不丢行/不断行）；
+- `.gitignore`：run 产物忽略项；
+- `README.md`：与 session 契约对齐的措辞；
+- `tests/test_muyan_pilot.py`、`tests/test_run_artifacts.py`：上述行为的
+  钉住测试；
+- 从树中移除 run 产物 `plan.md`/`test.log`。
+
+因此 `v0.1.1` 包含 `v0.1.0` 的全部内容，加上随 PR #92 实际发布的
+review 第 1 轮修复。
+
+## 子 Issue 结论（Epic #80 清单）
+
+每个核心项都有明确结论：MERGED（附 PR 证据）、已验证未完成（verified
+incomplete）、或明确排除（excluded）。
+
+| Issue | 项目 | 结论 | 证据 |
+|---|---|---|---|
+| #75 | llama/proxy 上游死时 Pi 退出并释放 slot | MERGED | PR #110（合并提交 `6e793e54b5cf830f84ce3311e468a62f1210ebf5`）；代码：`bootstrap_runner.py` 中 `PI_MODEL_WAIT_DEAD_SECONDS` 上游死亡 kill 路径 |
+| #77 | 进程死在 `ai-pr-opened` 时下一拍继续审查、合并 | MERGED | PR #85（合并提交 `d76045a734de717a1b8edfdd1e26a3f021919fd1`，为 #70 交付、覆盖同一缺陷）；Issue 已带证据评论关闭 |
+| #78 | Implementer 开 PR 前不做独立 review-fix 循环 | MERGED | PR #109（合并提交 `678c72f91ffc18f8bf79c09a6ccbec28c1f57d0f`）；守卫测试 `tests/test_agents_md.py` |
+| #79 | `ProgressPublisher` 全程旁路，不挡主交付 | MERGED | PR #107（合并提交 `e2cc6dca5b66e5a6b16df38fc9819a2c13a78fa7`）；代码：`progress_publish_failed` 只记日志路径 |
+| #82 | 审查在同一 session 内修复后再 verdict | MERGED | PR #87（合并提交 `724892763f90eaa166ee20f26157335b51111222`）；`prompt_review.md` 会话内修复契约 |
+| #52 | Runner 从最新 `origin/main` 代码启动 | MERGED | PR #92（`systemd/muyan-pilot.service` 的 ExecStartPre `git fetch origin main && git merge --ff-only origin/main`）；Epic #80 的 "(PR #112)" 引用不准确 —— PR #112 是 #103 的部署一致性；#52 代码落在 PR #92 |
+| #53 | PR body 使用 `Fixes #N`，GitHub 原生自动关闭 Issue | MERGED | PR #69（合并提交 `133786e391a3eec9c23f73c5172f6dedd6faea4c`） |
+| #71 | bug 优先于普通任务领取 | MERGED | PR #92（`bootstrap_runner.py` 的 `BUG_READY_SEARCH`；后由 #101 的 P0 扫描扩展） |
+| #73 | Prompt/skill/harness：外部行为先查文档，不凭记忆猜 | MERGED | PR #92（prompt.md "Hard rules for external behavior (Issue #73)"、prompt_review.md 验证规则、旁路只记日志规则；由 `tests/test_bootstrap_runner.py` prompt 契约测试钉住）。该 Issue 此前仍 OPEN 且无终态标签 —— 本次运行补 `ai-merged` 标签 + 证据评论后关闭 |
+| #74 | `muyan_pilot.py session [--follow] [--pretty]` | MERGED | PR #92（`muyan_pilot.py` 的 `session` 子命令）；真实调用 `muyan_pilot.py session --help` 退出码 0 且显示 `--follow`/`--pretty`（由 `tests/test_release_v01.py` 断言） |
+| #49 | 标签、run marker、恢复状态文档 | MERGED | PR #111（docs 站点）+ 契约测试 `tests/test_docs_labels.py`；由 #76 清理运行关闭 |
+| #76 | 关闭已带 `ai-merged` 且 PR 已合并的遗留 Issue | MERGED | 清理运行关闭 #49/#52/#71/#74（2026-08-27T01:56Z）及自身，附证据评论 |
+| #81 | 根目录 LICENSE | MERGED | PR #88（合并提交 `b9a7e1fe9021629bb14f2b36ea1302d818a5981c`） |
+| #83 | 实现/审查 Pi 使用不同 `--skill` 列表 | MERGED | PR #86（合并提交 `468fdd4e1251f1b497136ac232d97551d04bdf30`） |
+
+## 已验证未完成（保持 OPEN —— 不为清单勾选而关闭）
+
+| Issue | 项目 | 结论 | 证据 |
+|---|---|---|---|
+| #93 | Runner：识别并正确处理 Epic Issue | verified incomplete，保持 OPEN | 当前 main（`87ec2c4`）无实现证据：领取扫描无 `ai-epic` 跳过、无 `epic_not_claimed` 结构化日志、无 Epic 完成门禁、无单元测试，`labels.toml` 也没有 `ai-epic`。#80 不被领取只是因为它没有 `ai-ready`，而不是因为有 Epic 机制。已在 #93 添加证据评论；未改任何标签 |
+
+## v0.1 之外（不变，按 Epic #80）
+
+#94、#95、#98、#101、#105、#106、#114、#117 —— 保持在普通 backlog；
+均不是 v0.1 阻塞项。（#95、#101、#114、#117 后来已由各自 PR 交付；
+这不改变 v0.1 范围。）
+
+## 本次运行做出的 GitHub 状态变更（全部可审计）
+
+1. `gh issue edit 73 --add-label ai-merged` + 证据评论 +
+   `gh issue close 73`（评论带 run marker）。
+2. #93 证据评论（verified incomplete；保持 OPEN）。
+3. 在 `f82969e9` 创建注解 tag `v0.1.1`（release 说明即上文）；
+   `git push origin v0.1.1`；用 `git ls-remote --tags origin` 验证
+   （`v0.1.0` 未动）。
+4. 在 `f82969e9` 创建 GitHub Release `v0.1.1`（发布证据）。
+5. #80 证据评论（本对账表 + 收口项状态）。
+6. #97 对账结果评论，附完整命令证据。
+
+未修改保护分支、未创建第二个业务 PR、现有 `v0.1.0` tag 既未移动也
+未 force-push。

--- a/tests/test_release_v01.py
+++ b/tests/test_release_v01.py
@@ -1,0 +1,170 @@
+"""v0.1.0 release reconciliation record (Issue #97).
+
+The release state reconciliation is a one-time GitHub-state task: the
+durable, auditable artifact in the repository is the reconciliation
+record ``docs/release-v0.1.0.md``. These tests pin that record against
+the REAL git history and the REAL CLI:
+
+- the tag/commit relationship the record claims (``v0.1.0`` →
+  ``335fa274``, corrected ``v0.1.1`` → ``f82969e9``, PR #92 merge
+  commit ``f6c065e8``) is verified with actual ``git`` commands on this
+  repository — a record that guessed the relationship would fail;
+- every #80 checklist item has a conclusive verdict in the record
+  (MERGED with PR evidence, verified incomplete, or excluded);
+- the ``muyan_pilot.py session`` CLI contract the record cites is
+  asserted against one real call (``session --help``), not against a
+  guessed shape.
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RECORD = REPO_ROOT / "docs" / "release-v0.1.0.mdx"
+
+# The real release objects (verified against origin with
+# `git ls-remote --tags origin` and `gh pr view 92` — see the record).
+V010_TAG_OBJECT = "912631d390b0b1f7039afac52125ecf7e1d92589"
+V010_COMMIT = "335fa274e4b451a025bc2426b2a9fe7297ce8bb2"
+V011_COMMIT = "f82969e974b17803759493bad7e339bdcd6f463f"
+PR92_MERGE_COMMIT = "f6c065e8ec7ec53d7e9fb99e6475c1bc16c2dabf"
+
+# Every #80 core checklist item must carry a conclusive verdict.
+CORE_ISSUES = (
+    75, 77, 78, 79, 82, 52, 53, 71, 73, 74, 49, 76, 81, 83,
+)
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def is_ancestor(ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def record_text() -> str:
+    assert RECORD.is_file(), (
+        f"missing release reconciliation record: {RECORD}"
+    )
+    return RECORD.read_text(encoding="utf-8")
+
+
+def test_record_pins_real_tag_commit_relationship(record_text: str):
+    """Issue #97: the record must name the real tag object and commit
+    SHAs — and those SHAs must form the claimed relationship in the
+    actual git history (the record cannot assert a guessed
+    relationship green)."""
+    for sha in (V010_TAG_OBJECT, V010_COMMIT, V011_COMMIT, PR92_MERGE_COMMIT):
+        assert sha in record_text, f"record must pin SHA {sha}"
+    # The pinned objects must be real objects of this repository: the
+    # tag object is a tag, the commit SHAs resolve to commits.
+    assert git("cat-file", "-t", V010_TAG_OBJECT) == "tag", (
+        "the pinned v0.1.0 tag object is not a tag object here"
+    )
+    for sha in (V010_COMMIT, V011_COMMIT, PR92_MERGE_COMMIT):
+        assert git("rev-parse", f"{sha}^{{commit}}") == sha, (
+            f"the pinned SHA {sha} does not resolve to a commit"
+        )
+    # The real history says: v0.1.0 target is an ancestor of the
+    # corrected head, and the corrected head is the PR #92 branch head
+    # (an ancestor of the merge commit). The record's claim must match.
+    assert is_ancestor(V010_COMMIT, V011_COMMIT), (
+        "record claim contradicted by history: v0.1.0 target is not an "
+        "ancestor of the corrected head"
+    )
+    assert is_ancestor(V011_COMMIT, PR92_MERGE_COMMIT), (
+        "record claim contradicted by history: corrected head is not "
+        "inside the PR #92 merge commit"
+    )
+    assert not is_ancestor(PR92_MERGE_COMMIT, V010_COMMIT), (
+        "record claim contradicted by history: the merge commit cannot "
+        "be inside the v0.1.0 target"
+    )
+
+
+def test_record_names_review_fixes_missing_from_v010(record_text: str):
+    """Issue #97: the corrected release notes must state which fixes
+    the new tag adds over v0.1.0 (the review-round-1 commit)."""
+    assert "f82969e" in record_text
+    lowered = record_text.lower()
+    assert "review" in lowered, (
+        "record must explain that the missing commit is the PR #92 "
+        "review-round-1 fix"
+    )
+
+
+def test_record_has_conclusive_verdict_for_every_core_issue(
+    record_text: str,
+):
+    """Issue #97: every #80 checklist item gets a MERGED / verified
+    incomplete / excluded verdict — no silent checklist gaps."""
+    for number in CORE_ISSUES:
+        pattern = re.compile(
+            rf"#{number}\b[^\n]*\b(MERGED|verified incomplete|excluded)",
+            re.IGNORECASE,
+        )
+        assert pattern.search(record_text), (
+            f"issue #{number} has no conclusive verdict in the record"
+        )
+
+
+def test_record_verdict_73_closed_by_pr92(record_text: str):
+    """Issue #97: #73 (verify against docs) was implemented by PR #92
+    and must be recorded as MERGED/closed with that evidence."""
+    line = next(
+        line for line in record_text.splitlines() if re.search(r"#73\b", line)
+    )
+    assert "92" in line, "#73 verdict must cite PR #92 as the evidence"
+
+
+def test_record_verdict_93_verified_incomplete(record_text: str):
+    """Issue #97: #93 (Epic mechanism) has no implementation evidence —
+    the record must keep it OPEN (verified incomplete), never close it
+    to tick the checklist."""
+    line = next(
+        line for line in record_text.splitlines() if re.search(r"#93\b", line)
+    )
+    assert re.search(r"verified incomplete|stays? open", line, re.IGNORECASE), (
+        "#93 must be recorded as verified incomplete / stays OPEN"
+    )
+
+
+def test_git_helper_fails_fast_on_nonzero_exit():
+    """The helper must fail fast (no silent swallow) when git exits
+    non-zero — the same contract as the other git smoke helpers."""
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git("rev-parse", "no-such-ref")
+
+
+def test_session_cli_contract_matches_one_real_call():
+    """Issue #74/#97: the record cites the `session` CLI — assert the
+    real contract with one real call (verified against the actual
+    `muyan_pilot.py session --help` output), not a guessed shape."""
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "muyan_pilot.py"), "session", "--help"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        f"session --help failed rc={result.returncode} "
+        f"stderr={result.stderr.strip()}"
+    )
+    assert "--follow" in result.stdout
+    assert "--pretty" in result.stdout
+    assert "session" in result.stdout


### PR DESCRIPTION
Fixes #97

<!-- muyan-pilot:run=5ce476bd -->

run_id=5ce476bd · base=main (87ec2c4) · role=implement

## What this delivers

One-time v0.1.0 release-state reconciliation (Epic #80, release PR #92) — no
business feature re-implemented (the Release engine is #98, out of scope per the
Issue comment).

**GitHub state changes (all auditable, command evidence in the Issue #97 comment):**

1. **#73 closed** (`ai-merged` + evidence comment): implemented by PR #92
   (prompt.md/prompt_review.md hard rules, pinned by tests) but left OPEN with no
   terminal label.
2. **#93 evidence comment**: verified incomplete (no `ai-epic` claim-scan skip, no
   `epic_not_claimed` log, no Epic gate, no tests, not in `labels.toml`) — stays
   OPEN, not closed to tick the checklist.
3. **Corrected release tag `v0.1.1`** created (annotated) at `f82969e9` — the final
   PR #92 head (review-round-1 fixes) that `v0.1.0` (→ `335fa274`) does not contain.
   **`v0.1.0` was not moved and not force-pushed** (verified with
   `git ls-remote --tags origin` before/after).
4. **GitHub Release `v0.1.1`** at the same commit:
   https://github.com/xqliu/muyan-pilot/releases/tag/v0.1.1
5. **#80 reconciliation comment**: every checklist item has a conclusive verdict
   (14× MERGED with PR evidence; #93 verified incomplete).

## Repository changes

- `docs/release-v0.1.0.mdx` (+ `docs/zh/release-v0.1.0.mdx`): the durable
  reconciliation record — tag/commit relationship, per-Issue verdicts, the fixes
  `v0.1.1` adds over `v0.1.0`, and the auditable list of GitHub state changes.
- `tests/test_release_v01.py`: pins the record against the REAL git history
  (`git cat-file`/`merge-base --is-ancestor` on the pinned SHAs) and asserts the
  `muyan_pilot.py session` CLI contract against one real call (`session --help`).
- `docs/docs.json`: navigation entries for the new page (en + zh, per the docs-site
  i18n contract).

## Verification

- `timeout 600 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` →
  **839 passed** (baseline before the change: 832 passed).
- `timeout 120 /usr/bin/python3 -m coverage report` → **100% line/branch** (TOTAL
  10635 stmts, 0 miss, 1496 branches, 0 partial).
- `git ls-remote --tags origin`: `v0.1.0` unchanged (`912631d3` → `335fa274`);
  `v0.1.1` → `f82969e9`.
- No protected branch modified; no second business PR; only this feature branch
  pushed.
