### PR TITLE
Runner: claim scan skips ai-epic Issues with epic_not_claimed (Issue #93)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,34 @@ acceptance criteria.
 - review/merge failures of a P0 PR follow the existing same-PR, bounded
   review-round mechanism (no new loop).
 
+## Epic Issues (ai-epic)
+
+- An Epic is a coordination Issue that groups related tasks (a release
+  checklist, a multi-task grouping). It carries the plain `ai-epic`
+  label and is NOT an executable task: the actual work is split into
+  independent `ai-ready` sub-Issues, each with one runtime outcome, one
+  PR, one independent review and one merge. Preconditions between
+  sub-Issues use the native `blockedBy` relation (see Task
+  dependencies) — the Runner never parses body checkboxes or
+  `Depends on` lines to infer dependencies.
+- The ready claim scan NEVER claims an `ai-epic` Issue (Issue #93): no
+  `ai-in-progress`, no label change, no worktree, no run, no slot — a
+  structured `epic_not_claimed issue=N repo=...` line is written and
+  the next ready Issue is considered. The Epic check precedes the
+  blockedBy check: "it is an Epic" is the recorded cause, never a
+  `blocked_by` line. The restart-resume scan excludes `ai-epic` too:
+  a legacy Epic left behind with `ai-in-progress` (the #80 scene,
+  before the Epic mechanism existed) is never resumed into a run.
+- The Epic's completion is judged from GitHub evidence — sub-Issues
+  done, their PRs merged, the release tag/artifacts on the remote, no
+  leftover `ai-in-progress` — and the Epic is closed by a human or a
+  release task (a regular `ai-ready` Issue that reconciles that
+  evidence, typically with a final `Fixes #<epic>`). The Runner never
+  marks an Epic complete or closes it: while any completion condition
+  is unmet the Epic stays open. No database, queue or resident service
+  tracks the Epic — GitHub Issues/labels, native `blockedBy`, PRs and
+  the remote tag are the only state.
+
 ## Review, in-session fix and merge (same PR)
 
 - The review session is independent (a new Pi process, `prompt_review.md`,

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ done
 # p0 是紧急优先级 label（不是交付状态，见「领取优先级（P0）」）
 gh label create p0 --repo xqliu/muyan-pilot --force --color "fbca04" \
   --description "Muyan Pilot urgent priority: picked up before bugs and features"
+# ai-epic 是 Epic 协调 label（不是交付状态，见「Epic Issue（ai-epic）」）
+gh label create ai-epic --repo xqliu/muyan-pilot --force --color "bfdadc" \
+  --description "Epic coordination issue; not directly executable by Runner"
 gh label list --repo xqliu/muyan-pilot
 ```
 
@@ -194,6 +197,7 @@ gh label list --repo xqliu/muyan-pilot
 | `ai-merged` | 成功终态：Runner 已合并 PR 并确认 merge commit 落在保护分支 | Runner 合并并确认后添加（替代 `ai-pr-opened`） | 终态，不再自动变更；PR body 的 `Fixes #N` 在 merge 时自动关闭 Issue |
 | `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | 命令失败、现场无法恢复、审查超轮等 fail fast 场景 | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
 | `p0` | 紧急优先级（**不是交付状态**）：只改变领取顺序，不改变 Issue 粒度、交付状态或终态语义 | 人工加 label（生产链路出现高优先级故障时） | 人工移除；Runner 从不增删该 label |
+| `ai-epic` | Epic 协调 Issue（发布清单/多任务聚合，**不是可执行任务、不是交付状态**）：只负责聚合与发布门禁 | 人工加 label（创建 Epic 时） | 人工移除（Epic 完成并关闭时）；Runner 从不增删该 label，也从不领取带它的 Issue |
 
 ## 任务依赖（blockedBy）
 
@@ -222,6 +226,15 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 - 领取日志行携带明确的 `priority=p0` / `priority=normal` 字段；GitHub 进度评论显示 `priority` 字段；run 现场（`run_info`）与 started milestone 携带 `priority=...`；
 - P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；失败评论和 blocked 现场保留具体失败原因和可恢复现场；
 - P0 的 review/merge 失败沿用现有同一 PR、有限 review round（`MAX_REVIEW_ROUNDS=5`）机制，不引入新的循环。
+
+## Epic Issue（ai-epic）
+
+多任务工作（发布清单、跨任务聚合）用 `ai-epic` 标签的协调 Issue 表达（例如 v0.1 发布清单 #80、0.2.0 工作区 #133）——**不是**可执行任务，也不引入 DAG、数据库、队列或常驻服务：
+
+- **职责边界**：Epic 只负责聚合和发布门禁；实际开发项必须拆成独立的 `ai-ready` 子 Issue，每个子 Issue 一个 runtime outcome、一个 PR、一次独立审查、一次合并。子 Issue 之间的前置条件用 GitHub 原生 `blockedBy` 表达（见「任务依赖（blockedBy）」），Runner 不解析正文复选框或 `Depends on` 行；
+- **Runner 行为（Issue #93）**：普通领取扫描（P0/bug/普通三次扫描）**从不领取**带 `ai-epic` 的 Issue——不加 `ai-in-progress`、不改任何标签、不建 worktree、不启动 `run_pi`、不占执行 slot，记录结构化日志 `epic_not_claimed issue=N repo=...` 后继续检查下一个 ready Issue（Epic 检查先于 blockedBy 检查：「它是 Epic」才是被记录的原因）；重启恢复扫描同样排除 `ai-epic`——遗留 `ai-in-progress` 的 Epic（#80 场景）绝不会被恢复进 run；
+- **完成条件**：子 Issue 已完成、相关 PR 已合并、发布 tag/交付物已存在于远端、没有遗留 `ai-in-progress`。这些条件由 GitHub Issue/label、原生 `blockedBy`、PR 和远端 tag 证据确定；
+- **关闭门禁**：任一完成条件未满足时，Epic 不得被标记完成或自动关闭。Epic 由人工或 release task（一个普通 `ai-ready` Issue，职责是对账上述证据，通常伴随最后一个 `Fixes #<epic>` commit/PR）关闭——Runner 从不标记 Epic 完成，也从不自动关闭 Epic。
 
 ## 自动可观测（正常运行不需要执行任何命令）
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -133,6 +133,18 @@ BLOCKED_LABEL = "ai-blocked"
 # failed run — the ready scans exclude `ai-blocked`, so the `ai-ready`
 # residue never re-enters the queue (no infinite retry).
 P0_LABEL = "p0"
+# Epic marker (Issue #93): the plain `ai-epic` label marks a
+# coordination Issue (a release checklist or a multi-task grouping).
+# An Epic is NOT an executable task: the ready claim scan skips it
+# (structured `epic_not_claimed` line — no claim, no label change, no
+# worktree, no run, no slot) and the restart-resume scan excludes it
+# (a legacy Epic left behind with `ai-in-progress` must never be
+# resumed into a run). The actual work lives in independent `ai-ready`
+# sub-Issues (one runtime outcome, one PR each); the Epic's completion
+# is judged from GitHub evidence (sub-Issues done, PRs merged, release
+# tag on the remote, no leftover `ai-in-progress`) and closed by a
+# human or a release task — never by the claim path.
+EPIC_LABEL = "ai-epic"
 
 # Only comments posted by a repo maintainer are trusted to carry the
 # recovery scene: a public comment (authorAssociation=NONE) must never
@@ -372,6 +384,24 @@ def issue_priority(issue: dict) -> str:
     return "normal"
 
 
+def is_epic(issue: dict) -> bool:
+    """Return True when one issue carries the `ai-epic` label (Issue #93).
+
+    A pure function of the issue's `labels` (the scans fetch `labels`,
+    so no extra gh call), the same style as `issue_priority`. A
+    missing or malformed `labels` field fails open to "not an epic":
+    the scan always requests `labels`, so a shape change only loses
+    the Epic guard for one run — it must never deadlock the queue.
+    """
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") == EPIC_LABEL:
+            return True
+    return False
+
+
 def pick_issue(repo: str) -> dict | None:
     # A merged delivery keeps `ai-ready` + `ai-merged` on the (still
     # open) Issue; `ai-merged` is the success terminal state, so it is
@@ -380,10 +410,14 @@ def pick_issue(repo: str) -> dict | None:
     # reads the native GitHub dependency per Issue (Issue #54): an
     # Issue with open blockers is skipped — no claim, no label change,
     # no worktree — and the next ready Issue is considered instead.
-    # Issue #71/#101: the P0 scan runs first, then the bug scan; a P0
-    # or bug with open blockers is skipped there and the next scan
-    # still decides. The scan also fetches `labels` so the picked
-    # issue's priority is visible without an extra gh call.
+    # Issue #93: an `ai-epic` Issue is skipped too — no claim, no
+    # label change, no worktree, no run, no slot — with the structured
+    # `epic_not_claimed` line (the Epic check precedes the blockedBy
+    # check). Issue #71/#101: the P0 scan runs first, then the bug
+    # scan; a P0 or bug with open blockers is skipped there and the
+    # next scan still decides. The scan also fetches `labels` so the
+    # picked issue's priority (and Epic-ness) is visible without an
+    # extra gh call.
     for search in (P0_READY_SEARCH, BUG_READY_SEARCH, READY_SEARCH):
         try:
             raw = run_command([
@@ -404,6 +438,18 @@ def pick_issue(repo: str) -> dict | None:
             )
             return None
         for issue in issues:
+            # Epic skip (Issue #93): an `ai-epic` Issue is never
+            # claimed — no label change, no worktree, no run, no slot.
+            # The check precedes the blockedBy check: "it is an Epic"
+            # is the more fundamental reason, so the structured
+            # `epic_not_claimed` line (not a `blocked_by` line) is the
+            # recorded cause.
+            if is_epic(issue):
+                LOGGER.info(
+                    "epic_not_claimed issue=%s repo=%s",
+                    issue.get("number"), repo,
+                )
+                continue
             blockers = open_blocker_numbers(issue)
             if blockers:
                 LOGGER.info(
@@ -436,7 +482,11 @@ def pick_in_progress_issue(
     production flow. `process_issue`'s resume block (newest worktree's
     run id) then reuses the run instead of starting a second one. Every
     other delivery state is excluded: those Issues are owned by the
-    resumable-PR scan (`ai-fix-needed`) or are terminal.
+    resumable-PR scan (`ai-fix-needed`) or are terminal. `ai-epic` is
+    excluded too (Issue #93): a legacy Epic left behind with
+    `ai-in-progress` (the #80 scene, before the Epic mechanism existed)
+    must never be resumed into a run — an Epic is coordination, not an
+    executable task.
 
     The scan runs only when no OTHER runner is live: a slot held by
     another process proves a live runner is working (on this or another
@@ -455,7 +505,8 @@ def pick_in_progress_issue(
         "--search",
         "label:ai-ready label:ai-in-progress "
         f"-label:{PR_OPENED_LABEL} -label:{FIX_NEEDED_LABEL} "
-        f"-label:{MERGED_LABEL} -label:{BLOCKED_LABEL}",
+        f"-label:{MERGED_LABEL} -label:{BLOCKED_LABEL} "
+        f"-label:{EPIC_LABEL}",
         # `labels` (Issue #101): a P0 a killed runner left behind
         # keeps its priority in the progress comment on resume.
         "--json", "number,title,body,labels", "--limit", "1",

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -30,7 +30,7 @@ non-zero exit code.
    - the repo exists and the viewer has write permission
      (`gh repo view` → `viewerPermission` must be `WRITE`, `MAINTAIN`
      or `ADMIN`);
-   - the seven platform labels are aligned **declaratively** from the
+   - the eight platform labels are aligned **declaratively** from the
      repo-managed `labels.toml` (repo root) — the single source of
      truth for label name, color and description: a missing label is
      created, a drifted label is updated, nothing is deleted, and
@@ -86,14 +86,14 @@ containing spaces are quoted), so agents and scripts can parse it:
 
 ```text
 setup=ok version=1 base_branch=main
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
-`labels=7/7` means all seven platform labels match `labels.toml`;
+`labels=8/8` means all eight platform labels match `labels.toml`;
 `next` is the timer's next trigger time (`-` when it has none);
 `optional_proxy` is `healthy`, `unhealthy` or `unavailable` and never
 changes the exit code. `migrated=true` means setup rewrote an HTTPS
@@ -113,7 +113,7 @@ Success (exit code `0`):
 ```bash
 $ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=1 base_branch=main
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -129,10 +129,17 @@ DAG, no priority numbers, no separate queues:
   example the v0.1 release checklist). It is marked with the `ai-epic`
   label. An Epic is not itself a directly executable task: the actual
   work is split into independent `ai-ready` Issues, each with one runtime
-  outcome, one PR, one review and one merge. The Epic is closed only
-  after its sub-Issues are done and the release evidence exists on the
-  remote (tag, merged PRs) — typically with a final `Fixes #<epic>`
-  commit/PR.
+  outcome, one PR, one review and one merge. The Runner NEVER claims an
+  Epic (Issue #93): the ready claim scan skips it with the structured
+  `epic_not_claimed issue=N repo=...` journal line (no claim, no label
+  change, no worktree, no run, no slot), and the restart-resume scan
+  excludes it too. The Epic is closed only after its sub-Issues are
+  done and the release evidence exists on the remote (tag, merged PRs)
+  — the completion is judged from GitHub evidence (sub-Issues, native
+  `blockedBy`, merged PRs, remote tag, no leftover `ai-in-progress`),
+  and while any condition is unmet the Epic stays open: it is closed by
+  a human or a release task, typically with a final `Fixes #<epic>`
+  commit/PR — never by the Runner.
 - **Release task**: a regular `ai-ready` Issue whose job is release
   reconciliation — checking that the sub-Issues are merged, the version
   tag exists on the remote, and the release evidence is complete. Like

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -25,7 +25,7 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    OWNER/REPO` 时恰好一个）：
    - 仓库存在且 viewer 有写权限（`gh repo view` → `viewerPermission`
      必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）；
-   - 七个平台标签从仓库根目录的 `labels.toml` **声明式**对齐——标签
+   - 八个平台标签从仓库根目录的 `labels.toml` **声明式**对齐——标签
      名/颜色/描述的唯一事实源：缺的创建、漂移的更新、从不删除，业务
      标签（`bug`、`enhancement`、...）从不被碰。
 4. **Systemd units** — 仓库模板（`systemd/muyan-pilot.service`、
@@ -71,14 +71,14 @@ agent 和脚本可以解析：
 
 ```text
 setup=ok version=1 base_branch=main
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
-`labels=7/7` 表示七个平台标签都与 `labels.toml` 一致；`next` 是 timer
+`labels=8/8` 表示八个平台标签都与 `labels.toml` 一致；`next` 是 timer
 的下次触发时间（没有时为 `-`）；`optional_proxy` 是 `healthy`、
 `unhealthy` 或 `unavailable`，从不改变退出码。`migrated=true` 表示
 setup 把 HTTPS `origin` 改写成了 SSH URL（重跑后报告 `migrated=false`）；
@@ -97,7 +97,7 @@ muyan-pilot setup --config muyan-pilot.toml --json
 ```bash
 $ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=1 base_branch=main
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=7/7
+repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot.service sha256=9f2c...
 timer=enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -116,9 +116,15 @@ PR 验收时校验该关键词，缺失即 fail fast。
 - **Epic**：协调 Issue，把一组相关任务归在一起（例如 v0.1 release
   checklist）。它带 `ai-epic` 标签。Epic 本身不是可直接执行的任务：
   实际工作拆成独立的 `ai-ready` Issue，每个一个 runtime outcome、一个
-  PR、一次 review、一次 merge。只有当子 Issue 完成且 release 证据
-  （tag、已合并 PR）在远端存在后 Epic 才关闭——通常伴随最后一个
-  `Fixes #<epic>` commit/PR。
+  PR、一次 review、一次 merge。Runner **从不领取** Epic（Issue #93）：
+  普通领取扫描跳过它并记录结构化日志
+  `epic_not_claimed issue=N repo=...`（不领取、不改标签、不建 worktree、
+  不启动 run、不占 slot），重启恢复扫描也排除它。只有当子 Issue 完成
+  且 release 证据（tag、已合并 PR）在远端存在后 Epic 才关闭——完成条件
+  由 GitHub 证据（子 Issue、原生 `blockedBy`、已合并 PR、远端 tag、无
+  遗留 `ai-in-progress`）确定；任一条件未满足时 Epic 保持 open：由人工
+  或 release task 关闭（通常伴随最后一个 `Fixes #<epic>` commit/PR），
+  绝不由 Runner 关闭。
 - **Release task**：一个普通 `ai-ready` Issue，职责是 release 对账——
   检查子 Issue 已合并、版本 tag 在远端存在、release 证据完整。和任何
   任务一样通过一个 PR 交付（或当证据已在远端时直接关闭 Epic）。

--- a/labels.toml
+++ b/labels.toml
@@ -44,3 +44,8 @@ description = "Muyan Pilot stopped and needs human attention"
 name = "p0"
 color = "fbca04"
 description = "Muyan Pilot urgent priority: picked up before bugs and features"
+
+[[label]]
+name = "ai-epic"
+color = "bfdadc"
+description = "Epic coordination issue; not directly executable by Runner"

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -9,7 +9,8 @@ initialization entry for a new machine or new task-pool repository:
   ``systemctl --user`` user bus;
 - aligns the platform labels (``ai-ready``, ``ai-in-progress``,
   ``ai-pr-opened``, ``ai-fix-needed``, ``ai-merged``, ``ai-blocked``,
-  ``p0``) declaratively from the repo-managed ``labels.toml`` — the
+  ``p0``, ``ai-epic``) declaratively from the repo-managed
+  ``labels.toml`` — the
   single source of truth for label name, color and description. A
   missing label is created, a drifted label is updated, nothing is
   deleted, and no business label (``bug``, ``enhancement``, ...) is
@@ -54,6 +55,10 @@ REQUIRED_LABELS = (
     "ai-merged",
     "ai-blocked",
     "p0",
+    # Epic marker (Issue #93): the claim scan skips `ai-epic` Issues
+    # (`epic_not_claimed`), so the label is platform state the setup
+    # entry must guarantee — same as every delivery-state label.
+    "ai-epic",
 )
 COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")
 
@@ -78,7 +83,7 @@ class SetupError(RuntimeError):
 def load_label_defs(path: Path) -> list[dict]:
     """Parse and validate the repo-managed label definitions.
 
-    The file must define EXACTLY the 7 platform labels (no more, no
+    The file must define EXACTLY the 8 platform labels (no more, no
     less, no duplicates), each with a non-empty name, a 6-hex color and
     a non-empty description. Any deviation is a fail-fast SetupError:
     a typo'd or missing label would silently skip a delivery state.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -785,6 +785,230 @@ def test_issue_priority_reads_the_p0_label():
     }) == "normal"
 
 
+# --- Issue #93: Epic handling (ai-epic) --------------------------------------
+
+
+def test_is_epic_reads_the_ai_epic_label():
+    """Issue #93: `is_epic` is a pure function of the issue's `labels`
+    (the scans fetch `labels`, so no extra gh call): True when the
+    `ai-epic` label is present. A missing or malformed `labels` field
+    fails open to "not an epic" (the same style as `issue_priority`
+    failing to normal): the scan always requests `labels`, so a shape
+    change only loses the Epic guard for one run — it must never
+    deadlock the queue."""
+    assert runner.is_epic({
+        "number": 80,
+        "labels": [{"name": "ai-epic"}, {"name": "ai-ready"}],
+    }) is True
+    assert runner.is_epic({
+        "number": 10,
+        "labels": [{"name": "ai-ready"}, {"name": "bug"}],
+    }) is False
+    assert runner.is_epic({"number": 10}) is False
+    assert runner.is_epic({"number": 10, "labels": "nope"}) is False
+    assert runner.is_epic({
+        "number": 10, "labels": ["ai-epic", {"name": 7}],
+    }) is False
+
+
+def test_pick_issue_skips_epic_and_claims_next(monkeypatch, caplog):
+    """Issue #93: an `ai-ready` Issue carrying `ai-epic` is never
+    claimed — no label change, no worktree, no run: the runner logs a
+    structured `epic_not_claimed` line with the Issue number and repo
+    and moves on to the next ready Issue of the same repo."""
+    epic = {
+        "number": 80, "title": "v0.1 release checklist", "body": "",
+        "labels": [{"name": "ai-epic"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    ready = {
+        "number": 81, "title": "sub task", "body": "",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([epic, ready]),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == ready
+    assert "epic_not_claimed" in caplog.text
+    assert "issue=80" in caplog.text
+    assert "repo=xqliu/muyan-pilot" in caplog.text
+    # The Epic was skipped for being an Epic — not for blockers — so
+    # no `blocked_by` line is logged for it.
+    assert "blocked_by" not in caplog.text
+
+
+def test_pick_issue_returns_none_when_only_epics_are_ready(
+    monkeypatch, caplog,
+):
+    """Issue #93: a ready queue that only contains Epics yields no
+    claim — the tick ends idle upstream (`no_ready_issue`), so an
+    Epic never occupies a delivery slot."""
+    epic_a = {
+        "number": 80, "title": "v0.1 checklist", "body": "",
+        "labels": [{"name": "ai-epic"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    epic_b = {
+        "number": 133, "title": "0.2.0 workspace", "body": "",
+        "labels": [{"name": "ai-epic"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+
+    def fake_run(command, **kwargs):
+        search = command[command.index("--search") + 1]
+        # The Epics carry no p0/bug label: only the plain ready scan
+        # sees them.
+        if "label:p0" in search or "label:bug" in search:
+            return json.dumps([])
+        return json.dumps([epic_a, epic_b])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") is None
+    assert caplog.text.count("epic_not_claimed") == 2
+    assert "issue=80" in caplog.text
+    assert "issue=133" in caplog.text
+
+
+def test_pick_issue_epic_check_precedes_blocker_check(monkeypatch, caplog):
+    """Issue #93: an Epic is never claimed regardless of its blockedBy
+    state — the `epic_not_claimed` reason (it is an Epic) is more
+    fundamental than its blocker list, so the Epic check runs first
+    and no `blocked_by` line is logged for it."""
+    epic = {
+        "number": 80, "title": "epic", "body": "",
+        "labels": [{"name": "ai-epic"}, {"name": "ai-ready"}],
+        "blockedBy": {
+            "nodes": [{"number": 9}, {"number": 10}], "totalCount": 2,
+        },
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([epic]),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") is None
+    assert "epic_not_claimed" in caplog.text
+    assert "issue=80" in caplog.text
+    assert "blocked_by" not in caplog.text
+
+
+def test_pick_issue_skips_epic_in_p0_and_bug_scans(monkeypatch, caplog):
+    """Issue #93: the Epic skip applies to EVERY ready scan (P0, bug,
+    plain) — an `ai-epic` Issue is never claimed no matter which
+    priority queue it sits in; the next non-Epic ready Issue is
+    claimed instead."""
+    epic_p0 = {
+        "number": 80, "title": "epic p0", "body": "",
+        "labels": [
+            {"name": "ai-epic"}, {"name": "ai-ready"}, {"name": "p0"},
+        ],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    epic_bug = {
+        "number": 81, "title": "epic bug", "body": "",
+        "labels": [
+            {"name": "ai-epic"}, {"name": "ai-ready"}, {"name": "bug"},
+        ],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    feature = {
+        "number": 10, "title": "feature", "body": "",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+
+    def fake_run(command, **kwargs):
+        search = command[command.index("--search") + 1]
+        if "label:p0" in search:
+            return json.dumps([epic_p0])
+        if "label:bug" in search:
+            return json.dumps([epic_bug])
+        return json.dumps([feature])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/muyan-pilot") == feature
+    assert caplog.text.count("epic_not_claimed") == 2
+    assert "issue=80" in caplog.text
+    assert "issue=81" in caplog.text
+
+
+def test_pick_in_progress_issue_scan_excludes_epics(monkeypatch, tmp_path):
+    """Issue #93: the restart-resume scan excludes `ai-epic` — a
+    legacy Epic left behind with `ai-in-progress` (the #80 scene,
+    before the Epic mechanism existed) must never be resumed into
+    `run_pi`: an Epic is coordination, not an executable task."""
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_in_progress_issue(
+        "xqliu/muyan-pilot", tmp_path / "slots", 1,
+    ) is None
+    assert calls == [[
+        "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
+        "--state", "open", "--search",
+        "label:ai-ready label:ai-in-progress -label:ai-pr-opened "
+        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked "
+        "-label:ai-epic",
+        "--json", "number,title,body,labels", "--limit", "1",
+    ]]
+
+
+def test_main_epic_only_queue_ends_idle_without_process_issue(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #93: when the ready queue contains only `ai-epic`
+    Issues, the tick ends idle (`no_ready_issue`): no claim, no
+    worktree, no `run_pi` — an Epic never enters the delivery
+    pipeline and never occupies a slot through a delivery."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
+    epic = {
+        "number": 80, "title": "v0.1 release checklist", "body": "",
+        "labels": [{"name": "ai-epic"}, {"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["gh", "issue", "list"]:
+            search = command[command.index("--search") + 1]
+            # The resumable-PR and in-flight restart scans are idle;
+            # the ready scans see the Epic.
+            if search.startswith("label:ai-fix-needed") or search.startswith(
+                "label:ai-ready label:ai-in-progress",
+            ):
+                return "[]"
+            return json.dumps([epic])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    # The fake rejects anything that is not issue-list traffic.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
+
+    def fail_process(*args, **kwargs):
+        raise AssertionError("process_issue must not run for an Epic")
+
+    monkeypatch.setattr(runner, "process_issue", fail_process)
+    # The guard itself must fail loudly if it is ever reached.
+    with pytest.raises(AssertionError, match="must not run for an Epic"):
+        fail_process()
+    with caplog.at_level("INFO"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert "no_ready_issue" in caplog.text
+    assert "epic_not_claimed" in caplog.text
+    assert "issue=80" in caplog.text
+
+
 def test_pick_in_progress_issue_scan_fetches_labels(monkeypatch, tmp_path):
     """Issue #101: the in-flight restart scan fetches `labels` too, so
     a P0 a killed runner left behind keeps its priority in the
@@ -808,7 +1032,8 @@ def test_pick_in_progress_issue_scan_fetches_labels(monkeypatch, tmp_path):
         "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
         "--state", "open", "--search",
         "label:ai-ready label:ai-in-progress -label:ai-pr-opened "
-        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
+        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked "
+        "-label:ai-epic",
         "--json", "number,title,body,labels", "--limit", "1",
     ]]
 
@@ -838,7 +1063,8 @@ def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):
         "gh", "issue", "list", "--repo", "xqliu/muyan-pilot",
         "--state", "open", "--search",
         "label:ai-ready label:ai-in-progress -label:ai-pr-opened "
-        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked",
+        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked "
+        "-label:ai-epic",
         "--json", "number,title,body,labels", "--limit", "1",
     ]]
 

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -18,7 +18,8 @@ README = REPO_ROOT / "README.md"
 AGENTS = REPO_ROOT / "AGENTS.md"
 
 # The runner's delivery-state labels plus the claim label (`ai-ready`
-# is a literal in the scans, not a runner constant).
+# is a literal in the scans, not a runner constant) and the Epic marker
+# (Issue #93: the claim scan skips `ai-epic` Issues).
 KNOWN_LABELS = frozenset({
     "ai-ready",
     runner.IN_PROGRESS_LABEL,
@@ -26,6 +27,7 @@ KNOWN_LABELS = frozenset({
     runner.FIX_NEEDED_LABEL,
     runner.MERGED_LABEL,
     runner.BLOCKED_LABEL,
+    runner.EPIC_LABEL,
 })
 
 LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -297,9 +297,9 @@ def test_docs_document_labels_run_marker_epic_release_task_and_p0():
     coordination issues (ai-epic), Release tasks, and the P0 pickup
     order (the plain `p0` label, Issue #101: `ai-ready`+`p0` before
     `ai-ready`+`bug` before plain `ai-ready`, failed P0 enters
-    `ai-blocked` with no infinite retry). Epic/Release task/P0 are
-    workflow concepts — the docs must not claim runner features that are
-    not implemented yet (Issue #93/#98 are still open)."""
+    `ai-blocked` with no infinite retry). The Epic skip is implemented
+    behavior (Issue #93: the claim scan never claims an `ai-epic`
+    Issue and logs `epic_not_claimed`)."""
     text = page_text("workflow")
     assert "ai-epic" in text, "workflow must explain Epic issues (ai-epic)"
     assert "Release" in text, "workflow must explain Release tasks"
@@ -453,14 +453,17 @@ def test_docs_smoke_walkthrough_is_clone_path_independent():
         )
 
 
-def test_docs_do_not_document_unimplemented_runner_features():
-    """Acceptance: no unimplemented feature. The runner does not skip
-    ai-epic Issues yet (Issue #93 open) and has no P0 priority field
-    (Issue #101 open) — the docs may name the concepts but must not
-    claim that behavior from the current code."""
-    text = page_text("workflow").lower()
-    assert "epic_not_claimed" not in text, (
-        "the runner does not log epic_not_claimed yet (Issue #93 is open)"
+def test_docs_document_the_implemented_epic_skip():
+    """Issue #93: the runner skips `ai-epic` Issues in the claim scan
+    with the structured `epic_not_claimed` line — the workflow page
+    must document that real behavior (the docs may name a concept only
+    when the code carries it)."""
+    text = page_text("workflow")
+    assert "ai-epic" in text, (
+        "workflow must name the ai-epic label the claim scan skips"
+    )
+    assert "epic_not_claimed" in text, (
+        "workflow must document the structured epic_not_claimed log line"
     )
     operations = page_text("operations").lower()
     assert "priority" not in operations or "bug" in operations, (

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -39,6 +39,9 @@ VALID_DEFS = [
     {"name": "ai-merged", "color": "0e8a16", "description": "merged"},
     {"name": "ai-blocked", "color": "d73a4a", "description": "blocked"},
     {"name": "p0", "color": "fbca04", "description": "urgent"},
+    # Issue #93: the Epic marker is platform state (the claim scan
+    # skips `ai-epic`), so it is part of the platform label set.
+    {"name": "ai-epic", "color": "bfdadc", "description": "epic"},
 ]
 
 
@@ -162,12 +165,12 @@ def test_fake_run_factory_rejects_an_unexpected_command():
 # --- labels.toml: the single source of truth -------------------------------
 
 
-def test_load_label_defs_parses_all_seven_platform_labels(tmp_path):
+def test_load_label_defs_parses_all_eight_platform_labels(tmp_path):
     path = write_labels_toml(tmp_path, VALID_DEFS)
     defs = pilot_setup.load_label_defs(path)
     assert [entry["name"] for entry in defs] == [
         "ai-ready", "ai-in-progress", "ai-pr-opened",
-        "ai-fix-needed", "ai-merged", "ai-blocked", "p0",
+        "ai-fix-needed", "ai-merged", "ai-blocked", "p0", "ai-epic",
     ]
     assert defs[0] == {
         "name": "ai-ready", "color": "1d76db", "description": "dispatched",
@@ -183,10 +186,10 @@ def test_load_label_defs_rejects_a_missing_platform_label(tmp_path):
 
 def test_load_label_defs_rejects_an_unknown_label(tmp_path):
     defs = VALID_DEFS + [
-        {"name": "ai-epic", "color": "bfdadc", "description": "epic"},
+        {"name": "ai-unknown", "color": "bfdadc", "description": "x"},
     ]
     path = write_labels_toml(tmp_path, defs)
-    with pytest.raises(pilot_setup.SetupError, match="ai-epic"):
+    with pytest.raises(pilot_setup.SetupError, match="ai-unknown"):
         pilot_setup.load_label_defs(path)
 
 
@@ -225,8 +228,8 @@ def test_load_label_defs_rejects_malformed_toml(tmp_path):
         pilot_setup.load_label_defs(path)
 
 
-def test_committed_labels_toml_covers_the_seven_platform_labels():
-    """The committed labels.toml (repo root) must define exactly the 7
+def test_committed_labels_toml_covers_the_eight_platform_labels():
+    """The committed labels.toml (repo root) must define exactly the 8
     platform labels with valid colors and non-empty descriptions."""
     path = Path(__file__).resolve().parent.parent / "labels.toml"
     defs = pilot_setup.load_label_defs(path)
@@ -390,8 +393,8 @@ def test_align_labels_creates_missing_and_edits_drifted(tmp_path):
         run_command=fake_run,
     )
     assert result["repo"] == "xqliu/muyan-pilot"
-    assert result["aligned"] == 7
-    assert result["total"] == 7
+    assert result["aligned"] == 8
+    assert result["total"] == 8
     # Only the drifted p0 label is written; ai-ready already matches and
     # the business label `bug` is never touched.
     creates = [c for c in calls if c[:3] == ["gh", "label", "create"]]
@@ -413,7 +416,7 @@ def test_align_labels_is_idempotent_when_everything_matches(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 7
+    assert result["aligned"] == 8
     assert [c for c in calls if c[:3] == ["gh", "label", "create"]] == []
 
 
@@ -426,9 +429,9 @@ def test_align_labels_reports_partial_alignment(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 7
-    assert result["total"] == 7
-    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 7
+    assert result["aligned"] == 8
+    assert result["total"] == 8
+    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 8
 
 
 def test_align_labels_fails_fast_on_a_label_write_error(tmp_path):
@@ -818,7 +821,7 @@ def test_run_setup_success_reports_all_steps(tmp_path):
             "repo": "xqliu/muyan-pilot",
             "permission": "ADMIN",
             "default_branch": "main",
-            "labels": {"aligned": 7, "total": 7},
+            "labels": {"aligned": 8, "total": 8},
         },
     ]
     assert result["service"]["installed"] is True
@@ -972,7 +975,7 @@ def sample_result() -> dict:
                 "repo": "xqliu/muyan-pilot",
                 "permission": "ADMIN",
                 "default_branch": "main",
-                "labels": {"aligned": 7, "total": 7},
+                "labels": {"aligned": 8, "total": 8},
             },
         ],
         "service": {
@@ -1008,7 +1011,7 @@ def test_format_setup_renders_stable_key_value_lines():
     assert lines[0] == "setup=ok version=1 base_branch=main"
     assert (
         "repo=xqliu/muyan-pilot permission=ADMIN "
-        "default_branch=main labels=7/7" in lines
+        "default_branch=main labels=8/8" in lines
     )
     assert (
         "service=installed path=/home/u/.config/systemd/user/"
@@ -1045,14 +1048,14 @@ def test_format_setup_renders_multiple_repos():
             "repo": "xqliu/muyan-ceo",
             "permission": "WRITE",
             "default_branch": "main",
-            "labels": {"aligned": 6, "total": 7},
+            "labels": {"aligned": 6, "total": 8},
         },
     )
     lines = pilot_setup.format_setup(result)
     repo_lines = [line for line in lines if line.startswith("repo=")]
     assert len(repo_lines) == 2
     assert repo_lines[1].startswith("repo=xqliu/muyan-ceo ")
-    assert "labels=6/7" in repo_lines[1]
+    assert "labels=6/8" in repo_lines[1]
 
 
 def test_install_units_step_result_is_json_serializable(tmp_path):


### PR DESCRIPTION
Fixes #93

<!-- muyan-pilot:run=8f9efd84 -->

run_id=8f9efd84

## What changed

The Runner now recognizes Epic Issues (the plain `ai-epic` label) and
never claims them — one run stays one deliverable:

- `bootstrap_runner.py`
  - new `EPIC_LABEL = "ai-epic"` and pure `is_epic(issue)` (reads the
    `labels` the scans already fetch; missing/malformed labels fail
    open to "not an epic", same style as `issue_priority`);
  - `pick_issue` skips an `ai-epic` Issue in ALL three ready scans
    (P0/bug/plain) BEFORE the `blockedBy` check: no claim, no label
    change, no worktree, no run, no slot — the structured
    `epic_not_claimed issue=N repo=...` line is the recorded cause and
    the next ready Issue is considered;
  - `pick_in_progress_issue` (restart-resume scan) now excludes
    `-label:ai-epic`: a legacy Epic left behind with `ai-in-progress`
    (the #80 scene) is never resumed into a run.
- `labels.toml` + `pilot_setup.py`: `ai-epic` joins the platform label
  set (7 → 8), values matching the live label (`bfdadc` / "Epic
  coordination issue; not directly executable by Runner");
  `muyan-pilot setup` aligns it declaratively like every other
  platform label.
- Docs: `AGENTS.md` (new "Epic Issues (ai-epic)" contract section),
  `README.md` (label table row, manual label commands, Epic/sub-Issue/
  release-gate boundary section), `docs/workflow.mdx` +
  `docs/zh/workflow.mdx` (the implemented Runner behavior:
  `epic_not_claimed`, restart-scan exclusion, completion judged from
  GitHub evidence, never auto-closed by the Runner),
  `docs/setup.mdx` + `docs/zh/setup.mdx` (eight platform labels,
  `labels=8/8`).

## What did NOT change

- Normal `ai-ready` sub-Issues flow through the existing pipeline
  unchanged (plan → implement → test → verify → review → merge);
  preconditions between sub-Issues stay on the native `blockedBy`.
- The Runner never marks an Epic complete and never closes it: while
  any completion condition (sub-Issues done, PRs merged, release tag
  on the remote, no leftover `ai-in-progress`) is unmet the Epic stays
  open — closed by a human or a release task, typically with a final
  `Fixes #<epic>`.
- No database, queue, DAG, daemon, risk engine or fallback: GitHub
  Issues/labels, native `blockedBy`, PRs and the remote tag are the
  only state.
- Historical v0.1 release notes stay unchanged.

## Verification

- TDD: 7 new tests failed red (old behavior logged `picked issue=80`),
  green after the change; full suite `935 passed` with 100% line and
  branch coverage (`plan.md`, `test.log` in the task worktree).
- External contract verified against the live GitHub API (gh 2.97.0):
  `gh issue list --search "label:ai-epic"` returns only the open Epic
  #133; `label:ai-ready -label:bug` correctly excludes the
  bug-labelled Issues, proving `-label:` is a real per-issue exclusion
  (so the restart scan's `-label:ai-epic` is a real exclusion, not a
  guessed path).