### PR TITLE
fix: pre-start unit-drift preflight self-heals with the idempotent install and re-verifies (Issue #142)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ acceptance criteria.
   next real start runs the latest code. No refresh service, worker,
   dispatcher or resident process is added; the 5-minute timer is
   unchanged.
-- Deployment consistency (Issue #103): the repo templates
+- Deployment consistency (Issue #103, #142): the repo templates
   `systemd/muyan-pilot.service` and `systemd/muyan-pilot.timer` are the
   single source of truth for the installed user units. The idempotent
   install is `muyan-pilot install-units` (copy both templates into the
@@ -171,14 +171,19 @@ acceptance criteria.
   service — a running Runner is never killed or restarted by an install,
   the new config takes effect at the next service start. Every Runner start
   checks BOTH installed units against the templates BEFORE any slot or
-  claim: drift logs a structured `unit_drift` line per unit (repo path,
-  installed path, sha256s, the install fix command) and fails fast — no
-  slot, no claim, no label change — until the units are synced. The
-  read-only report is `muyan-pilot doctor` (repo commit, unit drift,
-  timer/service active, slots, Pi session, current Issue, recent
-  journal). Full sequence:
-  merge to main -> install units -> daemon-reload -> timer next trigger ->
-  ExecStartPre syncs origin/main -> drift check -> Runner starts one Issue.
+  claim: drift is self-healed with the SAME idempotent install (the
+  pre-start sync, Issue #142) and re-verified with the SAME hash check —
+  clean logs one structured `unit_drift auto_synced` line per unit (before
+  and after sha256, deployed commit) and the start continues. Drift that
+  survives the sync — or a failing install step — logs a structured
+  `unit_drift` line per unit (repo path, installed path, sha256s, the
+  install fix command) and fails fast — no slot, no claim, no label
+  change. The read-only report is `muyan-pilot doctor` (repo commit,
+  unit drift, timer/service active, slots, Pi session, current Issue,
+  recent journal). Full sequence:
+  merge to main -> timer next trigger -> ExecStartPre syncs origin/main ->
+  drift check (auto-sync + re-verify when drifted) -> Runner starts one
+  Issue.
 - The service `ExecStart` is the installed `muyan-pilot` CLI (Issue #140):
   the official usage is the `uv tool`-installed console script (`uv tool
   install` / `uv tool upgrade`), and the unit uses the explicit
@@ -186,15 +191,18 @@ acceptance criteria.
   `systemd-analyze --user verify`); the direct-execution entry of
   `muyan_pilot.py` stays a development/compatibility path, never the
   documented usage.
-- A template change is a deployment change (Issue #131): a PR that
-  modifies `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
-  must be followed, after the merge to main, by the human-run
-  `muyan-pilot install-units` (the "install units" step of the
-  deployment sequence) — the Runner NEVER auto-copies or auto-overwrites
-  the installed units. An unsynced template change is caught by the
-  pre-start drift check (structured `unit_drift`, fail fast, no slot,
-  no claim) on every start until the human runs the sync command: the
-  gate is the canary for the deployment, not a bug to be bypassed.
+- A template change is a deployment change (Issue #131, #142): a PR
+  that modifies `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
+  takes effect without a human step — the NEXT timer trigger's
+  `ExecStartPre` syncs the checkout, and the pre-start drift check
+  self-heals the installed units with the same idempotent install
+  (copy, daemon-reload, enable the timer — never touches a running
+  Runner) before the tick continues. No per-tick drift loop until human
+  intervention (the #131/#140 scene). `muyan-pilot install-units` stays
+  the manual entry (setup, immediate sync); a drift the self-heal cannot
+  resolve is still caught by the pre-start check (structured
+  `unit_drift`, fail fast, no slot, no claim) — the gate stays the
+  canary for the deployment, not a bug to be bypassed.
 
 ## Git transport (Issue #114)
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ git fetch origin main && git merge --ff-only origin/main
 
 **幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`、`systemctl --user enable --now muyan-pilot.timer`，并输出部署 commit（部署 checkout 的 HEAD，即模板来源）和每个 unit 的 sha256。安装**不会**启动、停止或重启 service：当前运行中的 Runner 不被中断，新配置从下一次 service 启动生效。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
 
-**启动前漂移检查**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 都覆盖）。一致时记录 `unit_drift clean`；发现漂移时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签），直到 unit 同步：
+**启动前漂移检查（含自愈，Issue #142）**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 都覆盖）。一致时记录 `unit_drift clean`；发现漂移时用**同一个幂等安装**自愈（复制模板、`daemon-reload`、enable timer——不启动、停止或重启 service，运行中的 Runner 不受影响），再用**同一个哈希检查**复核：复核通过时每个 unit 记录一行结构化 `unit_drift auto_synced`（before/after sha256、部署 commit），本次启动继续；复核后仍然漂移（或安装步骤本身失败）时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签）：
 
 ```text
+unit_drift auto_synced unit=muyan-pilot.timer before_sha256=... after_sha256=... commit=<deployed HEAD>
 unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=muyan-pilot install-units
 ```
 
@@ -76,17 +77,15 @@ unit_drift unit=muyan-pilot.timer repo=<repo path> installed=<installed path> re
 **完整部署时序**（从代码合并到下一次 Runner 启动）：
 
 ```text
-git merge 到 main
-  -> install units（仓库模板复制到用户 systemd 目录，幂等，不碰运行中的 Runner）
-  -> daemon-reload
+git merge 到 main（含 unit 模板变更）
   -> timer 下一次触发
   -> ExecStartPre 同步 origin/main（fetch + fast-forward）
-  -> 启动前 unit 漂移检查（一致才继续）
+  -> 启动前 unit 漂移检查（漂移则幂等自愈 + 复核，见上；仍漂移才 fail fast）
   -> 启动前 Git transport 检查（SSH 且可达才继续，见下节）
   -> Runner 启动并执行一个 Issue
 ```
 
-**模板变更必须合并后重新同步（Issue #131）**：`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 是部署配置，不是普通代码——修改任一模板的 PR 合并到 main 后、下一次 timer 触发前，必须由人工运行 `muyan-pilot install-units --config muyan-pilot.toml` 同步两个 user unit（幂等，不碰运行中的 Runner）。Runner 本身 never auto-syncs（从不自动复制、自动覆盖已安装 unit）：模板变更未同步时，每次启动都会被启动前漂移检查 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行同步命令——这是设计内的哨兵行为，不是故障（2026-08-27 实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行 `install-units`，service 每次启动都因 `unit_drift` 失败，直到人工同步，见 Issue #131）。
+**模板变更不再需要人工同步（Issue #142）**：`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer` 仍是部署配置，但模板变更的 PR 合并到 main 后**不需要任何人工步骤**：下一次 timer 触发时 `ExecStartPre` 同步 checkout，启动前漂移检查发现已安装 unit 落后于模板，就用同一个幂等安装自愈（不碰运行中的 Runner）并复核，tick 继续——不再出现“每 5 分钟重复同一个 `unit_drift` 错误直到人工介入”的循环（#131、#140 两次实例的根因）。`muyan-pilot install-units --config muyan-pilot.toml` 保留为手工入口（首次 setup、需要立即同步时）；自愈后仍漂移（例如安装步骤失败、模板缺失）时，启动前检查仍然 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue）——哈希校验和哨兵边界不变。
 
 ## Git transport（Issue #114）
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -50,7 +50,11 @@ from pi_activity import (
     sanitize,
 )
 from progress import ProgressPublisher, format_elapsed, progress_body
-from systemd_deploy import UnitDriftError, check_unit_drift
+from systemd_deploy import (
+    UnitDriftError,
+    check_unit_drift,
+    sync_drifted_units,
+)
 
 
 LOGGER = logging.getLogger("muyan_pilot.bootstrap")
@@ -3127,15 +3131,20 @@ def main(argv: list[str] | None = None) -> int:
 
     config = load_config(args.config)
     validate_config(config)
-    # Deployment consistency (Issue #103): BEFORE any slot or claim the
-    # installed systemd units must match the repo templates (the
-    # templates the ExecStartPre-synced checkout just loaded). Drift
-    # logs a structured `unit_drift` line per unit and fails fast:
-    # this start takes no slot, claims no Issue and changes no label
-    # until the units are synced with the idempotent install command
-    # (`muyan_pilot.py install-units`). A currently RUNNING task is
-    # never interrupted — only the next start is blocked.
-    check_unit_drift(config["repo_dir"])
+    # Deployment consistency (Issue #103, #142): BEFORE any slot or
+    # claim the installed systemd units must match the repo templates
+    # (the templates the ExecStartPre-synced checkout just loaded).
+    # Drift is self-healed with the SAME idempotent install (copy the
+    # templates, daemon-reload, enable the timer — never start/stop/
+    # restart the service: a currently RUNNING task is never
+    # interrupted) and re-verified with the SAME hash check. Drift
+    # that survives the sync — or a failing install step — logs a
+    # structured `unit_drift` line per unit and fails fast: this
+    # start takes no slot, claims no Issue and changes no label.
+    try:
+        check_unit_drift(config["repo_dir"])
+    except UnitDriftError:
+        sync_drifted_units(config["repo_dir"], run_command=run_command)
     # Git transport preflight (Issue #114): BEFORE any slot or claim
     # the deployment checkout's git transport must be SSH and reachable
     # (the task worktrees share the checkout's single `origin` remote,

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -37,27 +37,27 @@ systemctl --user list-timers muyan-pilot.timer
 systemctl --user status muyan-pilot.service
 ```
 
-## After a unit template changes (Issue #131)
+## After a unit template changes (Issue #131, #142)
 
-The unit templates are deployment config, not ordinary code. When a PR
-changes `systemd/muyan-pilot.service` or `systemd/muyan-pilot.timer`
-and merges to main, run the idempotent install BEFORE the next timer
-trigger:
+The unit templates (`systemd/muyan-pilot.service` and
+`systemd/muyan-pilot.timer`) are deployment config, not ordinary code
+— but a template change needs NO human step after the merge. The next timer
+trigger's `ExecStartPre` fast-forwards the checkout, and the pre-start
+`unit_drift` check self-heals: it runs the SAME idempotent install
+(copy both templates into the user unit directory, daemon-reload,
+enable the timer — it never starts, stops or restarts a running
+Runner), re-verifies with the SAME hash check, and the tick continues
+with one structured `unit_drift auto_synced` line per unit (before and
+after sha256, deployed commit). There is no per-tick drift loop until
+human intervention (the #131/#140 scene: every start failed with
+`unit_drift` until a human ran the sync command).
 
-```bash
-muyan-pilot install-units --config muyan-pilot.toml
-```
-
-It copies both templates into the user unit directory, runs
-daemon-reload and enables the timer — it never starts, stops or
-restarts a running Runner. The Runner itself NEVER auto-copies or
-auto-overwrites the installed units: an unsynced template change makes
-every start fail the pre-start `unit_drift` check (structured
-`unit_drift` line, non-zero exit, no slot, no claim) until the sync
-command is run. That fail-fast is the designed canary for the
-deployment, not a bug (2026-08-27: PR #130 changed the timer from 15
-to 5 minutes; the post-merge `install-units` was never run, so every
-start failed with `unit_drift` until a human synced — Issue #131).
+`muyan-pilot install-units --config muyan-pilot.toml` stays the manual
+entry (first setup, or an immediate sync). A drift the self-heal cannot
+resolve — a failing install step, a missing template, a unit that
+drifts again before the re-verify — still fails the start (structured
+`unit_drift` line, non-zero exit, no slot, no claim): the hash check
+and the fail-fast canary are unchanged.
 
 ## Logs (journal)
 

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -32,25 +32,23 @@ systemctl --user list-timers muyan-pilot.timer
 systemctl --user status muyan-pilot.service
 ```
 
-## Unit 模板变更后（Issue #131）
+## Unit 模板变更后（Issue #131、#142）
 
-unit 模板是部署配置，不是普通代码。当 PR 修改
-`systemd/muyan-pilot.service` 或 `systemd/muyan-pilot.timer` 并合并到
-main 后，必须在下一次 timer 触发前运行幂等安装命令：
+unit 模板（`systemd/muyan-pilot.service` 和 `systemd/muyan-pilot.timer`）
+是部署配置，不是普通代码——但模板变更合并后**不需要任何人工步骤**。下一次 timer 触发时 `ExecStartPre` 同步 checkout，启动前
+`unit_drift` 检查自动自愈：用同一个幂等安装（把两个模板复制到用户
+unit 目录、daemon-reload、enable timer——从不启动、停止或重启运行中
+的 Runner）、再用同一个哈希检查复核，tick 继续，每个 unit 记录一行
+结构化 `unit_drift auto_synced`（before/after sha256、部署 commit）。
+不再出现“每 5 分钟重复同一个 `unit_drift` 错误直到人工介入”的循环
+（#131/#140 实例：每次启动都因 `unit_drift` 失败，直到人工运行同步
+命令）。
 
-```bash
-muyan-pilot install-units --config muyan-pilot.toml
-```
-
-它把两个模板复制到用户 unit 目录、daemon-reload、enable timer——从不
-启动、停止或重启运行中的 Runner。Runner 本身 NEVER auto-copies /
-auto-overwrites（从不自动复制、自动覆盖已安装 unit）：模板变更未同步
-时，每次启动都会被启动前 `unit_drift` 检查 fail fast（结构化
-`unit_drift` 行、非零退出、不取 slot、不领取 Issue），直到人工运行
-同步命令。这个 fail-fast 是部署的哨兵行为，不是缺陷（2026-08-27
-实例：PR #130 把 timer 从 15 分钟改为 5 分钟，合并后无人运行
-`install-units`，每次启动都因 `unit_drift` 失败，直到人工同步——
-Issue #131）。
+`muyan-pilot install-units --config muyan-pilot.toml` 保留为手工入口
+（首次 setup、需要立即同步时）。自愈后仍漂移（安装步骤失败、模板
+缺失、复核前 unit 再次漂移）时，启动仍然 fail fast（结构化
+`unit_drift` 行、非零退出、不取 slot、不领取 Issue）：哈希校验和
+哨兵边界不变。
 
 ## 日志（journal）
 

--- a/systemd_deploy.py
+++ b/systemd_deploy.py
@@ -153,6 +153,61 @@ def check_unit_drift(repo_dir: Path,
     )
 
 
+def sync_drifted_units(repo_dir: Path,
+                       installed_dir: Path | None = None,
+                       *, run_command) -> list[dict]:
+    """Pre-start self-heal for drifted units (Issue #142).
+
+    The normal scene: a template change merged to main, the
+    ExecStartPre-synced checkout carries the new templates, and the
+    installed units are still the old ones. Runs the SAME idempotent
+    install (``install_units``: copy the templates, daemon-reload,
+    enable the timer — never start/stop/restart the service, so a
+    currently running Runner is untouched) and re-verifies with the
+    SAME hash check (``unit_status``). Clean after the sync: logs one
+    structured ``unit_drift auto_synced`` line per unit (unit,
+    before/after sha256, deployed commit) and returns the per-unit
+    report. Still drifted after the sync: logs the structured
+    ``unit_drift`` lines and raises ``UnitDriftError`` (fail fast —
+    the caller claims no Issue). A failing install step propagates
+    unchanged. No drift: returns ``[]`` without touching anything.
+    """
+    repo_dir = Path(repo_dir)
+    if installed_dir is None:
+        installed_dir = installed_unit_dir()
+    installed_dir = Path(installed_dir)
+    before = unit_status(repo_dir, installed_dir)
+    if not any(entry["drifted"] for entry in before):
+        return []
+    result = install_units(repo_dir, installed_dir, run_command=run_command)
+    after = unit_status(repo_dir, installed_dir)
+    lines = drift_lines(after)
+    if lines:
+        for line in lines:
+            LOGGER.error(line)
+        raise UnitDriftError(
+            "installed systemd units still drift after the pre-start "
+            f"sync; sync with: {FIX_COMMAND}\n" + "\n".join(lines)
+        )
+    report: list[dict] = []
+    for entry_before, entry_after in zip(before, after):
+        LOGGER.info(
+            "unit_drift auto_synced unit=%s "
+            "before_sha256=%s after_sha256=%s commit=%s",
+            entry_after["unit"],
+            entry_before["installed_sha256"] or "-",
+            entry_after["installed_sha256"],
+            result["commit"],
+        )
+        report.append({
+            "unit": entry_after["unit"],
+            "before_sha256": entry_before["installed_sha256"],
+            "after_sha256": entry_after["installed_sha256"],
+            "commit": result["commit"],
+        })
+    return report
+
+
 def install_units(repo_dir: Path, installed_dir: Path | None = None,
                   *, run_command) -> dict:
     """Idempotently install the repo templates as the user units.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4742,10 +4742,32 @@ def _drift_world(tmp_path, drift: bool) -> tuple[Path, Path]:
     return repo, installed
 
 
+def _fake_preflight_run(monkeypatch, installed: Path) -> list:
+    """A recording run_command for the preflight self-heal (Issue #142).
+
+    The real `install_units` would run `systemctl --user` against the
+    real machine; the wiring tests record the commands instead and
+    keep the install's file copy real (that is what is under test).
+    `git rev-parse HEAD` returns a fixed commit; every other command
+    succeeds with empty output.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    return calls
+
+
 def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
                                                   caplog):
-    """Issue #103: a drifted installed unit fails the start BEFORE any
-    slot or claim: the structured `unit_drift` line (repo path,
+    """Issue #142: a drift the self-heal CANNOT resolve (the re-verify
+    still sees it after the idempotent install) fails the start BEFORE
+    any slot or claim: the structured `unit_drift` line (repo path,
     installed path, hashes, fix command) is logged, the tick raises
     (non-zero exit), no slot is taken and nothing is claimed — while
     a currently RUNNING task is never interrupted (only the next
@@ -4758,6 +4780,20 @@ def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
     monkeypatch.setattr(
         runner, "check_unit_drift", systemd_deploy.check_unit_drift,
     )
+    # The install's copy is real; the external steps are recorded.
+    calls = _fake_preflight_run(monkeypatch, installed)
+    # The installed timer is re-tampered right after every copy: the
+    # re-verify still sees the drift (an unresolvable scene).
+    real_write_bytes = Path.write_bytes
+
+    def re_tamper(self, data):
+        real_write_bytes(self, data)
+        if self.name == "muyan-pilot.timer" and str(self).startswith(
+            str(installed),
+        ):
+            real_write_bytes(self, data + b"# drift\n")
+
+    monkeypatch.setattr(Path, "write_bytes", re_tamper)
     _write_prompts(tmp_path)
     config = tmp_path / "muyan-pilot.toml"
     config.write_text(
@@ -4777,6 +4813,16 @@ def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
     with caplog.at_level("ERROR"):
         with pytest.raises(runner.UnitDriftError, match="unit_drift"):
             runner.main(["--config", str(config)])
+    # The self-heal ran the idempotent install (daemon-reload, enable
+    # the timer) before the re-verify failed — and never touched the
+    # service itself.
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot.timer",
+    ] in calls
+    for command in calls:
+        if command[:2] == ["systemctl", "--user"]:
+            assert command[2] in ("daemon-reload", "enable")
     # The structured line carries what the Issue requires.
     assert "unit_drift unit=muyan-pilot.timer" in caplog.text
     assert f"repo={repo / 'systemd' / 'muyan-pilot.timer'}" in caplog.text
@@ -4785,6 +4831,95 @@ def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
     assert "installed_sha256=" in caplog.text
     assert "fix=muyan-pilot install-units" in caplog.text
     # No slot was taken and nothing was claimed.
+    assert not (repo / ".muyan-pilot" / "slots").exists()
+
+
+def test_main_unit_drift_auto_syncs_and_proceeds_to_claim(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #142: the normal scene — a template change merged to main
+    (the ExecStartPre-synced checkout carries the new templates, the
+    installed units are still the old ones). The preflight self-heals
+    with the SAME idempotent install (copy, daemon-reload, enable the
+    timer — never start/stop/restart the service), the re-verify is
+    clean, the structured `auto_synced` line is logged and the tick
+    proceeds to the normal claim flow (slot taken, queue scanned).
+    No more per-tick drift loop until a human intervenes."""
+    import systemd_deploy
+
+    repo, installed = _drift_world(tmp_path, drift=True)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    monkeypatch.setattr(
+        runner, "check_unit_drift", systemd_deploy.check_unit_drift,
+    )
+    calls = _fake_preflight_run(monkeypatch, installed)
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        f'source_repos = ["owner/repo"]\nrepo_dir = "{repo}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency: None,
+    )
+    with caplog.at_level("INFO"):
+        assert runner.main(["--config", str(config)]) == 0
+    # The self-heal ran the idempotent install (and never the service).
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot.timer",
+    ] in calls
+    for command in calls:
+        if command[:2] == ["systemctl", "--user"]:
+            assert command[2] in ("daemon-reload", "enable")
+    # The repo template won: the installed unit matches it again.
+    status = systemd_deploy.unit_status(repo, installed)
+    assert all(entry["drifted"] is False for entry in status)
+    assert "unit_drift auto_synced unit=muyan-pilot.timer" in caplog.text
+    assert "commit=0123456789abcdef0123456789abcdef01234567" in caplog.text
+    # The tick proceeded: the slot was taken AFTER the preflight passed.
+    assert (repo / ".muyan-pilot" / "slots" / "slot-1").exists()
+
+
+def test_main_unit_drift_auto_sync_failure_blocks_claim(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #142: a failing self-heal (e.g. daemon-reload fails) fails
+    fast BEFORE any slot or claim — the install error propagates,
+    nothing is claimed, and the scene stays in the journal."""
+    import systemd_deploy
+
+    repo, installed = _drift_world(tmp_path, drift=True)
+    monkeypatch.setenv("MUYAN_PILOT_UNIT_DIR", str(installed))
+    monkeypatch.setattr(
+        runner, "check_unit_drift", systemd_deploy.check_unit_drift,
+    )
+
+    def failing_run(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "enable"]:
+            raise subprocess.CalledProcessError(1, command, stderr="nope")
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", failing_run)
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        f'source_repos = ["owner/repo"]\nrepo_dir = "{repo}"\n',
+        encoding="utf-8",
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("pick_next_delivery must not run on unit drift")
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fail_if_called)
+    # The guard itself must fail loudly if it is ever reached.
+    with pytest.raises(
+        AssertionError, match="must not run on unit drift",
+    ):
+        fail_if_called()
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.main(["--config", str(config)])
     assert not (repo / ".muyan-pilot" / "slots").exists()
 
 

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -1157,6 +1157,21 @@ def test_unit_drift_auto_syncs_and_claims_without_human_intervention(
     ) as handle:
         handle.write("# drift\n")
 
+    # A no-op fake systemctl on PATH: the self-heal runs the SAME
+    # idempotent install, whose external steps (daemon-reload, enable
+    # the timer) must succeed — but the e2e world has no user systemd
+    # bus (GitHub CI, Issue #56's clean environment), so the real
+    # `systemctl --user` would fail and the test would depend on the
+    # host machine. The file copy and the re-verify (what is under
+    # test) stay real; the `auto_synced` line below only appears after
+    # the install's systemctl steps succeeded.
+    fake_systemctl = bin_dir / "systemctl"
+    fake_systemctl.write_text(
+        "#!/bin/sh\nexit 0\n",
+        encoding="utf-8",
+    )
+    fake_systemctl.chmod(0o755)
+
     runner_proc = start_runner(
         config, bin_dir, state, pi_log, unit_dir=unit_dir,
     )

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -1133,14 +1133,16 @@ def test_live_pr_opened_delivery_is_not_resumed_by_second_runner(
     assert slots_held(clone, 2) == [(1, None), (2, None)]
 
 
-def test_unit_drift_blocks_the_start_without_claiming(clone, tmp_path):
-    """Issue #103: a drifted installed unit fails the start BEFORE any
-    claim: non-zero exit, the structured `unit_drift` line in the log
-    (repo path, installed path, hashes, fix command), no slot, no
-    label change, no Pi — and once the units are synced with the
-    idempotent install the same start passes the preflight and
-    claims normally. A currently RUNNING task is never interrupted;
-    only the next start is blocked."""
+def test_unit_drift_auto_syncs_and_claims_without_human_intervention(
+    clone, tmp_path,
+):
+    """Issue #142: the normal scene — a template change merged to main
+    (the installed units are still the old ones). The start self-heals
+    with the SAME idempotent install (copy, daemon-reload, enable the
+    timer — never start/stop/restart the service), the re-verify is
+    clean, the structured `unit_drift auto_synced` line is logged and
+    the tick claims normally — no per-tick drift loop until a human
+    intervenes. A clean deployment still logs `unit_drift clean`."""
     bin_dir = install_fakes(tmp_path)
     state = tmp_path / "gh-state.json"
     write_state(state, {"7": ["ai-ready"]})
@@ -1158,6 +1160,80 @@ def test_unit_drift_blocks_the_start_without_claiming(clone, tmp_path):
     runner_proc = start_runner(
         config, bin_dir, state, pi_log, unit_dir=unit_dir,
     )
+    wait_for(
+        lambda: "ai-in-progress" in read_state(state)["issues"]["7"]["labels"],
+        what="runner to self-heal the drift and claim",
+    )
+    runner_proc.kill()
+    out, err = runner_proc.communicate(timeout=30)
+    # The self-heal is logged with the structured auto_synced line.
+    assert "unit_drift auto_synced unit=muyan-pilot.timer" in err
+    assert "before_sha256=" in err
+    assert "after_sha256=" in err
+    assert "commit=" in err
+    # The repo template won: the installed unit matches it again.
+    assert (unit_dir / "muyan-pilot.timer").read_bytes() == (
+        clone / "systemd" / "muyan-pilot.timer"
+    ).read_bytes()
+    assert "ai-in-progress" in read_state(state)["issues"]["7"]["labels"]
+
+    # A clean deployment (the units now match the templates) passes
+    # the preflight without any sync and claims normally.
+    write_state(state, {"8": ["ai-ready"]})
+    runner_proc = start_runner(
+        config, bin_dir, state, pi_log, unit_dir=unit_dir,
+    )
+    wait_for(
+        lambda: "ai-in-progress" in read_state(state)["issues"]["8"]["labels"],
+        what="runner to claim on a clean deployment",
+    )
+    runner_proc.kill()
+    out, err = runner_proc.communicate(timeout=30)
+    assert "unit_drift clean" in err
+    assert "unit_drift auto_synced" not in err
+    assert "ai-in-progress" in read_state(state)["issues"]["8"]["labels"]
+
+
+def test_unit_drift_unresolvable_blocks_the_start_without_claiming(
+    clone, tmp_path,
+):
+    """Issue #142: a drift the self-heal CANNOT resolve (the installed
+    unit is re-tampered right after the install's copy, so the
+    re-verify still sees it) fails the start BEFORE any claim:
+    non-zero exit, the structured `unit_drift` line in the log (repo
+    path, installed path, hashes, fix command), no slot, no label
+    change, no Pi."""
+    bin_dir = install_fakes(tmp_path)
+    state = tmp_path / "gh-state.json"
+    write_state(state, {"7": ["ai-ready"]})
+    pi_log = tmp_path / "pi.log"
+    config = write_config(clone, tmp_path, 1)
+
+    # A drifted deployment: the installed timer carries one extra line.
+    unit_dir = tmp_path / "unresolvable-units"
+    install_deployed_units(unit_dir)
+    with (unit_dir / "muyan-pilot.timer").open(
+        "a", encoding="utf-8",
+    ) as handle:
+        handle.write("# drift\n")
+
+    # A fake systemctl on PATH: every daemon-reload re-tampers the
+    # installed timer AFTER the install's copy, so the re-verify still
+    # sees the drift (an unresolvable scene).
+    fake_systemctl = bin_dir / "systemctl"
+    fake_systemctl.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = '--user' ] && [ \"$2\" = 'daemon-reload' ]; then\n"
+        f"    printf '# drift\\n' >> {unit_dir / 'muyan-pilot.timer'}\n"
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_systemctl.chmod(0o755)
+
+    runner_proc = start_runner(
+        config, bin_dir, state, pi_log, unit_dir=unit_dir,
+    )
     out, err = runner_proc.communicate(timeout=60)
     assert runner_proc.returncode != 0, err
     assert "unit_drift unit=muyan-pilot.timer" in err
@@ -1166,24 +1242,10 @@ def test_unit_drift_blocks_the_start_without_claiming(clone, tmp_path):
     assert "repo_sha256=" in err
     assert "installed_sha256=" in err
     assert "fix=muyan-pilot install-units" in err
+    assert "unit_drift auto_synced" not in err
     # Nothing was claimed: no labels, no comments, no Pi, no slot.
     snap = read_state(state)
     assert snap["issues"]["7"]["labels"] == ["ai-ready"]
     assert snap["comments"] == []
     assert pi_invocations(pi_log) == []
     assert slot_files(clone) == []
-
-    # After syncing the units (the idempotent install), the same start
-    # passes the preflight and claims normally.
-    install_deployed_units(unit_dir)
-    runner_proc = start_runner(
-        config, bin_dir, state, pi_log, unit_dir=unit_dir,
-    )
-    wait_for(
-        lambda: "ai-in-progress" in read_state(state)["issues"]["7"]["labels"],
-        what="runner to claim after the units are synced",
-    )
-    runner_proc.kill()
-    out, err = runner_proc.communicate(timeout=30)
-    assert "unit_drift clean" in err
-    assert "ai-in-progress" in read_state(state)["issues"]["7"]["labels"]

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -334,3 +334,123 @@ def test_install_units_fails_fast_on_missing_template(tmp_path):
 
 def test_unit_drift_error_is_a_runtime_error():
     assert issubclass(systemd_deploy.UnitDriftError, RuntimeError)
+
+
+# --- pre-start self-heal (Issue #142) ---------------------------------------
+
+
+def test_sync_drifted_units_installs_and_reverifies_clean(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #142: a drifted unit (the normal scene after a template
+    change merges to main) is synced with the SAME idempotent install
+    (copy, daemon-reload, enable the timer — never start/stop/restart
+    the service) and re-verified: the tick can continue."""
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.timer")
+    before_sha = systemd_deploy.sha256_hex(installed / "muyan-pilot.timer")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        return ""
+
+    with caplog.at_level("INFO"):
+        report = systemd_deploy.sync_drifted_units(
+            repo, installed, run_command=fake_run,
+        )
+    # The install ran: daemon-reload + enable the timer, and the service
+    # is NEVER started/stopped/restarted by the sync.
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot.timer",
+    ] in calls
+    for command in calls:
+        if command[:2] == ["systemctl", "--user"]:
+            assert command[2] in ("daemon-reload", "enable")
+    # The repo template won: the installed unit matches it again.
+    status = systemd_deploy.unit_status(repo, installed)
+    assert all(entry["drifted"] is False for entry in status)
+    # The report carries one entry per unit with the before/after hashes
+    # and the deployed commit.
+    assert [entry["unit"] for entry in report] == list(
+        systemd_deploy.UNIT_NAMES,
+    )
+    timer = report[1]
+    assert timer["before_sha256"] == before_sha
+    assert timer["after_sha256"] == systemd_deploy.sha256_hex(
+        repo / "systemd" / "muyan-pilot.timer",
+    )
+    assert timer["commit"] == "0123456789abcdef0123456789abcdef01234567"
+    # The structured auto_synced line is logged for the synced unit.
+    assert "unit_drift auto_synced unit=muyan-pilot.timer" in caplog.text
+    assert f"before_sha256={before_sha}" in caplog.text
+    assert "after_sha256=" in caplog.text
+    assert "commit=0123456789abcdef0123456789abcdef01234567" in caplog.text
+
+
+def test_sync_drifted_units_is_a_no_op_when_clean(monkeypatch, tmp_path):
+    """Issue #142: with no drift nothing is installed (no systemctl
+    calls, no copy) — the preflight only heals a real drift."""
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    calls: list[list[str]] = []
+    report = systemd_deploy.sync_drifted_units(
+        repo, installed, run_command=lambda command, **kwargs: calls.append(command) or "",
+    )
+    assert report == []
+    assert calls == []
+
+
+def test_sync_drifted_units_install_failure_propagates(
+    monkeypatch, tmp_path,
+):
+    """Issue #142: a failing install step (here: enabling the timer)
+    fails fast — the error propagates, no auto_synced claim is made."""
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.service")
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "enable"]:
+            raise subprocess.CalledProcessError(1, command, stderr="nope")
+        return ""
+
+    with pytest.raises(subprocess.CalledProcessError):
+        systemd_deploy.sync_drifted_units(
+            repo, installed, run_command=fake_run,
+        )
+
+
+def test_sync_drifted_units_still_drifted_after_sync_fails_fast(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #142: the re-verify is the same hash check — if the units
+    still drift after the sync (the scene is not recoverable by the
+    idempotent install), the preflight fails fast with the structured
+    `unit_drift` lines and `UnitDriftError` (no slot, no claim)."""
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo, mutate="muyan-pilot.timer")
+    # A second process overwrites the installed unit right after the
+    # copy: the re-verify sees the drift again.
+    real_write_bytes = Path.write_bytes
+
+    def overwrite_after_copy(self, data):
+        real_write_bytes(self, data)
+        if self.name == "muyan-pilot.timer" and str(self).startswith(
+            str(installed),
+        ):
+            real_write_bytes(self, data + b"# drift\n")
+
+    monkeypatch.setattr(Path, "write_bytes", overwrite_after_copy)
+    with caplog.at_level("ERROR"):
+        with pytest.raises(
+            systemd_deploy.UnitDriftError, match="unit_drift",
+        ):
+            systemd_deploy.sync_drifted_units(
+                repo, installed, run_command=lambda command, **kwargs: "",
+            )
+    assert "unit_drift unit=muyan-pilot.timer" in caplog.text
+    assert "fix=muyan-pilot install-units" in caplog.text
+    assert "unit_drift auto_synced" not in caplog.text

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -206,17 +206,17 @@ def test_readme_documents_the_doctor_command():
 
 
 def test_readme_documents_the_full_deployment_sequence():
-    """Issue #103: the README must show the complete sequence from code
-    merge to the next Runner start: merge -> install units ->
-    daemon-reload -> timer next trigger -> ExecStartPre syncs
-    origin/main -> Runner starts one Issue."""
+    """Issue #103/#142: the README must show the complete sequence from
+    code merge to the next Runner start: merge (template changes need
+    no human step) -> timer next trigger -> ExecStartPre syncs
+    origin/main -> pre-start drift check (self-heal + re-verify when
+    drifted) -> Runner starts one Issue."""
     readme = README_FILE.read_text(encoding="utf-8")
     sequence = readme.split("完整部署时序", 1)[-1]
     assert "git merge 到 main" in sequence
-    assert "install units" in sequence
-    assert "daemon-reload" in sequence
     assert "timer 下一次触发" in sequence
     assert "ExecStartPre 同步 origin/main" in sequence
+    assert "启动前 unit 漂移检查" in sequence
     assert "Runner 启动并执行一个 Issue" in sequence
 
 
@@ -239,33 +239,33 @@ def test_agents_md_documents_the_deployment_consistency_contract():
     assert "no claim" in text or "no slot" in text
 
 
-def test_template_change_pins_the_post_merge_install_contract():
-    """Issue #131 regression: a `systemd/` template change is a
-    deployment change. The 2026-08-27 incident: PR #130 (Issue #51)
-    changed the timer template from 15 to 5 minutes and merged to
-    main; the documented post-merge `install-units` step was never
-    run, so every service start failed the pre-start `unit_drift`
-    check (fail fast, by design) until a human ran the fix command.
+def test_template_change_pins_the_self_healing_contract():
+    """Issue #131/#142 regression: a `systemd/` template change is a
+    deployment change. The 2026-08-27/#140 incidents: the timer
+    template change (PR #130) and the service `ExecStart` change
+    (#140) merged to main while the installed units stayed stale, so
+    every service start failed the pre-start `unit_drift` check until
+    a human ran the fix command — a per-tick drift loop.
 
     The contract must therefore be pinned in EVERY place it is
     documented — README, AGENTS.md and the EN/ZH operations pages —
     so a future template change cannot merge and strand the
-    deployment again without the mandatory sync step being visible:
-    after the merge to main the human runs
-    `muyan_pilot.py install-units`; the Runner itself NEVER
-    auto-copies or auto-overwrites the installed units (the drift
-    check stays fail-fast — it is the canary, not a bug)."""
+    deployment again: the change takes effect WITHOUT a human step
+    (the pre-start drift check self-heals with the same idempotent
+    install and re-verifies, `unit_drift auto_synced`), `install-units`
+    stays the manual entry, and the fail-fast canary is unchanged for
+    a drift the self-heal cannot resolve."""
     def template_change_contract(text: str) -> None:
         # The trigger: a change of either repo unit template.
         assert "systemd/muyan-pilot.timer" in text
         assert "systemd/muyan-pilot.service" in text
-        # The mandatory follow-up: the idempotent install command,
-        # run after the merge to main.
+        # The self-heal: the structured auto_synced line.
+        assert "unit_drift auto_synced" in text
+        # install-units stays the manual entry (setup, immediate sync).
         assert "install-units" in text
-        # The Runner never auto-syncs the installed units.
-        assert "never" in text.lower() and "auto" in text.lower()
-        # The unsynced state is caught by the fail-fast drift check.
+        # The drift check stays fail-fast for an unresolvable drift.
         assert "unit_drift" in text
+        assert "fail fast" in text
 
     readme = README_FILE.read_text(encoding="utf-8")
     # The README pins it in the deployment-consistency section (the


### PR DESCRIPTION
Fixes #142

<!-- muyan-pilot:run=339ef317 -->
run_id=339ef317

## Root cause

A unit template change merged to main (e.g. #131's timer interval, #140's
`ExecStart`) left the installed user units stale: the service's
`ExecStartPre` fast-forwards the checkout (repo templates become new)
while nothing in the deployment lifecycle syncs the installed units.
The pre-start `unit_drift` check correctly failed — and repeated the
same failure every 5-minute tick until a human ran
`muyan-pilot install-units`.

## Change

The pre-start drift check (still BEFORE any slot or claim) now
self-heals a legitimate template update:

- on drift it runs the **same idempotent install**
  (`systemd_deploy.install_units`: copy both templates,
  `systemctl --user daemon-reload`, `enable --now` the timer — it
  never starts/stops/restarts the service, so a currently running
  Runner is untouched), then re-verifies with the **same hash check**;
- clean after the sync: one structured
  `unit_drift auto_synced unit=... before_sha256=... after_sha256=...
  commit=...` line per unit, and the tick continues — no per-tick
  drift loop, no human step after a template merge;
- drift that survives the sync (or a failing install step) still fails
  fast with the structured `unit_drift` scene (repo path, installed
  path, both sha256s, fix command) — no slot, no claim, no label
  change. The hash check and fail-fast canary are unchanged.

New entry point: `systemd_deploy.sync_drifted_units()`; `main()` wraps
`check_unit_drift` in `try/except UnitDriftError`. No daemon, no
database, no queue, no timeout, no new state.

Docs updated (README 部署一致性 + 完整部署时序, AGENTS.md deployment
consistency, EN/ZH operations pages): the deployment sequence is now
`merge to main -> timer next trigger -> ExecStartPre syncs origin/main
-> drift check (auto-sync + re-verify when drifted) -> Runner starts
one Issue`; `install-units` stays the manual entry (setup, immediate
sync).

## Tests

- `tests/test_systemd_deploy.py`: `sync_drifted_units` — drift →
  install + re-verify + `auto_synced` lines; clean → no-op; failing
  install step propagates; still-drifted after sync → `UnitDriftError`
  with the structured lines.
- `tests/test_bootstrap_runner.py`: `main()` wiring — drift →
  auto-sync → proceeds to claim (slot taken, `auto_synced` logged,
  installed unit matches the template again); drift → sync →
  re-verify still drifted → `UnitDriftError`, no slot, no claim;
  failing install step → fail fast, no slot, no claim.
- `tests/test_concurrency_e2e.py` (real runner subprocess): the
  #142 scene end to end — drifted units self-heal and the tick claims
  without human intervention; a clean deployment logs `unit_drift
  clean`; an unresolvable drift (re-tampered after the install's copy,
  via a fake `systemctl`) fails the start with the structured scene,
  no slot/label/Pi.
- `tests/test_systemd_timer.py`: the README/AGENTS/EN-ZH contract
  tests now pin the self-healing contract (auto_synced line,
  install-units manual entry, fail-fast canary) in every documented
  place.

Full suite: **942 passed**, **100% line/branch coverage**
(`coverage run --branch -m pytest tests/ -q` +
`coverage report --fail-under=100`), see `test.log` in the task
worktree.