### PR TITLE
Support configurable Pi provider/model/thinking in TOML config (Issue #119)

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -25,6 +25,14 @@ base_branch = "main"
 # Runner exits, however it exits. A Runner that cannot take a slot logs
 # capacity_full and exits without claiming an Issue.
 max_concurrency = 1
+# Optional Pi model selection (Issue #119): passed to EVERY Pi session
+# (implement and review) as --provider/--model/--thinking. Omit a key to
+# keep Pi's own default for that setting; values are passed verbatim and
+# recorded in the journal (non-sensitive model identifiers, never keys).
+# pi_provider = "openai"
+# pi_model = "gpt-5.6-sol"
+# pi_thinking = "medium"
+
 # Optional Pi skills. Paths may be absolute, use ~, or be relative to this file.
 skills = []
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,22 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 - `muyan-pilot status` 显示配置容量和当前已占用 slot（`capacity: N`、`slots: k/N`、`slot-N: pid=...`）；占用判定用非阻塞 `flock` 探测（探测成功即空闲并立即解锁），PID 仅用于展示；
 - 直接在 Pilot 外手工运行的任意 `pi` 命令不属于该配置控制范围：`max_concurrency` 只约束 Runner 领取任务时启动的 Pi，手工 `pi` 不受 slot 管理，也不会释放或占用任何 slot。
 
+## Pi 默认 provider/model（pi_provider / pi_model / pi_thinking，Issue #119）
+
+部署者可以在 `muyan-pilot.toml` 中可选声明 Pi 的 provider、model 和 thinking level，不必修改全局 Pi 配置或启动脚本：
+
+```toml
+pi_provider = "openai"
+pi_model = "gpt-5.6-sol"
+pi_thinking = "medium"
+```
+
+- Runner 启动 implement 和 review 的 Pi 时都显式传递 `--provider <pi_provider> --model <pi_model> --thinking <pi_thinking>`（flag 契约以 `pi --help` 为准）；
+- 三个键彼此独立：未配置某项时不传对应参数，Pi 继续使用自身默认值；配置值以 TOML 为准，不依赖 `~/.pi/agent/settings.json`；
+- 配置值按原样传给 Pi 启动入口，并记录在 journal 的 `command=` 行（redacted 命令的一部分）——provider/model/thinking 是非敏感的模型标识，prompt 和 Issue 内容仍保持 redacted；
+- 键存在但为空字符串或非字符串时 `load_config` fail fast（`<key> must be a non-empty string`）；Pi 启动失败沿用现有 fail-fast 契约（非零退出/超时 → `run_failed` + 异常）；
+- 不按任务类型、label 或角色自动选择模型，不做动态路由、benchmark、成本路由或 fallback，不支持一个 run 中途切换模型；token/密钥不进入配置、日志、Issue 或 PR。
+
 ## 全链路 run_id（correlation ID）
 
 每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -222,6 +222,12 @@ def load_config(path: Path) -> dict:
         or max_concurrency < 1
     ):
         raise ValueError("max_concurrency must be a positive integer")
+    # Optional Pi model selection (Issue #119): each key is absent -> None
+    # (the Pi flag is not passed, Pi keeps its own default) or a non-empty
+    # string passed to Pi verbatim. Anything else fails fast.
+    pi_provider = _optional_pi_string(data, "pi_provider")
+    pi_model = _optional_pi_string(data, "pi_model")
+    pi_thinking = _optional_pi_string(data, "pi_thinking")
     repo_dir = _config_path(data.get("repo_dir", "."), base)
     return {
         "source_repos": source_repos,
@@ -238,11 +244,51 @@ def load_config(path: Path) -> dict:
         "base_branch": base_branch,
         "max_concurrency": max_concurrency,
         "slot_dir": slot_dir_for(repo_dir),
+        "pi_provider": pi_provider,
+        "pi_model": pi_model,
+        "pi_thinking": pi_thinking,
         # Multi-repo registry (Issue #134): the explicit per-repo entries
         # (name, path, github, base_branch). Absent section -> [] so the
         # single-repo config keeps its exact shape and flow.
         "repositories": parse_repositories(data.get("repositories", []), base),
     }
