### PR TITLE
Check uv explicitly in setup prerequisites with install guidance (Issue #156)

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -6,15 +6,28 @@ machine layout.
 
 ## Prerequisites
 
+You install these yourself — `muyan-pilot setup` only **checks** them
+(it verifies `git`, `gh`, `python3`, `uv` and the systemd user session
+on the machine); it never installs system packages, never installs
+`gh`, and never runs `gh auth login` (you log in first, setup only
+verifies the login).
+
 | Requirement | What it is used for | Check |
 |---|---|---|
 | Python 3.14 | The Runner and the test contract (CI pins the same minor version) | `python3 --version` |
-| [uv](https://docs.astral.sh/uv/) | Installs the `muyan-pilot` CLI into an isolated tool environment | `uv --version` |
+| [uv](https://docs.astral.sh/uv/) | Installs the `muyan-pilot` CLI into an isolated tool environment (setup's CLI editable step calls `uv tool install`) | `uv --version` |
 | [Pi](https://github.com/earendil-works/pi) CLI | The development agent; one full session per task | `pi --version` |
 | Git | Worktrees, branches, base freshness | `git --version` |
 | GitHub CLI (`gh`) | Issues, labels, PRs, merge | `gh auth status` |
 | systemd (user session) | The timer that triggers one tick every 5 minutes | `systemctl --user status` |
 | A working OpenAI-compatible model endpoint | Pi's model provider — a local llama.cpp server or any OpenAI-compatible API | one real `pi --print` call (below) |
+
+Install `uv` with the official installer (verified against the [uv
+docs](https://docs.astral.sh/uv/getting-started/installation/)):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
 Pi must be configured with a provider that can serve a coding agent
 stably (system prompt + tool schemas + long sessions). Verify the endpoint
@@ -122,14 +135,16 @@ context_files = []
 ## 4. Run the one-time setup
 
 The setup entry does the whole initialization in one command: it
-verifies or reinstalls the editable CLI install (Issue #152 — the
-running CLI must import from the deployment checkout), verifies
-`gh auth status` and the repo permissions, aligns the platform labels
-from the repo-managed `labels.toml` (the single source of truth for
-label name, color and description — a commit never creates labels, and
-a missing label makes the scan silently skip that state), installs the
-systemd user units and enables the timer, checks the checkout, and
-reports the optional model proxy:
+verifies the prerequisites you installed (git, gh, python3, uv, the
+systemd user session — a missing one fails fast with the actionable
+install guidance), verifies or reinstalls the editable CLI install
+(Issue #152 — the running CLI must import from the deployment
+checkout), verifies `gh auth status` and the repo permissions, aligns
+the platform labels from the repo-managed `labels.toml` (the single
+source of truth for label name, color and description — a commit never
+creates labels, and a missing label makes the scan silently skip that
+state), installs the systemd user units and enables the timer, checks
+the checkout, and reports the optional model proxy:
 
 ```bash
 muyan-pilot setup --config muyan-pilot.toml

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -21,10 +21,13 @@ Setup is **fail-fast**: a core prerequisite failure stops the run
 before any later mutation, with the concrete reason on stderr and a
 non-zero exit code.
 
-1. **Commands** — `git`, `gh`, `python3` and the installed
-   `muyan-pilot` CLI on the PATH, and a reachable `systemctl --user`
-   user bus (a container or headless session without a user bus fails
-   with the bus error).
+1. **Commands** — `git`, `gh`, `python3`, `uv` and the installed
+   `muyan-pilot` CLI on the PATH (you install these yourself — setup
+   only checks them; a missing one fails fast with the actionable
+   install guidance, e.g. `required command missing: uv (not on PATH)
+   — install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh`),
+   and a reachable `systemctl --user` user bus (a container or headless
+   session without a user bus fails with the bus error).
 2. **CLI editable install** (Issue #152) — the official local
    deployment is the EDITABLE `uv tool` install: the tool env imports
    `muyan_pilot` from the deployment checkout, so the `ExecStartPre`
@@ -148,6 +151,7 @@ but the core setup still succeeds with exit code `0`.)
 Failures (non-zero exit code, `setup_failed reason=...` on stderr):
 
 ```text
+setup_failed reason=required command missing: uv (not on PATH) — install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh (https://docs.astral.sh/uv/getting-started/installation/)
 setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
 setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
@@ -157,10 +161,11 @@ setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted change
 setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry
 ```
 
-A wrong repo, missing labels that cannot be created (permission), a
-dirty checkout, an unreachable SSH (no HTTPS fallback) or a missing
-systemd user bus all stop the setup with the concrete reason —
-nothing is half-initialized without a clear signal.
+A missing prerequisite command (e.g. `uv`), a wrong repo, missing
+labels that cannot be created (permission), a dirty checkout, an
+unreachable SSH (no HTTPS fallback) or a missing systemd user bus all
+stop the setup with the concrete reason — nothing is half-initialized
+without a clear signal.
 
 ## Idempotency
 

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -5,15 +5,27 @@ clone 路径下都能工作——不依赖任何特定机器布局。
 
 ## 前提
 
+这些前提由**你自己安装**——`muyan-pilot setup` 只**检查**它们（校验
+`git`、`gh`、`python3`、`uv` 和 systemd user session）；它从不自动安装
+系统包、从不安装 `gh`、也不执行 `gh auth login`（你先登录，setup 只
+验证登录状态）。
+
 | 要求 | 用途 | 检查 |
 |---|---|---|
 | Python 3.14 | Runner 和测试契约（CI 固定同一 minor 版本） | `python3 --version` |
-| [uv](https://docs.astral.sh/uv/) | 把 `muyan-pilot` CLI 装进隔离的 tool 环境 | `uv --version` |
+| [uv](https://docs.astral.sh/uv/) | 把 `muyan-pilot` CLI 装进隔离的 tool 环境（setup 的 CLI editable 步骤会调 `uv tool install`） | `uv --version` |
 | [Pi](https://github.com/earendil-works/pi) CLI | 开发 agent；每个任务一个完整 session | `pi --version` |
 | Git | worktree、分支、base 新鲜度 | `git --version` |
 | GitHub CLI（`gh`） | Issue、标签、PR、merge | `gh auth status` |
 | systemd（user session） | 每 5 分钟触发一个 tick 的 timer | `systemctl --user status` |
 | 可用的 OpenAI-compatible 模型 endpoint | Pi 的模型 provider——本地 llama.cpp server 或任意 OpenAI-compatible API | 一次真实 `pi --print` 调用（见下） |
+
+用官方安装器安装 `uv`（已对照
+[uv 官方文档](https://docs.astral.sh/uv/getting-started/installation/)）：
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
 Pi 必须配置一个能稳定服务 coding agent 的 provider（system prompt +
 tool schemas + 长 session）。派活之前先用一次真实调用验证 endpoint——
@@ -108,9 +120,12 @@ context_files = []
 
 ## 4. 运行一次性 setup
 
-setup 入口用一条命令完成全部初始化：验证 `gh auth status` 和仓库权限、
-从仓库管理的 `labels.toml`（标签名/颜色/描述的唯一事实源——commit 从不
-创建标签，缺标签会让扫描静默漏掉对应状态）声明式对齐平台标签、安装
+setup 入口用一条命令完成全部初始化：校验你安装好的前提（git、gh、
+python3、uv、systemd user session——缺失会 fail fast 并给出可执行的
+安装指引）、校验或重装 editable CLI 安装（Issue #152——运行中的 CLI
+必须从部署 checkout 导入）、验证 `gh auth status` 和仓库权限、从仓库
+管理的 `labels.toml`（标签名/颜色/描述的唯一事实源——commit 从不创建
+标签，缺标签会让扫描静默漏掉对应状态）声明式对齐平台标签、安装
 systemd user units 并 enable timer、检查 checkout、报告可选模型 proxy：
 
 ```bash

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -17,10 +17,13 @@ muyan-pilot setup --config muyan-pilot.toml
 setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下，stderr
 给出具体原因，退出码非零。
 
-1. **命令** — PATH 上有 `git`、`gh`、`python3` 和已安装的 `muyan-pilot`
-   CLI，且 `systemctl --user` user bus 可达（没有 user bus 的容器或
-   headless session 会以 bus 错误
-   失败）。
+1. **命令** — PATH 上有 `git`、`gh`、`python3`、`uv` 和已安装的
+   `muyan-pilot` CLI（这些前提由你自己安装——setup 只检查；缺失会
+   fail fast 并给出可执行的安装指引，例如 `required command missing:
+   uv (not on PATH) — install uv first: curl -LsSf
+   https://astral.sh/uv/install.sh | sh`），且 `systemctl --user`
+   user bus 可达（没有 user bus 的容器或 headless session 会以 bus
+   错误失败）。
 2. **CLI editable 安装**（Issue #152）——官方本地部署是 **editable**
    `uv tool` 安装：tool 环境直接从部署 checkout 导入 `muyan_pilot`，
    所以 `ExecStartPre` 的 checkout 同步会被下一个 CLI 进程自动取到。
@@ -128,6 +131,7 @@ setup 仍以退出码 `0` 成功。）
 失败（退出码非零，stderr 输出 `setup_failed reason=...`）：
 
 ```text
+setup_failed reason=required command missing: uv (not on PATH) — install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh (https://docs.astral.sh/uv/getting-started/installation/)
 setup_failed reason=systemctl --user user bus unavailable (is a systemd user session running?): ...
 setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
@@ -137,9 +141,9 @@ setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted change
 setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry
 ```
 
-仓库错误、无法创建的缺失标签（权限）、脏 checkout、SSH 不可达（没有
-HTTPS 回退）或缺 systemd user bus 都会带具体原因停下——不会半初始化
-而没有明确信号。
+缺失的前提命令（例如 `uv`）、仓库错误、无法创建的缺失标签（权限）、
+脏 checkout、SSH 不可达（没有 HTTPS 回退）或缺 systemd user bus 都会
+带具体原因停下——不会半初始化而没有明确信号。
 
 ## 幂等性
 

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -5,8 +5,9 @@ initialization entry for a new machine or new task-pool repository:
 
 - verifies ``gh auth status`` and the viewer's read/write permission on
   every target repo;
-- verifies the required commands (``git``, ``gh``, ``python3``) and the
-  ``systemctl --user`` user bus;
+- verifies the required commands (``git``, ``gh``, ``python3``, ``uv``,
+  the ``muyan-pilot`` CLI — a missing one fails fast with its
+  actionable install guidance) and the ``systemctl --user`` user bus;
 - aligns the platform labels (``ai-ready``, ``ai-in-progress``,
   ``ai-pr-opened``, ``ai-fix-needed``, ``ai-merged``, ``ai-blocked``,
   ``p0``, ``ai-epic``) declaratively from the repo-managed
@@ -71,7 +72,39 @@ WRITE_PERMISSIONS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
 # Required local commands (checked with shutil.which). Issue #140:
 # the installed `muyan-pilot` CLI is a prerequisite too — the systemd
 # entry it documents (and the service's ExecStart) must exist.
-REQUIRED_COMMANDS = ("git", "gh", "python3", "muyan-pilot")
+# Issue #156: `uv` is a prerequisite too — the CLI editable step
+# (Issue #152) calls `uv tool install`, so a machine that has the CLI
+# but no uv must fail HERE (with actionable install guidance), not
+# mid-install with an indirect error.
+REQUIRED_COMMANDS = ("git", "gh", "python3", "uv", "muyan-pilot")
+
+# Actionable install guidance per required command (Issue #156): the
+# missing-command error must tell the user how to install the
+# prerequisite. The uv entry is the official installer command, verified
+# against https://docs.astral.sh/uv/getting-started/installation/.
+COMMAND_INSTALL_HINTS = {
+    "git": (
+        "install git (e.g. `apt-get install git` / `dnf install git` / "
+        "`brew install git`)"
+    ),
+    "gh": (
+        "install the GitHub CLI (https://cli.github.com/) and log in "
+        "with `gh auth login` (setup verifies the login, it never runs "
+        "it for you)"
+    ),
+    "python3": (
+        "install Python 3.14 (the production minor version pinned by CI)"
+    ),
+    "uv": (
+        "install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh "
+        "(https://docs.astral.sh/uv/getting-started/installation/)"
+    ),
+    "muyan-pilot": (
+        "install the editable uv tool CLI from the deployment checkout: "
+        "uv tool install --force --reinstall --editable --python "
+        "/usr/bin/python3 <repo_dir>"
+    ),
+}
 
 # The optional local-llm-kv-cache proxy health endpoint (docs/
 # optional-kv-cache.mdx: the committed user unit listens on 18082).
@@ -198,17 +231,24 @@ def install_cli_step(repo_dir: Path, module_file: Path, *,
 def check_commands(run_command) -> dict:
     """Verify the required commands and the systemctl --user bus.
 
-    ``git``, ``gh``, ``python3`` and the installed ``muyan-pilot`` CLI
-    must be on the PATH; the systemd user bus must be reachable (a
-    probe ``systemctl --user show`` must succeed — a container or a
-    headless session without a user bus fails fast with the concrete
-    reason). No mutation happens here.
+    ``git``, ``gh``, ``python3``, ``uv`` and the installed
+    ``muyan-pilot`` CLI must be on the PATH (Issue #156: ``uv`` is
+    checked explicitly because the CLI editable step calls
+    ``uv tool install``); a missing command fails fast with the
+    actionable install guidance for that command (``COMMAND_INSTALL_
+    HINTS``). The systemd user bus must be reachable (a probe
+    ``systemctl --user show`` must succeed — a container or a headless
+    session without a user bus fails fast with the concrete reason).
+    No mutation happens here.
     """
     paths: dict[str, str] = {}
     for name in REQUIRED_COMMANDS:
         path = shutil.which(name)
         if path is None:
-            raise SetupError(f"required command missing: {name} (not on PATH)")
+            raise SetupError(
+                f"required command missing: {name} (not on PATH) — "
+                f"{COMMAND_INSTALL_HINTS[name]}"
+            )
         paths[name] = path
     # Probe an INSTANCE name (verified against the real CLI: `systemctl
     # show` rejects the bare template name `muyan-pilot@.timer` but

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -236,6 +236,9 @@ def test_setup_requires_the_installed_cli():
     assert "muyan-pilot" in pilot_setup.REQUIRED_COMMANDS
     for name in ("git", "gh", "python3"):
         assert name in pilot_setup.REQUIRED_COMMANDS
+    # Issue #156: setup calls `uv tool install` (the CLI editable step,
+    # Issue #152), so the prerequisite check must verify uv explicitly.
+    assert "uv" in pilot_setup.REQUIRED_COMMANDS
 
 
 # --- the documentation contract -----------------------------------------------

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -349,6 +349,31 @@ def test_chinese_kv_cache_page_matches_the_upstream_port_contract():
     )
 
 
+def test_chinese_docs_document_the_uv_prerequisite_boundary():
+    """Issue #156: the Chinese docs carry the same initialization
+    boundary as the English page — the user installs uv (official
+    installer command), setup only checks/verifies, and setup never
+    installs system packages, never installs gh, never runs
+    `gh auth login`. The Chinese setup page lists uv in the command
+    step and shows the uv-missing failure example."""
+    started = zh_page_text("getting-started")
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in started, (
+        "Chinese getting-started must give the official uv install command"
+    )
+    assert "gh auth login" in started, (
+        "Chinese getting-started must state that setup never runs "
+        "gh auth login"
+    )
+    setup = zh_page_text("setup")
+    assert "required command missing: uv" in setup, (
+        "Chinese setup must show the uv-missing setup_failed example"
+    )
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in setup, (
+        "Chinese setup's uv-missing failure example must carry the "
+        "actionable install guidance"
+    )
+
+
 def test_chinese_setup_documents_the_migration_and_ssh_failure():
     """Same setup facts as the English page: the HTTPS-to-SSH migration
     command and the SSH connectivity failure."""

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -413,6 +413,33 @@ def test_docs_document_the_minimal_implementation_principle():
     )
 
 
+def test_docs_document_the_uv_prerequisite_boundary():
+    """Issue #156: the docs must draw the initialization boundary — the
+    USER installs git/gh/python3/systemd user session/uv (uv with the
+    official installer command), while `muyan-pilot setup` only checks
+    auth, repos, the CLI editable install, units and timers; setup never
+    installs system packages, never installs gh, never runs
+    `gh auth login`. The setup page must list uv in the command step and
+    show the uv-missing failure example."""
+    started = page_text("getting-started")
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in started, (
+        "getting-started must give the official uv install command "
+        "(verified against the uv docs)"
+    )
+    assert "gh auth login" in started, (
+        "getting-started must state that setup never runs gh auth login "
+        "(the user logs in)"
+    )
+    setup = page_text("setup")
+    assert "required command missing: uv" in setup, (
+        "setup must show the uv-missing setup_failed example"
+    )
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in setup, (
+        "setup's uv-missing failure example must carry the actionable "
+        "install guidance"
+    )
+
+
 def test_docs_document_the_git_transport_boundary():
     """Issue #114: the docs must document the two-channel boundary —
     git data operations over SSH (including workflow file pushes),

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -291,6 +291,9 @@ def test_check_commands_reports_the_required_commands(monkeypatch):
         "git": "/usr/bin/git",
         "gh": "/usr/bin/gh",
         "python3": "/usr/bin/python3",
+        # Issue #156: setup calls `uv tool install` in the CLI editable
+        # step (Issue #152), so uv is a checked prerequisite too.
+        "uv": "/usr/bin/uv",
         # Issue #140: the installed CLI is a prerequisite too (the
         # systemd entry it documents must exist on the machine).
         "muyan-pilot": "/usr/bin/muyan-pilot",
@@ -307,6 +310,26 @@ def test_check_commands_fails_fast_on_a_missing_command(monkeypatch):
         pilot_setup.check_commands(
             run_command=lambda command, **kwargs: "loaded",
         )
+
+
+def test_check_commands_fails_fast_when_uv_is_missing(monkeypatch):
+    """Issue #156: a machine with the CLI but no uv used to fail only in
+    the later CLI editable install step with an indirect error. The
+    prerequisite check must fail fast at the commands step, name uv and
+    carry actionable install guidance (the official uv installer, verified
+    against https://docs.astral.sh/uv/getting-started/installation/)."""
+    monkeypatch.setattr(
+        pilot_setup.shutil, "which",
+        lambda name: None if name == "uv" else f"/usr/bin/{name}",
+    )
+    with pytest.raises(pilot_setup.SetupError) as excinfo:
+        pilot_setup.check_commands(
+            run_command=lambda command, **kwargs: "loaded",
+        )
+    reason = str(excinfo.value)
+    assert "uv" in reason
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in reason
+    assert "https://docs.astral.sh/uv/" in reason
 
 
 def test_check_commands_fails_fast_without_a_user_bus(monkeypatch):


### PR DESCRIPTION
Fixes #156

<!-- muyan-pilot:run=7eff5472 -->

run_id=7eff5472

## What

`muyan-pilot setup` now explicitly checks `uv` in its prerequisite
command check (it was missing from `REQUIRED_COMMANDS`, so a machine
with the CLI but no uv failed only in the later CLI editable install
step with an indirect error).

## Changes

- `pilot_setup.py`:
  - `REQUIRED_COMMANDS` gains `uv` (`git`, `gh`, `python3`, `uv`,
    `muyan-pilot`);
  - new `COMMAND_INSTALL_HINTS` map: the missing-command
    `SetupError` now carries actionable install guidance per command.
    The uv entry is the official installer command, verified against
    https://docs.astral.sh/uv/getting-started/installation/ :
    `curl -LsSf https://astral.sh/uv/install.sh | sh`.
- Docs (EN + ZH, same facts):
  - `getting-started`: the prerequisites are explicitly USER-installed
    (git, gh, python3, systemd user session, uv — with the official uv
    install command); setup only checks them and never installs system
    packages, never installs `gh`, never runs `gh auth login`;
  - `setup`: step 1 lists `uv`; the failure examples show the
    uv-missing `setup_failed reason=...` line with the install
    guidance.
- Tests:
  - `test_check_commands_fails_fast_when_uv_is_missing` (regression:
    fail fast at the commands step, error names uv + official install
    command + docs URL);
  - `test_check_commands_reports_the_required_commands` expects `uv`;
  - `test_setup_requires_the_installed_cli` asserts `uv` in
    `REQUIRED_COMMANDS`;
  - new docs contract tests (EN `test_docs_document_the_uv_prerequisite_boundary`,
    ZH `test_chinese_docs_document_the_uv_prerequisite_boundary`).

## Verification

- `timeout 900 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`
  → 996 passed;
- `timeout 60 /usr/bin/python3 -m coverage report` → TOTAL 100%
  line/branch;
- smoke (real `check_commands`, uv stubbed absent):
  `setup_failed reason=required command missing: uv (not on PATH) —
  install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh
  (https://docs.astral.sh/uv/getting-started/installation/)`;
- base freshness: `git fetch origin main` +
  `git merge-base --is-ancestor origin/main HEAD` → HEAD contains the
  latest remote base.

Existing setup flow with uv installed is unchanged (all 996 tests
green, no behavior change beyond the new prerequisite check).
