### PR TITLE
ci: fetch full history + all tags in CI checkout for release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,21 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
+      # The release reconciliation tests (tests/test_release_v01.py) verify
+      # the real annotated tag object (v0.1.0) and its commit relationships
+      # with `git cat-file` / `git rev-parse` / `git merge-base --is-ancestor`
+      # against the checkout. The default shallow checkout (fetch-depth: 1)
+      # runs `git fetch --no-tags` (verified against the official
+      # actions/checkout@v4 source), so the tag object is absent and the
+      # test fails with `could not get object info` (Issue #126).
+      # fetch-depth: 0 makes the action fetch all branches and
+      # +refs/tags/*:refs/tags/* without --depth (full history plus every
+      # tag object), so the release verification uses the real remote
+      # objects. No tags are moved, overwritten, or rewritten.
+      - name: Check out the repository (full history + all tags)
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.14 (production minor version)
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ git remote set-url origin git@github.com:OWNER/REPO.git
 
 与本地的差异：生产运行时是 Runner 机器的 `/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以 workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过 PATH 上固定的 `python3` 执行（命令与本地相同，只有解释器路径不同）。
 
+Checkout 用 `fetch-depth: 0`（完整历史 + 全部 tags）：发布对账测试（`tests/test_release_v01.py`）用 `git cat-file` / `git rev-parse` 对 checkout 里的真实 annotated tag object（`v0.1.0`）及其 commit 关系做校验，而默认浅 checkout（`fetch-depth: 1`）以 `--no-tags` 抓取，CI 环境里没有 tag object，测试会以 `could not get object info` 失败（Issue #126）。现有 tags 只是在 CI 里可见，不被移动、覆盖或重写。
+
 ## 任务派发与状态
 
 `muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -27,6 +27,15 @@ version and runs the identical commands through `python3` on PATH),
 `requirements.txt` installed, then the two contract commands above. No
 lint, no matrix, no cache.
 
