### PR TITLE
Make the editable uv tool install the official CLI deployment (Issue #152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,16 @@ jobs:
           # from the checkout (not a site-packages copy): the tool
           # env's python (the console script's own interpreter, from
           # its shebang) reports the import source and it must start
-          # with the checkout path.
+          # with the checkout path. The probe runs from a NEUTRAL cwd
+          # (`cd /`): `python -c` puts the cwd first on sys.path, so
+          # run from the checkout the checkout's own `muyan_pilot.py`
+          # would shadow the tool env's import (editable finder and
+          # site-packages alike) and the check would pass even for a
+          # non-editable install (verified against a real non-editable
+          # install: checkout cwd reports the checkout file, a neutral
+          # cwd reports the site-packages copy).
           tool_python=$(head -n 1 ~/.local/bin/muyan-pilot | sed 's/^#!//')
-          source_path=$("$tool_python" -c "import muyan_pilot; print(muyan_pilot.__file__)")
+          source_path=$(cd / && "$tool_python" -c "import muyan_pilot; print(muyan_pilot.__file__)")
           case "$source_path" in
             "$GITHUB_WORKSPACE"/*)
               echo "cli_source ok: $source_path"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,30 +48,48 @@ jobs:
           python3 -m pip install -r requirements.txt
           python3 -m pip install pytest coverage pyyaml
 
-      # CLI packaging (Issue #140): the console script must install in a
-      # clean environment and the entry must work (`muyan-pilot --help`
-      # and `muyan-pilot --version`, exit 0). The packaging file is the
-      # PEP 621 pyproject.toml.
+      # CLI packaging (Issue #140, #152): the console script must
+      # install in a clean environment and the entry must work
+      # (`muyan-pilot --help` and `muyan-pilot --version`, exit 0).
+      # The packaging file is the PEP 621 pyproject.toml.
       #
-      # The install uses the DOCUMENTED production flow (`uv tool
-      # install`, the uv-tool console script) — not a plain `pip
-      # install .`: uv tool places the self-contained executable at
-      # ~/.local/bin/muyan-pilot, the same path the service template's
-      # ExecStart (%h/.local/bin/muyan-pilot) uses, so the real
-      # `systemd-analyze --user verify` test resolves the unit's
-      # absolute ExecStart against the real executable here (a plain
-      # pip install would put the script in the venv bin, where the
-      # unit's %h path does not point).
+      # The install uses the DOCUMENTED production flow — the EDITABLE
+      # uv tool install (Issue #152), not a plain `pip install .` and
+      # not a non-editable `uv tool install`: uv tool places the
+      # executable at ~/.local/bin/muyan-pilot (the same path the
+      # service template's ExecStart %h/.local/bin/muyan-pilot uses, so
+      # the real `systemd-analyze --user verify` test resolves the
+      # unit's absolute ExecStart against the real executable here),
+      # and --editable makes the tool env import `muyan_pilot` from
+      # the checkout instead of copying the source into site-packages —
+      # the official local deployment, where the ExecStartPre checkout
+      # sync is picked up by the next CLI process automatically.
       - name: Install uv (the documented CLI installer)
         run: |
           python3 -m pip install uv
           uv --version
 
-      - name: Install the CLI (uv tool, the documented flow) and verify the entry (Issue #140)
+      - name: Install the CLI (uv tool EDITABLE, the documented flow) and verify the entry and import source (Issue #140, #152)
         run: |
-          uv tool install --python 3.14 .
+          uv tool install --force --reinstall --editable --python 3.14 .
           ~/.local/bin/muyan-pilot --help
           ~/.local/bin/muyan-pilot --version
+          # Issue #152: the editable install must import `muyan_pilot`
+          # from the checkout (not a site-packages copy): the tool
+          # env's python (the console script's own interpreter, from
+          # its shebang) reports the import source and it must start
+          # with the checkout path.
+          tool_python=$(head -n 1 ~/.local/bin/muyan-pilot | sed 's/^#!//')
+          source_path=$("$tool_python" -c "import muyan_pilot; print(muyan_pilot.__file__)")
+          case "$source_path" in
+            "$GITHUB_WORKSPACE"/*)
+              echo "cli_source ok: $source_path"
+              ;;
+            *)
+              echo "cli_source DRIFT: $source_path (expected $GITHUB_WORKSPACE)" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Run the full test suite with branch coverage (contract)
         run: python3 -m coverage run --branch -m pytest tests/ -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,13 +192,23 @@ acceptance criteria.
   merge to main -> timer next trigger -> ExecStartPre syncs origin/main ->
   drift check (auto-sync + re-verify when drifted) -> Runner starts one
   Issue.
-- The service `ExecStart` is the installed `muyan-pilot` CLI (Issue #140):
-  the official usage is the `uv tool`-installed console script (`uv tool
-  install` / `uv tool upgrade`), and the unit uses the explicit
-  deployable entry `%h/.local/bin/muyan-pilot` (verifiable with
+- The service `ExecStart` is the installed `muyan-pilot` CLI (Issue #140,
+  #152): the official usage is the EDITABLE `uv tool`-installed console
+  script (`uv tool install --force --reinstall --editable --python
+  /usr/bin/python3 <deployment checkout>` — the tool env imports
+  `muyan_pilot` from the deployment checkout, so the ExecStartPre
+  checkout sync is picked up by the next CLI process automatically and
+  ordinary source/template changes need NO reinstall or upgrade), and
+  the unit uses the explicit deployable entry
+  `%h/.local/bin/muyan-pilot` (verifiable with
   `systemd-analyze --user verify`); the direct-execution entry of
   `muyan_pilot.py` stays a development/compatibility path, never the
-  documented usage.
+  documented usage. A non-editable (site-packages) or stale CLI source
+  is reported by `muyan-pilot doctor` as `cli_source: DRIFT` with the
+  structured `cli_source_drift` line (actual import path, expected
+  repo_dir, the exact editable reinstall command) and repaired by
+  `muyan-pilot setup` (the CLI step verifies or force-reinstalls the
+  editable install); the Runner never installs the tool at start.
 - A template change is a deployment change (Issue #131, #142): a PR
   that modifies `systemd/muyan-pilot@.service` or `systemd/muyan-pilot@.timer`
   takes effect without a human step — the NEXT timer trigger's

--- a/README.md
+++ b/README.md
@@ -13,24 +13,23 @@
 - **系统架构总览**（GitHub Issues、systemd timer/service、Runner、Pi、worktree、llama-server、可选 `local-llm-kv-cache` proxy、PR/review/merge）：文档站首页 [index](docs/index.mdx) / [zh/index](docs/zh/index.mdx)；
 - **任务生命周期状态机**（`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked`，标出 Epic/Release task/P0 边界）：[workflow](docs/workflow.mdx) / [zh/workflow](docs/zh/workflow.mdx)。
 
-## CLI 安装与升级（Issue #140）
+## CLI 安装与升级（Issue #140、#152）
 
-正式使用方式是 `uv tool` 安装的可执行 CLI（console script `muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）：
+正式使用方式是 **editable** `uv tool` 安装的可执行 CLI（console script `muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）——这是官方本地部署方式：
 
 ```bash
 # 在部署 checkout 目录安装（如 /home/xqianliu/Documents/muyan/muyan-pilot）：
 # --python 固定生产解释器（本机 /usr/bin/python3，3.14）
-uv tool install --python /usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot
-# merge 到 main 之后升级（版本号变化时）：
-uv tool upgrade muyan-pilot
-# 或者从最新本地代码直接重装（版本号未变时；--reinstall 绕过构建缓存）：
-uv tool install --force --reinstall /home/xqianliu/Documents/muyan/muyan-pilot
+# --editable：tool 环境直接从部署 checkout 导入 muyan_pilot（不是复制到 site-packages）
+uv tool install --force --reinstall --editable --python /usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot
 # 验证安装：
 muyan-pilot --help
 muyan-pilot --version
 ```
 
-`uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件在 `~/.local/bin/muyan-pilot`（systemd unit 的 PATH 已包含该目录，见「部署一致性」）。发布包不携带第三方运行时依赖、token 或用户目录：配置（`muyan-pilot.toml`）和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径，不是正式使用方式。
+**为什么必须 editable（Issue #152）**：非 editable 安装会把源码复制进 tool 环境的 site-packages；`ExecStartPre` 把 checkout 同步到最新 main 之后，CLI 仍在执行旧副本——这正是 #152 的 P0 启动死锁（旧 CLI 检查旧的非模板 unit 路径，永远跑不到新的迁移代码）。editable 安装下，下一个 CLI 进程（下一个 timer 启动的 Runner）自动从 checkout 取到最新代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。只有依赖、入口点、包名、构建后端或 Python 版本变化时，才重新执行上面的 force editable 重装命令。
+
+`uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件在 `~/.local/bin/muyan-pilot`（systemd unit 的 PATH 已包含该目录，见「部署一致性」）。`muyan-pilot doctor` 报告 CLI 源码一致性：`cli_source: clean source=...`（运行进程从配置的 checkout 导入）或 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行（实际导入路径、期望 repo_dir、精确的 editable 重装命令）。发布包不携带第三方运行时依赖、token 或用户目录：配置（`muyan-pilot.toml`）和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径，不是正式使用方式。
 
 ## 当前运行
 
@@ -76,7 +75,7 @@ unit_drift auto_synced unit=muyan-pilot@.timer before_sha256=... after_sha256=..
 unit_drift unit=muyan-pilot@.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=muyan-pilot install-units
 ```
 
-**只读诊断**：`muyan-pilot doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
+**只读诊断**：`muyan-pilot doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、CLI 源码一致性（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行，见「CLI 安装与升级」）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
 
 **完整部署时序**（从代码合并到下一次 Runner 启动）：
 

--- a/cli_source.py
+++ b/cli_source.py
@@ -1,0 +1,131 @@
+"""CLI source consistency for Muyan Pilot (Issue #152).
+
+The official local deployment is the EDITABLE uv tool install:
+
+    uv tool install --force --reinstall --editable \\
+        --python /usr/bin/python3 <deployment checkout>
+
+The tool env's Python imports ``muyan_pilot`` directly from the
+deployment checkout (the setuptools editable finder maps every runtime
+module onto the checkout), so the ``ExecStartPre`` checkout sync
+(``git fetch origin main && git merge --ff-only origin/main``) is
+picked up by the NEXT CLI process automatically: there is no second
+copy of the source in site-packages and no per-version reinstall.
+
+A NON-EDITABLE install (the pre-#152 flow) copies the source into the
+tool env's site-packages at install time; the checkout then advances
+underneath it and the running CLI keeps executing the stale copy —
+with the #149 unit migration that deadlocked the deployment (the old
+CLI checked the old non-templated unit paths and could never run the
+new migration code). An editable install of a DIFFERENT (stale)
+checkout drifts the same way.
+
+This module is READ-ONLY: it reports the running process's
+``muyan_pilot`` import source against the configured ``repo_dir`` and
+the exact fix command. The fix is a HUMAN/setup step (``muyan-pilot
+setup`` runs it idempotently); the Runner never installs the tool at
+start, so two concurrent service instances cannot race the tool env.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import muyan_pilot
+from pi_activity import quote_value
+
+# The production interpreter pinned by the documented install command
+# (docs/getting-started.mdx: `--python` pins the production
+# interpreter, 3.14).
+PYTHON_INTERPRETER = "/usr/bin/python3"
+
+
+def reinstall_args(repo_dir: Path) -> list[str]:
+    """The editable force reinstall as an argv list (no shell).
+
+    Verified against the real ``uv tool install --help``: ``--force``
+    replaces the existing tool env, ``--reinstall`` bypasses the build
+    cache, ``--editable`` points the tool env at the checkout ("changes
+    in the package's source directory are reflected without
+    reinstallation") and ``--python`` pins the interpreter.
+    """
+    return [
+        "uv", "tool", "install", "--force", "--reinstall", "--editable",
+        "--python", PYTHON_INTERPRETER, str(Path(repo_dir)),
+    ]
+
+
+def reinstall_command(repo_dir: Path) -> str:
+    """The EXACT editable force reinstall command (one line, for a
+    human or the fix field of a ``cli_source_drift`` line).
+
+    It leads the repair, never ``muyan-pilot install-units`` alone
+    (the unit files are only half of the #152 scene). A checkout path
+    containing spaces is quoted so the line stays shell-executable.
+    """
+    args = reinstall_args(repo_dir)
+    return " ".join(
+        quote_value(arg) if arg is args[-1] else arg for arg in args
+    )
+
+
+def module_file() -> Path:
+    """The running process's ``muyan_pilot`` import source (resolved).
+
+    This is the ground truth for "which source is this CLI process
+    executing": the console script imports ``muyan_pilot`` at start,
+    so ``__file__`` is the file the interpreter actually loaded —
+    the checkout file for an editable install, a site-packages copy
+    for a non-editable one.
+    """
+    file = getattr(muyan_pilot, "__file__", None)
+    if not isinstance(file, str) or not file:
+        raise RuntimeError(
+            "cannot determine the muyan_pilot import source: the "
+            "module has no __file__ (the CLI source check must never "
+            "guess a path)"
+        )
+    return Path(file).resolve()
+
+
+def cli_source(expected_repo_dir: Path) -> dict:
+    """Read-only check of the CLI source against the configured repo.
+
+    ``actual`` is the running process's import source
+    (:func:`module_file`); ``expected`` is the configured ``repo_dir``
+    (both resolved: a symlinked checkout path is the same source as
+    the resolved one). ``editable`` is True exactly when the import
+    source sits DIRECTLY inside the checkout root — an editable
+    install (or the compat entry run inside the checkout) imports
+    ``<repo_dir>/muyan_pilot.py``; a non-editable install imports a
+    site-packages copy, a stale install a different checkout, and a
+    nested copy (e.g. a worktree's own file) is not the configured
+    source either. ``fix`` is the exact reinstall command for the
+    expected checkout.
+    """
+    expected = Path(expected_repo_dir).resolve()
+    actual = module_file()
+    return {
+        "actual": actual,
+        "expected": expected,
+        "editable": actual.parent == expected,
+        "fix": reinstall_command(expected_repo_dir),
+    }
+
+
+def drift_line(source: dict) -> str | None:
+    """One structured ``cli_source_drift`` line, or None when clean.
+
+    The line carries the actual import path, the expected repo_dir and
+    the exact fix command (the editable force reinstall — the repair
+    that makes the ExecStartPre sync reachable by the next CLI
+    process). Values containing spaces are quoted (the
+    pi_activity.quote_value convention, like every unit_drift line).
+    """
+    if source["editable"]:
+        return None
+    return (
+        "cli_source_drift "
+        f"source={quote_value(str(source['actual']))} "
+        f"expected={quote_value(str(source['expected']))} "
+        f"fix={quote_value(source['fix'])}"
+    )

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -45,24 +45,37 @@ cd muyan-pilot
 
 The official usage is the installed `muyan-pilot` console script (the
 PEP 621 packaging in `pyproject.toml` maps
-`muyan-pilot = muyan_pilot:main`). Install it with `uv tool` from the
-clone directory — `--python` pins the production interpreter (3.14):
+`muyan-pilot = muyan_pilot:main`), installed as an **editable**
+`uv tool` install — the official local deployment (Issue #152). From
+the clone directory, `--python` pins the production interpreter (3.14):
 
 ```bash
-uv tool install --python /usr/bin/python3 .
+uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 muyan-pilot --help
 ```
 
 `uv tool` keeps the CLI in an isolated tool environment; the executable
-lands in `~/.local/bin` (on the PATH of the systemd unit). After a merge
-to main, refresh it with `uv tool upgrade muyan-pilot` (when the version
-changes) or `uv tool install --force --reinstall .` from the clone
-directory (when the version is unchanged — `--reinstall` bypasses the
-build cache). The release package carries no third-party runtime
-dependency, no token and no user directory — the config file and the
-user systemd dir stay machine-local. The direct-execution entry of
-`muyan_pilot.py` (running the file with the interpreter) stays a
-development/compatibility path.
+lands in `~/.local/bin` (on the PATH of the systemd unit).
+
+**Why `--editable` matters**: a non-editable install copies the source
+into the tool environment's site-packages. The service's `ExecStartPre`
+fast-forwards the checkout to the latest `main` before every start —
+with a copied source the CLI would keep executing the stale copy
+(bootstrap deadlock: Issue #152). With the editable install the tool
+env imports `muyan_pilot` directly from the clone directory, so the
+next CLI process (the next timer-triggered Runner) picks up the merged
+code automatically: **ordinary Python source and systemd
+template/migration changes need NO reinstall and no upgrade command**.
+Only when dependencies, the entry point, the
+package name, the build backend or the Python version changes do you
+re-run the exact force editable reinstall command above. `muyan-pilot
+doctor` reports the consistency (`cli_source: clean` or
+`cli_source: DRIFT` with the structured `cli_source_drift` line), and
+`muyan-pilot setup` verifies or reinstalls it idempotently. The release
+package carries no third-party runtime dependency, no token and no user
+directory — the config file and the user systemd dir stay
+machine-local. The direct-execution entry of `muyan_pilot.py` (running
+the file with the interpreter) stays a development/compatibility path.
 
 ## 3. Create the configuration
 
@@ -109,11 +122,13 @@ context_files = []
 ## 4. Run the one-time setup
 
 The setup entry does the whole initialization in one command: it
-verifies `gh auth status` and the repo permissions, aligns the platform
-labels from the repo-managed `labels.toml` (the single source of truth
-for label name, color and description — a commit never creates labels,
-and a missing label makes the scan silently skip that state), installs
-the systemd user units and enables the timer, checks the checkout, and
+verifies or reinstalls the editable CLI install (Issue #152 — the
+running CLI must import from the deployment checkout), verifies
+`gh auth status` and the repo permissions, aligns the platform labels
+from the repo-managed `labels.toml` (the single source of truth for
+label name, color and description — a commit never creates labels, and
+a missing label makes the scan silently skip that state), installs the
+systemd user units and enables the timer, checks the checkout, and
 reports the optional model proxy:
 
 ```bash

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -113,10 +113,17 @@ fast through the normal `ai-blocked` path.
 
 ## The CLI (`muyan-pilot`)
 
-The official entry is the installed `muyan-pilot` console script
-(`uv tool install --python /usr/bin/python3 <clone dir>`; refresh with
-`uv tool upgrade muyan-pilot` or `uv tool install --force --reinstall
-<clone dir>` — see [Getting started](/getting-started)). The
+The official entry is the installed `muyan-pilot` console script, as an
+**editable** `uv tool` install (the official local deployment — the
+tool env imports `muyan_pilot` from the clone dir, so the
+`ExecStartPre` checkout sync is picked up by the next CLI process
+automatically and ordinary source/template changes need no reinstall or
+upgrade; `uv tool install --force --reinstall --editable --python
+/usr/bin/python3 <clone dir>` — see [Getting started](/getting-started)).
+`muyan-pilot doctor` reports the consistency (`cli_source: clean` or
+`cli_source: DRIFT` with the structured `cli_source_drift` line: actual
+import path, expected repo_dir, the exact editable reinstall command),
+and `muyan-pilot setup` verifies or reinstalls it. The
 direct-execution entry of `muyan_pilot.py` stays a development/
 compatibility path.
 
@@ -130,11 +137,12 @@ muyan-pilot add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
 # repo (ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked)
 muyan-pilot status --config muyan-pilot.toml
 
-# Read-only deployment/health report: repo commit, unit drift, git
-# transport (configured origin URL, protocol, expected SSH URL, SSH
-# probe — a failed transport is reported as `transport: FAILED ...`,
-# not raised), timer/service instance state, slots, Pi session,
-# current Issue, recent journal
+# Read-only deployment/health report: repo commit, unit drift, CLI
+# source (cli_source: clean / DRIFT + the structured cli_source_drift
+# line), git transport (configured origin URL, protocol, expected SSH
+# URL, SSH probe — a failed transport is reported as `transport:
+# FAILED ...`, not raised), timer/service instance state, slots, Pi
+# session, current Issue, recent journal
 muyan-pilot doctor --config muyan-pilot.toml
 
 # One-time, idempotent initialization (new machine / new repo): gh

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -1,10 +1,11 @@
 # One-time setup
 
 `muyan-pilot setup` is the one-time, config-driven initialization
-entry for a new machine or a new task-pool repository. It verifies the
-local prerequisites, aligns the platform labels, installs the systemd
-user units, checks the checkout, and reports the optional model proxy —
-in one command, with a stable machine-readable result.
+entry for a new machine or a new task-pool repository. It verifies or
+reinstalls the editable CLI install, verifies the local prerequisites,
+aligns the platform labels, installs the systemd user units, checks
+the checkout, and reports the optional model proxy — in one command,
+with a stable machine-readable result.
 
 ```bash
 muyan-pilot setup --config muyan-pilot.toml
@@ -24,8 +25,20 @@ non-zero exit code.
    `muyan-pilot` CLI on the PATH, and a reachable `systemctl --user`
    user bus (a container or headless session without a user bus fails
    with the bus error).
-2. **Auth** — `gh auth status` (logged in with a usable token).
-3. **Per target repository** (every configured `source_repos` entry by
+2. **CLI editable install** (Issue #152) — the official local
+   deployment is the EDITABLE `uv tool` install: the tool env imports
+   `muyan_pilot` from the deployment checkout, so the `ExecStartPre`
+   checkout sync is picked up by the next CLI process automatically.
+   When the running process already imports from the configured
+   `repo_dir` the step verifies it (no uv call, `cli=verified`);
+   otherwise it runs the exact force editable reinstall
+   (`uv tool install --force --reinstall --editable --python
+   /usr/bin/python3 <repo_dir>`, `cli=installed`). A failing install
+   fails fast — no unit install, no half-initialized state. The step
+   never touches a running Runner process (the new source is loaded by
+   the next CLI start).
+3. **Auth** — `gh auth status` (logged in with a usable token).
+4. **Per target repository** (every configured `source_repos` entry by
    default; exactly one with `--repo OWNER/REPO`):
    - the repo exists and the viewer has write permission
      (`gh repo view` → `viewerPermission` must be `WRITE`, `MAINTAIN`
@@ -35,7 +48,7 @@ non-zero exit code.
      truth for label name, color and description: a missing label is
      created, a drifted label is updated, nothing is deleted, and
      business labels (`bug`, `enhancement`, ...) are never touched.
-4. **Systemd units** — the repo templates
+5. **Systemd units** — the repo templates
    (`systemd/muyan-pilot@.service`, `systemd/muyan-pilot@.timer`) are
    installed idempotently into the user unit directory (the same
    install `install-units` performs: copy, migrate the pre-#149
@@ -43,7 +56,7 @@ non-zero exit code.
    instances `muyan-pilot@1.timer` / `muyan-pilot@2.timer` — the
    service is never started, stopped or restarted), then each timer
    instance's enabled/active state and next trigger time are reported.
-5. **Checkout + git transport** — check of the configured `repo_dir`:
+6. **Checkout + git transport** — check of the configured `repo_dir`:
    the `origin` remote's **transport** (Issue #114): git data
    operations (fetch, push — including `.github/workflows/*.yml`) must
    go over SSH (`git@github.com:owner/repo.git`), so an existing
@@ -63,7 +76,7 @@ non-zero exit code.
    (local `HEAD` vs freshly fetched `origin/<base_branch>` —
    reported, not a failure: the timer fast-forwards a clean checkout
    at each start).
-6. **Optional model proxy** — the `local-llm-kv-cache` proxy health
+7. **Optional model proxy** — the `local-llm-kv-cache` proxy health
    endpoint (`http://127.0.0.1:18082/health`) is checked and reported
    as **optional**: its absence or unhealthiness is a warning in the
    output and never blocks the core GitHub/Pilot setup.
@@ -86,7 +99,8 @@ The default output is stable `key=value` lines (one per concern; values
 containing spaces are quoted), so agents and scripts can parse it:
 
 ```text
-setup=ok version=1 base_branch=main
+setup=ok version=2 base_branch=main
+cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
@@ -95,7 +109,10 @@ checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@git
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
-`labels=8/8` means all eight platform labels match `labels.toml`;
+`cli=verified` means the running CLI already imports `muyan_pilot`
+from the deployment checkout (the editable install is in place);
+`cli=installed` means the force editable reinstall ran. `labels=8/8`
+means all eight platform labels match `labels.toml`;
 there is one `timer=` line per timer instance and its `next` is that
 instance's next trigger time (`-` when it has none);
 `optional_proxy` is `healthy`, `unhealthy` or `unavailable` and never
@@ -115,7 +132,8 @@ Success (exit code `0`):
 
 ```bash
 $ muyan-pilot setup --config muyan-pilot.toml
-setup=ok version=1 base_branch=main
+setup=ok version=2 base_branch=main
+cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
@@ -131,6 +149,7 @@ Failures (non-zero exit code, `setup_failed reason=...` on stderr):
 
 ```text
 setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
+setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
 setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
 setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -40,22 +40,31 @@ cd muyan-pilot
 ## 2. 安装 CLI
 
 正式使用方式是安装后的 `muyan-pilot` console script（`pyproject.toml`
-的 PEP 621 打包把 `muyan-pilot = muyan_pilot:main` 映射为可执行文件）。
-在 clone 目录里用 `uv tool` 安装——`--python` 固定生产解释器（3.14）：
+的 PEP 621 打包把 `muyan-pilot = muyan_pilot:main` 映射为可执行文件），
+以 **editable** `uv tool` 安装——这是官方本地部署方式（Issue #152）。
+在 clone 目录里安装，`--python` 固定生产解释器（3.14）：
 
 ```bash
-uv tool install --python /usr/bin/python3 .
+uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 muyan-pilot --help
 ```
 
 `uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件落在 `~/.local/bin`
-（systemd unit 的 PATH 已包含该目录）。merge 到 main 之后用
-`uv tool upgrade muyan-pilot` 刷新（版本号变化时），或在 clone 目录里
-`uv tool install --force --reinstall .` 直接重装（版本号未变时——
-`--reinstall` 绕过构建缓存）。发布包不携带第三方运行时依赖、token
-或用户目录——配置文件和用户 systemd 目录保持机器本地。
-`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为
-开发/兼容路径。
+（systemd unit 的 PATH 已包含该目录）。
+
+**为什么必须 `--editable`**：非 editable 安装会把源码复制进 tool
+环境的 site-packages；service 的 `ExecStartPre` 每次启动前把 checkout
+快进到最新 `main`——源码被复制后 CLI 仍在执行旧副本（启动死锁：
+Issue #152）。editable 安装下 tool 环境直接从 clone 目录导入
+`muyan_pilot`，下一个 CLI 进程（下一个 timer 启动的 Runner）自动取到
+merge 后的代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要
+任何重装或升级命令**。只有依赖、入口点、
+包名、构建后端或 Python 版本变化时，才重新执行上面的 force editable
+重装命令。`muyan-pilot doctor` 报告一致性（`cli_source: clean` 或
+`cli_source: DRIFT` + 结构化 `cli_source_drift` 行），`muyan-pilot
+setup` 幂等地校验或重装。发布包不携带第三方运行时依赖、token 或用户
+目录——配置文件和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的
+直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径。
 
 ## 3. 创建配置
 

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -88,10 +88,15 @@ idle 告警和上游已死 kill 是日志/健康阈值——它们不是每 5 �
 
 ## CLI（`muyan-pilot`）
 
-正式入口是安装后的 `muyan-pilot` console script（`uv tool install
---python /usr/bin/python3 <clone 目录>` 安装，`uv tool upgrade
-muyan-pilot` 或 `uv tool install --force --reinstall <clone 目录>`
-刷新——见[快速开始](/zh/getting-started)）。
+正式入口是安装后的 `muyan-pilot` console script，以 **editable**
+`uv tool` 安装（官方本地部署——tool 环境直接从 clone 目录导入
+`muyan_pilot`，`ExecStartPre` 的 checkout 同步会被下一个 CLI 进程自动
+取到，普通源码/模板变更无需重装或升级；`uv tool install --force
+--reinstall --editable --python /usr/bin/python3 <clone 目录>`——见
+[快速开始](/zh/getting-started)）。`muyan-pilot doctor` 报告一致性
+（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化
+`cli_source_drift` 行：实际导入路径、期望 repo_dir、精确的 editable
+重装命令），`muyan-pilot setup` 校验或重装。
 `muyan_pilot.py` 的直接执行入口保留为开发/兼容路径。
 
 ```bash
@@ -104,7 +109,8 @@ muyan-pilot add "task title" --repo OWNER/BACKLOG-REPO --config muyan-pilot.toml
 # ai-merged / ai-blocked）
 muyan-pilot status --config muyan-pilot.toml
 
-# 只读部署/健康报告：repo commit、unit drift、git transport（配置的
+# 只读部署/健康报告：repo commit、unit drift、CLI 源码（cli_source:
+# clean / DRIFT + 结构化 cli_source_drift 行）、git transport（配置的
 # origin URL、protocol、期望 SSH URL、SSH 探测——传输失败报告为
 # `transport: FAILED ...`，不抛出）、timer/service 实例状态、slots、
 # Pi session、当前 Issue、最近 journal

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -1,8 +1,9 @@
 # 一次性 setup
 
 `muyan-pilot setup` 是新机器或新任务池仓库的一次性、配置驱动的初始化
-入口。它验证本地前提、对齐平台标签、安装 systemd user units、检查
-checkout、报告可选模型 proxy——一条命令，稳定的机器可读结果。
+入口。它校验或重装 editable CLI 安装、验证本地前提、对齐平台标签、
+安装 systemd user units、检查 checkout、报告可选模型 proxy——一条
+命令，稳定的机器可读结果。
 
 ```bash
 muyan-pilot setup --config muyan-pilot.toml
@@ -20,22 +21,31 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    CLI，且 `systemctl --user` user bus 可达（没有 user bus 的容器或
    headless session 会以 bus 错误
    失败）。
-2. **认证** — `gh auth status`（已登录且 token 可用）。
-3. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
+2. **CLI editable 安装**（Issue #152）——官方本地部署是 **editable**
+   `uv tool` 安装：tool 环境直接从部署 checkout 导入 `muyan_pilot`，
+   所以 `ExecStartPre` 的 checkout 同步会被下一个 CLI 进程自动取到。
+   运行进程已经从配置的 `repo_dir` 导入时只校验（不调 uv，
+   `cli=verified`）；否则执行精确的 force editable 重装（`uv tool
+   install --force --reinstall --editable --python /usr/bin/python3
+   <repo_dir>`，`cli=installed`）。安装失败 fail fast——不装 unit、
+   不半初始化。该步骤从不碰运行中的 Runner 进程（新源码由下一个 CLI
+   启动加载）。
+3. **认证** — `gh auth status`（已登录且 token 可用）。
+4. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
    OWNER/REPO` 时恰好一个）：
    - 仓库存在且 viewer 有写权限（`gh repo view` → `viewerPermission`
      必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）；
    - 八个平台标签从仓库根目录的 `labels.toml` **声明式**对齐——标签
      名/颜色/描述的唯一事实源：缺的创建、漂移的更新、从不删除，业务
      标签（`bug`、`enhancement`、...）从不被碰。
-4. **Systemd units** — 仓库模板（`systemd/muyan-pilot@.service`、
+5. **Systemd units** — 仓库模板（`systemd/muyan-pilot@.service`、
    `systemd/muyan-pilot@.timer`）幂等安装到 user unit 目录（与
    `install-units` 相同的安装：复制、一次性迁移 #149 之前的非模板
    unit、`daemon-reload`、enable 两个 timer 实例
    `muyan-pilot@1.timer` / `muyan-pilot@2.timer`——从不启动、停止或
    重启 service），然后报告每个 timer 实例的 enabled/active 状态和
    下次触发时间。
-5. **Checkout + git transport** — 检查配置的 `repo_dir`：`origin`
+6. **Checkout + git transport** — 检查配置的 `repo_dir`：`origin`
    remote 的**传输协议**（Issue #114）：git 数据操作（fetch、push——
    包括 `.github/workflows/*.yml`）必须走 SSH
    （`git@github.com:owner/repo.git`），所以已有的 HTTPS `origin` 在这里
@@ -51,7 +61,7 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    无法启动）、base 新鲜度（本地 `HEAD` 对比刚 fetch 的
    `origin/<base_branch>`——只报告，不失败：timer 每次启动都会把干净
    checkout fast-forward）。
-6. **可选模型 proxy** — 检查 `local-llm-kv-cache` proxy 的 health
+7. **可选模型 proxy** — 检查 `local-llm-kv-cache` proxy 的 health
    endpoint（`http://127.0.0.1:18082/health`），报告为**可选**：它的
    缺失或不健康只是输出里的 warning，从不阻塞核心 GitHub/Pilot setup。
 
@@ -72,7 +82,8 @@ setup 从不创建业务 Issue、从不领取任务、从不启动 Pi、从不�
 agent 和脚本可以解析：
 
 ```text
-setup=ok version=1 base_branch=main
+setup=ok version=2 base_branch=main
+cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
@@ -81,6 +92,8 @@ checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@git
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
+`cli=verified` 表示运行中的 CLI 已经从部署 checkout 导入 `muyan_pilot`
+（editable 安装就位）；`cli=installed` 表示 force editable 重装已执行。
 `labels=8/8` 表示八个平台标签都与 `labels.toml` 一致；`next` 是 timer
 的下次触发时间（没有时为 `-`）；`optional_proxy` 是 `healthy`、
 `unhealthy` 或 `unavailable`，从不改变退出码。`migrated=true` 表示
@@ -99,7 +112,8 @@ muyan-pilot setup --config muyan-pilot.toml --json
 
 ```bash
 $ muyan-pilot setup --config muyan-pilot.toml
-setup=ok version=1 base_branch=main
+setup=ok version=2 base_branch=main
+cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
@@ -115,6 +129,7 @@ setup 仍以退出码 `0` 成功。）
 
 ```text
 setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
+setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
 setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
 setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -32,6 +32,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import bootstrap_runner
+import cli_source
 import git_transport
 import systemd_deploy
 
@@ -418,6 +419,23 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
             lines.append(
                 f"  {entry['unit']}: sha256={entry['installed_sha256']}"
             )
+    # CLI source (Issue #152): the official local deployment is the
+    # editable uv tool install — the tool env imports `muyan_pilot`
+    # from the deployment checkout, so the ExecStartPre sync is picked
+    # up by the next CLI process. A non-editable (site-packages) or
+    # stale (different checkout) source is REPORTED with the
+    # structured `cli_source_drift` line (actual path, expected
+    # repo_dir, the exact editable reinstall command — the fix leads
+    # with the editable reinstall, never with
+    # `muyan-pilot install-units` alone). Read-only: the report stays
+    # readable and the rest of the health report is still produced.
+    source = cli_source.cli_source(repo_dir)
+    line = cli_source.drift_line(source)
+    if line is None:
+        lines.append(f"cli_source: clean source={source['actual']}")
+    else:
+        lines.append("cli_source: DRIFT")
+        lines.append(f"  {line}")
     # Issue #149: report the INSTANCES (verified against the real CLI:
     # `systemctl show` rejects the bare template name, and `journalctl
     # -u` with a template-name glob fails when no instance exists —

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -39,12 +39,14 @@ import shutil
 import tomllib
 from pathlib import Path
 
+import cli_source
 import git_transport
 import systemd_deploy
 from pi_activity import quote_value
 
 # Bumped whenever the setup output contract changes shape.
-SETUP_VERSION = 1
+# Issue #152 added the `cli=` line (the editable install step).
+SETUP_VERSION = 2
 
 # The repo-managed single source of truth for the platform labels.
 LABELS_FILE = "labels.toml"
@@ -152,6 +154,45 @@ def load_label_defs(path: Path) -> list[dict]:
             f"missing={missing} unknown={unknown}"
         )
     return defs
+
+
+def install_cli_step(repo_dir: Path, module_file: Path, *,
+                     run_command) -> dict:
+    """Install or verify the editable uv tool install (Issue #152).
+
+    The official local deployment is the EDITABLE tool install: the
+    tool env imports ``muyan_pilot`` from the deployment checkout, so
+    the ``ExecStartPre`` checkout sync is picked up by the NEXT CLI
+    process automatically (no per-version reinstall, no second copy
+    of the source in site-packages). ``module_file`` is the RUNNING
+    process's import source (``cli_source.module_file()`` in the real
+    CLI): when it already sits directly inside ``repo_dir`` the
+    editable install is verified WITHOUT any uv call (idempotent
+    re-run); otherwise the exact editable force reinstall from
+    ``repo_dir`` runs via ``run_command`` (``uv tool install --force
+    --reinstall --editable --python /usr/bin/python3 <repo_dir>``).
+    A failing install raises ``SetupError`` (fail fast, no fallback,
+    no half-initialized state). The step NEVER touches a running
+    Runner process — the new source is loaded by the next CLI start.
+    """
+    repo_dir = Path(repo_dir).resolve()
+    actual = Path(module_file).resolve()
+    if actual.parent == repo_dir:
+        return {
+            "action": "verified",
+            "source": str(actual),
+        }
+    try:
+        run_command(cli_source.reinstall_args(repo_dir))
+    except Exception as exc:
+        raise SetupError(
+            f"editable tool install failed for {repo_dir}: {exc} "
+            f"(fix: {cli_source.reinstall_command(repo_dir)})"
+        ) from exc
+    return {
+        "action": "installed",
+        "source": str(repo_dir / "muyan_pilot.py"),
+    }
 
 
 def check_commands(run_command) -> dict:
@@ -481,7 +522,8 @@ def run_setup(config: dict, installed_dir: Path | None, *,
     """Run the full one-time setup and return its result document.
 
     Order (fail fast, no mutation before the prerequisites pass):
-    commands -> auth -> per target repo (permission check, then label
+    commands -> CLI editable install (verify or reinstall, Issue
+    #152) -> auth -> per target repo (permission check, then label
     alignment) -> unit install -> read-only checkout check -> optional
     proxy health (warning only). ``repos`` overrides the target set
     (the ``--repo`` flag); it must be a non-empty subset of the
@@ -502,6 +544,13 @@ def run_setup(config: dict, installed_dir: Path | None, *,
     repo_dir = config["repo_dir"]
     defs = load_label_defs(repo_dir / LABELS_FILE)
     check_commands(run_command)
+    # Issue #152: the CLI source step precedes every other step — the
+    # running CLI must import from the deployment checkout, otherwise
+    # the unit migration below (and the pre-start self-heal it
+    # repairs) could never run the new code (the #152 deadlock).
+    cli = install_cli_step(
+        repo_dir, cli_source.module_file(), run_command=run_command,
+    )
     check_auth(run_command)
     repo_results = []
     for repo in targets:
@@ -522,6 +571,7 @@ def run_setup(config: dict, installed_dir: Path | None, *,
         "version": SETUP_VERSION,
         "base_branch": config["base_branch"],
         "repos": repo_results,
+        "cli": cli,
         "service": units["service"],
         "timer": units["timer"],
         "checkout": checkout,
@@ -540,6 +590,13 @@ def format_setup(result: dict) -> list[str]:
         (
             f"setup={result['setup']} version={result['version']} "
             f"base_branch={result['base_branch']}"
+        ),
+        # Issue #152: the editable install step result (verified = the
+        # running CLI already imports from the checkout; installed =
+        # the editable force reinstall ran).
+        (
+            f"cli={result['cli']['action']} "
+            f"source={quote_value(result['cli']['source'])}"
         ),
     ]
     for entry in result["repos"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
 # Standard Python packaging for the Muyan Pilot CLI (Issue #140).
 #
-# The official usage is the installed console script:
+# The official usage is the installed console script, installed as an
+# EDITABLE uv tool (Issue #152): the tool env imports the modules
+# directly from the deployment checkout, so the ExecStartPre checkout
+# sync is picked up by the next CLI process automatically (no
+# per-version reinstall):
 #
-#     uv tool install --python /usr/bin/python3 <this repo>
+#     uv tool install --force --reinstall --editable \
+#         --python /usr/bin/python3 <this repo>
 #     muyan-pilot --help
 #
-# `uv tool upgrade muyan-pilot` refreshes the installed CLI after a
-# merge to main. The direct-execution entry `python3 muyan_pilot.py`
-# stays as a development/compatibility path.
+# The direct-execution entry `python3 muyan_pilot.py` stays as a
+# development/compatibility path.
 #
 # The release package is machine-independent: no third-party runtime
 # dependency (the bootstrap intentionally has none), no token, no user
@@ -44,4 +48,6 @@ py-modules = [
     "pi_activity",
     "pi_recovery",
     "progress",
+    # Issue #152: the CLI source consistency check (doctor/setup).
+    "cli_source",
 ]

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -205,6 +205,45 @@ def test_ci_workflow_installs_the_cli_and_verifies_the_entry():
     )
 
 
+def test_ci_workflow_installs_the_cli_editable_and_verifies_the_import_source():
+    """Issue #152: the CI install is the REAL editable uv tool install
+    (`--editable`: the tool env imports `muyan_pilot` from the
+    checkout, the official local deployment) and the CI verifies the
+    IMPORT SOURCE (`muyan_pilot.__file__` inside the checkout path) —
+    a non-editable install would silently copy the source into
+    site-packages and the ExecStartPre sync could never reach it."""
+    commands = step_commands(steps_of(load_workflow()))
+    editable_installs = [
+        command for command in commands
+        if any(
+            line.lstrip().startswith("uv tool install")
+            and "--editable" in line
+            for line in command.splitlines()
+        )
+    ]
+    assert editable_installs, (
+        "CI must install the CLI with the EDITABLE uv tool install "
+        "(uv tool install --editable), steps run: {commands!r}"
+    )
+    # The import-source verification: the tool env's python must report
+    # `muyan_pilot.__file__` and the step must check it against the
+    # checkout path (GITHUB_WORKSPACE).
+    source_checks = [
+        command for command in commands
+        if "muyan_pilot.__file__" in command
+    ]
+    assert source_checks, (
+        "CI must verify the editable import source "
+        "(muyan_pilot.__file__), steps run: {commands!r}"
+    )
+    assert any(
+        "GITHUB_WORKSPACE" in command for command in source_checks
+    ), (
+        "the import-source check must compare against the checkout "
+        f"path (GITHUB_WORKSPACE), got: {source_checks!r}"
+    )
+
+
 def test_ci_workflow_runs_the_contract_test_command():
     commands = step_commands(steps_of(load_workflow()))
     assert any(

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -242,6 +242,28 @@ def test_ci_workflow_installs_the_cli_editable_and_verifies_the_import_source():
         "the import-source check must compare against the checkout "
         f"path (GITHUB_WORKSPACE), got: {source_checks!r}"
     )
+    # The probe must run from a NEUTRAL cwd: `python -c` puts the cwd
+    # first on sys.path, so run from the checkout the checkout's own
+    # `muyan_pilot.py` shadows the tool env's import (editable finder
+    # and site-packages alike) and the check would pass even for a
+    # non-editable install (verified against a real non-editable
+    # install). The probe line must `cd /` before the interpreter.
+    probe_lines = [
+        line
+        for command in source_checks
+        for line in command.splitlines()
+        if "muyan_pilot.__file__" in line
+    ]
+    assert probe_lines, (
+        f"no probe line for muyan_pilot.__file__ in: {source_checks!r}"
+    )
+    for line in probe_lines:
+        assert "cd / &&" in line, (
+            "the import-source probe must run from a neutral cwd "
+            "(`cd / &&`), otherwise the checkout's own muyan_pilot.py "
+            f"shadows the tool env's import and the check is a no-op: "
+            f"{line!r}"
+        )
 
 
 def test_ci_workflow_runs_the_contract_test_command():

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -47,6 +47,8 @@ RUNTIME_MODULES = (
     "pi_activity",
     "pi_recovery",
     "progress",
+    # Issue #152: the CLI source consistency check (doctor/setup).
+    "cli_source",
 )
 
 # The docs pages that document user-facing commands (EN + ZH parity).
@@ -239,20 +241,54 @@ def test_setup_requires_the_installed_cli():
 # --- the documentation contract -----------------------------------------------
 
 
-def test_readme_uses_the_cli_and_the_uv_tool_install():
+def test_readme_uses_the_cli_and_the_editable_uv_tool_install():
     readme = README_FILE.read_text(encoding="utf-8")
     # The official commands are the installed CLI.
     assert "muyan-pilot install-units" in readme
     assert "muyan-pilot doctor" in readme
     assert "muyan-pilot setup" in readme
     assert "muyan-pilot add" in readme
-    # The install/upgrade flow is the verifiable uv tool flow.
+    # Issue #152: the official local deployment is the EDITABLE uv
+    # tool install (the tool env imports the source from the
+    # deployment checkout; the ExecStartPre sync is picked up by the
+    # next CLI process — no per-version reinstall).
     assert "uv tool install" in readme
-    assert "uv tool upgrade" in readme
+    assert "--editable" in readme
+    assert "uv tool install --force --reinstall --editable" in readme
     # The user is no longer required to hand-write the Python entry.
     assert "python3 muyan_pilot.py" not in readme
     # The compatibility path stays documented (development use only).
     assert "muyan_pilot.py" in readme
+
+
+def test_docs_make_the_editable_install_the_official_deployment():
+    """Issue #152: README, AGENTS and the EN/ZH docs make the
+    editable uv tool install the official local deployment and never
+    require `uv tool upgrade` for ordinary Python source or systemd
+    template/migration changes (with the editable install the
+    ExecStartPre checkout sync is picked up automatically — the
+    upgrade command is gone from the documented flow). The exact
+    force-reinstall command is documented as the fix for a
+    non-editable/stale CLI source."""
+    pages = {
+        "README.md": README_FILE,
+        "AGENTS.md": AGENTS_FILE,
+    }
+    for slug in DOC_PAGES:
+        pages[slug] = REPO_ROOT / "docs" / slug
+    for name, path in pages.items():
+        text = path.read_text(encoding="utf-8")
+        assert "uv tool upgrade" not in text, (
+            f"{name} still requires `uv tool upgrade`: with the "
+            "editable install ordinary source/template changes need "
+            "no reinstall"
+        )
+    # The install/upgrade pages (EN + ZH) name the editable install.
+    for slug in ("getting-started.mdx", "zh/getting-started.mdx"):
+        page = (REPO_ROOT / "docs" / slug).read_text(encoding="utf-8")
+        assert "--editable" in page, (
+            f"docs/{slug} must document the editable uv tool install"
+        )
 
 
 def test_agents_md_uses_the_cli():

--- a/tests/test_cli_source.py
+++ b/tests/test_cli_source.py
@@ -1,0 +1,192 @@
+"""CLI source consistency tests (Issue #152).
+
+The official local deployment is the EDITABLE uv tool install: the tool
+env's Python imports `muyan_pilot` directly from the deployment checkout
+(a setuptools editable finder), so the ExecStartPre checkout sync is
+picked up by the NEXT CLI process automatically — there is no second
+copy of the source in site-packages and no per-version reinstall.
+
+These tests pin:
+
+- the exact editable force-reinstall command (verified against the real
+  `uv tool install --help`: `--force`, `--reinstall`, `--editable` and
+  `--python` all exist);
+- the read-only source check: the running process's `muyan_pilot`
+  import file must sit directly inside the configured `repo_dir`
+  (a non-editable site-packages source or a stale other-checkout
+  source is drift);
+- the structured `cli_source_drift` line (actual path, expected
+  repo_dir, the exact reinstall command) and its absence when clean.
+"""
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+import cli_source
+from pi_activity import quote_value
+
+
+def _fake_module_file(path: str) -> ModuleType:
+    """A stand-in for the imported `muyan_pilot` module."""
+    module = ModuleType("muyan_pilot")
+    module.__file__ = path
+    return module
+
+
+def _patch_module_file(monkeypatch, path: str) -> None:
+    monkeypatch.setattr(
+        cli_source, "muyan_pilot", _fake_module_file(path),
+    )
+
+
+# --- the exact reinstall command -------------------------------------------
+
+
+def test_reinstall_command_is_the_editable_force_reinstall():
+    """The fix command is the editable force reinstall from the
+    configured checkout (the Issue's recovery command, verbatim):
+    `--force` replaces the existing tool env, `--reinstall` bypasses
+    the build cache, `--editable` points the tool env at the checkout,
+    `--python` pins the production interpreter."""
+    command = cli_source.reinstall_command(
+        Path("/home/xqianliu/Documents/muyan/muyan-pilot"),
+    )
+    assert command == (
+        "uv tool install --force --reinstall --editable "
+        "--python /usr/bin/python3 "
+        "/home/xqianliu/Documents/muyan/muyan-pilot"
+    )
+
+
+# --- the read-only source check ---------------------------------------------
+
+
+def test_cli_source_clean_for_the_checkout_source(tmp_path, monkeypatch):
+    """An editable install (or the compat entry run inside the
+    checkout) imports `muyan_pilot` from the checkout root: clean."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    _patch_module_file(monkeypatch, str(repo / "muyan_pilot.py"))
+    source = cli_source.cli_source(repo)
+    assert source["editable"] is True
+    assert source["actual"] == (repo / "muyan_pilot.py").resolve()
+    assert source["expected"] == repo.resolve()
+    assert source["fix"] == cli_source.reinstall_command(repo)
+
+
+def test_cli_source_clean_when_the_expected_dir_is_a_symlink(
+    tmp_path, monkeypatch,
+):
+    """The comparison resolves both sides: a symlinked checkout path
+    (e.g. `/home/xqianliu/Documents/muyan/muyan-pilot` reached through
+    a link) is the same source as the resolved one."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    _patch_module_file(monkeypatch, str(real / "muyan_pilot.py"))
+    source = cli_source.cli_source(link)
+    assert source["editable"] is True
+    assert source["actual"] == (real / "muyan_pilot.py").resolve()
+
+
+def test_cli_source_drifts_for_a_site_packages_source(tmp_path, monkeypatch):
+    """A NON-EDITABLE uv tool install copies the source into the tool
+    env's site-packages: the import source is outside the checkout, so
+    the ExecStartPre sync can never reach it (the #152 deadlock)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    site_packages = (
+        tmp_path / "uv" / "tools" / "muyan-pilot"
+        / "lib" / "python3.14" / "site-packages"
+    )
+    site_packages.mkdir(parents=True)
+    _patch_module_file(
+        monkeypatch, str(site_packages / "muyan_pilot.py"),
+    )
+    source = cli_source.cli_source(repo)
+    assert source["editable"] is False
+    assert source["actual"] == (site_packages / "muyan_pilot.py").resolve()
+    assert source["fix"] == cli_source.reinstall_command(repo)
+
+
+def test_cli_source_drifts_for_a_stale_other_checkout(tmp_path, monkeypatch):
+    """An editable install of a DIFFERENT (stale) checkout also drifts:
+    the import source is not inside the configured repo_dir."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    stale = tmp_path / "old-clone"
+    stale.mkdir()
+    _patch_module_file(monkeypatch, str(stale / "muyan_pilot.py"))
+    source = cli_source.cli_source(repo)
+    assert source["editable"] is False
+    assert source["actual"] == (stale / "muyan_pilot.py").resolve()
+
+
+def test_cli_source_drifts_for_a_nested_copy(tmp_path, monkeypatch):
+    """A copy of the source nested INSIDE the checkout (e.g. a
+    worktree's own `muyan_pilot.py` shadowing the checkout root file)
+    is not the configured source either: only the checkout ROOT
+    `muyan_pilot.py` counts."""
+    repo = tmp_path / "checkout"
+    (repo / ".worktrees" / "wt").mkdir(parents=True)
+    _patch_module_file(
+        monkeypatch, str(repo / ".worktrees" / "wt" / "muyan_pilot.py"),
+    )
+    source = cli_source.cli_source(repo)
+    assert source["editable"] is False
+
+
+# --- the structured drift line ----------------------------------------------
+
+
+def test_drift_line_carries_source_expected_and_fix(tmp_path, monkeypatch):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    stale = tmp_path / "old-clone"
+    stale.mkdir()
+    _patch_module_file(monkeypatch, str(stale / "muyan_pilot.py"))
+    source = cli_source.cli_source(repo)
+    line = cli_source.drift_line(source)
+    assert line is not None
+    assert line.startswith("cli_source_drift ")
+    assert f"source={quote_value(str(source['actual']))}" in line
+    assert f"expected={quote_value(str(repo.resolve()))}" in line
+    # The fix command carries spaces, so the field is quoted (the
+    # pi_activity.quote_value convention, like every unit_drift line).
+    assert (
+        f"fix={quote_value(cli_source.reinstall_command(repo))}"
+    ) in line
+
+
+def test_drift_line_is_none_when_clean(tmp_path, monkeypatch):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    _patch_module_file(monkeypatch, str(repo / "muyan_pilot.py"))
+    source = cli_source.cli_source(repo)
+    assert cli_source.drift_line(source) is None
+
+
+# --- the real module file ----------------------------------------------------
+
+
+def test_module_file_is_the_running_muyan_pilot_file():
+    """`module_file()` is the running process's `muyan_pilot` import
+    source (asserted against the real imported module — one real call,
+    not a guessed shape)."""
+    import muyan_pilot
+
+    assert cli_source.module_file() == Path(
+        muyan_pilot.__file__,
+    ).resolve()
+
+
+def test_module_file_fails_fast_without_a_file_attribute(monkeypatch):
+    """A module without `__file__` cannot be located: the check fails
+    fast with the concrete reason (never a guessed path)."""
+    module = ModuleType("muyan_pilot")
+    monkeypatch.setattr(cli_source, "muyan_pilot", module)
+
+    with pytest.raises(RuntimeError, match="no __file__"):
+        cli_source.module_file()

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1199,8 +1199,12 @@ def _setup_result() -> dict:
     """A complete run_setup result document (format_setup contract)."""
     return {
         "setup": "ok",
-        "version": 1,
+        "version": 2,
         "base_branch": "main",
+        "cli": {
+            "action": "verified",
+            "source": "/repo/muyan_pilot.py",
+        },
         "repos": [
             {
                 "repo": "xqliu/muyan-pilot",
@@ -1425,6 +1429,105 @@ def test_doctor_report_drift_carries_paths_hashes_and_fix(
         f"installed_sha256={entry['installed_sha256']}"
     ) in lines
     assert f"  fix: {systemd_deploy.FIX_COMMAND}" in lines
+
+
+def _fake_cli_source(monkeypatch, drifted: bool = False) -> dict:
+    """Stub the read-only CLI source check (Issue #152) for the doctor
+    tests: a clean editable source from the world's checkout, or a
+    drifted site-packages source with the exact fix command."""
+    import types
+
+    if drifted:
+        actual = Path(
+            "/home/u/.local/share/uv/tools/muyan-pilot/"
+            "lib/python3.14/site-packages/muyan_pilot.py",
+        )
+    else:
+        actual = None  # filled per-world below
+    state = {"actual": actual}
+
+    def fake_cli_source(expected_repo_dir):
+        if state["actual"] is None:
+            state["actual"] = Path(expected_repo_dir) / "muyan_pilot.py"
+        return {
+            "actual": Path(state["actual"]),
+            "expected": Path(expected_repo_dir).resolve(),
+            "editable": not drifted,
+            "fix": (
+                "uv tool install --force --reinstall --editable "
+                f"--python /usr/bin/python3 {Path(expected_repo_dir)}"
+            ),
+        }
+
+    def fake_drift_line(source):
+        if source["editable"]:
+            return None
+        from pi_activity import quote_value
+
+        return (
+            "cli_source_drift "
+            f"source={quote_value(str(source['actual']))} "
+            f"expected={quote_value(str(source['expected']))} "
+            f"fix={quote_value(source['fix'])}"
+        )
+
+    stub = types.SimpleNamespace(
+        cli_source=fake_cli_source, drift_line=fake_drift_line,
+    )
+    monkeypatch.setattr(muyan_pilot, "cli_source", stub)
+    return state
+
+
+def test_doctor_report_cli_source_clean(tmp_path, monkeypatch):
+    """Issue #152: doctor read-only verifies that the running process
+    imports `muyan_pilot` from the configured repo_dir (the editable
+    uv tool install): the clean report names the import source."""
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    _fake_cli_source(monkeypatch, drifted=False)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert any(
+        line.startswith("cli_source: clean") for line in lines
+    ), report
+    assert (
+        f"cli_source: clean source={config['repo_dir'] / 'muyan_pilot.py'}"
+    ) in lines
+    assert "cli_source_drift" not in report
+
+
+def test_doctor_report_cli_source_drift_carries_source_expected_fix(
+    tmp_path, monkeypatch,
+):
+    """Issue #152: a non-editable (site-packages) or stale source is
+    REPORTED with the structured `cli_source_drift` line (actual path,
+    expected repo_dir, the exact editable reinstall command) — the fix
+    leads with the editable reinstall, never with
+    `muyan-pilot install-units` alone. The report stays readable and
+    the rest of the health report is still produced."""
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    _fake_cli_source(monkeypatch, drifted=True)
+    monkeypatch.setattr(muyan_pilot, "current_issue", lambda repo: None)
+    report = muyan_pilot.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert "cli_source: DRIFT" in lines
+    assert any(
+        line.startswith("  cli_source_drift ")
+        and "source=/home/u/.local/share/uv/tools/muyan-pilot/"
+        in line
+        and f"expected={config['repo_dir'].resolve()}" in line
+        and (
+            'fix="uv tool install --force --reinstall --editable '
+            '--python /usr/bin/python3 '
+            f"{config['repo_dir']}\""
+        ) in line
+        for line in lines
+    ), f"drift line missing or malformed in:\n{report}"
+    # The report continues past the drift (doctor is read-only).
+    assert "slots: 0/1" in lines
+    assert "journal:" in lines
 
 
 def test_doctor_report_missing_installed_unit_is_drift(tmp_path, monkeypatch):

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -31,6 +31,32 @@ def _default_command_lookup(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _cli_source_world(monkeypatch, tmp_path):
+    """Issue #152: the setup's CLI step checks the RUNNING process's
+    `muyan_pilot` import source. The test world simulates a CLI
+    running from its own checkout (an editable install of
+    `make_repo`'s `tmp_path/repo`); a test that needs a drifted
+    source re-points `world["module_file"]` before calling
+    `run_setup`."""
+    import types
+
+    world = {"module_file": tmp_path / "repo" / "muyan_pilot.py"}
+    stub = types.SimpleNamespace(
+        module_file=lambda: world["module_file"],
+        reinstall_args=lambda repo_dir: [
+            "uv", "tool", "install", "--force", "--reinstall",
+            "--editable", "--python", "/usr/bin/python3", str(repo_dir),
+        ],
+        reinstall_command=lambda repo_dir: (
+            "uv tool install --force --reinstall --editable "
+            f"--python /usr/bin/python3 {repo_dir}"
+        ),
+    )
+    monkeypatch.setattr(pilot_setup, "cli_source", stub)
+    return world
+
+
 VALID_DEFS = [
     {"name": "ai-ready", "color": "1d76db", "description": "dispatched"},
     {"name": "ai-in-progress", "color": "fbca04", "description": "work"},
@@ -159,6 +185,9 @@ def fake_run_factory(state: dict):
         if head[:2] == ["systemctl", "--user"] and head[2] in (
             "daemon-reload", "enable",
         ):
+            return ""
+        # Issue #152: the editable tool install (uv tool install ...).
+        if head[:2] == ["uv", "tool"]:
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
@@ -857,6 +886,75 @@ def test_check_optional_proxy_reports_a_missing_curl_without_raising():
     assert result["optional"] is True
 
 
+# --- CLI editable install (Issue #152) ----------------------------------------
+
+
+def test_install_cli_step_verifies_an_existing_editable_install(tmp_path):
+    """The running CLI already imports `muyan_pilot` from the
+    configured checkout (the editable install): setup verifies it
+    WITHOUT any uv call (idempotent re-run, no per-setup reinstall)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    calls: list = []
+    result = pilot_setup.install_cli_step(
+        repo, repo / "muyan_pilot.py",
+        run_command=lambda command, **kwargs: calls.append(command) or "",
+    )
+    assert calls == []
+    assert result == {
+        "action": "verified",
+        "source": str((repo / "muyan_pilot.py").resolve()),
+    }
+
+
+def test_install_cli_step_installs_the_editable_tool_when_drifted(tmp_path):
+    """A non-editable (site-packages) or stale source triggers the
+    EXACT editable force reinstall from the configured checkout
+    (the flags verified against the real `uv tool install --help`:
+    `--force`, `--reinstall`, `--editable`, `--python`)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    calls: list = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return ""
+
+    result = pilot_setup.install_cli_step(
+        repo,
+        "/home/u/.local/share/uv/tools/muyan-pilot/"
+        "lib/python3.14/site-packages/muyan_pilot.py",
+        run_command=fake_run,
+    )
+    assert calls == [[
+        "uv", "tool", "install", "--force", "--reinstall", "--editable",
+        "--python", "/usr/bin/python3", str(repo),
+    ]]
+    assert result == {
+        "action": "installed",
+        "source": str((repo / "muyan_pilot.py").resolve()),
+    }
+
+
+def test_install_cli_step_fails_fast_on_a_failed_reinstall(tmp_path):
+    """A failing `uv tool install` fails the setup with the concrete
+    reason (fail fast, no fallback, no half-initialized state)."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+
+    def failing(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command, stderr="uv boom",
+        )
+
+    with pytest.raises(
+        pilot_setup.SetupError, match="editable tool install",
+    ):
+        pilot_setup.install_cli_step(
+            repo, "/elsewhere/muyan_pilot.py", run_command=failing,
+        )
+
+
 # --- run_setup orchestration ---------------------------------------------------
 
 
@@ -898,6 +996,14 @@ def test_run_setup_success_reports_all_steps(tmp_path):
     assert result["checkout"]["clean"] is True
     assert result["checkout"]["base_fresh"] is True
     assert result["optional_proxy"]["optional"] is True
+    # Issue #152: the CLI step reports the editable install verified
+    # (the test process imports muyan_pilot from the repo world).
+    assert result["cli"]["action"] == "verified"
+    assert result["cli"]["source"] == str(
+        (repo / "muyan_pilot.py").resolve(),
+    )
+    # No uv call: an existing editable install is never reinstalled.
+    assert [c for c in calls if c[:2] == ["uv", "tool"]] == []
 
 
 def test_run_setup_repo_override_limits_the_target(tmp_path):
@@ -963,6 +1069,66 @@ def test_run_setup_fails_fast_on_a_label_error_before_units(tmp_path):
 
     config = runner.load_config(make_config(tmp_path, repo))
     with pytest.raises(pilot_setup.SetupError, match="label"):
+        pilot_setup.run_setup(
+            config, installed, run_command=failing,
+        )
+    assert [c for c in calls if c[:3] == ["systemctl", "--user", "daemon-reload"]] == []
+
+
+def test_run_setup_installs_the_editable_cli_when_drifted(tmp_path,
+                                                        _cli_source_world):
+    """Issue #152: a non-editable (site-packages) or stale CLI source
+    is reinstalled with the editable force reinstall BEFORE any unit
+    install — the #152 deadlock was that the old CLI could never run
+    the new migration code, so the source fix must precede the unit
+    work."""
+    repo, installed, state = make_run_state(tmp_path)
+    _cli_source_world["module_file"] = (
+        "/home/u/.local/share/uv/tools/muyan-pilot/"
+        "lib/python3.14/site-packages/muyan_pilot.py"
+    )
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo))
+    result = pilot_setup.run_setup(
+        config, installed, run_command=fake_run,
+    )
+    assert result["setup"] == "ok"
+    assert result["cli"]["action"] == "installed"
+    assert result["cli"]["source"] == str(
+        (repo / "muyan_pilot.py").resolve(),
+    )
+    uv_calls = [c for c in calls if c[:2] == ["uv", "tool"]]
+    assert uv_calls == [[
+        "uv", "tool", "install", "--force", "--reinstall", "--editable",
+        "--python", "/usr/bin/python3", str(repo),
+    ]]
+    # The reinstall precedes the unit install (daemon-reload).
+    uv_index = calls.index(uv_calls[0])
+    reload_index = next(
+        i for i, c in enumerate(calls)
+        if c[:3] == ["systemctl", "--user", "daemon-reload"]
+    )
+    assert uv_index < reload_index
+
+
+def test_run_setup_fails_fast_on_a_failed_cli_reinstall(
+    tmp_path, _cli_source_world,
+):
+    """Issue #152: a failing editable reinstall fails the setup
+    before any unit install (fail fast, no half-initialized state)."""
+    repo, installed, state = make_run_state(tmp_path)
+    _cli_source_world["module_file"] = "/elsewhere/muyan_pilot.py"
+    fake_run, calls = fake_run_factory(state)
+
+    def failing(command, **kwargs):
+        if command[:2] == ["uv", "tool"]:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="uv boom",
+            )
+        return fake_run(command, **kwargs)
+
+    config = runner.load_config(make_config(tmp_path, repo))
+    with pytest.raises(pilot_setup.SetupError, match="editable tool install"):
         pilot_setup.run_setup(
             config, installed, run_command=failing,
         )
@@ -1036,7 +1202,8 @@ def test_run_setup_missing_labels_file_fails_fast(tmp_path):
 def sample_result() -> dict:
     return {
         "setup": "ok",
-        "version": 1,
+        # Issue #152 bumped the setup output contract (the cli line).
+        "version": 2,
         "base_branch": "main",
         "repos": [
             {
@@ -1082,12 +1249,22 @@ def sample_result() -> dict:
             "proxy": "healthy",
             "url": "http://127.0.0.1:18082/health",
         },
+        # Issue #152: the CLI editable-install step result.
+        "cli": {
+            "action": "verified",
+            "source": "/home/u/repo/muyan_pilot.py",
+        },
     }
 
 
 def test_format_setup_renders_stable_key_value_lines():
     lines = pilot_setup.format_setup(sample_result())
-    assert lines[0] == "setup=ok version=1 base_branch=main"
+    assert lines[0] == "setup=ok version=2 base_branch=main"
+    # Issue #152: the CLI line reports the editable install state and
+    # the import source (the checkout root `muyan_pilot.py`).
+    assert lines[1] == (
+        "cli=verified source=/home/u/repo/muyan_pilot.py"
+    )
     assert (
         "repo=xqliu/muyan-pilot permission=ADMIN "
         "default_branch=main labels=8/8" in lines


### PR DESCRIPTION
Fixes #152

run_id=fccacd14

## What

The official local deployment is now the **editable** `uv tool` install:

```bash
uv tool install --force --reinstall --editable --python /usr/bin/python3 <deployment checkout>
```

The tool env imports `muyan_pilot` directly from the deployment checkout,
so the `ExecStartPre` checkout sync (`git fetch origin main && git merge
--ff-only origin/main`) is picked up by the NEXT CLI process
automatically — no second copy of the source in site-packages, no
per-version reinstall, and **no `uv tool upgrade` for ordinary Python
source or systemd template/migration changes**. The force editable
reinstall is required only when dependencies, the entry point, the
package name, the build backend or the Python version floor changes.

## Why (root cause)

A non-editable `uv tool` install copies the source into the tool env's
site-packages at install time. After `ExecStartPre` fast-forwards the
checkout, the CLI keeps executing the stale copy: with the #149 unit
migration that deadlocked the deployment (the old CLI checked the old
non-templated unit paths and could never run the new migration code).

## Changes

- **`cli_source.py`** (new flat module): read-only check of the running
  process's `muyan_pilot` import source against the configured
  `repo_dir` (both resolved; clean = the import file sits directly
  inside the checkout root) + the exact editable reinstall command and
  the structured `cli_source_drift` line (actual path, expected
  repo_dir, fix — values quoted per the `pi_activity.quote_value`
  convention).
- **`muyan-pilot doctor`**: reports `cli_source: clean source=...` or
  `cli_source: DRIFT` + the structured drift line. Read-only: the fix
  hint leads with the editable reinstall, never with
  `muyan-pilot install-units` alone; the rest of the health report is
  still produced.
- **`muyan-pilot setup`**: new CLI step before every other step — when
  the running process already imports from the configured `repo_dir` it
  verifies the editable install WITHOUT any uv call (`cli=verified`);
  otherwise it runs the exact force editable reinstall
  (`cli=installed`); a failing install fails fast (no unit install, no
  half-initialized state). The step never touches a running Runner
  process. `SETUP_VERSION` 1 → 2 (`cli=` line in the output).
- **CI** (`.github/workflows/ci.yml`): the real editable install
  (`uv tool install --force --reinstall --editable --python 3.14 .`)
  plus the entry checks (`--help`, `--version`) and the import-source
  verification (`muyan_pilot.__file__` from the console script's own
  interpreter must start with the checkout path).
- **Docs** (README, AGENTS.md, EN+ZH getting-started/operations/setup):
  the editable install is the official local deployment; no `uv tool
  upgrade` step for ordinary changes; doctor's `cli_source` check and
  setup's CLI step documented (EN + ZH).
- **Unchanged**: the systemd templates (`ExecStart` stays
  `%h/.local/bin/muyan-pilot`), the Runner (zero `uv` invocations — it
  never installs the tool at start, so two concurrent service
  instances cannot race the tool env), no per-tick reinstall, no
  updater daemon, no database/queue/second release state.

## Verification (run artifacts in the task worktree: plan.md, test.log)

- TDD red → green; full suite `993 passed` with **100% line and branch
  coverage** (`coverage run --branch -m pytest tests/ -q` +
  `coverage report --show-missing`).
- Real machine:
  - doctor from the worktree code against the deployment config
    reports the structured `cli_source_drift` line (source = worktree
    file, expected = the deployment checkout, exact editable reinstall
    fix);
  - the clean determination verified with the real import mechanism
    (a process importing `muyan_pilot` from the checkout root:
    `editable=True`, no drift line);
  - `install_cli_step` real-path simulation: verified branch (no uv
    call) and installed branch (exact reinstall argv);
  - the installed CLI (old code, editable from the main checkout) still
    runs (`muyan-pilot --version` → 0.2.0, `doctor` ok) — no running
    Runner process was touched;
  - `systemd-analyze --user verify` on both templates → exit 0.

<!-- muyan-pilot:run=fccacd14 -->
