### PR TITLE
feat: parse and validate the explicit multi-repo registry config

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -237,7 +237,48 @@ def load_config(path: Path) -> dict:
         "base_branch": base_branch,
         "max_concurrency": max_concurrency,
         "slot_dir": slot_dir_for(repo_dir),
+        # Multi-repo registry (Issue #134): the explicit per-repo entries
+        # (name, path, github, base_branch). Absent section -> [] so the
+        # single-repo config keeps its exact shape and flow.
+        "repositories": parse_repositories(data.get("repositories", []), base),
     }
+
+
+def parse_repositories(entries: object, base: Path) -> list[dict]:
+    """Parse the explicit multi-repo registry (Issue #134).
+
+    Each entry is a TOML table with the required string fields `name`,
+    `path`, `github` and `base_branch`; `path` is resolved relative to
+    the config file's directory. A missing/empty/non-string field, a
+    non-table entry or a duplicate `name` fails fast — the existence and
+    Git-checkout checks happen in `validate_config`.
+    """
+    if not isinstance(entries, list):
+        raise ValueError("repositories must be a list of tables")
+    repos: list[dict] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"repositories[{index}] must be a table")
+        missing = [
+            field for field in ("name", "path", "github", "base_branch")
+            if not isinstance(entry.get(field), str) or not entry.get(field)
+        ]
+        if missing:
+            raise ValueError(
+                f"repositories[{index}] is missing required field(s): "
+                + ", ".join(missing)
+            )
+        if any(repo["name"] == entry["name"] for repo in repos):
+            raise ValueError(
+                f"duplicate repositories name: {entry['name']!r}"
+            )
+        repos.append({
+            "name": entry["name"],
+            "path": _config_path(entry["path"], base),
+            "github": entry["github"],
+            "base_branch": entry["base_branch"],
+        })
+    return repos
 
 
 def render_prompt(template: str, values: dict[str, str]) -> str:
@@ -256,6 +297,19 @@ def validate_config(config: dict) -> None:
     ]:
         if not path.is_file():
             raise FileNotFoundError(path)
+    # Multi-repo registry (Issue #134): every registered path must exist
+    # and be a Git checkout — a `.git` directory (a plain checkout) or a
+    # `.git` file (a linked worktree). Absent key -> no registry, so a
+    # single-repo config keeps its exact flow.
+    for repo in config.get("repositories", []):
+        path = repo["path"]
+        if not path.is_dir():
+            raise FileNotFoundError(path)
+        if not (path / ".git").exists():
+            raise ValueError(
+                f"repositories entry {repo['name']!r}: {path} "
+                "is not a git checkout"
+            )
 
 
 def single_line(value: str) -> str:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -87,6 +87,153 @@ def test_load_config_rejects_empty_base_branch(tmp_path):
         runner.load_config(config_path)
 
 
