### PR TITLE
fix: flatten multi-line command args to one journal line in the command= log (Issue #143)

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -258,6 +258,20 @@ def validate_config(config: dict) -> None:
             raise FileNotFoundError(path)
 
 
+def single_line(value: str) -> str:
+    """Flatten a log value to one journal line (Issue #143).
+
+    A command argument may carry line breaks (the multi-line progress
+    comment body behind `gh api ... --field body=...`); emitted verbatim,
+    they split one `command=` log into several systemd journal lines with
+    the same timestamp and PID. Escape each line break to the visible
+    two-character sequence `\\n` so the field content stays readable on
+    one line. This only changes the log display — the real command is
+    never modified.
+    """
+    return value.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+
+
 def run_command(command: list[str], *, cwd: Path | None = None,
                 timeout: int | None = None,
                 log_command: list[str] | None = None,
@@ -265,7 +279,7 @@ def run_command(command: list[str], *, cwd: Path | None = None,
     """Run one external command; log context and fail fast on any error."""
     LOGGER.info(
         "command=%s cwd=%s",
-        " ".join(log_command or command), cwd or Path.cwd(),
+        single_line(" ".join(log_command or command)), cwd or Path.cwd(),
     )
     try:
         result = subprocess.run(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -277,6 +277,56 @@ def test_run_command_logs_optional_timeout_and_reraises(tmp_path, caplog):
     assert "command_timeout timeout=7 stdout=partial stderr=wait" in caplog.text
 
 
+def test_single_line_flattens_line_breaks_to_visible_escapes():
+    assert runner.single_line("a\nb") == "a\\nb"
+    assert runner.single_line("a\r\nb") == "a\\nb"
+    assert runner.single_line("a\rb") == "a\\nb"
+    assert runner.single_line("no breaks") == "no breaks"
+
+
+def test_run_command_logs_multiline_body_as_one_journal_line(
+        monkeypatch, tmp_path, caplog):
+    # The progress comment body (progress.py) is multi-line; it reaches
+    # the journal through the `command=` log of the gh api call.
+    body = (
+        "<!-- muyan-pilot:run=e6f5ec8a -->\n"
+        "**Muyan Pilot progress**\n"
+        "- run_id=e6f5ec8a\n"
+        "- role: implement\n"
+        "- priority: normal\n"
+        "- phase: read\n"
+        "- elapsed: 8m 2s"
+    )
+    command = [
+        "gh", "api", "repos/xqliu/muyan-pilot/issues/143/comments",
+        "--method", "POST", "--field", f"body={body}",
+    ]
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    completed = Mock(stdout='{"id": 1}', stderr="")
+    monkeypatch.setattr(runner.subprocess, "run", Mock(return_value=completed))
+    with caplog.at_level("INFO"):
+        assert runner.run_command(command, cwd=tmp_path) == '{"id": 1}'
+    # Exactly one command= record and it is a single journal line.
+    command_records = [
+        record for record in caplog.records
+        if record.getMessage().startswith("command=")
+    ]
+    assert len(command_records) == 1
+    message = command_records[0].getMessage()
+    assert "\n" not in message
+    # The body fields stay fully visible on that one line.
+    for field in (
+        "- run_id=e6f5ec8a", "- role: implement", "- priority: normal",
+        "- phase: read", "- elapsed: 8m 2s",
+    ):
+        assert field in message
+    # The real command (and thus the GitHub comment body) is unchanged.
+    runner.subprocess.run.assert_called_once_with(
+        command, cwd=tmp_path, capture_output=True,
+        text=True, check=True, timeout=None,
+    )
+
+
 def test_pick_issue_uses_github_queue(monkeypatch):
     issue = {
         "number": 9, "title": "task", "body": "body",


### PR DESCRIPTION
Fixes #143

<!-- muyan-pilot:run=e6f5ec8a -->

run_id=e6f5ec8a

## Problem

The Runner logs every external command via `bootstrap_runner.run_command`
as one `command=<joined args> cwd=...` journal line. The multi-line
progress comment body reaches the journal through
`gh api ... --field body=<body>`, so systemd journal split that single
log into several lines (same timestamp, same PID) — fields like
`- run_id=...`, `- role: implement` looked like independent events.

## Change (minimal, KISS)

- `bootstrap_runner.py`: new `single_line()` helper escapes line breaks
  (`\r\n` / `\n` / `\r`) to the visible two-character sequence `\n`
  (backslash + n); `run_command` logs
  `single_line(" ".join(log_command or command))`.
- Only the log display changes: the `command` list handed to
  `subprocess.run` is untouched, so the comment body sent to GitHub is
  byte-identical. No new files, no new dependencies.

## Tests

- `test_single_line_flattens_line_breaks_to_visible_escapes` — LF, CRLF,
  CR, no-break branches.
- `test_run_command_logs_multiline_body_as_one_journal_line` — a
  progress-body-like `--field body=...` argument produces exactly ONE
  `command=` record with no newline in its message, every field
  (`run_id`, `role`, `priority`, `phase`, `elapsed`) still visible, and
  `subprocess.run` receives the original multi-line argument verbatim.

## Verification

- Full suite: `944 passed` (`/usr/bin/python3 -m coverage run --branch
  -m pytest tests/ -q`).
- Coverage: `TOTAL 11851 0 1678 0 100%` (100% line and branch).
- Live smoke: a real `run_command` call with the
  `--field body=<multi-line progress body>` shape logs ONE journal line
  with visible `\n` escapes, and the subprocess receives the body
  byte-identical to the GitHub body.
- TDD: red (2 failed, log split reproduced) → green (2 passed) → full
  suite. Details in the run's `test.log`.