### PR TITLE
feat: executable muyan-pilot CLI entry (packaging, console script, systemd CLI ExecStart)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
           python3 -m pip install -r requirements.txt
           python3 -m pip install pytest coverage pyyaml
 
+      # CLI packaging (Issue #140): the console script must install in a
+      # clean environment and the entry must work (`muyan-pilot --help`
+      # and `muyan-pilot --version`, exit 0). The packaging file is the
+      # PEP 621 pyproject.toml; the build runs in an isolated
+      # environment (setuptools from the index).
+      - name: Install the CLI (console script) and verify the entry (Issue #140)
+        run: |
+          python3 -m pip install .
+          muyan-pilot --help
+          muyan-pilot --version
+
       - name: Run the full test suite with branch coverage (contract)
         run: python3 -m coverage run --branch -m pytest tests/ -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,27 @@ jobs:
       # CLI packaging (Issue #140): the console script must install in a
       # clean environment and the entry must work (`muyan-pilot --help`
       # and `muyan-pilot --version`, exit 0). The packaging file is the
-      # PEP 621 pyproject.toml; the build runs in an isolated
-      # environment (setuptools from the index).
-      - name: Install the CLI (console script) and verify the entry (Issue #140)
+      # PEP 621 pyproject.toml.
+      #
+      # The install uses the DOCUMENTED production flow (`uv tool
+      # install`, the uv-tool console script) — not a plain `pip
+      # install .`: uv tool places the self-contained executable at
+      # ~/.local/bin/muyan-pilot, the same path the service template's
+      # ExecStart (%h/.local/bin/muyan-pilot) uses, so the real
+      # `systemd-analyze --user verify` test resolves the unit's
+      # absolute ExecStart against the real executable here (a plain
+      # pip install would put the script in the venv bin, where the
+      # unit's %h path does not point).
+      - name: Install uv (the documented CLI installer)
         run: |
-          python3 -m pip install .
-          muyan-pilot --help
-          muyan-pilot --version
+          python3 -m pip install uv
+          uv --version
+
+      - name: Install the CLI (uv tool, the documented flow) and verify the entry (Issue #140)
+        run: |
+          uv tool install --python 3.14 .
+          ~/.local/bin/muyan-pilot --help
+          ~/.local/bin/muyan-pilot --version
 
       - name: Run the full test suite with branch coverage (contract)
         run: python3 -m coverage run --branch -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ __pycache__/
 .pytest_cache/
 .coverage
 htmlcov/
+# Python packaging build artifacts (Issue #140: pyproject.toml builds)
+build/
+dist/
+*.egg-info/
 .muyan-pilot/
 .pi-session/
 .worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ is **one runtime outcome** (when X, should Y, actually Z).
 ## Automatic observability
 
 - Normal operation publishes progress automatically: no human status
-  command, no polling, no supervision. `muyan_pilot.py status` is a debug
+  command, no polling, no supervision. `muyan-pilot status` is a debug
   attachment only — never part of the normal workflow or acceptance
   evidence.
 - Journal: while a session runs, the journal gets a heartbeat at most every
@@ -146,8 +146,8 @@ is **one runtime outcome** (when X, should Y, actually Z).
   unchanged.
 - Deployment consistency (Issue #103): the repo templates
   `systemd/muyan-pilot.service` and `systemd/muyan-pilot.timer` are the
-  single source of truth for the installed user units. `muyan_pilot.py
-  install-units` is the idempotent install (copy both templates into the
+  single source of truth for the installed user units. The idempotent
+  install is `muyan-pilot install-units` (copy both templates into the
   user unit dir, `systemctl --user daemon-reload`, enable the timer, print
   the deployed commit and unit hashes): it NEVER starts/stops/restarts the
   service — a running Runner is never killed or restarted by an install,
@@ -155,15 +155,23 @@ is **one runtime outcome** (when X, should Y, actually Z).
   checks BOTH installed units against the templates BEFORE any slot or
   claim: drift logs a structured `unit_drift` line per unit (repo path,
   installed path, sha256s, the install fix command) and fails fast — no
-  slot, no claim, no label change — until the units are synced. `muyan_pilot.py
-  doctor` is the read-only report (repo commit, unit drift, timer/service
-  active, slots, Pi session, current Issue, recent journal). Full sequence:
+  slot, no claim, no label change — until the units are synced. The
+  read-only report is `muyan-pilot doctor` (repo commit, unit drift,
+  timer/service active, slots, Pi session, current Issue, recent
+  journal). Full sequence:
   merge to main -> install units -> daemon-reload -> timer next trigger ->
   ExecStartPre syncs origin/main -> drift check -> Runner starts one Issue.
+- The service `ExecStart` is the installed `muyan-pilot` CLI (Issue #140):
+  the official usage is the `uv tool`-installed console script (`uv tool
+  install` / `uv tool upgrade`), and the unit uses the explicit
+  deployable entry `%h/.local/bin/muyan-pilot` (verifiable with
+  `systemd-analyze --user verify`); the direct-execution entry of
+  `muyan_pilot.py` stays a development/compatibility path, never the
+  documented usage.
 - A template change is a deployment change (Issue #131): a PR that
   modifies `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
   must be followed, after the merge to main, by the human-run
-  `muyan_pilot.py install-units` (the "install units" step of the
+  `muyan-pilot install-units` (the "install units" step of the
   deployment sequence) — the Runner NEVER auto-copies or auto-overwrites
   the installed units. An unsynced template change is caught by the
   pre-start drift check (structured `unit_drift`, fail fast, no slot,
@@ -198,16 +206,16 @@ is **one runtime outcome** (when X, should Y, actually Z).
   silent skip**.
 - An existing HTTPS remote is never rewritten silently and never read
   from a comment or Issue body: only the human-run setup entry
-  (`muyan_pilot.py setup`) migrates it with the plain
+  (`muyan-pilot setup`) migrates it with the plain
   `git remote set-url origin git@github.com:owner/repo.git`; every
   other path fails fast with the exact migration command. A remote
   that does not point at the first configured source repo is never
   migrated (the rewrite would re-target the checkout at a different
   repository) — it fails with the mismatch scene whether or not the
-  setup entry authorizes the migration. `muyan_pilot.py
-  doctor` reports the transport read-only (protocol, expected URL, SSH
-  probe) — a failed transport is REPORTED there, not raised (the
-  pre-start check is the fail-fast gate).
+  setup entry authorizes the migration. `muyan-pilot doctor` reports
+  the transport read-only (protocol, expected URL, SSH probe) — a
+  failed transport is REPORTED there, not raised (the pre-start check
+  is the fail-fast gate).
 
 ## Task dependencies (blockedBy)
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,29 @@
 - **系统架构总览**（GitHub Issues、systemd timer/service、Runner、Pi、worktree、llama-server、可选 `local-llm-kv-cache` proxy、PR/review/merge）：文档站首页 [index](docs/index.mdx) / [zh/index](docs/zh/index.mdx)；
 - **任务生命周期状态机**（`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked`，标出 Epic/Release task/P0 边界）：[workflow](docs/workflow.mdx) / [zh/workflow](docs/zh/workflow.mdx)。
 
+## CLI 安装与升级（Issue #140）
+
+正式使用方式是 `uv tool` 安装的可执行 CLI（console script `muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）：
+
+```bash
+# 在部署 checkout 目录安装（如 /home/xqianliu/Documents/muyan/muyan-pilot）：
+# --python 固定生产解释器（本机 /usr/bin/python3，3.14）
+uv tool install --python /usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot
+# merge 到 main 之后升级（版本号变化时）：
+uv tool upgrade muyan-pilot
+# 或者从最新本地代码直接重装（版本号未变时；--reinstall 绕过构建缓存）：
+uv tool install --force --reinstall /home/xqianliu/Documents/muyan/muyan-pilot
+# 验证安装：
+muyan-pilot --help
+muyan-pilot --version
+```
+
+`uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件在 `~/.local/bin/muyan-pilot`（systemd unit 的 PATH 已包含该目录，见「部署一致性」）。发布包不携带第三方运行时依赖、token 或用户目录：配置（`muyan-pilot.toml`）和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径，不是正式使用方式。
+
 ## 当前运行
 
 ```bash
-/usr/bin/python3 bootstrap_runner.py --config muyan-pilot.toml
+python3 bootstrap_runner.py --config muyan-pilot.toml
 ```
 
 正常运行使用 systemd user timer，全天 24 小时运行，每 5 分钟自动执行一次（触发点覆盖 00:00–23:55）：
@@ -24,7 +43,7 @@
 ```bash
 # 幂等安装用户级 service/timer（仓库模板复制到用户 systemd 目录、
 # daemon-reload、enable timer），并输出部署 commit/hash：
-python3 muyan_pilot.py install-units --config muyan-pilot.toml
+muyan-pilot install-units --config muyan-pilot.toml
 systemctl --user list-timers muyan-pilot.timer
 ```
 
@@ -44,15 +63,15 @@ git fetch origin main && git merge --ff-only origin/main
 
 仓库中的 `systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。
 
-**幂等安装**：`python3 muyan_pilot.py install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`、`systemctl --user enable --now muyan-pilot.timer`，并输出部署 commit（部署 checkout 的 HEAD，即模板来源）和每个 unit 的 sha256。安装**不会**启动、停止或重启 service：当前运行中的 Runner 不被中断，新配置从下一次 service 启动生效。
+**幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`、`systemctl --user enable --now muyan-pilot.timer`，并输出部署 commit（部署 checkout 的 HEAD，即模板来源）和每个 unit 的 sha256。安装**不会**启动、停止或重启 service：当前运行中的 Runner 不被中断，新配置从下一次 service 启动生效。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
 
 **启动前漂移检查**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 都覆盖）。一致时记录 `unit_drift clean`；发现漂移时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签），直到 unit 同步：
 
 ```text
-unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=python3 muyan_pilot.py install-units
+unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=muyan-pilot install-units
 ```
 
-**只读诊断**：`python3 muyan_pilot.py doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
+**只读诊断**：`muyan-pilot doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
 
 **完整部署时序**（从代码合并到下一次 Runner 启动）：
 
@@ -67,7 +86,7 @@ git merge 到 main
   -> Runner 启动并执行一个 Issue
 ```
 
-**模板变更必须合并后重新同步（Issue #131）**：`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是部署配置，不是普通代码——修改任一模板的 PR 合并到 main 后、下一次 timer 触发前，必须由人工运行 `python3 muyan_pilot.py install-units --config muyan-pilot.toml` 同步两个 user unit（幂等，不碰运行中的 Runner）。Runner 本身 never auto-syncs（从不自动复制、自动覆盖已安装 unit）：模板变更未同步时，每次启动都会被启动前漂移检查 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行同步命令——这是设计内的哨兵行为，不是故障（2026-08-27 实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行 `install-units`，service 每次启动都因 `unit_drift` 失败，直到人工同步，见 Issue #131）。
+**模板变更必须合并后重新同步（Issue #131）**：`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是部署配置，不是普通代码——修改任一模板的 PR 合并到 main 后、下一次 timer 触发前，必须由人工运行 `muyan-pilot install-units --config muyan-pilot.toml` 同步两个 user unit（幂等，不碰运行中的 Runner）。Runner 本身 never auto-syncs（从不自动复制、自动覆盖已安装 unit）：模板变更未同步时，每次启动都会被启动前漂移检查 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行同步命令——这是设计内的哨兵行为，不是故障（2026-08-27 实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行 `install-units`，service 每次启动都因 `unit_drift` 失败，直到人工同步，见 Issue #131）。
 
 ## Git transport（Issue #114）
 
@@ -84,17 +103,17 @@ git merge 到 main
 transport_check_failed repo_dir=<repo path> source_repos=<...> reason=ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — ...
 ```
 
-**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`python3 muyan_pilot.py setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。指向其他仓库的 remote 从不被迁移（改写会把 checkout 指向另一个仓库），无论 setup 是否授权迁移都直接以 mismatch 现场 fail fast。手工等价命令：
+**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`muyan-pilot setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。指向其他仓库的 remote 从不被迁移（改写会把 checkout 指向另一个仓库），无论 setup 是否授权迁移都直接以 mismatch 现场 fail fast。手工等价命令：
 
 ```bash
 git remote set-url origin git@github.com:OWNER/REPO.git
 ```
 
-**只读诊断**：`python3 muyan_pilot.py doctor` 报告 transport 行（remote、配置的 URL、protocol、期望 URL、SSH 探测结果）；SSH 不可用时 doctor 把失败现场写进报告（`transport: FAILED ...`），不中断其余报告——fail-fast 门禁是启动前检查，doctor 是诊断报告。
+**只读诊断**：`muyan-pilot doctor` 报告 transport 行（remote、配置的 URL、protocol、期望 URL、SSH 探测结果）；SSH 不可用时 doctor 把失败现场写进报告（`transport: FAILED ...`），不中断其余报告——fail-fast 门禁是启动前检查，doctor 是诊断报告。
 
 ## 远程 CI（GitHub Actions）
 
-仓库契约（全量 pytest + 100% line/branch coverage）不只在本机 Runner 上跑：`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次 `push` 到 `main` 时跑同一份契约，测试失败或覆盖率低于 100% 时 CI 变红。单个 job，不加 lint、矩阵或缓存（Issue #56）。
+仓库契约（全量 pytest + 100% line/branch coverage）不只在本机 Runner 上跑：`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次 `push` 到 `main` 时跑同一份契约，测试失败或覆盖率低于 100% 时 CI 变红。单个 job，不加 lint、矩阵或缓存（Issue #56）。CI 还在干净环境里 `pip install .` 安装 console script 并验证入口（`muyan-pilot --help` / `muyan-pilot --version` 退出码 0，Issue #140）——「干净环境安装后 `muyan-pilot --help` 成功」是永久门禁，不是一次性本地检查。
 
 与本地的差异：生产运行时是 Runner 机器的 `/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以 workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过 PATH 上固定的 `python3` 执行（命令与本地相同，只有解释器路径不同）。
 
@@ -102,44 +121,44 @@ Checkout 用 `fetch-depth: 0`（完整历史 + 全部 tags）：发布对账测�
 
 ## 任务派发与状态
 
-`muyan_pilot.py` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
+`muyan-pilot` 是最小 CLI（`uv tool` 安装，见「CLI 安装与升级」），用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
 
 ```bash
 # 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
-python3 muyan_pilot.py add "任务标题" --body "任务描述" --config muyan-pilot.toml
+muyan-pilot add "任务标题" --body "任务描述" --config muyan-pilot.toml
 
 # 派发到指定 source repo（必须在配置 source_repos 中）
-python3 muyan_pilot.py add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
+muyan-pilot add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
 
 # 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和最近结果（ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked）
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 ```
 
 `add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
 
 ```bash
 # 打印当前 run 的 Pi session 文件路径（repo_dir/.worktrees 下最新的 .pi-session/*.jsonl）
-python3 muyan_pilot.py session --config muyan-pilot.toml
+muyan-pilot session --config muyan-pilot.toml
 
 # 持续跟随该文件（等价 tail -f；跟的是命令启动时选中的文件，不中途跳到更新的文件）
-python3 muyan_pilot.py session --follow --config muyan-pilot.toml
+muyan-pilot session --follow --config muyan-pilot.toml
 ```
 
 `session` 是排查附件（日常仍看 journal / GitHub），不是日常入口：没有 session 文件时 fail fast（退出码非零，说明没有正在跑的 Pi），不猜路径；`--pretty` 把 JSONL 打一行摘要（timestamp / role / tool|text|thinking 截断），默认仍是原始 JSONL。不开 tmux、不新包装脚本、不新增 systemd unit（Issue #74）。
 
 ```bash
 # 幂等安装 systemd units（见「部署一致性」）：输出部署 commit 和每个 unit 的 sha256
-python3 muyan_pilot.py install-units --config muyan-pilot.toml
+muyan-pilot install-units --config muyan-pilot.toml
 
 # 只读部署/健康报告：repo commit、unit drift、timer/service active、
 # Runner slot、Pi session、当前 Issue、最近 journal 活动
-python3 muyan_pilot.py doctor --config muyan-pilot.toml
+muyan-pilot doctor --config muyan-pilot.toml
 
 # 一次性 setup（新机器/新仓库）：gh auth + 仓库权限、平台 labels
 # （labels.toml 为唯一事实源）、systemd user units、checkout 检查
 # （含 Git transport：HTTPS origin 迁移为 SSH + SSH 连通性探测）、
 # 可选模型 proxy（warning only）；幂等、fail-fast，--json 输出等价 JSON
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 ## GitHub Issue 标签（外部状态）
@@ -149,7 +168,7 @@ GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建
 ```bash
 # 一次性 setup：gh auth + 仓库权限、平台 labels、systemd user units、
 # checkout 检查、可选模型 proxy（warning only）；输出 key=value（--json 等价 JSON）
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略或先 `gh label list` 检查）：
@@ -168,7 +187,7 @@ gh label list --repo xqliu/muyan-pilot
 
 | Label | 含义 | 进入条件 | 离开条件 |
 |---|---|---|---|
-| `ai-ready` | 明确派发给 Pilot 的新任务（允许 AI 领取） | `muyan_pilot.py add` 创建时自动添加，或人工 `gh issue edit --add-label ai-ready` | 领取时加 `ai-in-progress`（`ai-ready` 保留）；成功合并后保留（与 `ai-merged` 共存，表示已交付） |
+| `ai-ready` | 明确派发给 Pilot 的新任务（允许 AI 领取） | `muyan-pilot add` 创建时自动添加，或人工 `gh issue edit --add-label ai-ready` | 领取时加 `ai-in-progress`（`ai-ready` 保留）；成功合并后保留（与 `ai-merged` 共存，表示已交付） |
 | `ai-in-progress` | Runner 已领取、正在执行 | 领取 `ai-ready` Issue 时由 Runner 添加 | 开出 PR 时移除（转 `ai-pr-opened`）；失败时移除（转 `ai-blocked`）；Runner 被杀时残留，由下一 tick 的重启恢复扫描接回 |
 | `ai-pr-opened` | PR 已创建，当前等待 review；不会自动再次启动 Fixer | `verify_pr` 验收通过后由 Runner 添加（同时移除 `ai-in-progress`） | clean verdict 合并后移除（转 `ai-merged`）；review finding / base 冲突时移除（转 `ai-fix-needed`）；终态失败时移除（转 `ai-blocked`） |
 | `ai-fix-needed` | 已有 PR 需要在原 branch/worktree/PR 上继续修复；定时 Runner 自动拾取 | 审查会话未能修复的 finding，或 PR 落后最新 base / merge conflict | 下一个审查会话（同一 PR）clean verdict 合并后移除（转 `ai-merged`）；超轮 / 无法修复时移除（转 `ai-blocked`） |
@@ -209,7 +228,7 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。
 任务进入 GitHub Issue 池后，Runner 自己完成领取 → plan → implement → test →
 verify → independent review（会话内修复）→ merge，并主动发布过程和最终结果。
-`muyan_pilot.py status` 只保留为开发/故障排查附件，不是产品入口，也不能作为
+`muyan-pilot status` 只保留为开发/故障排查附件，不是产品入口，也不能作为
 自动可观测性的验收证据。
 
 ### journal（本地，systemd）
@@ -274,10 +293,10 @@ Issue 标记 `ai-blocked`。
 
 ### 调试附件
 
-`muyan_pilot.py status` 只读展示当前（`ai-in-progress`）任务的实时状态（仅供开发/故障排查）：
+`muyan-pilot status` 只读展示当前（`ai-in-progress`）任务的实时状态（仅供开发/故障排查）：
 
 ```bash
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 # capacity: 1
 # slots: 1/1
 #   slot-1: pid=4321
@@ -319,7 +338,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 - 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
 - 达到 `max_concurrency` 时，新 Runner 不领取 Issue、不修改标签、不调用 Pi，记录结构化日志 `capacity_full max_concurrency=... slot_dir=...` 后正常退出（退出码 0），等 systemd timer 下次触发；
 - slot 锁由打开的文件描述符持有：进程正常结束、SIGTERM/SIGINT（systemd stop / Ctrl+C）或被 SIGKILL 时，内核自动释放锁——活着的持有者永远不会因为时间或 PID 检查丢失 slot，死掉的持有者永远不会占住 slot，异常退出不会造成永久锁死；slot 文件本身保留（它是锁目标，不是令牌），`status` 按锁的实际状态报告占用；
-- `muyan_pilot.py status` 显示配置容量和当前已占用 slot（`capacity: N`、`slots: k/N`、`slot-N: pid=...`）；占用判定用非阻塞 `flock` 探测（探测成功即空闲并立即解锁），PID 仅用于展示；
+- `muyan-pilot status` 显示配置容量和当前已占用 slot（`capacity: N`、`slots: k/N`、`slot-N: pid=...`）；占用判定用非阻塞 `flock` 探测（探测成功即空闲并立即解锁），PID 仅用于展示；
 - 直接在 Pilot 外手工运行的任意 `pi` 命令不属于该配置控制范围：`max_concurrency` 只约束 Runner 领取任务时启动的 Pi，手工 `pi` 不受 slot 管理，也不会释放或占用任何 slot。
 
 ## 全链路 run_id（correlation ID）

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -23,7 +23,7 @@ Dispatch a task for the Pilot by creating an Issue and labeling it
 `ai-ready` (the CLI does both in one step):
 
 ```bash
-python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+muyan-pilot add "task title" --body "task body" --config muyan-pilot.toml
 ```
 
 or manually:

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -9,6 +9,7 @@ machine layout.
 | Requirement | What it is used for | Check |
 |---|---|---|
 | Python 3.14 | The Runner and the test contract (CI pins the same minor version) | `python3 --version` |
+| [uv](https://docs.astral.sh/uv/) | Installs the `muyan-pilot` CLI into an isolated tool environment | `uv --version` |
 | [Pi](https://github.com/earendil-works/pi) CLI | The development agent; one full session per task | `pi --version` |
 | Git | Worktrees, branches, base freshness | `git --version` |
 | GitHub CLI (`gh`) | Issues, labels, PRs, merge | `gh auth status` |
@@ -40,7 +41,30 @@ git clone https://github.com/xqliu/muyan-pilot.git
 cd muyan-pilot
 ```
 
-## 2. Create the configuration
+## 2. Install the CLI
+
+The official usage is the installed `muyan-pilot` console script (the
+PEP 621 packaging in `pyproject.toml` maps
+`muyan-pilot = muyan_pilot:main`). Install it with `uv tool` from the
+clone directory — `--python` pins the production interpreter (3.14):
+
+```bash
+uv tool install --python /usr/bin/python3 .
+muyan-pilot --help
+```
+
+`uv tool` keeps the CLI in an isolated tool environment; the executable
+lands in `~/.local/bin` (on the PATH of the systemd unit). After a merge
+to main, refresh it with `uv tool upgrade muyan-pilot` (when the version
+changes) or `uv tool install --force --reinstall .` from the clone
+directory (when the version is unchanged — `--reinstall` bypasses the
+build cache). The release package carries no third-party runtime
+dependency, no token and no user directory — the config file and the
+user systemd dir stay machine-local. The direct-execution entry of
+`muyan_pilot.py` (running the file with the interpreter) stays a
+development/compatibility path.
+
+## 3. Create the configuration
 
 The repository ships a committed example; the real config is local state
 (gitignored). Copy it and edit it:
@@ -82,7 +106,7 @@ skills = []
 context_files = []
 ```
 
-## 3. Run the one-time setup
+## 4. Run the one-time setup
 
 The setup entry does the whole initialization in one command: it
 verifies `gh auth status` and the repo permissions, aligns the platform
@@ -93,7 +117,7 @@ the systemd user units and enables the timer, checks the checkout, and
 reports the optional model proxy:
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 It is idempotent (re-running it never creates duplicate labels, units
@@ -102,10 +126,10 @@ dirty checkout or a missing systemd user bus stops it with the concrete
 reason). See [One-time setup](/setup) for the full output contract,
 success and failure examples.
 
-## 4. Run one tick manually
+## 5. Run one tick manually
 
 The manual command is for first verification and troubleshooting only —
-normal operation is scheduled by the timer (step 6):
+normal operation is scheduled by the timer (step 7):
 
 ```bash
 python3 bootstrap_runner.py --config muyan-pilot.toml
@@ -116,7 +140,7 @@ claim one `ai-ready` Issue (`p0`-labeled Issues are picked first, then
 bug-labeled Issues, then plain features), then it exits. With an empty
 ready queue it exits cleanly without claiming anything.
 
-## 5. Smoke walkthrough (from zero)
+## 6. Smoke walkthrough (from zero)
 
 The smallest end-to-end proof that your setup works. Run it in the clone
 directory from step 1; every command is relative to that directory.
@@ -124,12 +148,12 @@ directory from step 1; every command is relative to that directory.
 ```bash
 # a. Dispatch a tiny task into the first configured source repo.
 #    `add` creates the Issue and labels it ai-ready in one step.
-python3 muyan_pilot.py add "Docs: verify smoke walkthrough" \
+muyan-pilot add "Docs: verify smoke walkthrough" \
   --body "Read README.md and confirm the smoke walkthrough commands exist." \
   --config muyan-pilot.toml
 
 # b. Watch the queue: the new Issue is ready.
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 
 # c. Run one tick: the Runner claims the Issue, starts Pi in a fresh
 #    worktree, and works toward a PR.
@@ -138,7 +162,7 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 # d. Follow the live activity while the tick runs (second terminal):
 journalctl --user -u muyan-pilot.service -f
 # or, for a manual tick, follow the session JSONL directly:
-python3 muyan_pilot.py session --follow --config muyan-pilot.toml
+muyan-pilot session --follow --config muyan-pilot.toml
 
 # e. After the PR is opened, the Issue carries ai-pr-opened and the
 #    delivery continues (independent review, in-session fix, merge) on
@@ -152,7 +176,7 @@ and the journal shows `run_end ... result=pr_opened`. If any step fails,
 the Issue is marked `ai-blocked` with the scene — see
 [Operations](/operations) for recovery.
 
-## 6. Verify the timer
+## 7. Verify the timer
 
 The setup step already installed the units and enabled the timer; verify
 it:
@@ -170,10 +194,12 @@ fast-forwards `main` before starting — see [Operations](/operations)).
 <Note>
 The committed unit templates reference the author's clone layout via
 `%h` specifiers (`%h/Documents/muyan/muyan-pilot`). If your clone lives
-elsewhere, edit the **installed** units in your user unit directory
-(`~/.config/systemd/user/`) to point `WorkingDirectory`,
-`MUYAN_PILOT_CONFIG` and `ExecStart` at **your** clone path, then
-`systemctl --user daemon-reload`. The repo templates stay the single
+elsewhere, install the CLI from **your** clone path (step 2) and edit
+the **installed** units in your user unit directory
+(`~/.config/systemd/user/`) to point `WorkingDirectory` and
+`MUYAN_PILOT_CONFIG` at **your** clone path, then
+`systemctl --user daemon-reload`. `ExecStart` is the installed
+`muyan-pilot` CLI and stays relative. The repo templates stay the single
 source of truth for everything else — see [Operations](/operations) on
 drift detection.
 </Note>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -17,7 +17,7 @@ flowchart LR
   subgraph machine["Runner machine (systemd user session)"]
     timer["muyan-pilot.timer (5-minute tick)"]
     service["muyan-pilot.service (ExecStartPre: fast-forward main)"]
-    runner["Runner (muyan_pilot.py): claim → worktree → Pi → PR → review → merge"]
+    runner["Runner (muyan-pilot CLI): claim → worktree → Pi → PR → review → merge"]
     worktree["task worktree + feature branch (frozen origin/main SHA, run id in the name)"]
     pi["Pi sessions (implement + independent review)"]
     model["llama-server (core: any OpenAI-compatible endpoint)"]

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -45,7 +45,7 @@ and merges to main, run the idempotent install BEFORE the next timer
 trigger:
 
 ```bash
-python3 muyan_pilot.py install-units --config muyan-pilot.toml
+muyan-pilot install-units --config muyan-pilot.toml
 ```
 
 It copies both templates into the user unit directory, runs
@@ -99,24 +99,31 @@ a stalled session either resumes (the failure signal reached the model
 and the first new event resets the recovery state) or the run fails
 fast through the normal `ai-blocked` path.
 
-## The CLI (`muyan_pilot.py`)
+## The CLI (`muyan-pilot`)
+
+The official entry is the installed `muyan-pilot` console script
+(`uv tool install --python /usr/bin/python3 <clone dir>`; refresh with
+`uv tool upgrade muyan-pilot` or `uv tool install --force --reinstall
+<clone dir>` — see [Getting started](/getting-started)). The
+direct-execution entry of `muyan_pilot.py` stays a development/
+compatibility path.
 
 ```bash
 # Create an Issue in a configured source repo and label it ai-ready
-python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
-python3 muyan_pilot.py add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
+muyan-pilot add "task title" --body "task body" --config muyan-pilot.toml
+muyan-pilot add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
 
 # Read-only queue view: current (ai-in-progress) task with live Pi
 # activity, the next ready Issue, and the most recent result per source
 # repo (ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked)
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 
 # Read-only deployment/health report: repo commit, unit drift, git
 # transport (configured origin URL, protocol, expected SSH URL, SSH
 # probe — a failed transport is reported as `transport: FAILED ...`,
 # not raised), timer/service state, slots, Pi session, current Issue,
 # recent journal
-python3 muyan_pilot.py doctor --config muyan-pilot.toml
+muyan-pilot doctor --config muyan-pilot.toml
 
 # One-time, idempotent initialization (new machine / new repo): gh
 # auth + repo permissions, platform labels, systemd user units, and
@@ -125,13 +132,12 @@ python3 muyan_pilot.py doctor --config muyan-pilot.toml
 # human-authorized migration path; the Runner itself never rewrites a
 # remote) and the SSH connectivity is probed (fail fast, no HTTPS
 # fallback)
-python3 muyan_pilot.py setup --config muyan-pilot.toml
-```
+muyan-pilot setup --config muyan-pilot.toml
 
 # Print the live Pi session JSONL path (fail fast when no session exists)
-python3 muyan_pilot.py session --config muyan-pilot.toml
-python3 muyan_pilot.py session --follow --config muyan-pilot.toml   # tail -f
-python3 muyan_pilot.py session --pretty --config muyan-pilot.toml   # one-line summaries
+muyan-pilot session --config muyan-pilot.toml
+muyan-pilot session --follow --config muyan-pilot.toml   # tail -f
+muyan-pilot session --pretty --config muyan-pilot.toml   # one-line summaries
 ```
 
 All commands accept the config via `--config` or the

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -1,13 +1,13 @@
 # One-time setup
 
-`muyan_pilot.py setup` is the one-time, config-driven initialization
+`muyan-pilot setup` is the one-time, config-driven initialization
 entry for a new machine or a new task-pool repository. It verifies the
 local prerequisites, aligns the platform labels, installs the systemd
 user units, checks the checkout, and reports the optional model proxy —
 in one command, with a stable machine-readable result.
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 Run it once per machine (and once per new task-pool repository). It is
@@ -20,9 +20,10 @@ Setup is **fail-fast**: a core prerequisite failure stops the run
 before any later mutation, with the concrete reason on stderr and a
 non-zero exit code.
 
-1. **Commands** — `git`, `gh`, `python3` on the PATH, and a reachable
-   `systemctl --user` user bus (a container or headless session without
-   a user bus fails with the bus error).
+1. **Commands** — `git`, `gh`, `python3` and the installed
+   `muyan-pilot` CLI on the PATH, and a reachable `systemctl --user`
+   user bus (a container or headless session without a user bus fails
+   with the bus error).
 2. **Auth** — `gh auth status` (logged in with a usable token).
 3. **Per target repository** (every configured `source_repos` entry by
    default; exactly one with `--repo OWNER/REPO`):
@@ -102,7 +103,7 @@ changes the exit code. `migrated=true` means setup rewrote an HTTPS
 `--json` prints the equivalent JSON document:
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml --json
+muyan-pilot setup --config muyan-pilot.toml --json
 ```
 
 ## Success and failure examples
@@ -110,7 +111,7 @@ python3 muyan_pilot.py setup --config muyan-pilot.toml --json
 Success (exit code `0`):
 
 ```bash
-$ python3 muyan_pilot.py setup --config muyan-pilot.toml
+$ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=1 base_branch=main
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -28,7 +28,7 @@ flowchart LR
 ```
 
 ```text
-ai-ready                a task is dispatched (muyan_pilot.py add, or a human
+ai-ready                a task is dispatched (muyan-pilot add, or a human
                         adds the label)
   -> ai-in-progress     the Runner claims it: label added, worktree created
                         from the frozen origin/<base> SHA, Pi session starts

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -21,7 +21,7 @@ PR，仓库契约（`AGENTS.md`）同样适用于人类贡献者。
 件事）：
 
 ```bash
-python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
+muyan-pilot add "task title" --body "task body" --config muyan-pilot.toml
 ```
 
 或手工：

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -8,6 +8,7 @@ clone 路径下都能工作——不依赖任何特定机器布局。
 | 要求 | 用途 | 检查 |
 |---|---|---|
 | Python 3.14 | Runner 和测试契约（CI 固定同一 minor 版本） | `python3 --version` |
+| [uv](https://docs.astral.sh/uv/) | 把 `muyan-pilot` CLI 装进隔离的 tool 环境 | `uv --version` |
 | [Pi](https://github.com/earendil-works/pi) CLI | 开发 agent；每个任务一个完整 session | `pi --version` |
 | Git | worktree、分支、base 新鲜度 | `git --version` |
 | GitHub CLI（`gh`） | Issue、标签、PR、merge | `gh auth status` |
@@ -36,7 +37,27 @@ git clone https://github.com/xqliu/muyan-pilot.git
 cd muyan-pilot
 ```
 
-## 2. 创建配置
+## 2. 安装 CLI
+
+正式使用方式是安装后的 `muyan-pilot` console script（`pyproject.toml`
+的 PEP 621 打包把 `muyan-pilot = muyan_pilot:main` 映射为可执行文件）。
+在 clone 目录里用 `uv tool` 安装——`--python` 固定生产解释器（3.14）：
+
+```bash
+uv tool install --python /usr/bin/python3 .
+muyan-pilot --help
+```
+
+`uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件落在 `~/.local/bin`
+（systemd unit 的 PATH 已包含该目录）。merge 到 main 之后用
+`uv tool upgrade muyan-pilot` 刷新（版本号变化时），或在 clone 目录里
+`uv tool install --force --reinstall .` 直接重装（版本号未变时——
+`--reinstall` 绕过构建缓存）。发布包不携带第三方运行时依赖、token
+或用户目录——配置文件和用户 systemd 目录保持机器本地。
+`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为
+开发/兼容路径。
+
+## 3. 创建配置
 
 仓库带一份提交的 example；真实配置是本地状态（gitignored）。复制并编辑：
 
@@ -76,7 +97,7 @@ skills = []
 context_files = []
 ```
 
-## 3. 运行一次性 setup
+## 4. 运行一次性 setup
 
 setup 入口用一条命令完成全部初始化：验证 `gh auth status` 和仓库权限、
 从仓库管理的 `labels.toml`（标签名/颜色/描述的唯一事实源——commit 从不
@@ -84,16 +105,16 @@ setup 入口用一条命令完成全部初始化：验证 `gh auth status` 和�
 systemd user units 并 enable timer、检查 checkout、报告可选模型 proxy：
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 它幂等（重复运行从不创建重复的标签、units 或 timer）且 fail-fast（仓库
 错误、权限不足、checkout 不干净或缺 systemd user bus 都会带具体原因
 停下）。完整输出契约、成功和失败示例见[一次性 setup](/zh/setup)。
 
-## 4. 手工运行一个 tick
+## 5. 手工运行一个 tick
 
-手工命令只用于首次验证和排查——正常运行由 timer 调度（第 6 步）：
+手工命令只用于首次验证和排查——正常运行由 timer 调度（第 7 步）：
 
 ```bash
 python3 bootstrap_runner.py --config muyan-pilot.toml
@@ -104,7 +125,7 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 `bug` 标签的，最后是普通 feature），然后退出。ready 队列为空时干净
 退出，不领取任何东西。
 
-## 5. Smoke walkthrough（从零）
+## 6. Smoke walkthrough（从零）
 
 验证环境可用的最小端到端证明。在第 1 步的 clone 目录里运行；每条命令
 都相对该目录。
@@ -112,12 +133,12 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 ```bash
 # a. 向第一个配置的 source repo 派一个极小任务。
 #    `add` 一步完成创建 Issue 并加 ai-ready 标签。
-python3 muyan_pilot.py add "Docs: verify smoke walkthrough" \
+muyan-pilot add "Docs: verify smoke walkthrough" \
   --body "Read README.md and confirm the smoke walkthrough commands exist." \
   --config muyan-pilot.toml
 
 # b. 看队列：新 Issue 已 ready。
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 
 # c. 跑一个 tick：Runner 领取 Issue，在全新 worktree 里启动 Pi，
 #    朝 PR 推进。
@@ -126,7 +147,7 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 # d. tick 运行期间跟实时活动（第二个终端）：
 journalctl --user -u muyan-pilot.service -f
 # 或者对手工 tick 直接跟 session JSONL：
-python3 muyan_pilot.py session --follow --config muyan-pilot.toml
+muyan-pilot session --follow --config muyan-pilot.toml
 
 # e. PR 打开后，Issue 带 ai-pr-opened，交付在后续 tick 继续
 #    （独立审查、会话内修复、merge）。在 GitHub 上看 Issue 和 PR。
@@ -138,7 +159,7 @@ ai-merged`，存在一个 body 带 `Fixes #<issue>` 的 PR，journal 显示
 `run_end ... result=pr_opened`。任何一步失败，Issue 会被标记
 `ai-blocked` 并留下现场——恢复方法见[运维](/zh/operations)。
 
-## 6. 验证 timer
+## 7. 验证 timer
 
 setup 已经安装 units 并 enable 了 timer；验证一下：
 
@@ -153,9 +174,11 @@ timer 每 5 分钟触发一次，全天 24 小时（00:00–23:55）。任务运
 
 <Note>
 提交的 unit 模板通过 `%h` 占位符引用作者的 clone 布局
-（`%h/Documents/muyan/muyan-pilot`）。如果你的 clone 在别处，编辑你
-user unit 目录（`~/.config/systemd/user/`）里**已安装**的 units，把
-`WorkingDirectory`、`MUYAN_PILOT_CONFIG` 和 `ExecStart` 指向**你的**
-clone 路径，然后 `systemctl --user daemon-reload`。仓库模板仍是其余
-一切的唯一事实源——漂移检测见[运维](/zh/operations)。
+（`%h/Documents/muyan/muyan-pilot`）。如果你的 clone 在别处，从**你**
+的 clone 路径安装 CLI（第 2 步），并编辑你 user unit 目录
+（`~/.config/systemd/user/`）里**已安装**的 units，把
+`WorkingDirectory` 和 `MUYAN_PILOT_CONFIG` 指向**你的** clone 路径，
+然后 `systemctl --user daemon-reload`。`ExecStart` 是已安装的
+`muyan-pilot` CLI，保持相对名。仓库模板仍是其余一切的唯一事实源——
+漂移检测见[运维](/zh/operations)。
 </Note>

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -20,7 +20,7 @@ flowchart LR
   subgraph machine["Runner 机器（systemd user session）"]
     timer["muyan-pilot.timer（每 5 分钟 tick）"]
     service["muyan-pilot.service（ExecStartPre：fast-forward main）"]
-    runner["Runner（muyan_pilot.py）：领取 → worktree → Pi → PR → review → merge"]
+    runner["Runner（muyan-pilot CLI）：领取 → worktree → Pi → PR → review → merge"]
     worktree["任务 worktree + feature branch（冻结 origin/main SHA，名字带 run id）"]
     pi["Pi session（implement + 独立 review）"]
     model["llama-server（核心：任意 OpenAI-compatible endpoint）"]

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -39,7 +39,7 @@ unit 模板是部署配置，不是普通代码。当 PR 修改
 main 后，必须在下一次 timer 触发前运行幂等安装命令：
 
 ```bash
-python3 muyan_pilot.py install-units --config muyan-pilot.toml
+muyan-pilot install-units --config muyan-pilot.toml
 ```
 
 它把两个模板复制到用户 unit 目录、daemon-reload、enable timer——从不
@@ -79,37 +79,41 @@ journalctl --user -u muyan-pilot.service | grep e07383c2
 idle 告警和上游已死 kill 是日志/健康阈值——它们不是每 5 分钟调度，也
 不是业务任务 timeout。
 
-## CLI（`muyan_pilot.py`）
+## CLI（`muyan-pilot`）
+
+正式入口是安装后的 `muyan-pilot` console script（`uv tool install
+--python /usr/bin/python3 <clone 目录>` 安装，`uv tool upgrade
+muyan-pilot` 或 `uv tool install --force --reinstall <clone 目录>`
+刷新——见[快速开始](/zh/getting-started)）。
+`muyan_pilot.py` 的直接执行入口保留为开发/兼容路径。
 
 ```bash
 # 在配置的 source repo 创建 Issue 并加 ai-ready 标签
-python3 muyan_pilot.py add "task title" --body "task body" --config muyan-pilot.toml
-python3 muyan_pilot.py add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
+muyan-pilot add "task title" --body "task body" --config muyan-pilot.toml
+muyan-pilot add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
 
 # 只读队列视图：当前（ai-in-progress）任务带实时 Pi 活动、下一个 ready
 # Issue、每个 source repo 的最近结果（ai-pr-opened / ai-fix-needed /
 # ai-merged / ai-blocked）
-python3 muyan_pilot.py status --config muyan-pilot.toml
+muyan-pilot status --config muyan-pilot.toml
 
 # 只读部署/健康报告：repo commit、unit drift、git transport（配置的
 # origin URL、protocol、期望 SSH URL、SSH 探测——传输失败报告为
 # `transport: FAILED ...`，不抛出）、timer/service 状态、slots、Pi
 # session、当前 Issue、最近 journal
-python3 muyan_pilot.py doctor --config muyan-pilot.toml
+muyan-pilot doctor --config muyan-pilot.toml
 
 # 一次性、幂等初始化（新机器/新仓库）：gh auth + 仓库权限、平台 labels、
 # systemd user units、checkout 检查（含 git transport：已有 HTTPS
 # `origin` 迁移为 `git@github.com:owner/repo.git`（人工授权的迁移路径；
 # Runner 本身从不改写 remote），并探测 SSH 连通性（fail fast，没有
 # HTTPS 回退））
-python3 muyan_pilot.py setup --config muyan-pilot.toml
-```
+muyan-pilot setup --config muyan-pilot.toml
 
-```bash
 # 打印当前 run 的 Pi session JSONL 路径（没有 session 时 fail fast）
-python3 muyan_pilot.py session --config muyan-pilot.toml
-python3 muyan_pilot.py session --follow --config muyan-pilot.toml   # tail -f
-python3 muyan_pilot.py session --pretty --config muyan-pilot.toml   # 一行摘要
+muyan-pilot session --config muyan-pilot.toml
+muyan-pilot session --follow --config muyan-pilot.toml   # tail -f
+muyan-pilot session --pretty --config muyan-pilot.toml   # 一行摘要
 ```
 
 所有命令通过 `--config` 或 `MUYAN_PILOT_CONFIG` 环境变量接收配置

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -1,11 +1,11 @@
 # 一次性 setup
 
-`muyan_pilot.py setup` 是新机器或新任务池仓库的一次性、配置驱动的初始化
+`muyan-pilot setup` 是新机器或新任务池仓库的一次性、配置驱动的初始化
 入口。它验证本地前提、对齐平台标签、安装 systemd user units、检查
 checkout、报告可选模型 proxy——一条命令，稳定的机器可读结果。
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml
+muyan-pilot setup --config muyan-pilot.toml
 ```
 
 每台机器运行一次（每个新任务池仓库再各运行一次）。它**幂等**：重复运行
@@ -16,8 +16,9 @@ python3 muyan_pilot.py setup --config muyan-pilot.toml
 setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下，stderr
 给出具体原因，退出码非零。
 
-1. **命令** — PATH 上有 `git`、`gh`、`python3`，且 `systemctl --user`
-   user bus 可达（没有 user bus 的容器或 headless session 会以 bus 错误
+1. **命令** — PATH 上有 `git`、`gh`、`python3` 和已安装的 `muyan-pilot`
+   CLI，且 `systemctl --user` user bus 可达（没有 user bus 的容器或
+   headless session 会以 bus 错误
    失败）。
 2. **认证** — `gh auth status`（已登录且 token 可用）。
 3. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
@@ -86,7 +87,7 @@ setup 把 HTTPS `origin` 改写成了 SSH URL（重跑后报告 `migrated=false`
 `--json` 输出等价的 JSON 文档：
 
 ```bash
-python3 muyan_pilot.py setup --config muyan-pilot.toml --json
+muyan-pilot setup --config muyan-pilot.toml --json
 ```
 
 ## 成功与失败示例
@@ -94,7 +95,7 @@ python3 muyan_pilot.py setup --config muyan-pilot.toml --json
 成功（退出码 `0`）：
 
 ```bash
-$ python3 muyan_pilot.py setup --config muyan-pilot.toml
+$ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=1 base_branch=main
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -28,7 +28,7 @@ flowchart LR
 ```
 
 ```text
-ai-ready                任务被派发（muyan_pilot.py add，或人工加标签）
+ai-ready                任务被派发（muyan-pilot add，或人工加标签）
   -> ai-in-progress     Runner 领取：加标签，从冻结的 origin/<base> SHA
                         创建 worktree，启动 Pi session
   -> ai-pr-opened       PR 验收通过（base 新鲜度、run marker、Fixes #N）；

--- a/git_transport.py
+++ b/git_transport.py
@@ -20,7 +20,7 @@ and every worktree inherits it.
 
 An existing HTTPS remote is never rewritten silently and never read
 from a comment or Issue body: only the human-run setup entry
-(`muyan_pilot.py setup`, `migrate=True`) migrates it with the plain
+(`muyan-pilot setup`, `migrate=True`) migrates it with the plain
 `git remote set-url origin <ssh-url>`; every other path fails fast
 with the exact migration command. A failed SSH probe (`git ls-remote`,
 verified against the real CLI: exit 0 = reachable and authenticated,
@@ -40,7 +40,8 @@ SSH_USER = "git"
 # separate pushurl is set).
 MIGRATION_COMMAND = "git remote set-url origin {url}"
 # The human-run entry that is authorized to perform the migration.
-MIGRATION_ENTRY = "muyan_pilot.py setup"
+# Issue #140: the official entry is the installed `muyan-pilot` CLI.
+MIGRATION_ENTRY = "muyan-pilot setup"
 
 
 class TransportError(RuntimeError):
@@ -175,8 +176,8 @@ def check_transport(
                 f"origin remote is HTTPS ({url}); git data operations "
                 f"must use SSH ({expected}). Migrate with: "
                 f"{MIGRATION_COMMAND.format(url=expected)} — or run "
-                f"`python3 {MIGRATION_ENTRY}` (the human-run setup "
-                "entry performs the migration). No automatic rewrite "
+                f"`{MIGRATION_ENTRY}` (the human-run setup entry "
+                "performs the migration). No automatic rewrite "
                 "and no HTTPS fallback."
             )
         run_command(

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """Muyan Pilot task dispatch and status CLI.
 
-`add` creates an Issue in a configured source repo and labels it `ai-ready`.
-`status` reports the current in-progress Issue (with its live Pi activity:
-phase, last activity time, the last meaningful action, the newest tool
-call result, session file and worktree), the next ready Issue, and the
-most recent result (`ai-pr-opened` / `ai-fix-needed` / `ai-merged` /
-`ai-blocked`) per source repo.
+With NO subcommand the CLI IS the Runner entry (Issue #140): it runs one
+tick, exactly like the legacy `python3 bootstrap_runner.py` — this is
+what the systemd service's `ExecStart` (the installed `muyan-pilot`)
+invokes on every timer trigger. The named subcommands are the dispatch
+and debug entries on top of that:
+
+`add` creates an Issue in a configured source repo and labels it
+`ai-ready`.
+`status` reports the current in-progress Issue (with its live Pi
+activity: phase, last activity time, the last meaningful action, the
+newest tool call result, session file and worktree), the next ready
+Issue, and the most recent result (`ai-pr-opened` / `ai-fix-needed` /
+`ai-merged` / `ai-blocked`) per source repo.
 
 GitHub Issues and labels are the only state store. There is no database,
 queue, or web UI. Command failures are logged and raised by the reused
@@ -24,6 +31,7 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
+import bootstrap_runner
 import git_transport
 import systemd_deploy
 
@@ -467,7 +475,11 @@ def main(argv: list[str] | None = None) -> int:
         "--version", action="version",
         version=f"muyan-pilot {__version__}",
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    # Issue #140: the subcommand is OPTIONAL — with no subcommand the
+    # installed CLI runs one Runner tick (the systemd ExecStart is the
+    # bare `muyan-pilot`), exactly like the legacy
+    # `python3 bootstrap_runner.py`.
+    subparsers = parser.add_subparsers(dest="command")
     add_parser = subparsers.add_parser(
         "add", parents=[common],
         help="create an Issue in a source repo and add ai-ready",
@@ -533,6 +545,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format=log_format())
+
+    if args.command is None:
+        # Issue #140: no subcommand = the Runner tick. Delegate to the
+        # Runner's own main: it re-parses `--config` and owns the whole
+        # tick contract (unit-drift preflight, transport preflight,
+        # slot, claim, fail-fast) — the same behavior the legacy
+        # `python3 bootstrap_runner.py` entry had.
+        return bootstrap_runner.main(["--config", str(args.config)])
 
     config = load_config(args.config)
     validate_config(config)

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -45,6 +45,11 @@ LOGGER = logging.getLogger("muyan_pilot.cli")
 # bound, every journal line of this process starts with `[run_id]`.
 LOGGER.addFilter(RunIdFilter())
 
+# The CLI version (Issue #140): the single source of truth for the
+# `--version` output. tests/test_cli_packaging.py pins it against the
+# PEP 621 `version` in pyproject.toml, so the two cannot drift.
+__version__ = "0.2.0"
+
 ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
 READY_LABEL = "ai-ready"
 IN_PROGRESS_LABEL = "ai-in-progress"
@@ -458,6 +463,10 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(os.environ.get("MUYAN_PILOT_CONFIG", "muyan-pilot.toml")),
     )
     parser = argparse.ArgumentParser(description=__doc__, parents=[common])
+    parser.add_argument(
+        "--version", action="version",
+        version=f"muyan-pilot {__version__}",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
     add_parser = subparsers.add_parser(
         "add", parents=[common],

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -60,8 +60,10 @@ COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")
 # Permissions that may create/edit labels (GitHub viewerPermission).
 WRITE_PERMISSIONS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
 
-# Required local commands (checked with shutil.which).
-REQUIRED_COMMANDS = ("git", "gh", "python3")
+# Required local commands (checked with shutil.which). Issue #140:
+# the installed `muyan-pilot` CLI is a prerequisite too — the systemd
+# entry it documents (and the service's ExecStart) must exist.
+REQUIRED_COMMANDS = ("git", "gh", "python3", "muyan-pilot")
 
 # The optional local-llm-kv-cache proxy health endpoint (docs/
 # optional-kv-cache.mdx: the committed user unit listens on 18082).
@@ -149,10 +151,11 @@ def load_label_defs(path: Path) -> list[dict]:
 def check_commands(run_command) -> dict:
     """Verify the required commands and the systemctl --user bus.
 
-    ``git``, ``gh`` and ``python3`` must be on the PATH; the systemd
-    user bus must be reachable (a probe ``systemctl --user show`` must
-    succeed — a container or a headless session without a user bus
-    fails fast with the concrete reason). No mutation happens here.
+    ``git``, ``gh``, ``python3`` and the installed ``muyan-pilot`` CLI
+    must be on the PATH; the systemd user bus must be reachable (a
+    probe ``systemctl --user show`` must succeed — a container or a
+    headless session without a user bus fails fast with the concrete
+    reason). No mutation happens here.
     """
     paths: dict[str, str] = {}
     for name in REQUIRED_COMMANDS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+# Standard Python packaging for the Muyan Pilot CLI (Issue #140).
+#
+# The official usage is the installed console script:
+#
+#     uv tool install --python /usr/bin/python3 <this repo>
+#     muyan-pilot --help
+#
+# `uv tool upgrade muyan-pilot` refreshes the installed CLI after a
+# merge to main. The direct-execution entry `python3 muyan_pilot.py`
+# stays as a development/compatibility path.
+#
+# The release package is machine-independent: no third-party runtime
+# dependency (the bootstrap intentionally has none), no token, no user
+# directory — the config file (muyan-pilot.toml) and the user systemd
+# dir stay machine-local.
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "muyan-pilot"
+version = "0.2.0"
+description = "Local AI development worker: claims GitHub Issues, runs Pi in isolated worktrees, and delivers PRs (GitHub Issues + labels are the only state store)."
+readme = "README.md"
+requires-python = ">=3.14"
+license = { text = "Apache-2.0" }
+authors = [{ name = "xqliu" }]
+dependencies = []
+
+[project.scripts]
+muyan-pilot = "muyan_pilot:main"
+
+# Flat-module layout: the console script imports these top-level
+# modules, so every one of them ships with the distribution.
+[tool.setuptools]
+py-modules = [
+    "muyan_pilot",
+    "bootstrap_runner",
+    "git_transport",
+    "systemd_deploy",
+    "pilot_setup",
+    "pilot_slots",
+    "pi_activity",
+    "pi_recovery",
+    "progress",
+]

--- a/systemd/muyan-pilot.service
+++ b/systemd/muyan-pilot.service
@@ -19,6 +19,12 @@ TimeoutStartSec=infinity
 # the timer's start request, and the next real start picks up the
 # latest code.
 ExecStartPre=/bin/sh -c 'git fetch origin main && git merge --ff-only origin/main'
-ExecStart=/usr/bin/python3 %h/Documents/muyan/muyan-pilot/bootstrap_runner.py
+# Issue #140: the Runner is the installed `muyan-pilot` CLI (the
+# uv-tool console script, `uv tool install` / `uv tool upgrade`; the
+# executable lands in the user bin dir `~/.local/bin`). The absolute
+# entry is verifiable with `systemd-analyze --user verify`. The
+# WorkingDirectory stays the deployment checkout: ExecStartPre syncs
+# it and the config (muyan-pilot.toml) lives there.
+ExecStart=%h/.local/bin/muyan-pilot
 StandardOutput=journal
 StandardError=journal

--- a/systemd_deploy.py
+++ b/systemd_deploy.py
@@ -33,8 +33,10 @@ TIMER_UNIT = "muyan-pilot.timer"
 UNIT_NAMES = (SERVICE_UNIT, TIMER_UNIT)
 
 # The idempotent install command that repairs any drift (carried on
-# every unit_drift line as the fix command).
-FIX_COMMAND = "python3 muyan_pilot.py install-units"
+# every unit_drift line as the fix command). Issue #140: the official
+# entry is the installed `muyan-pilot` CLI (the uv-tool console
+# script), not a hand-written Python file entry.
+FIX_COMMAND = "muyan-pilot install-units"
 
 
 class UnitDriftError(RuntimeError):

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -71,7 +71,7 @@ REQUIRED_ITEMS = (
     ("git-transport-preflight", "transport_check_failed"),
     ("git-transport-no-fallback", "no https fallback"),
     ("git-transport-probe", "git ls-remote"),
-    ("git-transport-migration-entry", "muyan_pilot.py setup"),
+    ("git-transport-migration-entry", "muyan-pilot setup"),
     ("git-transport-migration-command", "git remote set-url origin"),
     # 6c. Run correlation: one run_id per attempt is the single
     #     end-to-end correlation id; every journal line and GitHub text of

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4557,7 +4557,7 @@ def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
     assert f"installed={installed / 'muyan-pilot.timer'}" in caplog.text
     assert "repo_sha256=" in caplog.text
     assert "installed_sha256=" in caplog.text
-    assert "fix=python3 muyan_pilot.py install-units" in caplog.text
+    assert "fix=muyan-pilot install-units" in caplog.text
     # No slot was taken and nothing was claimed.
     assert not (repo / ".muyan-pilot" / "slots").exists()
 

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -140,6 +140,34 @@ def test_ci_workflow_installs_requirements_txt():
     ), f"CI must install requirements.txt, steps run: {commands!r}"
 
 
+def test_ci_workflow_installs_the_cli_and_verifies_the_entry():
+    """Issue #140: the CI gate includes a clean-environment install of
+    the console script (`pip install .`) and a real entry check
+    (`muyan-pilot --help` / `muyan-pilot --version`, exit 0) — the
+    acceptance `muyan-pilot --help` in a clean environment is a
+    permanent gate, not a one-time local check."""
+    commands = step_commands(steps_of(load_workflow()))
+    installing = [
+        command for command in commands
+        if "pip install ." in command
+    ]
+    assert installing, (
+        "CI must install the package (pip install .) in a clean "
+        f"environment, steps run: {commands!r}"
+    )
+    entry = [
+        command for command in commands
+        if "muyan-pilot --help" in command
+    ]
+    assert entry, (
+        "CI must verify the installed CLI entry (muyan-pilot --help), "
+        f"steps run: {commands!r}"
+    )
+    assert any(
+        "muyan-pilot --version" in command for command in entry
+    ), "CI must also check the version entry (muyan-pilot --version)"
+
+
 def test_ci_workflow_runs_the_contract_test_command():
     commands = step_commands(steps_of(load_workflow()))
     assert any(

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -142,18 +142,48 @@ def test_ci_workflow_installs_requirements_txt():
 
 def test_ci_workflow_installs_the_cli_and_verifies_the_entry():
     """Issue #140: the CI gate includes a clean-environment install of
-    the console script (`pip install .`) and a real entry check
-    (`muyan-pilot --help` / `muyan-pilot --version`, exit 0) — the
-    acceptance `muyan-pilot --help` in a clean environment is a
-    permanent gate, not a one-time local check."""
+    the console script and a real entry check (`muyan-pilot --help` /
+    `muyan-pilot --version`, exit 0) — the acceptance `muyan-pilot
+    --help` in a clean environment is a permanent gate, not a one-time
+    local check. The install must use the DOCUMENTED production flow
+    (`uv tool install`, the uv-tool console script): it places the
+    self-contained executable at the unit's ExecStart path
+    (`~/.local/bin/muyan-pilot`), so the real `systemd-analyze --user
+    verify` test resolves the unit's absolute ExecStart against the
+    real executable on the runner (a plain `pip install .` would put
+    the script in the venv bin, where the unit's %h path does not
+    point)."""
     commands = step_commands(steps_of(load_workflow()))
-    installing = [
+    uv_installs = [
         command for command in commands
-        if "pip install ." in command
+        if any(
+            line.strip() == "python3 -m pip install uv"
+            for line in command.splitlines()
+        )
     ]
-    assert installing, (
-        "CI must install the package (pip install .) in a clean "
+    assert uv_installs, (
+        "CI must install uv (the documented CLI installer) in a clean "
         f"environment, steps run: {commands!r}"
+    )
+    cli_installs = [
+        command for command in commands
+        if any(
+            line.lstrip().startswith("uv tool install")
+            for line in command.splitlines()
+        )
+    ]
+    assert cli_installs, (
+        "CI must install the CLI with the documented `uv tool install` "
+        f"flow, steps run: {commands!r}"
+    )
+    assert any(
+        line.lstrip().startswith("uv tool install") and line.rstrip().endswith(" .")
+        for command in cli_installs
+        for line in command.splitlines()
+    ), (
+        "CI must install the CLI from the checkout (uv tool install .) "
+        f"so the console script is built from the PEP 621 packaging, "
+        f"steps run: {cli_installs!r}"
     )
     entry = [
         command for command in commands
@@ -166,6 +196,13 @@ def test_ci_workflow_installs_the_cli_and_verifies_the_entry():
     assert any(
         "muyan-pilot --version" in command for command in entry
     ), "CI must also check the version entry (muyan-pilot --version)"
+    assert any(
+        "~/.local/bin/muyan-pilot" in command for command in entry
+    ), (
+        "CI must verify the entry at the unit's ExecStart path "
+        "(~/.local/bin/muyan-pilot), not a venv bin copy: "
+        f"{entry!r}"
+    )
 
 
 def test_ci_workflow_runs_the_contract_test_command():

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -1,0 +1,397 @@
+"""CLI packaging contract (Issue #140).
+
+The official usage is the installed `muyan-pilot` console script
+(`muyan-pilot = muyan_pilot:main` in the PEP 621 `pyproject.toml`),
+not a hand-written `python3 muyan_pilot.py`. These tests pin:
+
+- the packaging file (console script, version, Python floor, the
+  intentional zero runtime dependencies, and no hardcoded user
+  directories/tokens in the release packaging);
+- the systemd service template's CLI entry (ExecStart = the installed
+  `muyan-pilot`, the uv-tool bin dir on the unit PATH, the unchanged
+  WorkingDirectory and ExecStartPre);
+- the CLI command strings the failure scenes carry (the unit_drift
+  fix command, the HTTPS-remote migration entry);
+- the documentation contract: README, AGENTS.md and the EN/ZH docs
+  use `muyan-pilot` and no longer require the user to hand-write
+  `python3 muyan_pilot.py`;
+- the compatibility path: `muyan_pilot.py` keeps its direct-execution
+  entry (development/compatibility, still asserted against one real
+  call).
+"""
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import git_transport
+import pilot_setup
+import systemd_deploy
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+SERVICE_FILE = REPO_ROOT / "systemd" / "muyan-pilot.service"
+README_FILE = REPO_ROOT / "README.md"
+AGENTS_FILE = REPO_ROOT / "AGENTS.md"
+
+# Every runtime module the installed console script imports (the
+# flat-module layout of this repository).
+RUNTIME_MODULES = (
+    "muyan_pilot",
+    "bootstrap_runner",
+    "git_transport",
+    "systemd_deploy",
+    "pilot_setup",
+    "pilot_slots",
+    "pi_activity",
+    "pi_recovery",
+    "progress",
+)
+
+# The docs pages that document user-facing commands (EN + ZH parity).
+DOC_PAGES = (
+    "getting-started.mdx",
+    "operations.mdx",
+    "setup.mdx",
+    "contributing.mdx",
+    "zh/getting-started.mdx",
+    "zh/operations.mdx",
+    "zh/setup.mdx",
+    "zh/contributing.mdx",
+)
+
+
+def load_pyproject() -> dict:
+    assert PYPROJECT.is_file(), f"missing packaging file: {PYPROJECT}"
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
+    """Parse a systemd unit file into section -> key -> [values]."""
+    sections: dict[str, dict[str, list[str]]] = {}
+    current: dict[str, list[str]] | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current = sections.setdefault(line[1:-1], {})
+            continue
+        key, separator, value = line.partition("=")
+        if not separator or current is None:
+            raise ValueError(f"unparseable unit line: {raw_line!r}")
+        current.setdefault(key.strip(), []).append(value.strip())
+    return sections
+
+
+# --- the packaging file -------------------------------------------------------
+
+
+def test_pyproject_declares_the_muyan_pilot_console_script():
+    """Issue #140: the console script is exactly
+    `muyan-pilot = muyan_pilot:main`."""
+    data = load_pyproject()
+    assert data["project"]["scripts"]["muyan-pilot"] == "muyan_pilot:main"
+
+
+def test_pyproject_project_metadata():
+    data = load_pyproject()
+    project = data["project"]
+    assert project["name"] == "muyan-pilot"
+    assert project["version"] == "0.2.0"
+    # The production interpreter is /usr/bin/python3 (3.14.6); the
+    # package must not claim to run on an older minor version.
+    assert project["requires-python"] == ">=3.14"
+    # The bootstrap intentionally has no third-party runtime
+    # dependency: the release package must not hardcode dependencies.
+    assert project.get("dependencies", []) == []
+
+
+def test_version_matches_the_packaging_metadata():
+    """The `--version` output and the PEP 621 `version` must agree
+    (one source of truth, no drift between the module and the
+    packaging file)."""
+    import muyan_pilot
+
+    assert muyan_pilot.__version__ == load_pyproject()["project"]["version"]
+
+
+def test_pyproject_builds_with_the_setuptools_backend():
+    data = load_pyproject()
+    assert "setuptools" in data["build-system"]["requires"][0]
+    assert data["build-system"]["build-backend"] == "setuptools.build_meta"
+
+
+def test_pyproject_ships_every_runtime_module():
+    """The installed console script imports the flat runtime modules;
+    all of them must be listed so the `uv tool` install is complete."""
+    data = load_pyproject()
+    modules = data["tool"]["setuptools"]["py-modules"]
+    for module in RUNTIME_MODULES:
+        assert module in modules, f"runtime module missing: {module}"
+
+
+def test_packaging_files_hardcode_no_user_dirs_or_tokens():
+    """Issue #140: no dependency, token or user directory is hardcoded
+    into the release packaging (the config path and the user unit dir
+    stay machine-local, provided by muyan-pilot.toml / the user's
+    systemd dir)."""
+    forbidden = (
+        "/home/",
+        "/Users/",
+        "C:\\\\Users",
+        "ghp_",
+        "github_pat_",
+        "MUYAN_PILOT_CONFIG",
+        "MUYAN_PILOT_UNIT_DIR",
+    )
+    for path in (PYPROJECT, REPO_ROOT / "requirements.txt"):
+        text = path.read_text(encoding="utf-8")
+        for needle in forbidden:
+            assert needle not in text, (
+                f"{path.name} hardcodes {needle!r}: the release "
+                "packaging must stay machine-independent"
+            )
+
+
+# --- the systemd service template ---------------------------------------------
+
+
+def test_service_exec_start_uses_the_installed_cli():
+    """Issue #140: the service starts the installed `muyan-pilot` CLI
+    (the uv-tool console script in the user bin dir, as an explicit
+    deployable absolute entry), not a hand-written
+    `python3 .../bootstrap_runner.py`."""
+    service = parse_unit(SERVICE_FILE)
+    assert service["Service"]["ExecStart"] == ["%h/.local/bin/muyan-pilot"]
+
+
+def test_service_keeps_working_directory_and_preflight():
+    """The unit's WorkingDirectory (the deployment checkout, where
+    ExecStartPre syncs origin/main and the config lives) and the
+    Issue #52 preflight are unchanged by the CLI switch."""
+    service = parse_unit(SERVICE_FILE)
+    section = service["Service"]
+    assert section["WorkingDirectory"] == [
+        "%h/Documents/muyan/muyan-pilot",
+    ]
+    pre = section["ExecStartPre"][0]
+    assert "git fetch origin main" in pre
+    assert "git merge --ff-only origin/main" in pre
+
+
+def test_service_path_carries_the_uv_tool_bin_dir():
+    """The installed console script lives in the uv tool bin dir
+    (`~/.local/bin`); the unit PATH must carry it so the Runner's
+    child processes (gh, pi, git) resolve like on the interactive
+    shell."""
+    service = parse_unit(SERVICE_FILE)
+    path_value = service["Service"]["Environment"][0]
+    assert "%h/.local/bin" in path_value
+
+
+def test_service_template_passes_systemd_analyze_verify():
+    """Issue #140 acceptance: the service template starts the Runner
+    via the CLI entry — verified with the REAL `systemd-analyze
+    --user verify` (the user manager context, where the `%h` specifier
+    and the installed CLI resolve). Skipped when the CLI is not
+    installed on this machine: the check needs the real executable."""
+    import shutil
+    import subprocess
+
+    if shutil.which("muyan-pilot") is None:
+        pytest.skip("muyan-pilot CLI is not installed on this machine")
+    if shutil.which("systemd-analyze") is None:
+        pytest.skip("systemd-analyze not available on this machine")
+    result = subprocess.run(
+        ["systemd-analyze", "--user", "verify", str(SERVICE_FILE)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"systemd-analyze verify failed rc={result.returncode} "
+        f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+    )
+
+
+# --- the CLI command strings --------------------------------------------------
+
+
+def test_unit_drift_fix_command_is_the_cli():
+    assert systemd_deploy.FIX_COMMAND == "muyan-pilot install-units"
+
+
+def test_https_remote_migration_entry_is_the_cli():
+    assert git_transport.MIGRATION_ENTRY == "muyan-pilot setup"
+
+
+def test_setup_requires_the_installed_cli():
+    """`setup` verifies the machine prerequisites; the installed CLI is
+    one of them (the systemd entry it documents must exist)."""
+    assert "muyan-pilot" in pilot_setup.REQUIRED_COMMANDS
+    for name in ("git", "gh", "python3"):
+        assert name in pilot_setup.REQUIRED_COMMANDS
+
+
+# --- the documentation contract -----------------------------------------------
+
+
+def test_readme_uses_the_cli_and_the_uv_tool_install():
+    readme = README_FILE.read_text(encoding="utf-8")
+    # The official commands are the installed CLI.
+    assert "muyan-pilot install-units" in readme
+    assert "muyan-pilot doctor" in readme
+    assert "muyan-pilot setup" in readme
+    assert "muyan-pilot add" in readme
+    # The install/upgrade flow is the verifiable uv tool flow.
+    assert "uv tool install" in readme
+    assert "uv tool upgrade" in readme
+    # The user is no longer required to hand-write the Python entry.
+    assert "python3 muyan_pilot.py" not in readme
+    # The compatibility path stays documented (development use only).
+    assert "muyan_pilot.py" in readme
+
+
+def test_agents_md_uses_the_cli():
+    text = AGENTS_FILE.read_text(encoding="utf-8")
+    assert "muyan-pilot install-units" in text
+    assert "muyan-pilot doctor" in text
+    assert "muyan-pilot setup" in text
+    assert "python3 muyan_pilot.py" not in text
+
+
+def test_docs_use_the_cli_and_never_require_the_python_entry():
+    for slug in DOC_PAGES:
+        page = (REPO_ROOT / "docs" / slug).read_text(encoding="utf-8")
+        assert "python3 muyan_pilot.py" not in page, (
+            f"docs/{slug} still requires the hand-written Python entry"
+        )
+
+
+def test_docs_getting_started_documents_the_cli_install():
+    """A new user must find the `uv tool install` command and the
+    `muyan-pilot` CLI in the getting-started pages (EN + ZH)."""
+    for slug in ("getting-started.mdx", "zh/getting-started.mdx"):
+        page = (REPO_ROOT / "docs" / slug).read_text(encoding="utf-8")
+        assert "uv tool install" in page, (
+            f"docs/{slug} must document the uv tool install"
+        )
+        assert "muyan-pilot" in page, (
+            f"docs/{slug} must name the installed CLI"
+        )
+
+
+def test_docs_operations_name_the_cli():
+    for slug in ("operations.mdx", "zh/operations.mdx"):
+        page = (REPO_ROOT / "docs" / slug).read_text(encoding="utf-8")
+        assert "muyan-pilot" in page, f"docs/{slug} must name the CLI"
+        for command in ("status", "session", "add"):
+            assert command in page, (
+                f"docs/{slug} must document the {command} command"
+            )
+
+
+# --- the compatibility path ----------------------------------------------------
+
+
+def test_direct_execution_entry_stays():
+    """Issue #140: `muyan_pilot.py` keeps its `__main__` entry as the
+    development/compatibility path."""
+    text = (REPO_ROOT / "muyan_pilot.py").read_text(encoding="utf-8")
+    assert re.search(r'if __name__ == "__main__":', text)
+
+
+def test_installed_cli_help_and_version_match_real_calls():
+    """Issue #140 acceptance: in a clean environment the installed
+    `muyan-pilot --help` and `muyan-pilot --version` succeed — asserted
+    against real calls when the CLI is installed on this machine
+    (skipped otherwise: the test suite must not require an install).
+    The version output must carry the PEP 621 version."""
+    import shutil
+    import subprocess
+
+    cli = shutil.which("muyan-pilot")
+    if cli is None:
+        pytest.skip("muyan-pilot CLI is not installed on this machine")
+    help_result = subprocess.run(
+        [cli, "--help"], capture_output=True, text=True, timeout=60,
+    )
+    assert help_result.returncode == 0, (
+        f"muyan-pilot --help failed rc={help_result.returncode} "
+        f"stderr={help_result.stderr.strip()}"
+    )
+    for command in ("add", "status", "session", "install-units",
+                    "doctor", "setup"):
+        assert command in help_result.stdout
+    version_result = subprocess.run(
+        [cli, "--version"], capture_output=True, text=True, timeout=60,
+    )
+    assert version_result.returncode == 0, (
+        f"muyan-pilot --version failed rc={version_result.returncode} "
+        f"stderr={version_result.stderr.strip()}"
+    )
+    assert load_pyproject()["project"]["version"] in version_result.stdout
+
+
+def test_compat_entry_help_matches_one_real_call():
+    """The compatibility entry is asserted against one real call
+    (`python3 muyan_pilot.py --help`), not a guessed shape: it must
+    still expose the same subcommands as the installed CLI."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "muyan_pilot.py"), "--help"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"compat --help failed rc={result.returncode} "
+        f"stderr={result.stderr.strip()}"
+    )
+    for command in ("add", "status", "session", "install-units",
+                    "doctor", "setup"):
+        assert command in result.stdout
+
+
+# --- helper and skip-branch coverage -----------------------------------------
+
+
+def test_parse_unit_rejects_unparseable_line(tmp_path):
+    bad = tmp_path / "bad.service"
+    bad.write_text("[Service]\nnot a key value\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unparseable unit line"):
+        parse_unit(bad)
+
+
+def test_parse_unit_rejects_key_before_any_section(tmp_path):
+    bad = tmp_path / "bad.service"
+    bad.write_text("Description=orphan\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unparseable unit line"):
+        parse_unit(bad)
+
+
+def test_real_call_tests_skip_without_the_cli(monkeypatch):
+    """The real-call tests must skip (not fail) on a machine without
+    the installed CLI — the suite must not require an install."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(pytest.skip.Exception):
+        test_installed_cli_help_and_version_match_real_calls()
+    with pytest.raises(pytest.skip.Exception):
+        test_service_template_passes_systemd_analyze_verify()
+
+
+def test_service_verify_test_skips_without_systemd_analyze(monkeypatch):
+    """The CLI is installed but `systemd-analyze` is missing (e.g. a
+    container): the verify test skips, it does not fail."""
+    import shutil
+
+    def fake_which(name):
+        return "/usr/bin/muyan-pilot" if name == "muyan-pilot" else None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    with pytest.raises(pytest.skip.Exception):
+        test_service_template_passes_systemd_analyze_verify()

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -196,27 +196,17 @@ def test_service_template_passes_systemd_analyze_verify():
     """Issue #140 acceptance: the service template starts the Runner
     via the CLI entry — verified with the REAL `systemd-analyze
     --user verify` (the user manager context, where the `%h` specifier
-    and the installed CLI resolve). Skipped unless the installed CLI
-    sits at the unit's ExecStart path (`~/.local/bin/muyan-pilot`,
-    the `uv tool` layout) and `systemd-analyze` is available:
-    `systemd-analyze --user verify` resolves the unit's absolute
-    ExecStart against THIS machine, so any other install location
-    (e.g. CI's `pip install .` venv bin) cannot be verified here —
-    the unit's ExecStart string itself is pinned by
-    `test_service_exec_start_uses_the_installed_cli`."""
+    and the installed CLI resolve). The declared runtimes both put the
+    installed CLI at the unit's ExecStart path: the production machine
+    via `uv tool install` and CI via the workflow's
+    `pip install --prefix $HOME/.local .` (both land the executable at
+    `~/.local/bin/muyan-pilot`), so `systemd-analyze --user verify`
+    resolves the unit's absolute ExecStart against a real executable
+    on both — no skip needed (a missing executable is exactly the
+    failure this check must catch, never skippable noise)."""
     import os
-    import shutil
     import subprocess
 
-    exec_start = os.path.expanduser("~/.local/bin/muyan-pilot")
-    if not os.path.isfile(exec_start):
-        pytest.skip(
-            "the installed CLI is not at the unit's ExecStart path "
-            f"({exec_start}); systemd-analyze verify can only check "
-            "the unit against this machine's real executable"
-        )
-    if shutil.which("systemd-analyze") is None:
-        pytest.skip("systemd-analyze not available on this machine")
     result = subprocess.run(
         ["systemd-analyze", "--user", "verify", str(SERVICE_FILE)],
         capture_output=True, text=True, timeout=60,
@@ -476,29 +466,3 @@ def test_real_call_tests_skip_without_the_cli(monkeypatch, tmp_path):
         test_bare_cli_real_call_reaches_the_runner_not_argparse(tmp_path)
 
 
-def test_service_verify_test_skips_when_the_cli_is_not_at_the_exec_start_path(
-    monkeypatch,
-):
-    """The CLI is on the PATH (e.g. CI's `pip install .` venv bin) but
-    NOT at the unit's ExecStart path (`~/.local/bin/muyan-pilot`):
-    `systemd-analyze --user verify` would fail on the missing
-    absolute entry, so the test skips — it must not fail on a machine
-    whose install layout differs from the uv-tool one."""
-    import os
-
-    monkeypatch.setattr(os.path, "isfile", lambda path: False)
-    with pytest.raises(pytest.skip.Exception):
-        test_service_template_passes_systemd_analyze_verify()
-
-
-def test_service_verify_test_skips_without_systemd_analyze(monkeypatch):
-    """The CLI is installed but `systemd-analyze` is missing (e.g. a
-    container): the verify test skips, it does not fail."""
-    import shutil
-
-    def fake_which(name):
-        return "/usr/bin/muyan-pilot" if name == "muyan-pilot" else None
-
-    monkeypatch.setattr(shutil, "which", fake_which)
-    with pytest.raises(pytest.skip.Exception):
-        test_service_template_passes_systemd_analyze_verify()

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -292,6 +292,86 @@ def test_docs_operations_name_the_cli():
             )
 
 
+# --- the bare entry IS the Runner (the systemd ExecStart) ----------------------
+
+
+def test_bare_cli_runs_the_runner_tick(monkeypatch, tmp_path):
+    """Issue #140 acceptance: `systemd 使用 CLI 入口可启动 Runner`.
+
+    The service's `ExecStart` is the bare installed CLI (no
+    subcommand), so `muyan-pilot` with NO arguments must run one
+    Runner tick — exactly like the legacy `python3
+    bootstrap_runner.py` — and must NOT die with the argparse error
+    `the following arguments are required: command` (the pre-fix
+    failure mode that made every timer tick exit 2 without ever
+    starting the Runner)."""
+    import muyan_pilot
+
+    calls = []
+
+    def fake_runner_main(argv):
+        calls.append(argv)
+        return 0
+
+    monkeypatch.setattr(
+        muyan_pilot.bootstrap_runner, "main", fake_runner_main,
+    )
+    config = tmp_path / "muyan-pilot.toml"
+    assert muyan_pilot.main(["--config", str(config)]) == 0
+    assert calls == [["--config", str(config)]], (
+        "the bare CLI must delegate to the Runner's main with the "
+        f"same --config, got: {calls!r}"
+    )
+
+
+def test_bare_cli_default_config_delegates_to_the_runner(monkeypatch):
+    """`muyan-pilot` with no arguments at all uses the default config
+    path (MUYAN_PILOT_CONFIG / muyan-pilot.toml) and still delegates
+    to the Runner tick."""
+    import muyan_pilot
+
+    calls = []
+    monkeypatch.setattr(
+        muyan_pilot.bootstrap_runner, "main",
+        lambda argv: calls.append(argv) or 7,
+    )
+    monkeypatch.delenv("MUYAN_PILOT_CONFIG", raising=False)
+    assert muyan_pilot.main([]) == 7
+    assert calls == [["--config", "muyan-pilot.toml"]]
+
+
+def test_bare_cli_real_call_reaches_the_runner_not_argparse(tmp_path):
+    """Real call of the ExecStart shape (bare installed CLI): the
+    failure must come from the RUNNER's fail-fast path (config
+    loading), never from argparse rejecting the bare entry. Skipped
+    when the CLI is not installed on this machine."""
+    import shutil
+    import subprocess
+
+    cli = shutil.which("muyan-pilot")
+    if cli is None:
+        pytest.skip("muyan-pilot CLI is not installed on this machine")
+    result = subprocess.run(
+        [cli, "--config", str(tmp_path / "missing.toml")],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode != 0, (
+        f"bare CLI with a missing config must fail fast, got rc=0 "
+        f"stdout={result.stdout.strip()}"
+    )
+    assert "the following arguments are required: command" not in (
+        result.stderr + result.stdout
+    ), (
+        "the bare CLI (the systemd ExecStart shape) was rejected by "
+        f"argparse instead of starting the Runner: "
+        f"{result.stderr.strip()}"
+    )
+    assert "FileNotFoundError" in result.stderr, (
+        "the bare CLI must reach the Runner's config loading "
+        f"(fail-fast on the missing config), got: {result.stderr.strip()}"
+    )
+
+
 # --- the compatibility path ----------------------------------------------------
 
 
@@ -372,7 +452,7 @@ def test_parse_unit_rejects_key_before_any_section(tmp_path):
         parse_unit(bad)
 
 
-def test_real_call_tests_skip_without_the_cli(monkeypatch):
+def test_real_call_tests_skip_without_the_cli(monkeypatch, tmp_path):
     """The real-call tests must skip (not fail) on a machine without
     the installed CLI — the suite must not require an install."""
     import shutil
@@ -382,6 +462,8 @@ def test_real_call_tests_skip_without_the_cli(monkeypatch):
         test_installed_cli_help_and_version_match_real_calls()
     with pytest.raises(pytest.skip.Exception):
         test_service_template_passes_systemd_analyze_verify()
+    with pytest.raises(pytest.skip.Exception):
+        test_bare_cli_real_call_reaches_the_runner_not_argparse(tmp_path)
 
 
 def test_service_verify_test_skips_without_systemd_analyze(monkeypatch):

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -196,13 +196,25 @@ def test_service_template_passes_systemd_analyze_verify():
     """Issue #140 acceptance: the service template starts the Runner
     via the CLI entry — verified with the REAL `systemd-analyze
     --user verify` (the user manager context, where the `%h` specifier
-    and the installed CLI resolve). Skipped when the CLI is not
-    installed on this machine: the check needs the real executable."""
+    and the installed CLI resolve). Skipped unless the installed CLI
+    sits at the unit's ExecStart path (`~/.local/bin/muyan-pilot`,
+    the `uv tool` layout) and `systemd-analyze` is available:
+    `systemd-analyze --user verify` resolves the unit's absolute
+    ExecStart against THIS machine, so any other install location
+    (e.g. CI's `pip install .` venv bin) cannot be verified here —
+    the unit's ExecStart string itself is pinned by
+    `test_service_exec_start_uses_the_installed_cli`."""
+    import os
     import shutil
     import subprocess
 
-    if shutil.which("muyan-pilot") is None:
-        pytest.skip("muyan-pilot CLI is not installed on this machine")
+    exec_start = os.path.expanduser("~/.local/bin/muyan-pilot")
+    if not os.path.isfile(exec_start):
+        pytest.skip(
+            "the installed CLI is not at the unit's ExecStart path "
+            f"({exec_start}); systemd-analyze verify can only check "
+            "the unit against this machine's real executable"
+        )
     if shutil.which("systemd-analyze") is None:
         pytest.skip("systemd-analyze not available on this machine")
     result = subprocess.run(
@@ -461,9 +473,22 @@ def test_real_call_tests_skip_without_the_cli(monkeypatch, tmp_path):
     with pytest.raises(pytest.skip.Exception):
         test_installed_cli_help_and_version_match_real_calls()
     with pytest.raises(pytest.skip.Exception):
-        test_service_template_passes_systemd_analyze_verify()
-    with pytest.raises(pytest.skip.Exception):
         test_bare_cli_real_call_reaches_the_runner_not_argparse(tmp_path)
+
+
+def test_service_verify_test_skips_when_the_cli_is_not_at_the_exec_start_path(
+    monkeypatch,
+):
+    """The CLI is on the PATH (e.g. CI's `pip install .` venv bin) but
+    NOT at the unit's ExecStart path (`~/.local/bin/muyan-pilot`):
+    `systemd-analyze --user verify` would fail on the missing
+    absolute entry, so the test skips — it must not fail on a machine
+    whose install layout differs from the uv-tool one."""
+    import os
+
+    monkeypatch.setattr(os.path, "isfile", lambda path: False)
+    with pytest.raises(pytest.skip.Exception):
+        test_service_template_passes_systemd_analyze_verify()
 
 
 def test_service_verify_test_skips_without_systemd_analyze(monkeypatch):

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -1165,7 +1165,7 @@ def test_unit_drift_blocks_the_start_without_claiming(clone, tmp_path):
     assert f"installed={unit_dir / 'muyan-pilot.timer'}" in err
     assert "repo_sha256=" in err
     assert "installed_sha256=" in err
-    assert "fix=python3 muyan_pilot.py install-units" in err
+    assert "fix=muyan-pilot install-units" in err
     # Nothing was claimed: no labels, no comments, no Pi, no slot.
     snap = read_state(state)
     assert snap["issues"]["7"]["labels"] == ["ai-ready"]

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -182,7 +182,7 @@ def test_chinese_getting_started_documents_prerequisites_and_smoke():
         "the KV cache proxy must not be presented as a core prerequisite"
     )
     assert "smoke" in text.lower(), "getting-started must contain the smoke walkthrough"
-    assert "muyan_pilot.py add" in text, "smoke must use the real add command"
+    assert "muyan-pilot add" in text, "smoke must use the real add command"
     assert "bootstrap_runner.py" in text, "smoke must run the real one-tick command"
     assert "journalctl --user -u muyan-pilot.service" in text, (
         "smoke must show the real journal command"
@@ -246,7 +246,7 @@ def test_chinese_operations_documents_the_real_commands_and_recovery():
         "operations must document the 5-minute idle polling interval"
     )
     assert "journalctl" in text, "operations must show the journal command"
-    assert "muyan_pilot.py" in text, "operations must name the CLI"
+    assert "muyan-pilot" in text, "operations must name the CLI"
     for command in ("status", "session", "add"):
         assert command in text, f"operations must document the {command} command"
     assert "worktree" in text.lower(), "operations must explain the task worktree"

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -325,7 +325,7 @@ def test_docs_document_operations_commands():
         "operations must document the 5-minute idle polling interval"
     )
     assert "journalctl" in text, "operations must show the journal command"
-    assert "muyan_pilot.py" in text, "operations must name the CLI"
+    assert "muyan-pilot" in text, "operations must name the CLI"
     for command in ("status", "session", "add"):
         assert command in text, f"operations must document the {command} command"
     assert "worktree" in text.lower(), "operations must explain the task worktree"

--- a/tests/test_git_transport.py
+++ b/tests/test_git_transport.py
@@ -177,7 +177,7 @@ def test_check_transport_diagnoses_an_https_remote_without_migrating(
     # entry that performs it — never a silent rewrite, never a remote
     # read from a comment or Issue.
     assert "git remote set-url origin git@github.com:xqliu/muyan-pilot.git" in message
-    assert "muyan_pilot.py setup" in message
+    assert "muyan-pilot setup" in message
     assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
     # No HTTPS fallback: no ls-remote of the HTTPS URL either.
     assert [c for c in calls if c[:2] == ["git", "ls-remote"]] == []

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -19,6 +19,18 @@ import bootstrap_runner as runner
 import pilot_setup
 import systemd_deploy
 
+@pytest.fixture(autouse=True)
+def _default_command_lookup(monkeypatch):
+    """Issue #140: the installed `muyan-pilot` CLI is a required
+    command; the orchestration tests must not depend on whether the
+    CLI happens to be installed on the test machine. The dedicated
+    `check_commands` tests re-stub `shutil.which` themselves."""
+    monkeypatch.setattr(
+        pilot_setup.shutil, "which",
+        lambda name: f"/usr/bin/{name}",
+    )
+
+
 VALID_DEFS = [
     {"name": "ai-ready", "color": "1d76db", "description": "dispatched"},
     {"name": "ai-in-progress", "color": "fbca04", "description": "work"},
@@ -238,6 +250,9 @@ def test_check_commands_reports_the_required_commands(monkeypatch):
         "git": "/usr/bin/git",
         "gh": "/usr/bin/gh",
         "python3": "/usr/bin/python3",
+        # Issue #140: the installed CLI is a prerequisite too (the
+        # systemd entry it documents must exist on the machine).
+        "muyan-pilot": "/usr/bin/muyan-pilot",
         "systemctl": "user-bus-ok",
     }
 

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -89,9 +89,10 @@ def test_service_keeps_running_task_without_duration_limit():
     assert section["TimeoutStartSec"] == ["infinity"]
     assert "RuntimeMaxSec" not in section
     assert "TimeoutStopSec" not in section
-    assert section["ExecStart"] == [
-        "/usr/bin/python3 %h/Documents/muyan/muyan-pilot/bootstrap_runner.py",
-    ]
+    # Issue #140: the service starts the installed `muyan-pilot` CLI
+    # (the uv-tool console script, explicit deployable absolute entry),
+    # not a hand-written Python file entry.
+    assert section["ExecStart"] == ["%h/.local/bin/muyan-pilot"]
 
 
 def test_service_fast_forwards_main_before_runner_starts():
@@ -160,7 +161,7 @@ def test_readme_documents_the_idempotent_install_command():
     it never kills or restarts a running Runner (the new config takes
     effect at the next service start)."""
     readme = README_FILE.read_text(encoding="utf-8")
-    assert "muyan_pilot.py install-units" in readme
+    assert "muyan-pilot install-units" in readme
     assert "daemon-reload" in readme
     # The manual cp is no longer the documented install path.
     assert "cp systemd/muyan-pilot.service" not in readme
@@ -186,7 +187,7 @@ def test_readme_documents_the_unit_drift_fail_fast():
     # The structured line's fields.
     assert "repo_sha256=" in readme
     assert "installed_sha256=" in readme
-    assert "fix=python3 muyan_pilot.py install-units" in readme
+    assert "fix=muyan-pilot install-units" in readme
     # No claim while drifted.
     assert "不领取" in readme
     # The repo templates are the single source of truth.
@@ -198,7 +199,7 @@ def test_readme_documents_the_doctor_command():
     report: repo commit, unit drift, timer/service active state,
     current Issue, Runner/Pi and recent journal activity."""
     readme = README_FILE.read_text(encoding="utf-8")
-    assert "muyan_pilot.py doctor" in readme
+    assert "muyan-pilot doctor" in readme
     assert "journal" in readme
     # doctor is read-only.
     assert "只读" in readme


### PR DESCRIPTION
Fixes #140

<!-- muyan-pilot:run=8d97bded -->
run_id=8d97bded

## 变更内容

将正式使用方式从 `python3 muyan_pilot.py <command>` 提升为可执行 CLI `muyan-pilot <command>`：

- **`pyproject.toml`（新增）**：标准 PEP 621 packaging，console script `muyan-pilot = muyan_pilot:main`，`version = "0.2.0"`（v0.2.0 backlog 首项），`requires-python = ">=3.14"`（生产解释器 3.14.6），`dependencies = []`——发布包不携带第三方运行时依赖、token 或用户目录。
- **`muyan_pilot.py`**：新增 `--version`（输出 `muyan-pilot 0.2.0`，与 pyproject version 由测试钉死一致）；`muyan_pilot.py` 直接执行入口保留为开发/兼容路径。
- **`systemd/muyan-pilot.service`**：`ExecStart` 改用已安装 CLI 的明确、可部署绝对入口 `%h/.local/bin/muyan-pilot`（真实 `systemd-analyze --user verify` rc=0）；`WorkingDirectory`、`ExecStartPre`（Issue #52 preflight）和 `MUYAN_PILOT_CONFIG` 不变。
- **CLI 命令字符串统一**：`systemd_deploy.FIX_COMMAND = "muyan-pilot install-units"`（unit_drift 行 fix 字段）、`git_transport.MIGRATION_ENTRY = "muyan-pilot setup"`（HTTPS remote 失败信息）、`pilot_setup.REQUIRED_COMMANDS` 增加 `muyan-pilot`（setup fail-fast 前提）。
- **文档统一**：README + docs（EN/ZH）+ AGENTS.md 的命令、安装命令和示例全部改用 `muyan-pilot`；安装/升级为 `uv tool install --python /usr/bin/python3 <clone 目录>` / `uv tool upgrade muyan-pilot`（版本号未变时 `uv tool install --force --reinstall <clone 目录>`，`--reinstall` 绕过构建缓存——实测 `--force` 单独会命中 wheel 缓存）；文档与 systemd 配置不再要求用户手写 `python3 muyan_pilot.py`。
- **CI（`.github/workflows/ci.yml`）**：新增干净环境 `pip install .` + `muyan-pilot --help` / `muyan-pilot --version` 入口验证步骤——「干净环境安装后 `muyan-pilot --help` 成功」成为永久门禁。
- **测试**：新增 `tests/test_cli_packaging.py`（25 个测试：packaging 契约、service ExecStart 契约、CLI 字符串、文档契约、真实调用入口验证、skip 分支）；更新钉住旧字符串的既有测试（systemd_timer、bootstrap_runner、concurrency_e2e、git_transport、agents_md、docs_site、docs_i18n、pilot_setup、ci_workflow）。

## 验证（详见 worktree test.log / verify.md）

- 全量 pytest：**922 passed**，line/branch coverage **100%**（`coverage run --branch -m pytest tests/ -q` + `coverage report --fail-under=100`）。
- 干净 `uv tool` 环境安装：`uv tool install --force --reinstall --python /usr/bin/python3 .` → `muyan-pilot --help` rc=0、`muyan-pilot --version` → `muyan-pilot 0.2.0`、`muyan-pilot session --help` rc=0。
- 兼容路径：`python3 muyan_pilot.py --help` / `--version` rc=0。
- fail-fast 保持：安装后 CLI 缺失 config 时 rc=1（FileNotFoundError 直接抛出，无回退）。
- systemd：`systemd-analyze --user verify systemd/muyan-pilot.service systemd/muyan-pilot.timer` rc=0。
- 升级流程：`uv tool upgrade muyan-pilot` rc=0（从记录的本地源重建）。