+def test_load_config_parses_repositories_registry(tmp_path):
+    """Issue #134: an explicit [[repositories]] section parses into a
+    registry of name/path/github/base_branch, with each path resolved
+    relative to the config file."""
+    (tmp_path / "checkouts" / "pilot").mkdir(parents=True)
+    (tmp_path / "checkouts" / "ceo").mkdir(parents=True)
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n'
+        "[[repositories]]\n"
+        'name = "pilot"\n'
+        'path = "checkouts/pilot"\n'
+        'github = "owner/pilot"\n'
+        'base_branch = "main"\n'
+        "[[repositories]]\n"
+        'name = "ceo"\n'
+        'path = "checkouts/ceo"\n'
+        'github = "owner/ceo"\n'
+        'base_branch = "develop"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["repositories"] == [
+        {
+            "name": "pilot",
+            "path": (tmp_path / "checkouts" / "pilot").resolve(),
+            "github": "owner/pilot",
+            "base_branch": "main",
+        },
+        {
+            "name": "ceo",
+            "path": (tmp_path / "checkouts" / "ceo").resolve(),
+            "github": "owner/ceo",
+            "base_branch": "develop",
+        },
+    ]
+
+
+def test_load_config_defaults_repositories_to_empty_list(tmp_path):
+    """Issue #134: without a repositories section the config keeps the
+    exact single-repo shape (empty registry, all existing keys intact)."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\nrepo_dir = "repo"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["repositories"] == []
+    assert config["source_repos"] == ["owner/pilot"]
+    assert config["repo_dir"] == (tmp_path / "repo").resolve()
+    assert config["base_branch"] == "main"
+
+
+@pytest.mark.parametrize("field", ["name", "path", "github", "base_branch"])
+def test_load_config_rejects_repository_missing_field(tmp_path, field):
+    """Issue #134: a repository entry missing one required field is
+    rejected, naming the field."""
+    entry = {
+        "name": "pilot",
+        "path": "checkouts/pilot",
+        "github": "owner/pilot",
+        "base_branch": "main",
+    }
+    del entry[field]
+    lines = ["source_repos = [\"owner/pilot\"]\n", "[[repositories]]\n"]
+    lines += [f'{key} = "{value}"\n' for key, value in entry.items()]
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text("".join(lines), encoding="utf-8")
+    with pytest.raises(ValueError, match=field):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_repository_empty_field(tmp_path):
+    """Issue #134: an empty required field counts as missing."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n'
+        "[[repositories]]\n"
+        'name = "pilot"\n'
+        'path = ""\n'
+        'github = "owner/pilot"\n'
+        'base_branch = "main"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="path"):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_repository_non_string_field(tmp_path):
+    """Issue #134: a required field with a non-string type is rejected."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n'
+        "[[repositories]]\n"
+        'name = "pilot"\n'
+        'path = "checkouts/pilot"\n'
+        'github = "owner/pilot"\n'
+        "base_branch = 1\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="base_branch"):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_repository_non_table_entry(tmp_path):
+    """Issue #134: a repositories entry that is not a table is rejected."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n'
+        'repositories = ["pilot"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=r"repositories\[0\]"):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_repositories_not_a_list(tmp_path):
+    """Issue #134: a repositories section that is not a list is rejected."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n'
+        'repositories = "pilot"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="repositories must be a list"):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_duplicate_repository_name(tmp_path):
+    """Issue #134: two entries with the same name are rejected, naming
+    the duplicate."""
+    entry = (
+        "[[repositories]]\n"
+        'name = "pilot"\n'
+        'path = "checkouts/pilot"\n'
+        'github = "owner/pilot"\n'
+        'base_branch = "main"\n'
+    )
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/pilot"]\n' + entry + entry,
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate.*pilot"):
+        runner.load_config(config_path)
+
+
 def test_render_prompt_replaces_context_values():
     rendered = runner.render_prompt(
         "{{SOURCE_REPO}} #{{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{CONTEXT_FILES}}",
@@ -218,6 +365,109 @@ def test_validate_config_rejects_missing_repo_dir(tmp_path):
             "skills": [],
             "context_files": [],
         })
+
+
+def _git_checkout(path: Path) -> Path:
+    """A real Git checkout with one commit (verified against the real
+    CLI; the commit lets `git worktree add` check a branch out)."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(path)],
+        check=True,
+        capture_output=True,
+    )
+    (path / "README.md").write_text("repo", encoding="utf-8")
+    identity = ["-c", "user.name=test", "-c", "user.email=test@example.com"]
+    subprocess.run(
+        ["git", *identity, "add", "README.md"],
+        cwd=path, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", *identity, "commit", "-q", "-m", "init"],
+        cwd=path, check=True, capture_output=True,
+    )
+    return path
+
+
+def _base_config(tmp_path: Path) -> dict:
+    """The minimal valid single-repo config (no repositories key)."""
+    prompt = tmp_path / "prompt.md"
+    prompt_review = tmp_path / "prompt_review.md"
+    for path in (prompt, prompt_review):
+        path.write_text("ok", encoding="utf-8")
+    return {
+        "repo_dir": tmp_path,
+        "prompt": prompt,
+        "prompt_review": prompt_review,
+        "skills": [],
+        "context_files": [],
+    }
+
+
+def test_validate_config_accepts_repository_git_checkout(tmp_path):
+    """Issue #134: a registered path that is a real Git checkout passes."""
+    checkout = _git_checkout(tmp_path / "pilot")
+    config = _base_config(tmp_path)
+    config["repositories"] = [{
+        "name": "pilot",
+        "path": checkout,
+        "github": "owner/pilot",
+        "base_branch": "main",
+    }]
+    runner.validate_config(config)
+
+
+def test_validate_config_accepts_repository_linked_worktree(tmp_path):
+    """Issue #134: a linked worktree (a .git FILE, not a directory) is a
+    Git checkout too."""
+    main_repo = _git_checkout(tmp_path / "main")
+    worktree = tmp_path / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", "-q", str(worktree)],
+        cwd=main_repo,
+        check=True,
+        capture_output=True,
+    )
+    assert (worktree / ".git").is_file()
+    config = _base_config(tmp_path)
+    config["repositories"] = [{
+        "name": "wt",
+        "path": worktree,
+        "github": "owner/pilot",
+        "base_branch": "main",
+    }]
+    runner.validate_config(config)
+
+
+def test_validate_config_rejects_missing_repository_path(tmp_path):
+    """Issue #134: a registered path that does not exist is rejected."""
+    config = _base_config(tmp_path)
+    config["repositories"] = [{
+        "name": "pilot",
+        "path": tmp_path / "no-such-checkout",
+        "github": "owner/pilot",
+        "base_branch": "main",
+    }]
+    with pytest.raises(FileNotFoundError, match="no-such-checkout"):
+        runner.validate_config(config)
+
+
+def test_validate_config_rejects_repository_path_not_a_git_checkout(
+    tmp_path,
+):
+    """Issue #134: an existing path without a .git (file or directory)
+    is not a Git checkout and is rejected."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    config = _base_config(tmp_path)
+    config["repositories"] = [{
+        "name": "plain",
+        "path": plain,
+        "github": "owner/plain",
+        "base_branch": "main",
+    }]
+    with pytest.raises(ValueError, match="not a git checkout"):
+        runner.validate_config(config)
 
 
 def test_run_command_returns_stdout(monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #134

<!-- muyan-pilot:run=df456009 -->

run_id=df456009

## 多 Repo Registry：显式配置与兼容单 Repo

Add the explicit `[[repositories]]` config section. Each entry carries
`name`, `path`, `github` and `base_branch`.

- `load_config` parses the registry and fail-fast validates each entry:
  a missing/empty/non-string field, a non-table entry, a non-list
  section and a duplicate `name` are rejected with precise messages
  (field names, entry index, the duplicate name). Each `path` is
  resolved relative to the config file's directory (absolute, `~` and
  `$VAR` handled by the existing `_config_path`).
- `validate_config` rejects a registered `path` that does not exist
  (`FileNotFoundError`) or is not a Git checkout — a `.git` directory
  (plain checkout) or a `.git` file (linked worktree) — with
  `ValueError`.
- Compatibility: without a `repositories` section the config keeps its
  exact single-repo shape (`config["repositories"] == []`) and the
  existing `muyan-pilot` flow is unchanged — the whole existing suite
  passes untouched.

## Tests (TDD: RED 13 failed -> GREEN 15 passed)

15 new tests in `tests/test_bootstrap_runner.py`:

- parsing: two-entry registry resolves (name/path/github/base_branch,
  relative paths resolved against the config dir); absent section ->
  `[]` with all existing keys intact; missing field (parametrized over
  all four fields); empty field; non-string field; non-table entry;
  non-list section; duplicate name.
- validation: a real `git init` checkout is accepted; a real linked
  worktree (`.git` file, created with `git worktree add`) is accepted;
  a missing path is rejected; an existing non-Git directory is
  rejected; a config dict without the key stays compatible.

## Verification

- Full suite: `959 passed`
  (`/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`).
- 100% line and branch coverage
  (`/usr/bin/python3 -m coverage report --show-missing`;
  `bootstrap_runner.py` 100%).
- Acceptance example checked against real checkouts: a config with
  `[[repositories]]` entries parses and validates (both a `.git`
  directory checkout and a `.git` file worktree); a config without
  `repositories` behaves exactly as before.