### PR TITLE
docs: complete the release navigation with the real v0.1.1/v0.1.2 pages and fix the zh home title

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -43,7 +43,9 @@
           {
             "group": "Releases",
             "pages": [
-              "release-v0.1.0"
+              "release-v0.1.0",
+              "release-v0.1.1",
+              "release-v0.1.2"
             ]
           }
         ]
@@ -83,7 +85,9 @@
           {
             "group": "发布",
             "pages": [
-              "zh/release-v0.1.0"
+              "zh/release-v0.1.0",
+              "zh/release-v0.1.1",
+              "zh/release-v0.1.2"
             ]
           }
         ]

--- a/docs/release-v0.1.1.mdx
+++ b/docs/release-v0.1.1.mdx
@@ -1,0 +1,33 @@
+# v0.1.1 release (corrected release tag)
+
+`v0.1.1` is the corrected release tag of the v0.1.0 release (Epic #80,
+release PR #92, merge commit `f6c065e8ec7ec53d7e9fb99e6475c1bc16c2dabf`).
+GitHub Release `v0.1.1` was published 2026-08-27.
+
+## Tag state (verified against origin)
+
+| Ref | Object | Points at |
+|---|---|---|
+| `v0.1.1` | annotated tag `b68d4f7d46582760ee04bac4308b785b4cc12c5d` | commit `f82969e974b17803759493bad7e339bdcd6f463f` ("Fix review round 1 findings: session follow, run artifacts, state chain (Issue #80)") |
+
+## Why a corrected tag
+
+`v0.1.0` points at `335fa274`, an intermediate commit of the PR #92
+branch. The head that was reviewed and merged is `f82969e9` — the
+review-round-1 fix — which `v0.1.0` does not contain. `v0.1.1`
+corrects the release pointer without moving `v0.1.0` (immutable, never
+force-pushed).
+
+## Fixes included over v0.1.0
+
+- `muyan_pilot.py`: session-follow line handling (follow the given
+  file only; no fragmented/dropped lines for the `--pretty` parser)
+- `.gitignore`: run-artifact ignore entries
+- `README.md`: wording aligned with the session contract
+- `tests/test_muyan_pilot.py`, `tests/test_run_artifacts.py`: pinning
+  tests
+- removal of the run artifacts `plan.md`/`test.log` from the tree
+
+The durable reconciliation record (every Epic #80 item with its
+verdict and PR evidence) is the
+[v0.1.0 release reconciliation record](/release-v0.1.0) (Issue #97).

--- a/docs/release-v0.1.2.mdx
+++ b/docs/release-v0.1.2.mdx
@@ -1,0 +1,27 @@
+# v0.1.2 release (latest)
+
+`v0.1.2` is the latest release (GitHub Release `Muyan Pilot v0.1.2`,
+published 2026-08-27): the first complete 0.1 release of the current
+main line.
+
+## Tag state (verified against origin)
+
+| Ref | Object | Points at |
+|---|---|---|
+| `v0.1.2` | annotated tag `209af556a9e0d49c068ee361fcacb7a1a49153cf` | commit `abe48f1e64aa6fa2e76633023df5b52141b35082` |
+
+## What this release contains
+
+- GitHub Issue-driven local AI development Runner
+- isolated worktree, feature branch and run marker
+- Pi implement → test → PR → independent review/fix → merge flow
+- systemd timer/service scheduling and restart recovery
+- fail-fast with the full journal and the GitHub progress scene
+- SSH git transport and the one-time setup entry
+- P0 priority pickup
+- Chinese docs, Mintlify configuration and the Mermaid
+  architecture/lifecycle diagrams
+- the release tag/Issue/PR/CI reconciliation record
+
+The existing `v0.1.0` and `v0.1.1` tags stay immutable; `v0.1.2` is
+the final 0.1 release of the current complete main.

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -1,3 +1,7 @@
+---
+title: "Muyan Pilot"
+---
+
 # Muyan Pilot
 
 Muyan Pilot 是一个本地 AI 开发 Worker：把任务放进 GitHub Issue，它自动领取

--- a/docs/zh/release-v0.1.1.mdx
+++ b/docs/zh/release-v0.1.1.mdx
@@ -1,0 +1,30 @@
+# v0.1.1 发布（修正版 release tag）
+
+`v0.1.1` 是 v0.1.0 发布（Epic #80，发布 PR #92，合并提交
+`f6c065e8ec7ec53d7e9fb99e6475c1bc16c2dabf`）的修正版 release tag。
+GitHub Release `v0.1.1` 发布于 2026-08-27。
+
+## Tag 状态（对 origin 验证）
+
+| Ref | 对象 | 指向 |
+|---|---|---|
+| `v0.1.1` | 注解 tag `b68d4f7d46582760ee04bac4308b785b4cc12c5d` | 提交 `f82969e974b17803759493bad7e339bdcd6f463f`（"Fix review round 1 findings: session follow, run artifacts, state chain (Issue #80)"） |
+
+## 为什么是修正版 tag
+
+`v0.1.0` 指向 `335fa274`，这是 PR #92 分支上的一个中间提交。经过审查
+并合并的最终 head 是 `f82969e9` —— review 第 1 轮的修复 —— 它不在
+`v0.1.0` 指向的可达范围内。`v0.1.1` 修正了发布指针，且没有移动
+`v0.1.0`（不可变，从未 force-push）。
+
+## 相对 v0.1.0 包含的修复
+
+- `muyan_pilot.py`：session-follow 行处理（只跟随给定文件；`--pretty`
+  解析器不丢行/不断行）
+- `.gitignore`：run 产物忽略项
+- `README.md`：与 session 契约对齐的措辞
+- `tests/test_muyan_pilot.py`、`tests/test_run_artifacts.py`：钉住测试
+- 从树中移除 run 产物 `plan.md`/`test.log`
+
+持久、可审计的对账记录（Epic #80 每一项的结论与 PR 证据）见
+[v0.1.0 发布对账记录](/zh/release-v0.1.0)（Issue #97）。

--- a/docs/zh/release-v0.1.2.mdx
+++ b/docs/zh/release-v0.1.2.mdx
@@ -1,0 +1,25 @@
+# v0.1.2 发布（最新）
+
+`v0.1.2` 是最新 release（GitHub Release `Muyan Pilot v0.1.2`，发布于
+2026-08-27）：当前完整 main 的首个完整 0.1 发布版本。
+
+## Tag 状态（对 origin 验证）
+
+| Ref | 对象 | 指向 |
+|---|---|---|
+| `v0.1.2` | 注解 tag `209af556a9e0d49c068ee361fcacb7a1a49153cf` | 提交 `abe48f1e64aa6fa2e76633023df5b52141b35082` |
+
+## 本版本包含
+
+- GitHub Issues 驱动的本地 AI 开发 Runner
+- 独立 worktree、feature branch 和 run marker
+- Pi implement → test → PR → 独立 review/fix → merge 流程
+- systemd timer/service 全天候调度与重启恢复
+- fail-fast、完整 journal 和 GitHub 进度现场
+- SSH Git transport 与一次性 setup
+- P0 优先 pickup
+- 中文文档、Mintlify 配置和 Mermaid 架构/生命周期图
+- 发布 tag/Issue/PR/CI 对账记录
+
+已有 `v0.1.0` 与 `v0.1.1` tag 保持不可变；`v0.1.2` 是当前完整 main
+的最终 0.1 发布。

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -106,6 +106,48 @@ def test_chinese_and_english_page_sets_stay_the_same_source_of_truth():
     )
 
 
+def test_chinese_homepage_carries_a_real_frontmatter_title():
+    """Issue #128: the zh language index page has no filename-derived
+    title the renderer can use, so without a frontmatter `title` the
+    renderer falls back to the capitalized language code — the live
+    site showed "Zh" in the sidebar, breadcrumb and page header (and
+    `/zh.md` injected `# Zh` before the content). The frontmatter
+    `title` is the documented page-metadata mechanism (official
+    Mintlify i18n guide). The title must be a real, natural title that
+    names the project — never the internal language code."""
+    text = zh_page_text("index")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match is not None, (
+        "zh/index.mdx must start with YAML frontmatter (page metadata)"
+    )
+    title_match = re.search(
+        r'^title:\s*["\']?([^"\'\n]+?)["\']?\s*$',
+        match.group(1),
+        re.MULTILINE,
+    )
+    assert title_match is not None, "frontmatter must set a title"
+    title = title_match.group(1).strip()
+    assert title, "the frontmatter title must not be empty"
+    assert title.lower() != "zh", (
+        f"the title must not be the internal language code, got: {title!r}"
+    )
+    assert "Muyan Pilot" in title, (
+        "the Chinese home title must name the project, "
+        f"got: {title!r}"
+    )
+
+
+def test_english_homepage_keeps_its_existing_title_behavior():
+    """Issue #128 scope: the English page behavior is unaffected — the
+    English index keeps no frontmatter title (the renderer keeps its
+    pre-Issue-128 filename fallback "Index")."""
+    text = (DOCS_DIR / "index.mdx").read_text(encoding="utf-8")
+    assert not text.startswith("---"), (
+        "the English index must not gain a frontmatter title "
+        "(English behavior stays unchanged)"
+    )
+
+
 def test_chinese_overview_names_the_task_pool_and_mvp_boundary():
     """The Chinese overview (index) must say what the project is (GitHub
     Issue task pool) and the explicit MVP boundary (no database/queue/

--- a/tests/test_docs_releases.py
+++ b/tests/test_docs_releases.py
@@ -1,0 +1,267 @@
+"""Release documentation contract (Issue #128).
+
+The docs `Releases`/`发布` group must mirror the REAL release state of
+the repository — verified against origin with `git ls-remote --tags
+origin` and `gh release list` (this run): tags `v0.1.0`, `v0.1.1`,
+`v0.1.2` exist; GitHub Releases `v0.1.1`, `v0.1.2` exist; **no
+`v0.1.3` tag or release exists**. Therefore:
+
+- every listed release page corresponds to a real tag (no dead links,
+  nothing real missing, nothing invented listed);
+- `v0.1.3` must not appear anywhere in the docs (fact-based handling:
+  no page, no navigation entry, no text claim);
+- the release pages pin the REAL tag objects and commits (verified
+  with actual `git` commands — a guessed SHA fails, the same
+  anti-guessing contract as tests/test_release_v01.py);
+- the v0.1.1 pages state that v0.1.1 is the CORRECTED release tag over
+  v0.1.0 (the v0.1.0 record page stays the durable reconciliation
+  artifact) and keep the link to it;
+- the v0.1.2 pages mark the LATEST release of the current main.
+
+The EN/ZH page-set parity and the nav↔file exact match are enforced by
+tests/test_docs_i18n.py and tests/test_docs_site.py.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+DOCS_CONFIG = DOCS_DIR / "docs.json"
+
+# The real release objects (verified against origin with
+# `git ls-remote --tags origin` at run time — Issue #128).
+RELEASES = {
+    "v0.1.0": {
+        "tag_object": "912631d390b0b1f7039afac52125ecf7e1d92589",
+        "commit": "335fa274e4b451a025bc2426b2a9fe7297ce8bb2",
+    },
+    "v0.1.1": {
+        "tag_object": "b68d4f7d46582760ee04bac4308b785b4cc12c5d",
+        "commit": "f82969e974b17803759493bad7e339bdcd6f463f",
+    },
+    "v0.1.2": {
+        "tag_object": "209af556a9e0d49c068ee361fcacb7a1a49153cf",
+        "commit": "abe48f1e64aa6fa2e76633023df5b52141b35082",
+    },
+}
+
+# The only versions with a real tag on origin — and therefore the only
+# versions the docs may list (in version order). No v0.1.3 exists
+# (no tag, no GitHub Release), so it must not be documented.
+REAL_RELEASE_SLUGS = [
+    f"release-{version}"
+    for version in ("v0.1.0", "v0.1.1", "v0.1.2")
+]
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def docs_files() -> list[Path]:
+    return sorted(
+        path for path in DOCS_DIR.rglob("*")
+        if path.is_file() and path.suffix in (".md", ".mdx")
+    )
+
+
+def release_group_pages(language_code: str) -> list[str]:
+    """The page list of the release group of one navigation language
+    (en: `Releases`, zh: `发布`)."""
+    assert DOCS_CONFIG.is_file(), f"missing Mintlify config: {DOCS_CONFIG}"
+    config = json.loads(DOCS_CONFIG.read_text(encoding="utf-8"))
+    navigation = config.get("navigation")
+    assert isinstance(navigation, dict) and navigation, (
+        "docs.json has no navigation section"
+    )
+    languages = navigation.get("languages")
+    assert isinstance(languages, list) and languages, (
+        "docs.json navigation must use the languages array (Mintlify i18n)"
+    )
+    lang = next(
+        (
+            entry for entry in languages
+            if isinstance(entry, dict)
+            and entry.get("language") == language_code
+        ),
+        None,
+    )
+    assert lang is not None, f"docs.json has no {language_code!r} language"
+    groups = lang.get("groups")
+    assert isinstance(groups, list) and groups, (
+        f"navigation language {language_code!r} has no groups"
+    )
+    for group in groups:
+        if isinstance(group, dict) and group.get("group") in ("Releases", "发布"):
+            pages = group.get("pages")
+            assert isinstance(pages, list) and pages, (
+                f"release group of {language_code!r} has no pages"
+            )
+            return list(pages)
+    raise AssertionError(
+        f"{language_code} navigation has no Releases/发布 group"
+    )
+
+
+def test_git_helper_fails_fast_on_nonzero_exit():
+    """The helper must fail fast (no silent swallow) when git exits
+    non-zero — the same contract as the other git smoke helpers."""
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git("rev-parse", "no-such-ref")
+
+
+def test_release_group_lookup_fails_fast_when_the_release_group_is_missing(
+    tmp_path, monkeypatch
+):
+    """A navigation language without a Releases/发布 group must fail
+    fast with a named reason (no silent empty list)."""
+    module = sys.modules[__name__]
+    config = tmp_path / "docs.json"
+    config.write_text(
+        json.dumps({
+            "navigation": {
+                "languages": [
+                    {
+                        "language": "en",
+                        "groups": [{"group": "Other", "pages": ["index"]}],
+                    }
+                ]
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "DOCS_CONFIG", config)
+    with pytest.raises(AssertionError, match=r"no Releases/发布 group"):
+        module.release_group_pages("en")
+
+
+def test_release_navigation_lists_exactly_the_real_releases_in_order():
+    """Acceptance: the Chinese (and English) release navigation matches
+    the real v0.1.x tags — every listed page exists, nothing real is
+    missing, nothing invented is listed."""
+    en_pages = release_group_pages("en")
+    zh_pages = release_group_pages("zh")
+    assert en_pages == REAL_RELEASE_SLUGS, (
+        f"en Releases group must list exactly {REAL_RELEASE_SLUGS} in "
+        f"version order, got: {en_pages!r}"
+    )
+    assert zh_pages == [f"zh/{slug}" for slug in REAL_RELEASE_SLUGS], (
+        f"zh 发布 group must list exactly "
+        f"{[f'zh/{slug}' for slug in REAL_RELEASE_SLUGS]} in version "
+        f"order, got: {zh_pages!r}"
+    )
+
+
+def test_every_listed_release_page_exists_in_both_languages():
+    """No dead link: every listed release page has a real file (en at
+    the docs root, zh under docs/zh/)."""
+    for slug in REAL_RELEASE_SLUGS:
+        en_path = DOCS_DIR / f"{slug}.mdx"
+        zh_path = DOCS_DIR / "zh" / f"{slug}.mdx"
+        assert en_path.is_file(), f"missing English release page: {en_path}"
+        assert zh_path.is_file(), f"missing Chinese release page: {zh_path}"
+
+
+def test_no_fabricated_release_version_anywhere_in_the_docs():
+    """Fact-based handling of v0.1.3 (acceptance): origin has no
+    `v0.1.3` tag and no `v0.1.3` GitHub Release, so the docs must not
+    list, link or claim it anywhere — no page file, no navigation
+    entry, no text mention."""
+    for path in docs_files():
+        content = path.read_text(encoding="utf-8")
+        assert "v0.1.3" not in content, (
+            f"{path.name} mentions v0.1.3, which has no tag or GitHub "
+            f"Release on origin (invented version)"
+        )
+    config_text = DOCS_CONFIG.read_text(encoding="utf-8")
+    assert "v0.1.3" not in config_text, (
+        "docs.json navigation lists v0.1.3, which does not exist on origin"
+    )
+    stray = list(DOCS_DIR.glob("release-v0.1.3.mdx")) + list(
+        (DOCS_DIR / "zh").glob("release-v0.1.3.mdx")
+    )
+    assert not stray, f"a v0.1.3 release page exists: {stray}"
+
+
+def test_release_v011_pages_pin_the_real_tag_and_commit():
+    """The v0.1.1 pages must pin the REAL tag object and commit: the
+    SHAs are named in the page AND resolve to real objects of this
+    repository (a guessed SHA fails)."""
+    for rel in ("release-v0.1.1.mdx", "zh/release-v0.1.1.mdx"):
+        text = (DOCS_DIR / rel).read_text(encoding="utf-8")
+        tag_object = RELEASES["v0.1.1"]["tag_object"]
+        commit = RELEASES["v0.1.1"]["commit"]
+        assert tag_object in text, (
+            f"{rel} must pin the real v0.1.1 tag object"
+        )
+        assert commit in text, f"{rel} must pin the real v0.1.1 commit"
+    assert git("cat-file", "-t", RELEASES["v0.1.1"]["tag_object"]) == "tag", (
+        "the pinned v0.1.1 tag object is not a tag object here"
+    )
+    assert git(
+        "rev-parse", f"{RELEASES['v0.1.1']['commit']}^{{commit}}"
+    ) == RELEASES["v0.1.1"]["commit"], (
+        "the pinned v0.1.1 SHA does not resolve to a commit"
+    )
+
+
+def test_release_v011_pages_state_that_they_correct_v010():
+    """v0.1.1 is the CORRECTED release tag over v0.1.0 (the real
+    GitHub Release body): the pages must say so and keep the link to
+    the durable v0.1.0 reconciliation record page."""
+    en = (DOCS_DIR / "release-v0.1.1.mdx").read_text(encoding="utf-8")
+    zh = (DOCS_DIR / "zh" / "release-v0.1.1.mdx").read_text(encoding="utf-8")
+    assert "v0.1.0" in en and "correct" in en.lower(), (
+        "en v0.1.1 page must state that it corrects v0.1.0"
+    )
+    assert "/release-v0.1.0" in en, (
+        "en v0.1.1 page must link the v0.1.0 record page"
+    )
+    assert "v0.1.0" in zh and "修正" in zh, (
+        "zh v0.1.1 page must state that it corrects (修正) v0.1.0"
+    )
+    assert "/zh/release-v0.1.0" in zh, (
+        "zh v0.1.1 page must link the Chinese v0.1.0 record page"
+    )
+
+
+def test_release_v012_pages_pin_the_real_tag_and_commit_and_mark_latest():
+    """v0.1.2 is the LATEST release (the real GitHub Release
+    `Muyan Pilot v0.1.2`, published 2026-08-27): the pages must pin
+    the real tag object and commit and mark it as the latest release."""
+    for rel in ("release-v0.1.2.mdx", "zh/release-v0.1.2.mdx"):
+        text = (DOCS_DIR / rel).read_text(encoding="utf-8")
+        tag_object = RELEASES["v0.1.2"]["tag_object"]
+        commit = RELEASES["v0.1.2"]["commit"]
+        assert tag_object in text, (
+            f"{rel} must pin the real v0.1.2 tag object"
+        )
+        assert commit in text, f"{rel} must pin the real v0.1.2 commit"
+    assert git("cat-file", "-t", RELEASES["v0.1.2"]["tag_object"]) == "tag", (
+        "the pinned v0.1.2 tag object is not a tag object here"
+    )
+    assert git(
+        "rev-parse", f"{RELEASES['v0.1.2']['commit']}^{{commit}}"
+    ) == RELEASES["v0.1.2"]["commit"], (
+        "the pinned v0.1.2 SHA does not resolve to a commit"
+    )
+    en = (DOCS_DIR / "release-v0.1.2.mdx").read_text(encoding="utf-8")
+    zh = (DOCS_DIR / "zh" / "release-v0.1.2.mdx").read_text(encoding="utf-8")
+    assert "latest" in en.lower(), (
+        "en v0.1.2 page must mark it the latest release"
+    )
+    assert "最新" in zh, (
+        "zh v0.1.2 page must mark it the latest release (最新)"
+    )


### PR DESCRIPTION
Fixes #128

run_id=d4484e2d

## What this PR changes

Two related defects of the Mintlify docs site (`docs/`), fixed with the
smallest complete change — verified against the REAL remote state, no
invented versions:

1. **Release navigation incomplete** — the `Releases`/`发布` group listed
   only `release-v0.1.0`, while origin actually has tags `v0.1.0`,
   `v0.1.1`, `v0.1.2` and GitHub Releases `v0.1.1`, `v0.1.2` (verified
   with `git ls-remote --tags origin` + `gh release list`).
   - `docs/release-v0.1.1.mdx` (+ `docs/zh/`): the corrected release tag
     over v0.1.0 — pins the real tag object `b68d4f7d…` and commit
     `f82969e9…` (verified with `git cat-file`/`rev-parse`), states the
     correction, links the durable v0.1.0 reconciliation record page.
   - `docs/release-v0.1.2.mdx` (+ `docs/zh/`): the latest release — pins
     the real tag object `209af556…` and commit `abe48f1e…`, keeps the
     real feature facts from the GitHub Release body.
   - `docs/docs.json`: en `Releases` + zh `发布` groups now list exactly
     `release-v0.1.0` / `release-v0.1.1` / `release-v0.1.2` in version
     order.
   - **v0.1.3 (fact-based handling):** origin has NO `v0.1.3` tag and NO
     `v0.1.3` GitHub Release, so no page, navigation entry or text
     mention is added; a new test pins that `v0.1.3` must not appear
     anywhere in the docs.
2. **Chinese home title showed the internal language code "Zh"** — the
   zh language index page had no frontmatter `title`, so Mintlify fell
   back to the capitalized language code in the sidebar, breadcrumb,
   page header and `/zh.md` (verified on the live site; the frontmatter
   `title` is the documented page-metadata mechanism in the official
   Mintlify i18n guide).
   - `docs/zh/index.mdx`: frontmatter `title: "Muyan Pilot"` — the
     Chinese home now shows a clear, natural title in every visible
     place. English page behavior is untouched (no frontmatter added to
     `docs/index.mdx`; pinned by a test).

## Tests

- New `tests/test_docs_releases.py`: release navigation lists exactly
  the real releases (both languages, version order); every listed page
  exists (no dead links); no fabricated `v0.1.3` anywhere; the v0.1.1 /
  v0.1.2 pages pin the REAL tag objects and commits (verified with
  actual `git` commands — a guessed SHA fails); v0.1.1 states it
  corrects v0.1.0 and links the record page; v0.1.2 is marked latest.
- Extended `tests/test_docs_i18n.py`: zh index frontmatter title
  contract (real title, not the language code) + English index keeps no
  frontmatter title.
- Existing contracts kept green: nav↔file exact match, EN/ZH page-set
  parity, label/path/timer content checks, the v0.1.0 record tests.

## Verification (commands + results in the run's test.log)

- `/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q` →
  **895 passed**, `coverage report --fail-under=100` → **100%** line and
  branch coverage.
- `cd docs && mint validate` (same strict gate as CI) → **passed**.
- **Playwright against the real Mintlify renderer** (`mint dev` local
  preview, real interaction + assertions + console/network checks):
  - RED on the unfixed tree: 8/17 — page header `Zh`, sidebar item
    `Index`, 发布 group only `Release v0.1.0`, v0.1.1/v0.1.2 sidebar
    items missing.
  - GREEN after the fix: **19/19** — header + sidebar `Muyan Pilot`,
    发布 group lists `Release v0.1.0` / `v0.1.1` / `v0.1.2`, every
    listed page loads with real content (no 404), English home behavior
    unchanged (document title `Index - Muyan Pilot`, content H1
    `Muyan Pilot`), mobile viewport verified, no console errors, no
    failed network requests.
  - Screenshots (red/green, desktop + mobile) saved under the run
    artifacts (`.muyan-pilot/runs/issue-128-d4484e2d/playwright/`).

No runner code, CI workflow or GitHub state change; no new tag or
release — the pages document the existing remote objects.

<!-- muyan-pilot:run=d4484e2d -->