### PR TITLE
fix: pin the post-merge install-units contract for unit template changes (Issue #131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,15 @@ is **one runtime outcome** (when X, should Y, actually Z).
   active, slots, Pi session, current Issue, recent journal). Full sequence:
   merge to main -> install units -> daemon-reload -> timer next trigger ->
   ExecStartPre syncs origin/main -> drift check -> Runner starts one Issue.
+- A template change is a deployment change (Issue #131): a PR that
+  modifies `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
+  must be followed, after the merge to main, by the human-run
+  `muyan_pilot.py install-units` (the "install units" step of the
+  deployment sequence) — the Runner NEVER auto-copies or auto-overwrites
+  the installed units. An unsynced template change is caught by the
+  pre-start drift check (structured `unit_drift`, fail fast, no slot,
+  no claim) on every start until the human runs the sync command: the
+  gate is the canary for the deployment, not a bug to be bypassed.
 
 ## Git transport (Issue #114)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ git merge 到 main
   -> Runner 启动并执行一个 Issue
 ```
 
+**模板变更必须合并后重新同步（Issue #131）**：`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是部署配置，不是普通代码——修改任一模板的 PR 合并到 main 后、下一次 timer 触发前，必须由人工运行 `python3 muyan_pilot.py install-units --config muyan-pilot.toml` 同步两个 user unit（幂等，不碰运行中的 Runner）。Runner 本身 never auto-syncs（从不自动复制、自动覆盖已安装 unit）：模板变更未同步时，每次启动都会被启动前漂移检查 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行同步命令——这是设计内的哨兵行为，不是故障（2026-08-27 实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行 `install-units`，service 每次启动都因 `unit_drift` 失败，直到人工同步，见 Issue #131）。
+
 ## Git transport（Issue #114）
 
 两条认证通道，职责边界清晰：

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -37,6 +37,28 @@ systemctl --user list-timers muyan-pilot.timer
 systemctl --user status muyan-pilot.service
 ```
 
+## After a unit template changes (Issue #131)
+
+The unit templates are deployment config, not ordinary code. When a PR
+changes `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
+and merges to main, run the idempotent install BEFORE the next timer
+trigger:
+
+```bash
+python3 muyan_pilot.py install-units --config muyan-pilot.toml
+```
+
+It copies both templates into the user unit directory, runs
+daemon-reload and enables the timer — it never starts, stops or
+restarts a running Runner. The Runner itself NEVER auto-copies or
+auto-overwrites the installed units: an unsynced template change makes
+every start fail the pre-start `unit_drift` check (structured
+`unit_drift` line, non-zero exit, no slot, no claim) until the sync
+command is run. That fail-fast is the designed canary for the
+deployment, not a bug (2026-08-27: PR #130 changed the timer from 15
+to 5 minutes; the post-merge `install-units` was never run, so every
+start failed with `unit_drift` until a human synced — Issue #131).
+
 ## Logs (journal)
 
 The journal is the local record. Every line of a run starts with the run

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -32,6 +32,26 @@ systemctl --user list-timers muyan-pilot.timer
 systemctl --user status muyan-pilot.service
 ```
 
+## Unit 模板变更后（Issue #131）
+
+unit 模板是部署配置，不是普通代码。当 PR 修改
+`systemd/muyan-pilot.service` 或 `systemd/muyan-pilot.timer` 并合并到
+main 后，必须在下一次 timer 触发前运行幂等安装命令：
+
+```bash
+python3 muyan_pilot.py install-units --config muyan-pilot.toml
+```
+
+它把两个模板复制到用户 unit 目录、daemon-reload、enable timer——从不
+启动、停止或重启运行中的 Runner。Runner 本身 NEVER auto-copies /
+auto-overwrites（从不自动复制、自动覆盖已安装 unit）：模板变更未同步
+时，每次启动都会被启动前 `unit_drift` 检查 fail fast（结构化
+`unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行
+同步命令。这个 fail-fast 是部署的哨兵行为，不是缺陷（2026-08-27
+实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行
+`install-units`，每次启动都因 `unit_drift` 失败，直到人工同步——
+Issue #131）。
+
 ## 日志（journal）
 
 journal 是本地记录。一个 run 的每行都以 run id 前缀 `[<run_id>]` 开头，

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -236,3 +236,50 @@ def test_agents_md_documents_the_deployment_consistency_contract():
     assert "restart" in text
     # Drift blocks the start before any claim.
     assert "no claim" in text or "no slot" in text
+
+
+def test_template_change_pins_the_post_merge_install_contract():
+    """Issue #131 regression: a `systemd/` template change is a
+    deployment change. The 2026-08-27 incident: PR #130 (Issue #51)
+    changed the timer template from 15 to 5 minutes and merged to
+    main; the documented post-merge `install-units` step was never
+    run, so every service start failed the pre-start `unit_drift`
+    check (fail fast, by design) until a human ran the fix command.
+
+    The contract must therefore be pinned in EVERY place it is
+    documented — README, AGENTS.md and the EN/ZH operations pages —
+    so a future template change cannot merge and strand the
+    deployment again without the mandatory sync step being visible:
+    after the merge to main the human runs
+    `muyan_pilot.py install-units`; the Runner itself NEVER
+    auto-copies or auto-overwrites the installed units (the drift
+    check stays fail-fast — it is the canary, not a bug)."""
+    def template_change_contract(text: str) -> None:
+        # The trigger: a change of either repo unit template.
+        assert "systemd/muyan-pilot.timer" in text
+        assert "systemd/muyan-pilot.service" in text
+        # The mandatory follow-up: the idempotent install command,
+        # run after the merge to main.
+        assert "install-units" in text
+        # The Runner never auto-syncs the installed units.
+        assert "never" in text.lower() and "auto" in text.lower()
+        # The unsynced state is caught by the fail-fast drift check.
+        assert "unit_drift" in text
+
+    readme = README_FILE.read_text(encoding="utf-8")
+    # The README pins it in the deployment-consistency section (the
+    # section that carries the full deployment sequence).
+    section = readme.split("部署一致性", 1)[-1]
+    template_change_contract(section)
+
+    agents = AGENTS_FILE.read_text(encoding="utf-8")
+    # AGENTS.md pins it inside the Base freshness / deployment
+    # consistency contract.
+    agents_section = agents.split("## Base freshness", 1)[-1]
+    template_change_contract(agents_section)
+
+    # EN/ZH operations pages carry the same contract (the i18n parity
+    # contract: both languages document the same fact).
+    for slug in ("operations.mdx", "zh/operations.mdx"):
+        page = (REPO_ROOT / "docs" / slug).read_text(encoding="utf-8")
+        template_change_contract(page)


### PR DESCRIPTION
Fixes #131

<!-- muyan-pilot:run=4445f16e -->

run_id=4445f16e · role=implement · base=bc5aed7 (frozen origin/main at claim time)

## Root cause (confirmed with journal evidence)

**Template change without the one-time deployment sync — NOT an
install-units / drift-check implementation defect.**

Timeline (2026-08-27, `journalctl --user`):

1. **22:31:02** — PR #130 (Issue #51, run a78f2860) merged to main
   (`bc5aed7`): `systemd/muyan-pilot.timer` changed
   `OnCalendar=*-*-* *:00/15` → `*:00/5`.
2. **22:31:17** — next timer tick: `ExecStartPre` fast-forwarded the
   checkout to the new main; the pre-start `check_unit_drift`
   (bootstrap_runner.py:3087) found the installed unit (15-min,
   `installed_sha256=6cd77f5d…`) drifted from the new template (5-min,
   `repo_sha256=5c111ff5…`) and raised `UnitDriftError` — the exact
   structured line from the Issue:
   `unit_drift unit=muyan-pilot.timer … fix=python3 muyan_pilot.py install-units`
   → service exited `status=1/FAILURE`. This is the Issue #103 contract
   working as designed: fail fast, no slot, no claim, no label change.
3. **23:25:42** — a human ran the documented recovery
   `python3 muyan_pilot.py install-units --config muyan-pilot.toml`
   (units synced, daemon-reload, timer re-enabled; the running service
   was never touched). **23:25:45** — service started,
   `unit_drift clean`, claimed Issue #131 (this run).

`install-units` (idempotent; copy templates → daemon-reload →
`enable --now` timer; never starts/stops/restarts the service) and the
drift gate are both correct — the check is the canary that caught the
unsynced deployment, and the fix command recovered it in one run. The
deployment-path gap: nothing pinned the mandatory post-merge
`install-units` step for `systemd/` template changes, so a merged
template change could silently strand the machine.

## Minimal fix (no contract bypass)

Pin the contract in every place it is documented and enforce it with a
regression test:

- `tests/test_systemd_timer.py` — new
  `test_template_change_pins_the_post_merge_install_contract`: the
  template-change → post-merge `install-units` contract must be present
  in README (部署一致性 section), AGENTS.md (Base freshness) and the
  EN/ZH operations pages; red before the text, green after.
- `README.md` — 部署一致性: a template change requires the post-merge
  human `install-units`; the Runner never auto-syncs; the fail-fast
  `unit_drift` gate is the canary, not a bug (incident recorded).
- `AGENTS.md` — Base freshness: "A template change is a deployment
  change (Issue #131)" bullet.
- `docs/operations.mdx` / `docs/zh/operations.mdx` — new "After a unit
  template changes (Issue #131)" / "Unit 模板变更后（Issue #131）"
  subsections (EN/ZH parity).

**No runtime code changed**: the `unit_drift` gate is not bypassed, no
hash check is relaxed, and the Runner never auto-copies or
auto-overwrites installed units.

## Recovery command (recorded per the Issue)

```bash
python3 muyan_pilot.py install-units --config muyan-pilot.toml
```

(already executed by a human at 2026-08-27 23:25:42; it is idempotent
and never starts/stops/restarts the service)

## Verification (real machine + suite)

- Full suite: **896 passed**; **100% line/branch coverage**
  (`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`;
  `coverage report --fail-under=100`).
- Docs build smoke (CI parity): `cd docs && mint validate` → success.
- Real deployment path: `muyan_pilot.py doctor` → `unit_drift: clean`
  (installed sha256 == template sha256 for BOTH units:
  service `1d6b6bf0…`, timer `5c111ff5…`), timer + service `active`;
  `systemd-analyze calendar '*-*-* *:00/5'` parses (normalized
  `*-*-* *:00/5:00`) — the live schedule matches the repo template and
  the documented contract.
- TDD red→green recorded in the run's `test.log`.
