### PR TITLE
feat: KISS/LEAN as the explicit development contract — minimal complete change only (Issue #118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,24 @@ is **one runtime outcome** (when X, should Y, actually Z).
   hundreds of lines. Title should work as a test name.
 - Open the Issue once the root cause is pinned.
 
+## Minimal implementation (KISS/LEAN)
+
+The positive contract for every implement and review session (Issue #118):
+implement the smallest complete change that satisfies the Issue's
+acceptance criteria.
+
+- KISS and LEAN are the default: no speculative feature, no
+  no-benefit abstraction, no extra framework layer, no fallback, no
+  future-proofing, no scope expansion beyond the Issue's acceptance
+  criteria.
+- 如无必要勿增实体 — do not multiply entities beyond necessity: every new
+  file, dependency, state, label, command and abstraction must map
+  to an acceptance criterion of the Issue.
+- When two designs both satisfy the requirements, choose the simpler one:
+  fewer concepts, fewer files.
+- The MVP scope below stays unchanged: no database, queue, DAG, daemon,
+  risk engine or fallback.
+
 ## Implement vs review
 
 - Implementer session: plan, TDD, tests, push one PR.

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -17,6 +17,23 @@ the desired behavior is pinned — not as a vague wish.
 - Multi-task work is organized as an Epic (see [Workflow](/workflow)):
   the Epic coordinates, the sub-Issues deliver.
 
+## Minimal implementation (KISS/LEAN)
+
+The Pilot implements the **smallest complete change** that satisfies the
+Issue's acceptance criteria — KISS and LEAN are the development contract
+(`AGENTS.md`, Issue #118):
+
+- No speculative features, no no-benefit abstractions, no extra framework
+  layers, no fallbacks, no future-proofing, no scope expansion beyond the
+  acceptance criteria.
+- 如无必要勿增实体 — do not multiply entities beyond necessity: every new
+  file, dependency, state, label, command and abstraction must map to an
+  acceptance criterion of the Issue.
+- When two designs both satisfy the requirements, the simpler one wins:
+  fewer concepts, fewer files.
+- The MVP boundary stays intact: no database, queue, DAG, daemon, risk
+  engine or fallback.
+
 ## Creating an Issue
 
 Dispatch a task for the Pilot by creating an Issue and labeling it

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -15,6 +15,19 @@ PR，仓库契约（`AGENTS.md`）同样适用于人类贡献者。
 - 多任务工作组织为 Epic（见[工作流](/zh/workflow)）：Epic 负责协调，
   子 Issue 负责交付。
 
+## 最小实现（KISS/LEAN）
+
+Pilot 只实现满足 Issue 验收标准的**最小完整变更**——KISS 和 LEAN 是
+开发契约（`AGENTS.md`，Issue #118）：
+
+- 不做 speculative feature、无收益抽象、额外框架层、fallback、未来功能
+  （future-proofing），不扩张验收标准之外的范围。
+- 如无必要勿增实体：每个新增文件、依赖、状态、label、命令和抽象都必须
+  对应 Issue 的一个验收条件。
+- 两个设计都满足需求时，选更简单的：概念更少、文件更少。
+- MVP 边界保持不变：无数据库、无队列、无 DAG、无 daemon、无风险模型、
+  无 fallback。
+
 ## 创建 Issue
 
 通过创建 Issue 并加 `ai-ready` 标签来给 Pilot 派活（CLI 一步完成两

--- a/prompt.md
+++ b/prompt.md
@@ -36,6 +36,21 @@ This project is intentionally an MVP. Do not invent a task platform, database,
 queue framework, policy engine, risk model, multi-agent DAG, daemon loop, or fallback path.
 Use the existing GitHub Issue task pool and fail fast with useful logs.
 
+Minimal implementation — KISS/LEAN (Issue #118):
+
+- Implement only the Issue's acceptance criteria: the smallest complete
+  change that makes the required behavior real. Speculative features,
+  no-benefit abstractions, extra framework layers, fallbacks,
+  future-proofing and scope expansion are forbidden — an Issue is one
+  runtime outcome, not a platform project.
+- 如无必要勿增实体 (do not multiply entities beyond necessity): every new
+  file, dependency, state, label, command and abstraction must map to an
+  acceptance criterion of this Issue.
+- When two designs both satisfy the requirements, choose the simpler one:
+  fewer concepts, fewer files.
+- This does not relax the MVP boundary: no database, queue, DAG, daemon,
+  risk engine or fallback.
+
 Hard rules for external behavior (Issue #73):
 
 - Before writing an external interface, CLI, config, or HTTP path, verify it

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -30,8 +30,8 @@ build files, and the changed code plus its callers before judging.
 
 - R1 parameters/contract, R2 core logic, R3 boundaries, R4 end-to-end call
   chain, R5 requirements/design (every acceptance item has evidence),
-  R6 dependencies/architecture, R7 observability, R8 KISS/equivalent refactor,
-  R9 exception propagation.
+  R6 dependencies/architecture, R7 observability, R8 KISS/scope and
+  equivalent refactor, R9 exception propagation.
 - Verify external behavior (Issue #73): every API path, CLI argument, config
   key and status code in the diff must be verified against the official docs
   or a real call — flag "this external behavior was not verified" when it was
@@ -49,6 +49,17 @@ build files, and the changed code plus its callers before judging.
   cap, or pytest-timeout), is a **Blocker** — the red phase must fail fast,
   never hang (the 99% CPU spin / forever `next(g)` class of hang must be
   caught here, not shipped).
+- Out-of-scope and over-engineering (R8, Issue #118): the diff may only
+  implement the Issue's acceptance criteria — the smallest complete
+  change. A speculative feature, no-benefit abstraction, extra framework
+  layer, fallback, future-proofing, or scope expansion is a finding, and
+  so is any new file, dependency, state, label, command or abstraction
+  that does not map to an acceptance criterion (如无必要勿增实体: do not
+  multiply entities beyond necessity). When two designs both satisfy the
+  requirements, the simpler one (fewer concepts, fewer files) is the
+  contract; a more complex design that adds no required behavior is a
+  finding. Every such finding states the minimal fix direction: delete or
+  shrink the out-of-scope part until only the acceptance criteria remain.
 - Verify the run evidence: the real test/build commands were run and pass in
   the repository's declared runtime; Python business code keeps 100% line and
   branch coverage when Python changed.

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -27,6 +27,24 @@ REQUIRED_ITEMS = (
     ("review-after-pr", "after the pr exists"),
     ("review-new-jsonl", "new jsonl"),
     ("review-prompt-review", "prompt_review.md"),
+    # 2d. Minimal implementation (KISS/LEAN, Issue #118): the smallest
+    #     complete change for the acceptance criteria; no speculative
+    #     features, no-benefit abstractions, extra framework layers,
+    #     fallback, future-proofing or scope expansion; 如无必要勿增实体
+    #     (every new entity maps to an acceptance criterion); the simpler
+    #     design (fewer concepts, fewer files) wins.
+    ("kiss-section", "minimal implementation (kiss/lean)"),
+    ("kiss-smallest", "smallest complete change"),
+    ("kiss-acceptance", "acceptance criteria"),
+    ("kiss-no-speculative", "speculative feature"),
+    ("kiss-no-abstraction", "no-benefit abstraction"),
+    ("kiss-no-framework", "extra framework layer"),
+    ("kiss-no-fallback", "fallback"),
+    ("kiss-no-future", "future-proofing"),
+    ("kiss-no-scope", "scope expansion"),
+    ("kiss-occam", "如无必要勿增实体"),
+    ("kiss-entity-mapping", "to an acceptance criterion"),
+    ("kiss-simpler", "fewer concepts, fewer files"),
     # 3. 100% line and branch coverage for Python code.
     ("coverage", "100% line and branch coverage"),
     # 4. UI work: real Playwright interaction, assertions, console/network

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -297,6 +297,31 @@ def test_chinese_contributing_documents_issue_bug_and_pr_paths():
     assert "Fixes #" in text, "contributing must document the PR body contract"
 
 
+def test_chinese_contributing_documents_the_minimal_implementation_principle():
+    """Issue #118: the Chinese contributing page carries the same
+    KISS/LEAN minimal implementation principle as the English page —
+    smallest complete change, forbidden expansion list, 如无必要勿增实体,
+    the simpler-design rule and the unchanged MVP boundary."""
+    text = zh_page_text("contributing")
+    assert "KISS" in text, "contributing must name KISS"
+    assert "LEAN" in text, "contributing must name LEAN"
+    assert "最小完整变更" in text, (
+        "contributing must state the smallest complete change principle"
+    )
+    assert "如无必要勿增实体" in text, (
+        "contributing must state 如无必要勿增实体"
+    )
+    assert "验收条件" in text, (
+        "contributing must tie every new entity to an acceptance criterion"
+    )
+    assert "概念更少、文件更少" in text, (
+        "contributing must prefer the simpler design"
+    )
+    assert "未来功能" in text or "future-proofing" in text, (
+        "contributing must forbid future features / future-proofing"
+    )
+
+
 def test_chinese_kv_cache_page_matches_the_upstream_port_contract():
     """Same port contract as the English page: the agent-facing port
     18082 (the committed unit's value) stays documented, but the

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -369,6 +369,45 @@ def test_docs_document_contributing_paths():
     assert "Fixes #" in text, "contributing must document the PR body contract"
 
 
+def test_docs_document_the_minimal_implementation_principle():
+    """Issue #118: the contributing page documents Issue granularity and
+    the KISS/LEAN minimal implementation principle — the smallest
+    complete change for the acceptance criteria, the forbidden expansion
+    list, 如无必要勿增实体 (every new entity maps to an acceptance
+    criterion), the simpler-design rule, and the unchanged MVP
+    boundary."""
+    text = page_text("contributing")
+    assert "issue granularity" in text.lower(), (
+        "contributing must document the Issue granularity"
+    )
+    assert "kiss" in text.lower(), "contributing must name KISS"
+    assert "lean" in text.lower(), "contributing must name LEAN"
+    assert "smallest complete" in text.lower(), (
+        "contributing must state the smallest complete change principle"
+    )
+    assert "speculative" in text.lower(), (
+        "contributing must forbid speculative features"
+    )
+    assert "no-benefit abstraction" in text.lower(), (
+        "contributing must forbid no-benefit abstractions"
+    )
+    assert "future-proofing" in text.lower(), (
+        "contributing must forbid future-proofing"
+    )
+    assert "scope expansion" in text.lower(), (
+        "contributing must forbid scope expansion"
+    )
+    assert "如无必要勿增实体" in text, (
+        "contributing must state 如无必要勿增实体"
+    )
+    assert "acceptance criterion" in text.lower(), (
+        "contributing must tie every new entity to an acceptance criterion"
+    )
+    assert "fewer concepts, fewer files" in text.lower(), (
+        "contributing must prefer the simpler design"
+    )
+
+
 def test_docs_document_the_git_transport_boundary():
     """Issue #114: the docs must document the two-channel boundary —
     git data operations over SSH (including workflow file pushes),

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -1,4 +1,5 @@
-"""Guard the prompt contract for blocking commands (Issue #95).
+"""Guard the prompt contract for blocking commands (Issue #95) and the
+KISS/LEAN minimal-implementation contract (Issue #118).
 
 Two real hangs (run cd855188 review session, run 9240f1e4 implement
 session) had the same pattern: a TDD red test driving a `while True`
@@ -8,6 +9,13 @@ wrap commands in `timeout` after a failure, but the contract must say
 it up front. These tests fail when the rule text is removed from
 `prompt.md`, `prompt_review.md` or the `AGENTS.md` TDD section, so the
 contract cannot silently drift away.
+
+Issue #118 adds the same guard for the KISS/LEAN contract: with stronger
+reasoning models an Issue gets expanded into extra architecture,
+abstractions, state or future features, so the implementer prompt must
+forbid scope expansion up front, the reviewer prompt must be able to
+report it as an out-of-scope finding, and the key wording is locked
+here so the constraint cannot be silently deleted or weakened.
 """
 from pathlib import Path
 
@@ -62,6 +70,44 @@ def test_prompt_md_keeps_the_blocking_command_rules():
     assert not missing, f"prompt.md is missing blocking-command rules: {missing}"
 
 
+# --- prompt.md (implementer): KISS/LEAN minimal implementation (Issue #118) ---
+
+PROMPT_KISS_ITEMS = (
+    # 1. The rule names itself and pins the scope to the acceptance
+    #    criteria: the smallest complete change, nothing more.
+    ("kiss-section", "minimal implementation"),
+    ("kiss-kiss", "kiss"),
+    ("kiss-lean", "lean"),
+    ("kiss-acceptance-only", "implement only the issue's acceptance criteria"),
+    ("kiss-smallest", "smallest complete"),
+    # 2. The forbidden expansion list is explicit.
+    ("kiss-no-speculative", "speculative features"),
+    ("kiss-no-abstraction", "no-benefit abstractions"),
+    ("kiss-no-framework", "extra framework layers"),
+    ("kiss-no-fallback", "fallback"),
+    ("kiss-no-future", "future-proofing"),
+    ("kiss-no-scope", "scope expansion"),
+    # 3. 如无必要勿增实体: every new entity must map to an acceptance
+    #    criterion (the full entity list is locked in one needle so it
+    #    cannot be quietly shortened).
+    ("kiss-occam", "如无必要勿增实体"),
+    ("kiss-entity-mapping",
+     "every new file, dependency, state, label, command and abstraction "
+     "must map to an acceptance criterion"),
+    # 4. When two designs both satisfy the requirements, the simpler one
+    #    wins: fewer concepts, fewer files.
+    ("kiss-two-designs", "when two designs both satisfy the requirements"),
+    ("kiss-fewer", "fewer concepts, fewer files"),
+    # 5. The MVP boundary is restated, not relaxed.
+    ("kiss-mvp-boundary", "no database, queue, dag, daemon, risk engine or fallback"),
+)
+
+
+def test_prompt_md_keeps_the_kiss_lean_rules():
+    missing = _missing(_text(PROMPT), PROMPT_KISS_ITEMS)
+    assert not missing, f"prompt.md is missing KISS/LEAN rules: {missing}"
+
+
 # --- prompt_review.md (reviewer) ----------------------------------------------
 
 REVIEW_ITEMS = (
@@ -82,6 +128,40 @@ def test_prompt_review_md_keeps_the_blocking_command_check():
     missing = _missing(_text(PROMPT_REVIEW), REVIEW_ITEMS)
     assert not missing, (
         f"prompt_review.md is missing the blocking-command check: {missing}"
+    )
+
+
+# --- prompt_review.md (reviewer): R8 scope/over-engineering (Issue #118) ------
+
+REVIEW_KISS_ITEMS = (
+    # The check names itself (R8), the Issue and the scope boundary.
+    ("review-kiss-name", "out-of-scope and over-engineering"),
+    ("review-kiss-issue", "issue #118"),
+    ("review-kiss-acceptance", "acceptance criteria"),
+    ("review-kiss-smallest", "smallest complete"),
+    # The forbidden expansion list is explicit, so a diff that adds an
+    # extra future feature is named as a finding, not waved through.
+    ("review-kiss-speculative", "speculative feature"),
+    ("review-kiss-abstraction", "no-benefit abstraction"),
+    ("review-kiss-framework", "extra framework layer"),
+    ("review-kiss-future", "future-proofing"),
+    ("review-kiss-scope", "scope expansion"),
+    # 如无必要勿增实体: an entity without an acceptance-criterion mapping
+    # is a finding.
+    ("review-kiss-occam", "如无必要勿增实体"),
+    ("review-kiss-mapping", "map to an acceptance criterion"),
+    # The simpler design is the contract.
+    ("review-kiss-fewer", "fewer concepts, fewer files"),
+    # Every such finding states the minimal fix direction.
+    ("review-kiss-minimal-fix", "minimal fix direction"),
+    ("review-kiss-shrink", "delete or shrink"),
+)
+
+
+def test_prompt_review_md_keeps_the_kiss_lean_check():
+    missing = _missing(_text(PROMPT_REVIEW), REVIEW_KISS_ITEMS)
+    assert not missing, (
+        f"prompt_review.md is missing the R8 KISS/LEAN check: {missing}"
     )
 
 


### PR DESCRIPTION
Fixes #118

<!-- muyan-pilot:run=095b2859 -->

run_id=095b2859

## What changed

KISS/LEAN becomes the explicit Muyan Pilot development contract, so agents
implement only the smallest complete behavior the Issue's acceptance
criteria require:

- **`prompt.md` (implementer)**: new "Minimal implementation — KISS/LEAN"
  rule — implement only the Issue's acceptance criteria (smallest complete
  change); speculative features, no-benefit abstractions, extra framework
  layers, fallbacks, future-proofing and scope expansion are forbidden;
  如无必要勿增实体 (every new file, dependency, state, label, command and
  abstraction must map to an acceptance criterion); when two designs both
  satisfy the requirements, choose the simpler one (fewer concepts, fewer
  files); the MVP boundary (no database, queue, DAG, daemon, risk engine or
  fallback) is restated, not relaxed.
- **`AGENTS.md`**: the same positive contract as a dedicated section, read
  by every implement/review session.
- **`prompt_review.md`**: dedicated R8 check — out-of-scope changes,
  complexity and unevidenced abstractions are findings (a diff that adds an
  extra future feature is exactly the named case); every such finding
  states the minimal fix direction: delete or shrink the out-of-scope part
  until only the acceptance criteria remain.
- **Docs (EN + ZH `contributing` pages)**: Issue granularity and the
  minimal implementation principle, same source of truth in both languages.
- **Contract tests**: `test_prompt_contract.py`, `test_agents_md.py`,
  `test_docs_site.py` and `test_docs_i18n.py` lock the key wording so the
  constraint cannot be silently deleted or weakened.

The system `tdd-dev` skill body is untouched (project-level constraints
live in the project prompts, per the Issue).

## Verification

- TDD: the 4 new contract tests failed fast first (5 failed, 43 passed in
  0.08s — pure text tests, no hang), then went green with the contract
  text.
- Full suite: `928 passed` (baseline 924 + 4 new tests).
- Coverage: `coverage run --branch` + `coverage report --fail-under=100`
  → 100% line and branch (TOTAL 11554 stmts, 0 missing).
- Commands and results recorded in the worktree `test.log`.

run_id=095b2859