+
+
+def _optional_pi_string(data: dict, key: str) -> str | None:
+    """Read one optional Pi model key (Issue #119).
+
+    Absent -> None (the corresponding `pi --provider/--model/--thinking`
+    flag is not passed and Pi keeps its own default). Present -> must be a
+    non-empty string, passed to Pi verbatim; anything else fails fast.
+    """
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _pi_model_args(config: dict) -> list[str]:
+    """Return the configured Pi model flags (Issue #119).
+
+    One `--flag value` pair per configured key, in the fixed order
+    provider, model, thinking; an unset key contributes nothing, so a
+    config without any of the three keys returns [] and the Pi command
+    keeps its exact pre-#119 shape. The values are non-sensitive model
+    identifiers (never keys or tokens) and are part of the redacted
+    `log_command`, so the journal run scene records what was launched.
+    """
+    args: list[str] = []
+    for flag, key in (
+        ("--provider", "pi_provider"),
+        ("--model", "pi_model"),
+        ("--thinking", "pi_thinking"),
+    ):
+        value = config.get(key)
+        if value is not None:
+            args.extend((flag, value))
+    return args
 
 
 def parse_repositories(entries: object, base: Path) -> list[dict]:
@@ -1438,6 +1484,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     context += "Complete the delivery process in the system prompt."
     command = [
         "pi", *_skill_args(_skills_for(config, IMPLEMENT_EXCLUDED_SKILLS)),
+        *_pi_model_args(config),
         "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
@@ -1446,7 +1493,8 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         cwd=worktree,
         timeout=timeout,
         log_command=[
-            "pi", "--print", "--session-dir", str(worktree / ".pi-session"),
+            "pi", *_pi_model_args(config), "--print", "--session-dir",
+            str(worktree / ".pi-session"),
             "--system-prompt", "<redacted>", "<issue-context-redacted>",
         ],
         run_id=config["run_id"],
@@ -1863,6 +1911,7 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     )
     command = [
         "pi", *_skill_args(_skills_for(config, REVIEW_EXCLUDED_SKILLS)),
+        *_pi_model_args(config),
         "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt,
         context,
@@ -1872,7 +1921,7 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
         cwd=worktree,
         timeout=timeout,
         log_command=[
-            "pi", "--print", "--session-dir",
+            "pi", *_pi_model_args(config), "--print", "--session-dir",
             str(worktree / ".pi-session"),
             "--system-prompt", "<redacted>", "<review-context-redacted>",
         ],

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -6666,3 +6666,215 @@ def test_main_holds_slot_through_delivery_wait(monkeypatch, tmp_path):
     thread.join(timeout=10)
     # After the wait ends, the slot is released.
     assert pilot_slots.slot_occupancy(slot_dir, 1) == [(1, None)]
+
+
+# --- configurable Pi provider/model/thinking (Issue #119) -------------------
+
+
+def _model_config(tmp_path, **extra):
+    """Build a minimal config for run_pi/run_review with model keys."""
+    config = {
+        "prompt": tmp_path / "prompt.md",
+        "prompt_review": tmp_path / "prompt_review.md",
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "a1b2c3d4",
+    }
+    config.update(extra)
+    return config
+
+
+def _command_model_args(command):
+    """Return the (flag, value) pairs for the pi model options."""
+    flags = ("--provider", "--model", "--thinking")
+    return [
+        (item, command[index + 1])
+        for index, item in enumerate(command)
+        if item in flags
+    ]
+
+
+def test_load_config_defaults_pi_model_keys_to_none(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    config = runner.load_config(config_path)
+    assert config["pi_provider"] is None
+    assert config["pi_model"] is None
+    assert config["pi_thinking"] is None
+
+
+def test_load_config_reads_pi_model_keys(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\n'
+        'pi_provider = "openai"\n'
+        'pi_model = "gpt-5.6-sol"\n'
+        'pi_thinking = "medium"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_provider"] == "openai"
+    assert config["pi_model"] == "gpt-5.6-sol"
+    assert config["pi_thinking"] == "medium"
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("pi_provider", '""'),
+        ("pi_provider", "123"),
+        ("pi_provider", "true"),
+        ("pi_model", '""'),
+        ("pi_model", "123"),
+        ("pi_model", "true"),
+        ("pi_thinking", '""'),
+        ("pi_thinking", "123"),
+        ("pi_thinking", "true"),
+    ],
+)
+def test_load_config_rejects_invalid_pi_model_keys(tmp_path, key, value):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        f'source_repos = ["owner/repo"]\n{key} = {value}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=f"{key} must be a non-empty string"):
+        runner.load_config(config_path)
+
+
+def test_run_pi_passes_configured_model_args(monkeypatch, tmp_path):
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "done",
+    )
+    config = _model_config(
+        tmp_path, pi_provider="openai", pi_model="gpt-5.6-sol",
+        pi_thinking="medium",
+    )
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    command, kwargs = calls[0]
+    assert _command_model_args(command) == [
+        ("--provider", "openai"),
+        ("--model", "gpt-5.6-sol"),
+        ("--thinking", "medium"),
+    ]
+    # The journal-visible redacted command carries the same non-sensitive
+    # values, so the run scene proves what was actually launched.
+    assert _command_model_args(kwargs["log_command"]) == [
+        ("--provider", "openai"),
+        ("--model", "gpt-5.6-sol"),
+        ("--thinking", "medium"),
+    ]
+    # The prompt and issue context stay redacted in the log command.
+    assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
+
+
+def test_run_pi_passes_partial_model_args(monkeypatch, tmp_path):
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "done",
+    )
+    config = _model_config(tmp_path, pi_provider="openai")
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    command, kwargs = calls[0]
+    assert _command_model_args(command) == [("--provider", "openai")]
+    assert "--model" not in command
+    assert "--thinking" not in command
+    assert _command_model_args(kwargs["log_command"]) == [("--provider", "openai")]
+
+
+def test_run_pi_omits_model_args_when_not_configured(monkeypatch, tmp_path):
+    """Default compatibility: without the keys the command is exactly the
+    pre-#119 shape (Pi keeps its own defaults)."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "done",
+    )
+    config = _model_config(tmp_path)
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    command, kwargs = calls[0]
+    assert "--provider" not in command
+    assert "--model" not in command
+    assert "--thinking" not in command
+    assert command[:3] == ["pi", "--print", "--session-dir"]
+    assert kwargs["log_command"] == [
+        "pi", "--print", "--session-dir", str(tmp_path / ".pi-session"),
+        "--system-prompt", "<redacted>", "<issue-context-redacted>",
+    ]
+
+
+def test_run_review_passes_configured_model_args(monkeypatch, tmp_path):
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "ok",
+    )
+    config = _model_config(
+        tmp_path, pi_provider="openai", pi_model="gpt-5.6-sol",
+        pi_thinking="medium",
+    )
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    command, kwargs = calls[0]
+    assert _command_model_args(command) == [
+        ("--provider", "openai"),
+        ("--model", "gpt-5.6-sol"),
+        ("--thinking", "medium"),
+    ]
+    assert _command_model_args(kwargs["log_command"]) == [
+        ("--provider", "openai"),
+        ("--model", "gpt-5.6-sol"),
+        ("--thinking", "medium"),
+    ]
+    assert kwargs["log_command"][-2:] == [
+        "<redacted>", "<review-context-redacted>",
+    ]
+
+
+def test_run_review_omits_model_args_when_not_configured(monkeypatch, tmp_path):
+    """Default compatibility for the review session as well."""
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "ok",
+    )
+    config = _model_config(tmp_path)
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    command, kwargs = calls[0]
+    assert "--provider" not in command
+    assert "--model" not in command
+    assert "--thinking" not in command
+    assert kwargs["log_command"] == [
+        "pi", "--print", "--session-dir", str(tmp_path / ".pi-session"),
+        "--system-prompt", "<redacted>", "<review-context-redacted>",
+    ]


### PR DESCRIPTION
Fixes #119

<!-- muyan-pilot:run=f1dacbdd -->

run_id=f1dacbdd

## 变更

让部署者通过 `muyan-pilot.toml` 可选声明 `pi_provider` / `pi_model` / `pi_thinking`，Runner 启动 implement 和 review 的 Pi 时都显式传递 `--provider <pi_provider> --model <pi_model> --thinking <pi_thinking>`（flag 契约以 `pi --help` 验证，Pi 0.84.3 真实调用 smoke 通过）。

- `load_config` 解析三个可选键：缺失 → 不传对应参数（Pi 保持自身默认）；存在 → 必须是非空字符串，按原样传递；其他值 fail fast（`<key> must be a non-empty string`）。
- `run_pi` / `run_review` 组装的命令与 redacted `log_command` 都携带配置值：provider/model/thinking 是非敏感的模型标识，记录在 journal 的 `command=` 行（运行现场可验证）；prompt 与 Issue 内容仍保持 redacted，token/密钥不进入配置、日志、Issue 或 PR。
- `.muyan-pilot.example.toml` 与 `README.md` 新增文档。

## 不做（按 Issue 范围）

不按任务类型/label/角色自动选择模型；不做动态路由、benchmark、成本路由或 fallback；不支持 run 中途切换模型；不引入数据库/队列/模型注册表/编排器；未配置时 Pi 默认行为不变。

## 验证

- TDD：RED（14 个新行为测试失败）→ GREEN → 重构。
- 全量 pytest：1012 passed。
- 100% line/branch coverage（`coverage run --branch`，TOTAL 100%，`bootstrap_runner.py` 100%）。
- Pi CLI 真实契约：`pi --provider openai --model gpt-5.6-sol --thinking medium --version` 及各单项组合均 exit 0。
- 详见 worktree 内 `test.log`（含基线说明：`test_concurrency_e2e.py::test_live_pr_opened_delivery_is_not_resumed_by_second_runner` 为 pre-existing flaky，与本变更无关）。