+The checkout uses `fetch-depth: 0` (full history + all tags): the release
+reconciliation tests (`tests/test_release_v01.py`) verify the REAL annotated
+tag object (`v0.1.0`) and its commit relationships with `git cat-file` /
+`git rev-parse` against the checkout, while the default shallow checkout
+(`fetch-depth: 1`) fetches with `--no-tags`, so the tag object is absent in
+the CI environment and the test fails with `could not get object info`
+(Issue #126). The existing tags are only made visible in CI — never moved,
+overwritten, or rewritten.
+
 The same single job also runs the Mintlify docs build smoke (Issue #116):
 the official `mint` CLI's `mint validate` (strict build validation of the
 `docs/` site — config, pages, links — non-zero exit on any warning or

--- a/docs/zh/testing.mdx
+++ b/docs/zh/testing.mdx
@@ -25,6 +25,13 @@
 `requirements.txt`，然后运行上面两条契约命令。没有 lint、没有矩阵、
 没有缓存。
 
+Checkout 用 `fetch-depth: 0`（完整历史 + 全部 tags）：发布对账测试
+（`tests/test_release_v01.py`）用 `git cat-file` / `git rev-parse` 对
+checkout 里的真实 annotated tag object（`v0.1.0`）及其 commit 关系做校验，
+而默认浅 checkout（`fetch-depth: 1`）以 `--no-tags` 抓取，CI 环境里没有
+tag object，测试会以 `could not get object info` 失败（Issue #126）。现有
+tags 只是在 CI 里可见，不被移动、覆盖或重写。
+
 CI 里还运行 Mintlify 文档构建 smoke（Issue #116）：官方 `mint` CLI
 的 `mint validate`（严格构建校验，任何 warning 或 error 都退出非零）
 ——文档配置、页面和链接在远端同样被门禁。

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -91,6 +91,34 @@ def test_ci_workflow_keeps_one_job_without_lint_matrix_or_cache():
         )
 
 
+def test_ci_workflow_checkout_fetches_full_history_and_tags():
+    """Issue #126: the release reconciliation tests
+    (tests/test_release_v01.py) verify the REAL annotated tag object
+    (v0.1.0 → 912631d3) and its commit relationships with `git
+    cat-file` / `git rev-parse` / `git merge-base --is-ancestor`
+    against the checkout. The default shallow checkout (fetch-depth: 1)
+    runs `git fetch --no-tags` (verified against the official
+    actions/checkout@v4 source: git-command-manager.ts), so the tag
+    object is absent in the CI environment and the test fails with
+    `could not get object info`. `fetch-depth: 0` makes the action
+    fetch all branches and `+refs/tags/*:refs/tags/*` without `--depth`
+    (full history plus every tag object), so the release verification
+    uses the real remote objects."""
+    steps = steps_of(load_workflow())
+    checkout = [
+        step for step in steps
+        if str(step.get("uses", "")).startswith("actions/checkout")
+    ]
+    assert checkout, "CI must check out the repository via actions/checkout"
+    assert len(checkout) == 1, f"exactly one checkout step, got {len(checkout)}"
+    with_options = checkout[0].get("with", {})
+    assert str(with_options.get("fetch-depth")) == "0", (
+        "CI checkout must fetch full history and all tags "
+        f"(fetch-depth: 0) so the annotated tag objects exist for the "
+        f"release reconciliation tests, got: {with_options!r}"
+    )
+
+
 def test_ci_workflow_pins_python_3_14_like_production():
     steps = steps_of(load_workflow())
     setup = [


### PR DESCRIPTION
Fixes #126

run_id=4c9c70e3

## Problem

The GitHub Actions `tests` job failed on
`tests/test_release_v01.py::test_record_pins_real_tag_commit_relationship`:

```text
fatal: git cat-file: could not get object info
```

The test verifies the REAL annotated tag object `912631d390b0b1f7039afac52125ecf7e1d92589`
(`v0.1.0`) and its commit relationships with `git cat-file` / `git rev-parse` /
`git merge-base --is-ancestor` against the checkout. The workflow used the
default shallow checkout (`actions/checkout@v4`, `fetch-depth: 1`), which runs
`git fetch --no-tags` (verified against the official `actions/checkout@v4`
source: `src/git-command-manager.ts`), so no tag objects exist in the CI
environment and the release verification cannot run.

## Fix

- `.github/workflows/ci.yml`: the checkout step now sets `fetch-depth: 0`.
  Verified against the official `actions/checkout@v4` source
  (`src/git-source-provider.ts`, `src/ref-helper.ts`): with `fetch-depth: 0`
  the action fetches all branches and `+refs/tags/*:refs/tags/*` without
  `--depth` — full history plus every tag object, including annotated tag
  objects.
- `tests/test_ci_workflow.py`: new regression test
  `test_ci_workflow_checkout_fetches_full_history_and_tags` pins the contract
  (exactly one `actions/checkout` step with `fetch-depth: 0`).
- README + `docs/testing.mdx` (en/zh): document the full-history + all-tags
  checkout and why the release reconciliation tests require it.

## Verification (real remote, exact action fetch commands)

- RED — exact default checkout fetch (`--no-tags --depth=1`):
  `git cat-file -t 912631d3…` → rc=128 `could not get object info`, no tags;
  `tests/test_release_v01.py` → 1 failed, 6 passed (the exact CI failure).
- GREEN — exact `fetch-depth: 0` fetch (all branches + all tags):
  `git cat-file -t 912631d3…` → `tag`, `v0.1.0^{commit}` → `335fa274…`,
  all pinned commits resolve, all ancestor relationships hold;
  `tests/test_release_v01.py` → 7 passed.
- Full contract suite: `840 passed`, coverage `TOTAL 10642 0 1496 0 100%`
  (100% line and branch, `--fail-under=100` gate green).

## Constraints honored

- Only the CI checkout/tag visibility changed; no new services, caches,
  matrix, lint, or release logic (KISS single job unchanged).
- `v0.1.0` / `v0.1.1` are not moved, overwritten, or rewritten — the fix
  only makes the existing remote tag objects visible in CI
  (`git ls-remote --tags origin` unchanged).
- Release verification kept intact (`tests/test_release_v01.py` unchanged).

<!-- muyan-pilot:run=4c9c70e3 -->