### PR TITLE
Change the idle polling timer from 15 to 5 minutes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ is **one runtime outcome** (when X, should Y, actually Z).
   currently running long task is never hot-updated or killed — while the
   service is active, systemd ignores the timer's start request, and the
   next real start runs the latest code. No refresh service, worker,
-  dispatcher or resident process is added; the 15-minute timer is
+  dispatcher or resident process is added; the 5-minute timer is
   unchanged.
 - Deployment consistency (Issue #103): the repo templates
   `systemd/muyan-pilot.service` and `systemd/muyan-pilot.timer` are the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 /usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
-正常运行使用 systemd user timer，全天 24 小时运行，每 15 分钟自动执行一次（触发点覆盖 00:00–23:45）：
+正常运行使用 systemd user timer，全天 24 小时运行，每 5 分钟自动执行一次（触发点覆盖 00:00–23:55）：
 
 ```bash
 # 幂等安装用户级 service/timer（仓库模板复制到用户 systemd 目录、
@@ -38,7 +38,7 @@ service 每次真正启动时，先由 `ExecStartPre` 在 Python Runner 进程�
 git fetch origin main && git merge --ff-only origin/main
 ```
 
-本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动。当前正在运行的长任务不会被热更新、不会被杀、也不会启动第二个 Runner（service active 时 systemd 忽略 timer 的 start 请求；下一次 service 真正启动时生效）。main 工作区不干净、fetch 失败或无法 fast-forward 时，preflight 命令失败，service 不启动，原因写入 systemd journal（fail fast）。不新增 refresh service、worker、dispatcher 或常驻进程；15 分钟 timer 配置保持不变。
+本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动。当前正在运行的长任务不会被热更新、不会被杀、也不会启动第二个 Runner（service active 时 systemd 忽略 timer 的 start 请求；下一次 service 真正启动时生效）。main 工作区不干净、fetch 失败或无法 fast-forward 时，preflight 命令失败，service 不启动，原因写入 systemd journal（fail fast）。不新增 refresh service、worker、dispatcher 或常驻进程；5 分钟 timer 配置保持不变。
 
 ## 部署一致性（Issue #103）
 
@@ -313,7 +313,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 
 本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是正整数，缺失时默认 1（本地 AI/GPU 只能稳定服务一个任务）；非整数、布尔值、0 或负数启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
 
-- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与空闲 timer 同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding 或 base 冲突）时，**下一个 tick 在同一 run、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
+- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与 Pi 活动轮询同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding 或 base 冲突）时，**下一个 tick 在同一 run、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
 - 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
 - 达到 `max_concurrency` 时，新 Runner 不领取 Issue、不修改标签、不调用 Pi，记录结构化日志 `capacity_full max_concurrency=... slot_dir=...` 后正常退出（退出码 0），等 systemd timer 下次触发；
 - slot 锁由打开的文件描述符持有：进程正常结束、SIGTERM/SIGINT（systemd stop / Ctrl+C）或被 SIGKILL 时，内核自动释放锁——活着的持有者永远不会因为时间或 PID 检查丢失 slot，死掉的持有者永远不会占住 slot，异常退出不会造成永久锁死；slot 文件本身保留（它是锁目标，不是令牌），`status` 按锁的实际状态报告占用；

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -2796,8 +2796,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
     delivery whose PR is open still needs the machine, and no other
     Runner may start a second Pi while it is held. The Runner is the
     owner of that lifecycle, so it re-checks the delivery every
-    `poll_interval` seconds (the same cadence as the idle timer and the
-    Pi activity poll):
+    `poll_interval` seconds (the same cadence as the Pi activity poll):
 
     - PR `MERGED` -> terminal: the delivery is done, the slot is
       released by the caller and the next tick may claim new work;

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -12,7 +12,7 @@ machine layout.
 | [Pi](https://github.com/earendil-works/pi) CLI | The development agent; one full session per task | `pi --version` |
 | Git | Worktrees, branches, base freshness | `git --version` |
 | GitHub CLI (`gh`) | Issues, labels, PRs, merge | `gh auth status` |
-| systemd (user session) | The timer that triggers one tick every 15 minutes | `systemctl --user status` |
+| systemd (user session) | The timer that triggers one tick every 5 minutes | `systemctl --user status` |
 | A working OpenAI-compatible model endpoint | Pi's model provider — a local llama.cpp server or any OpenAI-compatible API | one real `pi --print` call (below) |
 
 Pi must be configured with a provider that can serve a coding agent
@@ -162,8 +162,8 @@ systemctl --user list-timers muyan-pilot.timer
 ```
 
 The setup output carries `timer=enabled active=true next=...` (the next
-trigger time). The timer fires every 15 minutes, 24 hours a day
-(00:00–23:45). While a task is running, further timer starts are ignored
+trigger time). The timer fires every 5 minutes, 24 hours a day
+(00:00–23:55). While a task is running, further timer starts are ignored
 by systemd; the next real start picks up the latest code (the service
 fast-forwards `main` before starting — see [Operations](/operations)).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,7 +15,7 @@ flowchart LR
     prs["PRs (Fixes #N, run marker) + review/merge"]
   end
   subgraph machine["Runner machine (systemd user session)"]
-    timer["muyan-pilot.timer (15-minute tick)"]
+    timer["muyan-pilot.timer (5-minute tick)"]
     service["muyan-pilot.service (ExecStartPre: fast-forward main)"]
     runner["Runner (muyan_pilot.py): claim → worktree → Pi → PR → review → merge"]
     worktree["task worktree + feature branch (frozen origin/main SHA, run id in the name)"]
@@ -76,7 +76,7 @@ Muyan Pilot is intentionally an MVP. The boundary is part of the design:
 - GitHub Issues and labels are the **only** state store — no database, no
   message queue, no web UI.
 - The Python Runner is **not a daemon**: a systemd user timer triggers one
-  tick every 15 minutes; each tick processes at most one Issue (or resumes
+  tick every 5 minutes; each tick processes at most one Issue (or resumes
   one opened PR) and exits.
 - No task DAG, no multi-agent parallelism, no risk model, no policy
   engine, no fallback path — a command error fails fast and leaves the

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -8,8 +8,8 @@ verification, troubleshooting and recovery.
 
 ## The timer
 
-`systemd/muyan-pilot.timer` fires every 15 minutes, 24 hours a day
-(`OnCalendar=*-*-* *:00/15`, `AccuracySec=30s`, `Persistent=false` — a
+`systemd/muyan-pilot.timer` fires every 5 minutes, 24 hours a day
+(`OnCalendar=*-*-* *:00/5`, `AccuracySec=30s`, `Persistent=false` — a
 missed tick is dropped, never queued). Each tick starts
 `muyan-pilot.service`, which:
 
@@ -71,7 +71,7 @@ Stable `key=value` lines you will see:
   consecutive idle windows and the Runner kills the Pi session itself).
 
 The idle warning, the idle recovery and the upstream-dead kill are
-log/health thresholds — they are not the 15-minute schedule and not a
+log/health thresholds — they are not the 5-minute schedule and not a
 business task timeout. The idle recovery never holds the slot forever:
 a stalled session either resumes (the failure signal reached the model
 and the first new event resets the recovery state) or the run fails

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -52,7 +52,7 @@ requires a mergeable PR.
   and `gh` fixtures).
 - **Static contract tests** that pin the repository to its own docs and
   files: `AGENTS.md` contract items, the label set, the systemd units
-  (15-minute schedule, preflight), the CI workflow, the LICENSE, and the
+  (5-minute schedule, preflight), the CI workflow, the LICENSE, and the
   documentation site under `docs/` (this page's claims are enforced by
   `tests/test_docs_site.py`; the Chinese pages and the EN/ZH parity by
   `tests/test_docs_i18n.py`; the Mermaid diagrams by

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -11,7 +11,7 @@ clone 路径下都能工作——不依赖任何特定机器布局。
 | [Pi](https://github.com/earendil-works/pi) CLI | 开发 agent；每个任务一个完整 session | `pi --version` |
 | Git | worktree、分支、base 新鲜度 | `git --version` |
 | GitHub CLI（`gh`） | Issue、标签、PR、merge | `gh auth status` |
-| systemd（user session） | 每刻钟触发一个 tick 的 timer | `systemctl --user status` |
+| systemd（user session） | 每 5 分钟触发一个 tick 的 timer | `systemctl --user status` |
 | 可用的 OpenAI-compatible 模型 endpoint | Pi 的模型 provider——本地 llama.cpp server 或任意 OpenAI-compatible API | 一次真实 `pi --print` 调用（见下） |
 
 Pi 必须配置一个能稳定服务 coding agent 的 provider（system prompt +
@@ -147,7 +147,7 @@ systemctl --user list-timers muyan-pilot.timer
 ```
 
 setup 输出带 `timer=enabled active=true next=...`（下次触发时间）。
-timer 每刻钟触发一次，全天 24 小时（00:00–23:45）。任务运行期间，
+timer 每 5 分钟触发一次，全天 24 小时（00:00–23:55）。任务运行期间，
 后续 timer 启动请求被 systemd 忽略；下一次真正启动会取到最新代码
 （service 启动前先 fast-forward `main`——见[运维](/zh/operations)）。
 

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -18,7 +18,7 @@ flowchart LR
     prs["PR（Fixes #N、run marker）+ review/merge"]
   end
   subgraph machine["Runner 机器（systemd user session）"]
-    timer["muyan-pilot.timer（每刻钟 tick）"]
+    timer["muyan-pilot.timer（每 5 分钟 tick）"]
     service["muyan-pilot.service（ExecStartPre：fast-forward main）"]
     runner["Runner（muyan_pilot.py）：领取 → worktree → Pi → PR → review → merge"]
     worktree["任务 worktree + feature branch（冻结 origin/main SHA，名字带 run id）"]
@@ -74,7 +74,7 @@ Muyan Pilot 刻意是一个 MVP，边界是设计的一部分：
 
 - GitHub Issue 和标签是**唯一**状态存储——没有数据库、没有消息队列、
   没有 Web UI。
-- Python Runner **不是 daemon**：systemd user timer 每刻钟触发一个
+- Python Runner **不是 daemon**：systemd user timer 每 5 分钟触发一个
   tick；每个 tick 最多处理一个 Issue（或恢复一个已打开的 PR）然后退出。
 - 没有任务 DAG、没有多 Agent 并行、没有风险模型、没有 policy engine、
   没有 fallback 路径——命令错误立即失败（fail fast），现场留在 journal

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -6,8 +6,8 @@ journal 和 GitHub。正常路径永远不需要 status 命令、轮询或督工
 
 ## Timer
 
-`systemd/muyan-pilot.timer` 每刻钟触发一次，全天 24 小时
-（`OnCalendar=*-*-* *:00/15`、`AccuracySec=30s`、`Persistent=false`——
+`systemd/muyan-pilot.timer` 每 5 分钟触发一次，全天 24 小时
+（`OnCalendar=*-*-* *:00/5`、`AccuracySec=30s`、`Persistent=false`——
 错过的 tick 被丢弃，从不排队）。每个 tick 启动
 `muyan-pilot.service`，它：
 
@@ -56,7 +56,7 @@ journalctl --user -u muyan-pilot.service | grep e07383c2
   `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）判定上游模型已死，Runner
   杀掉 Pi）。
 
-idle 告警和上游已死 kill 是日志/健康阈值——它们不是每刻钟调度，也
+idle 告警和上游已死 kill 是日志/健康阈值——它们不是每 5 分钟调度，也
 不是业务任务 timeout。
 
 ## CLI（`muyan_pilot.py`）

--- a/docs/zh/testing.mdx
+++ b/docs/zh/testing.mdx
@@ -44,7 +44,7 @@ CI 红的时候 PR 不可合并——Runner 的 merge 门禁也要求 PR mergeab
   resume/review/merge 逻辑（套件主体，包括针对真实 `git` 和 `gh`
   fixture 的端到端测试）。
 - **静态契约测试**：把仓库钉在它自己的文档和文件上：`AGENTS.md`
-  契约项、标签集、systemd units（每刻钟调度、preflight）、CI
+  契约项、标签集、systemd units（每 5 分钟调度、preflight）、CI
   workflow、LICENSE、`docs/` 下的文档站（本页的声明由
   `tests/test_docs_site.py` 强制执行；中文页面和 EN/ZH 同一事实源由
   `tests/test_docs_i18n.py` 强制执行；Mermaid 图由

--- a/systemd/muyan-pilot.timer
+++ b/systemd/muyan-pilot.timer
@@ -2,7 +2,7 @@
 Description=Muyan Pilot — poll both GitHub Issue sources
 
 [Timer]
-OnCalendar=*-*-* *:00/15
+OnCalendar=*-*-* *:00/5
 AccuracySec=30s
 Persistent=false
 Unit=muyan-pilot.service

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4502,7 +4502,7 @@ def _drift_world(tmp_path, drift: bool) -> tuple[Path, Path]:
     (repo / "systemd").mkdir(parents=True)
     for name, body in (
         ("muyan-pilot.service", "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n"),
-        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/15\n"),
+        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/5\n"),
     ):
         (repo / "systemd" / name).write_text(body, encoding="utf-8")
     installed = tmp_path / "units"

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -3,7 +3,7 @@
 The Chinese docs live in `docs/zh/` (the verified Mintlify i18n layout:
 same structure as the default English pages at the `docs/` root) and keep
 the SAME single source of truth as the English pages — the implementation
-facts (labels, config fields, commands, ports, the 15-minute timer, the
+facts (labels, config fields, commands, ports, the 5-minute timer, the
 P0 pickup order, the PR body contract, the git transport boundary, the
 optional KV cache proxy) are asserted in the Chinese pages exactly as the
 English pages carry them. These tests fail when the Chinese entry or a
@@ -236,13 +236,15 @@ def test_chinese_workflow_documents_the_full_issue_to_merge_chain():
 
 def test_chinese_operations_documents_the_real_commands_and_recovery():
     """The Chinese operations page must carry the real operations facts:
-    the 15-minute timer, the journal, the CLI commands, the worktree and
+    the 5-minute timer, the journal, the CLI commands, the worktree and
     base freshness, the failure recovery (ai-blocked), the ExecStartPre
     code-update preflight, and the transport check without an HTTPS
     fallback — same facts as the English page."""
     text = zh_page_text("operations")
     assert "muyan-pilot.timer" in text
-    assert "15" in text, "operations must document the 15-minute idle polling interval"
+    assert "OnCalendar=*-*-* *:00/5" in text, (
+        "operations must document the 5-minute idle polling interval"
+    )
     assert "journalctl" in text, "operations must show the journal command"
     assert "muyan_pilot.py" in text, "operations must name the CLI"
     for command in ("status", "session", "add"):

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -15,7 +15,7 @@ commands, labels/run marker/Epic/Release task/P0, security boundary,
 test+coverage commands, contributing, smoke walkthrough), when a doc
 references a label or config field the implementation does not have, or
 when a doc (in any language) carries a personal absolute path, an
-unimplemented feature, or the stale 5-minute timer.
+unimplemented feature, or the stale 15-minute timer.
 """
 import json
 import re
@@ -316,12 +316,14 @@ def test_docs_document_labels_run_marker_epic_release_task_and_p0():
 
 
 def test_docs_document_operations_commands():
-    """Operations must cover first start, the 15-minute timer, journal
+    """Operations must cover first start, the 5-minute timer, journal
     logs, the status/session/add CLI, worktrees and failure recovery —
     with the commands the implementation actually provides."""
     text = page_text("operations")
     assert "muyan-pilot.timer" in text
-    assert "15" in text, "operations must document the 15-minute idle polling interval"
+    assert "OnCalendar=*-*-* *:00/5" in text, (
+        "operations must document the 5-minute idle polling interval"
+    )
     assert "journalctl" in text, "operations must show the journal command"
     assert "muyan_pilot.py" in text, "operations must name the CLI"
     for command in ("status", "session", "add"):
@@ -427,18 +429,18 @@ def test_docs_do_not_document_unimplemented_runner_features():
     )
 
 
-def test_docs_do_not_resurrect_the_stale_five_minute_timer():
-    """Acceptance: no stale 5-minute timer convention. The idle polling
-    interval stays 15 minutes (Issue #51 explicitly not in v0.1); the only
-    5-minute number in the contract is the PI_IDLE_WARN_SECONDS idle
-    warning, which is a log threshold, not a schedule."""
+def test_docs_document_the_five_minute_timer():
+    """Issue #51: the idle polling interval is 5 minutes. The operations
+    pages (EN and ZH) must document the real OnCalendar, and no stale
+    15-minute OnCalendar may remain in any doc page."""
+    en = page_text("operations")
+    assert "OnCalendar=*-*-* *:00/5" in en, (
+        "English operations must document the 5-minute timer"
+    )
     for path in docs_files():
         content = path.read_text(encoding="utf-8")
-        assert "5 分钟" not in content and "5分钟" not in content, (
-            f"{path.name} resurrects the stale 5-minute timer"
-        )
-        assert "00/5" not in content, (
-            f"{path.name} resurrects the stale 5-minute OnCalendar"
+        assert "00/15" not in content, (
+            f"{path.name} carries the stale 15-minute OnCalendar"
         )
 
 

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1082,7 +1082,7 @@ def _deploy_world(tmp_path, drift: bool = False) -> tuple[dict, Path]:
     (repo / "systemd").mkdir(parents=True)
     for name, body in (
         ("muyan-pilot.service", "[Service]\nExecStart=/usr/bin/python3 bootstrap_runner.py\n"),
-        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/15\n"),
+        ("muyan-pilot.timer", "[Timer]\nOnCalendar=*-*-* *:00/5\n"),
     ):
         (repo / "systemd" / name).write_text(body, encoding="utf-8")
     installed = tmp_path / "units"

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -52,7 +52,7 @@ def make_repo(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (systemd / "muyan-pilot.timer").write_text(
-        "[Timer]\nOnCalendar=*-*-* *:00/15\n", encoding="utf-8",
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
     )
     write_labels_toml(repo, VALID_DEFS)
     return repo

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -27,7 +27,7 @@ def make_repo(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (systemd / "muyan-pilot.timer").write_text(
-        "[Timer]\nOnCalendar=*-*-* *:00/15\n", encoding="utf-8",
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
     )
     return repo
 

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -1,7 +1,7 @@
-"""Regression tests for the systemd scheduling files (Issues #21, #33).
+"""Regression tests for the systemd scheduling files (Issues #21, #33, #51).
 
-The scheduler runs 24 hours a day: the idle polling interval is 15 minutes
-across the full day (00:00, 00:15, ..., 23:45). The timer must not add a
+The scheduler runs 24 hours a day: the idle polling interval is 5 minutes
+across the full day (00:00, 00:05, ..., 23:55). The timer must not add a
 task duration limit, must not queue catch-up ticks, and the README must
 document the same schedule as the unit files.
 """
@@ -37,18 +37,18 @@ def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
     return sections
 
 
-def test_timer_polls_ready_issues_every_15_minutes_all_day():
+def test_timer_polls_ready_issues_every_5_minutes_all_day():
     timer = parse_unit(TIMER_FILE)
     on_calendar = timer["Timer"]["OnCalendar"]
-    # Triggers: 00:00, 00:15, ..., 23:45 — every tick across the full day.
-    assert on_calendar == ["*-*-* *:00/15"]
+    # Triggers: 00:00, 00:05, ..., 23:55 — every tick across the full day.
+    assert on_calendar == ["*-*-* *:00/5"]
     # Semantic guard: the hour field must be open (no night-window range such
-    # as 01..06) and the minute field must step by 15 minutes.
+    # as 01..06) and the minute field must step by 5 minutes.
     date_part, time_part = on_calendar[0].split(" ")
     assert date_part == "*-*-*"
     hour_field, minute_field = time_part.split(":")
     assert hour_field == "*"
-    assert minute_field == "00/15"
+    assert minute_field == "00/5"
 
 
 def test_timer_calendar_expression_parses_with_systemd_analyze():


### PR DESCRIPTION
Fixes #51

<!-- muyan-pilot:run=a78f2860 -->
run_id=a78f2860

## What

The cross-process concurrency control (Issue #39 / PR #46, max_concurrency with
flock slots, default 1) is merged and live on main, so the systemd user timer
now polls every 5 minutes: OnCalendar=*-*-* *:00/5 (triggers 00:00, 00:05,
..., 23:55, 24 h a day).

- The single local Pi slot constraint is unchanged (max_concurrency default 1);
  no new business timeout, no task duration limit change.
- README, AGENTS.md and the EN/ZH docs (operations, getting-started, index,
  testing) document the 5-minute schedule; the timer tests pin the new
  OnCalendar and the former stale-5-minute-timer guard is inverted into a guard
  that no stale 15-minute OnCalendar remains in any doc page.
- The 15-second PR/activity poll no longer claims the idle timer's cadence
  (bootstrap_runner.py docstring, README).

## Verification

- TDD: red (4 failed, 47 passed, 0.09 s) -> green (224 passed in the six
  affected test files) -> full suite 895 passed in 74.24 s under
  /usr/bin/python3.
- Coverage gate: TOTAL 11303 statements / 1588 branches, 0 missed -> 100%
  line and branch.
- systemd: systemctl --user is-active muyan-pilot.timer -> active;
  systemd-analyze calendar '*-*-* *:00/5' -> Normalized *-*-* *:00/5:00,
  next elapse on a 5-minute boundary; the service was never manually started
  (the live install-units re-synced the identical frozen-base templates,
  doctor reports unit_drift: clean). After the merge, the documented
  post-merge install-units step switches the live timer to the 5-minute
  boundary (README 完整部署时序).

Run artifacts: .muyan-pilot/runs/issue-51-a78f2860/ (plan.md, test.log,
verify.md) in the task worktree.