### PR TITLE
Scope the fresh-claim scans to the configured active Milestone (Issue #139)

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -17,6 +17,17 @@ prompt_review = "prompt_review.md"
 # Delivery base branch: every task worktree is created from the latest
 # origin/<base_branch> (fetched and frozen at claim time). Default: "main".
 base_branch = "main"
+# Claim scope (Issue #139): the active GitHub Milestone title (e.g.
+# "v0.2.0") that the fresh-claim scans (p0, bug, plain) are restricted
+# to. The milestone:"<title>" qualifier is part of the gh search query,
+# so an Issue of another Milestone (or of no Milestone) never enters the
+# queue of this Runner; `ai-ready` stays the execution switch and the
+# pickup order (p0 -> bug -> plain) is unchanged. P0 does not cross
+# milestones. Resume states (opened PRs, in-flight restarts) are never
+# gated by the Milestone. Leave it out (or comment it out) to keep the
+# pre-#139 behavior: every `ai-ready` Issue is claimable. It is never
+# guessed — an empty or non-string value fails the start fast.
+# active_milestone = "v0.2.0"
 # Maximum concurrent Pilot tasks on this machine. Must be a positive integer;
 # missing means 1. The local AI/GPU can only serve one stable task, so keep
 # the default. A slot (flock on <repo_dir>/.muyan-pilot/slots/slot-N) is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,25 @@ acceptance criteria.
   P0 is skipped (falling back to the bug/plain scans) and an in-flight
   P0 is resumed by the restart scan (which fetches `labels` too, so the
   progress comment keeps showing `p0`).
+- Active Milestone claim scope (Issue #139): the optional config field
+  `active_milestone` (a Milestone TITLE, e.g. `v0.2.0`) restricts the
+  FRESH-claim scans to one version: with it set, all three ready scans
+  carry the `milestone:"<title>"` qualifier in the gh search query
+  (the quoted form — milestone titles may contain spaces or special
+  characters), so an Issue of another Milestone or of no Milestone
+  never enters the queue, and a Milestone Issue without `ai-ready`
+  never does either. The Milestone is a version scope, NOT a
+  replacement for the `ai-ready` execution switch. P0 does NOT cross
+  milestones (the active Milestone is the claim scope of every fresh
+  claim; `p0` only orders the pickup inside it). The scope is
+  query-layer only (the `is_epic` code-layer skip and the blockedBy
+  skip are the unchanged second layer), a failed scan still fails open
+  (never a silent claim of the wrong version), and resume states are
+  never gated by it: the opened-PR resume and the in-flight restart
+  scans run work to completion regardless of Milestone changes. The
+  value is explicit — never guessed from the repo's Milestone list;
+  absent it keeps the pre-#139 behavior exactly (compat), and an
+  empty/non-string value fails the start fast.
 - The pickup log line carries the explicit `priority=p0` /
   `priority=normal` field; the GitHub progress comment shows the
   `priority` field; the run scene (`run_info`) and the started

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 
 - ready 领取顺序固定为：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`（三次 `gh issue list` 扫描，共享同一组排除条件和 `blockedBy` 语义）；
 - P0 仍遵守全部现有排除规则（`ai-in-progress`、`ai-pr-opened`、`ai-fix-needed`、`ai-merged`、`ai-blocked`）和单 slot 约束：P0 被阻塞（open blocker）时跳过并回退到 bug/普通扫描，P0 已在途（`ai-in-progress`）时由重启恢复扫描接回（扫描同样携带 `labels`，恢复后进度评论继续显示 `p0`）；
+- active Milestone 领取范围（Issue #139）：可选配置 `active_milestone`（Milestone 标题，如 `v0.2.0`）把**新领取**扫描限制在一个版本内——设置后 p0/bug/普通三次扫描的 gh 搜索查询都携带 `milestone:"<title>"` 限定词（带引号形式，Milestone 标题可含空格/特殊字符），其他 Milestone 或无 Milestone 的 Issue 永远进不了队列，没有 `ai-ready` 的 Milestone Issue 也进不了（`ai-ready` 仍是执行开关，Milestone 只是版本范围）；**P0 不跨 Milestone**（active Milestone 是所有新领取的范围，`p0` 只在其内部排序）；范围只在查询层（`is_epic` 代码层跳过和 blockedBy 跳过是不变的第二层），扫描失败仍按 fail open 契约处理（绝不静默领取错误版本）；**恢复态不受 Milestone 限制**：已开 PR 的恢复扫描和在途重启扫描把任务跑完，不受 Milestone 变更影响；值必须显式配置（绝不从 repo 的 Milestone 列表猜），未设置时保持 #139 之前的行为（兼容），空串/非字符串启动即 fail fast；
 - 领取日志行携带明确的 `priority=p0` / `priority=normal` 字段；GitHub 进度评论显示 `priority` 字段；run 现场（`run_info`）与 started milestone 携带 `priority=...`；
 - P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；失败评论和 blocked 现场保留具体失败原因和可恢复现场；
 - P0 的 review/merge 失败沿用现有同一 PR、有限 review round（`MAX_REVIEW_ROUNDS=5`）机制，不引入新的循环。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -212,6 +212,17 @@ def load_config(path: Path) -> dict:
     base_branch = data.get("base_branch", "main")
     if not isinstance(base_branch, str) or not base_branch:
         raise ValueError("base_branch must be a non-empty string")
+    # Claim scope (Issue #139): the active Milestone is an EXPLICIT
+    # version scope for the fresh-claim scans — it is never guessed
+    # from the repo's Milestone list. Absent (None) keeps the current
+    # behavior exactly (compat); present it must be a non-empty
+    # string, otherwise the config is a misconfiguration and the start
+    # fails fast.
+    active_milestone = data.get("active_milestone")
+    if active_milestone is not None and (
+        not isinstance(active_milestone, str) or not active_milestone
+    ):
+        raise ValueError("active_milestone must be a non-empty string")
     # Concurrency cap (Issue #39): the local machine can only serve a
     # limited number of concurrent tasks, so the default is 1. Any other
     # value must be a positive integer; fail fast on anything else.
@@ -236,6 +247,7 @@ def load_config(path: Path) -> dict:
             _config_path(item, base) for item in data.get("context_files", [])
         ],
         "base_branch": base_branch,
+        "active_milestone": active_milestone,
         "max_concurrency": max_concurrency,
         "slot_dir": slot_dir_for(repo_dir),
         # Multi-repo registry (Issue #134): the explicit per-repo entries
@@ -431,9 +443,34 @@ READY_SCAN_EXCLUSIONS = (
     f"-label:{FIX_NEEDED_LABEL} -label:{MERGED_LABEL} "
     f"-label:{BLOCKED_LABEL}"
 )
-P0_READY_SEARCH = f"label:ai-ready label:{P0_LABEL} {READY_SCAN_EXCLUSIONS}"
-BUG_READY_SEARCH = f"label:ai-ready label:bug {READY_SCAN_EXCLUSIONS}"
-READY_SEARCH = f"label:ai-ready {READY_SCAN_EXCLUSIONS}"
+
+
+def ready_searches(active_milestone: str | None = None) -> tuple[str, str, str]:
+    """Return the three ready scans (p0, bug, plain) in pickup order.
+
+    With a configured `active_milestone` (Issue #139) every scan
+    carries the `milestone:"<title>"` qualifier — the quoted form is
+    the contract because milestone titles may contain spaces or
+    special characters (verified against the live API). The scope is
+    part of the QUERY, so an Issue of another Milestone (or of no
+    Milestone) never enters the result set, and a `v0.2.0` Issue
+    without `ai-ready` never does either: the `label:ai-ready`
+    qualifier stays. The Milestone is a version scope, not a
+    replacement for the `ai-ready` execution switch. P0 does NOT
+    cross milestones (Issue #139 decision): the active Milestone is
+    the claim scope of EVERY fresh claim, and `p0` only orders the
+    pickup inside it — one uniform rule, no special case. Without a
+    configured Milestone the searches are byte-identical to the
+    pre-#139 scans (compat).
+    """
+    scope = (
+        f' milestone:"{active_milestone}"' if active_milestone else ""
+    )
+    return (
+        f"label:ai-ready label:{P0_LABEL}{scope} {READY_SCAN_EXCLUSIONS}",
+        f"label:ai-ready label:bug{scope} {READY_SCAN_EXCLUSIONS}",
+        f"label:ai-ready{scope} {READY_SCAN_EXCLUSIONS}",
+    )
 
 
 def issue_priority(issue: dict) -> str:
@@ -475,7 +512,7 @@ def is_epic(issue: dict) -> bool:
     return False
 
 
-def pick_issue(repo: str) -> dict | None:
+def pick_issue(repo: str, active_milestone: str | None = None) -> dict | None:
     # A merged delivery keeps `ai-ready` + `ai-merged` on the (still
     # open) Issue; `ai-merged` is the success terminal state, so it is
     # excluded from the ready scan like every other delivery state.
@@ -490,8 +527,12 @@ def pick_issue(repo: str) -> dict | None:
     # scan; a P0 or bug with open blockers is skipped there and the
     # next scan still decides. The scan also fetches `labels` so the
     # picked issue's priority (and Epic-ness) is visible without an
-    # extra gh call.
-    for search in (P0_READY_SEARCH, BUG_READY_SEARCH, READY_SEARCH):
+    # extra gh call. Issue #139: with a configured `active_milestone`
+    # all three scans are scoped to that Milestone in the query itself
+    # (see `ready_searches`) — the Epic skip and the blockedBy skip
+    # above are the unchanged second (code) layer, and a failed scan
+    # still fails open (never a silent claim of the wrong version).
+    for search in ready_searches(active_milestone):
         try:
             raw = run_command([
                 "gh", "issue", "list", "--repo", repo, "--state", "open",
@@ -587,10 +628,12 @@ def pick_in_progress_issue(
     return parse_issue_list(raw)
 
 
-def pick_next_issue(repos: list[str]) -> tuple[str, dict] | None:
+def pick_next_issue(
+    repos: list[str], active_milestone: str | None = None,
+) -> tuple[str, dict] | None:
     """Scan sources in order; return the first ready issue and its source."""
     for repo in repos:
-        issue = pick_issue(repo)
+        issue = pick_issue(repo, active_milestone)
         if issue is not None:
             return repo, issue
     return None
@@ -861,6 +904,7 @@ def block_scene_failure(issue: dict, error: ValueError, repo: str,
 
 def pick_next_delivery(
     repos: list[str], slot_dir: Path, max_concurrency: int,
+    active_milestone: str | None = None,
 ) -> tuple[str, dict, dict | None] | None:
     """Scan sources in order: resumable PRs, in-flight restarts, ready.
 
@@ -873,6 +917,11 @@ def pick_next_delivery(
     scan: `process_issue`'s resume block reuses the newest worktree's
     run id, so the same progress comment is kept instead of a second
     run being started on an Issue that is already in flight.
+
+    Issue #139: `active_milestone` scopes only the FRESH claim
+    (`pick_issue`) — the resumable-PR and in-flight restart scans are
+    resume states, and running an in-flight or opened-PR delivery to
+    completion is never gated by a Milestone change.
     """
     for repo in repos:
         selected = pick_resumable_delivery(
@@ -888,7 +937,7 @@ def pick_next_delivery(
         if issue is not None:
             return repo, issue, None
     for repo in repos:
-        issue = pick_issue(repo)
+        issue = pick_issue(repo, active_milestone)
         if issue is not None:
             return repo, issue, None
     return None
@@ -3323,6 +3372,7 @@ def main(argv: list[str] | None = None) -> int:
         selected = pick_next_delivery(
             config["source_repos"], config["slot_dir"],
             config["max_concurrency"],
+            config["active_milestone"],
         )
         if selected is None:
             LOGGER.info(

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -110,6 +110,7 @@ directory):
 | `prompt` | no | `prompt.md` | Implementer prompt template (placeholders like `{{SOURCE_REPO}}` are rendered by the Runner) |
 | `prompt_review` | no | `prompt_review.md` | Review prompt template for the independent post-PR review session |
 | `base_branch` | no | `main` | Delivery base branch; every task worktree is created from the frozen `origin/<base_branch>` SHA |
+| `active_milestone` | no | unset | Claim scope for the fresh-claim scans (Issue #139): the active GitHub Milestone title (e.g. `v0.2.0`). Set it to restrict the p0/bug/plain ready scans to that Milestone (the `milestone:"<title>"` qualifier is part of the gh search query — an Issue of another or no Milestone never enters the queue); `ai-ready` stays the execution switch, the pickup order is unchanged, P0 does not cross milestones, and resume states (opened PRs, in-flight restarts) are never gated by it. Unset = every `ai-ready` Issue is claimable (pre-#139 behavior) |
 | `max_concurrency` | no | `1` | Concurrent Pilot tasks on this machine (positive integer; a local model/GPU usually serves one stable task) |
 | `skills` | no | `[]` | Optional Pi skill paths (absolute, `~`, or relative to the config file) |
 | `context_files` | no | `[]` | Optional Markdown context files injected into the prompt as paths |
@@ -167,8 +168,10 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 
 One tick does at most one thing: resume an opened PR (review/fix/merge) or
 claim one `ai-ready` Issue (`p0`-labeled Issues are picked first, then
-bug-labeled Issues, then plain features), then it exits. With an empty
-ready queue it exits cleanly without claiming anything.
+bug-labeled Issues, then plain features; with `active_milestone` set,
+only Issues of that Milestone are claimable — Issue #139), then it
+exits. With an empty ready queue it exits cleanly without claiming
+anything.
 
 ## 6. Smoke walkthrough (from zero)
 

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -96,6 +96,7 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 | `prompt` | 否 | `prompt.md` | 实现者 prompt 模板（`{{SOURCE_REPO}}` 等占位符由 Runner 渲染） |
 | `prompt_review` | 否 | `prompt_review.md` | PR 后独立审查 session 的 review prompt 模板 |
 | `base_branch` | 否 | `main` | 交付 base 分支；每个任务 worktree 都从冻结的 `origin/<base_branch>` SHA 创建 |
+| `active_milestone` | 否 | 未设置 | 新领取扫描的领取范围（Issue #139）：当前活跃的 GitHub Milestone 标题（如 `v0.2.0`）。设置后 p0/bug/普通三个 ready 扫描只领取该 Milestone 的 Issue（`milestone:"<title>"` 限定词直接进 gh 搜索查询——其他 Milestone 或无 Milestone 的 Issue 永远进不了队列）；`ai-ready` 仍是执行开关，领取顺序（p0 → bug → 普通）不变，P0 不跨 Milestone，恢复态（已开 PR、在途重启）不受 Milestone 限制。未设置 = 所有 `ai-ready` Issue 都可领取（#139 之前的行为） |
 | `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数（正整数；本地模型/GPU 通常只稳定服务一个任务） |
 | `skills` | 否 | `[]` | 可选 Pi skill 路径（绝对、`~`，或相对配置文件） |
 | `context_files` | 否 | `[]` | 可选 Markdown 上下文文件，以路径形式注入 prompt |
@@ -146,7 +147,8 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 
 一个 tick 最多做一件事：恢复一个已打开的 PR（review/fix/merge），或
 领取一个 `ai-ready` Issue（带 `p0` 标签的 Issue 最先被领取，然后是
-`bug` 标签的，最后是普通 feature），然后退出。ready 队列为空时干净
+`bug` 标签的，最后是普通 feature；设置 `active_milestone` 后只领取该
+Milestone 的 Issue——Issue #139），然后退出。ready 队列为空时干净
 退出，不领取任何东西。
 
 ## 6. Smoke walkthrough（从零）

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -87,6 +87,55 @@ def test_load_config_rejects_empty_base_branch(tmp_path):
         runner.load_config(config_path)
 
 
+def test_load_config_defaults_active_milestone_to_none(tmp_path):
+    """Issue #139: without an active_milestone the config keeps the
+    current compat behavior (no milestone filter on the ready scans)."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    config = runner.load_config(config_path)
+    assert config["active_milestone"] is None
+
+
+def test_load_config_reads_explicit_active_milestone(tmp_path):
+    """Issue #139: the active Milestone is an explicit claim scope —
+    it is never guessed from the repo's Milestone list."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.2.0"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["active_milestone"] == "v0.2.0"
+
+
+def test_load_config_rejects_empty_active_milestone(tmp_path):
+    """Issue #139: an empty active_milestone is a misconfiguration —
+    fail fast instead of silently disabling the scope."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = ""\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="active_milestone must be a non-empty string",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_non_string_active_milestone(tmp_path):
+    """Issue #139: a non-string active_milestone is a misconfiguration —
+    fail fast."""
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = 1\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="active_milestone must be a non-empty string",
+    ):
+        runner.load_config(config_path)
+
+
 def test_load_config_parses_repositories_registry(tmp_path):
     """Issue #134: an explicit [[repositories]] section parses into a
     registry of name/path/github/base_branch, with each path resolved
@@ -783,6 +832,158 @@ def test_pick_issue_fails_open_when_blocked_by_query_fails(
     assert "blocked_by_check_failed" in caplog.text
 
 
+def test_pick_issue_scopes_all_three_ready_scans_to_active_milestone(
+    monkeypatch,
+):
+    """Issue #139: with `active_milestone = "v0.2.0"` the ready scans
+    only see the active Milestone: every one of the three gh searches
+    (p0, bug, plain) carries the `milestone:"v0.2.0"` qualifier (the
+    quoted form is the contract — milestone titles may contain spaces
+    or special characters; verified against the live API). A
+    `v0.1.2 + ai-ready` Issue therefore never enters the queue of a
+    `v0.2.0` Runner, and a `v0.2.0` Issue without `ai-ready` never
+    enters it either (the `label:ai-ready` qualifier stays)."""
+    issue = {
+        "number": 139, "title": "task", "body": "body",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        search = command[command.index("--search") + 1]
+        if "label:p0" in search or "label:bug" in search:
+            return json.dumps([])
+        return json.dumps([issue])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_issue(
+        "xqliu/muyan-ceo", active_milestone="v0.2.0",
+    ) == issue
+    scope = ' milestone:"v0.2.0"'
+    exclusions = (
+        "-label:ai-in-progress -label:ai-pr-opened -label:ai-fix-needed "
+        "-label:ai-merged -label:ai-blocked"
+    )
+    assert calls == [
+        [
+            "gh", "issue", "list", "--repo", "xqliu/muyan-ceo",
+            "--state", "open", "--search",
+            f"label:ai-ready label:p0{scope} {exclusions}",
+            "--json", "number,title,body,labels,blockedBy",
+            "--limit", "200",
+        ],
+        [
+            "gh", "issue", "list", "--repo", "xqliu/muyan-ceo",
+            "--state", "open", "--search",
+            f"label:ai-ready label:bug{scope} {exclusions}",
+            "--json", "number,title,body,labels,blockedBy",
+            "--limit", "200",
+        ],
+        [
+            "gh", "issue", "list", "--repo", "xqliu/muyan-ceo",
+            "--state", "open", "--search",
+            f"label:ai-ready{scope} {exclusions}",
+            "--json", "number,title,body,labels,blockedBy",
+            "--limit", "200",
+        ],
+    ]
+
+
+def test_pick_issue_p0_scan_keeps_the_milestone_scope():
+    """Issue #139 (explicit decision): P0 does NOT cross milestones.
+    The active milestone is the claim scope of every fresh claim —
+    `p0` only orders the pickup inside the active milestone, so a P0
+    sitting in an old milestone never enters the current version's
+    queue (one uniform rule, no special case). The scan order itself
+    is unchanged: the p0 scan is still the FIRST one."""
+    p0_search, bug_search, plain_search = runner.ready_searches("v0.2.0")
+    for search in (p0_search, bug_search, plain_search):
+        assert 'milestone:"v0.2.0"' in search
+    assert "label:p0" in p0_search
+    assert "label:p0" not in bug_search
+    assert "label:p0" not in plain_search
+
+
+def test_ready_searches_without_milestone_are_the_compat_scans():
+    """Issue #139 compat: without a configured Milestone the three
+    ready scans are byte-identical to the pre-#139 scans — a config
+    without `active_milestone` behaves exactly like before."""
+    p0_search, bug_search, plain_search = runner.ready_searches(None)
+    assert p0_search == (
+        "label:ai-ready label:p0 -label:ai-in-progress "
+        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+        "-label:ai-blocked"
+    )
+    assert bug_search == (
+        "label:ai-ready label:bug -label:ai-in-progress "
+        "-label:ai-pr-opened -label:ai-fix-needed -label:ai-merged "
+        "-label:ai-blocked"
+    )
+    assert plain_search == (
+        "label:ai-ready -label:ai-in-progress -label:ai-pr-opened "
+        "-label:ai-fix-needed -label:ai-merged -label:ai-blocked"
+    )
+    # The default (no argument) is the same compat behavior.
+    assert runner.ready_searches() == runner.ready_searches(None)
+
+
+def test_pick_issue_keeps_epic_and_blocked_by_guards_with_milestone(
+    monkeypatch, caplog,
+):
+    """Issue #139: the milestone scope never weakens the existing
+    guards — an `ai-epic` Issue is still skipped by the code layer
+    (the query results can still contain it), and an Issue with open
+    native blockers is still skipped, inside the active Milestone."""
+    epic = {
+        "number": 141, "title": "epic", "body": "body",
+        "labels": [{"name": "ai-ready"}, {"name": "ai-epic"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    blocked = {
+        "number": 142, "title": "blocked", "body": "body",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [{"number": 9}], "totalCount": 1},
+    }
+    ready = {
+        "number": 143, "title": "free", "body": "body",
+        "labels": [{"name": "ai-ready"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([epic, blocked, ready]),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue(
+            "xqliu/muyan-pilot", active_milestone="v0.2.0",
+        ) == ready
+    assert "epic_not_claimed" in caplog.text
+    assert "blocked_by" in caplog.text
+
+
+def test_pick_issue_fails_open_when_milestone_query_fails(
+    monkeypatch, caplog,
+):
+    """Issue #139: a failed ready scan with the milestone qualifier
+    follows the existing fail-open contract (Issue #54) — the tick
+    claims nothing (never the wrong version), logs the structured
+    error, and the next tick retries."""
+    error = subprocess.CalledProcessError(
+        1, ["gh"], output="boom", stderr="rate limited",
+    )
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(error),
+    )
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue(
+            "xqliu/muyan-pilot", active_milestone="v0.2.0",
+        ) is None
+    assert "blocked_by_check_failed" in caplog.text
+
+
 def test_pick_issue_prefers_bug_labeled_issues(monkeypatch):
     """Issue #71: when an `ai-ready`+`bug` Issue and a plain `ai-ready`
     Issue exist at the same time, the runner claims the bug first —
@@ -1425,7 +1626,7 @@ def test_pick_next_delivery_recovers_in_flight_issue_before_ready(
             in_flight if repo == "r1" else None
         ),
     )
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: ready)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: ready)
     assert runner.pick_next_delivery(
         ["r1", "r2"], tmp_path / "slots", 1,
     ) == ("r1", in_flight, None)
@@ -1449,7 +1650,7 @@ def test_pick_next_delivery_keeps_resumable_delivery_first(
         runner, "pick_in_progress_issue",
         lambda repo, slot_dir, max_concurrency: in_flight,
     )
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: in_flight)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: in_flight)
     assert runner.pick_next_delivery(
         ["r1", "r2"], tmp_path / "slots", 1,
     ) == ("r2", resumable, scene)
@@ -1467,7 +1668,7 @@ def test_pick_next_delivery_falls_through_to_ready_when_no_in_flight(
         runner, "pick_in_progress_issue",
         lambda repo, slot_dir, max_concurrency: None,
     )
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: ready)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: ready)
     assert runner.pick_next_delivery(
         ["r1"], tmp_path / "slots", 1,
     ) == ("r1", ready, None)
@@ -1484,7 +1685,7 @@ def test_pick_next_delivery_returns_none_when_all_scans_empty(
         runner, "pick_in_progress_issue",
         lambda repo, slot_dir, max_concurrency: None,
     )
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: None)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: None)
     assert runner.pick_next_delivery(
         ["r1"], tmp_path / "slots", 1,
     ) is None
@@ -1494,7 +1695,7 @@ def test_pick_next_issue_returns_first_ready_source(monkeypatch):
     issue = {"number": 1, "title": "pilot", "body": ""}
     calls = []
 
-    def pick(repo):
+    def pick(repo, active_milestone=None):
         calls.append(repo)
         return issue if repo == "xqliu/muyan-ceo" else None
 
@@ -1509,7 +1710,7 @@ def test_pick_next_issue_falls_through_to_second_source(monkeypatch):
     issue = {"number": 2, "title": "pilot", "body": ""}
     calls = []
 
-    def pick(repo):
+    def pick(repo, active_milestone=None):
         calls.append(repo)
         return issue if repo == "xqliu/muyan-pilot" else None
 
@@ -1521,7 +1722,7 @@ def test_pick_next_issue_falls_through_to_second_source(monkeypatch):
 
 
 def test_pick_next_issue_returns_none_when_all_sources_empty(monkeypatch):
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: None)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: None)
     assert runner.pick_next_issue(["xqliu/muyan-ceo", "xqliu/muyan-pilot"]) is None
 
 
@@ -3035,12 +3236,54 @@ def _write_prompts(tmp_path):
 def test_main_returns_zero_when_queue_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     _write_prompts(tmp_path)
     config = tmp_path / "muyan-pilot.toml"
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     assert runner.main(["--config", str(config)]) == 0
+
+
+def test_main_passes_configured_active_milestone_to_the_claim_scan(
+    monkeypatch, tmp_path,
+):
+    """Issue #139: the configured `active_milestone` reaches the claim
+    scan (the fresh-claim scope), and an unconfigured one passes None
+    (the compat behavior — no milestone filter)."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.2.0"\n',
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
+        seen["milestone"] = active_milestone
+        return None
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen["milestone"] == "v0.2.0"
+
+
+def test_main_passes_none_active_milestone_when_unconfigured(
+    monkeypatch, tmp_path,
+):
+    """Issue #139 compat: without the config field the claim scan
+    receives None and keeps the pre-#139 scans."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    seen = {}
+
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
+        seen["milestone"] = active_milestone
+        return None
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen["milestone"] is None
 
 
 def test_main_processes_one_issue(monkeypatch, tmp_path):
@@ -3052,7 +3295,7 @@ def test_main_processes_one_issue(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\nprompt = \"prompt.md\"\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "xqliu/muyan-pilot", issue, None
         ),
     )
@@ -3093,7 +3336,7 @@ def test_main_routes_fix_needed_resume_to_delivery_wait(
     }
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "owner/repo", issue, scene,
         ),
     )
@@ -3139,7 +3382,7 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
     }
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "owner/repo", issue, scene,
         ),
     )
@@ -3169,7 +3412,7 @@ def test_main_accepts_repeated_source_repo(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"xqliu/muyan-pilot\", \"xqliu/muyan-ceo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             seen.append(repos) or (repos[0], issue, None)
         ),
     )
@@ -4947,7 +5190,7 @@ def test_main_capacity_full_does_not_pick_issue_or_call_pi(
     held = pilot_slots.acquire_slot(slot_dir, 1, os.getpid())
     assert held is not None
 
-    def fail_if_called(repos, slot_dir, max_concurrency):
+    def fail_if_called(repos, slot_dir, max_concurrency, active_milestone=None):
         raise AssertionError("pick_next_delivery must not run when capacity is full")
 
     monkeypatch.setattr(runner, "pick_next_delivery", fail_if_called)
@@ -4978,7 +5221,7 @@ def test_main_holds_slot_while_processing_issue(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     seen = {}
 
-    def fake_pick(repos, slot_dir, max_concurrency):
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
         seen["occupancy"] = pilot_slots.slot_occupancy(
             tmp_path / ".muyan-pilot" / "slots", 1,
         )
@@ -5000,7 +5243,7 @@ def test_main_reacquires_slot_after_previous_release(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
 
     assert runner.main(["--config", str(config)]) == 0
@@ -5162,7 +5405,7 @@ def test_main_unit_drift_auto_syncs_and_proceeds_to_claim(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -5244,7 +5487,7 @@ def test_main_unit_drift_clean_proceeds_to_claim(monkeypatch, tmp_path,
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -5269,7 +5512,7 @@ def test_main_preflight_receives_the_configured_repo_dir(
     config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     assert runner.main(["--config", str(config)]) == 0
     assert seen == [tmp_path]
@@ -5348,7 +5591,7 @@ def test_main_transport_check_clean_proceeds_to_claim(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -5381,7 +5624,7 @@ def test_main_transport_preflight_receives_the_configured_args(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
     )
     assert runner.main(["--config", str(config)]) == 0
     assert seen["repo_dir"] == tmp_path
@@ -6636,7 +6879,7 @@ def test_main_holds_slot_through_delivery_wait(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "owner/repo", issue, None
         ),
     )

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -60,6 +60,8 @@ KNOWN_CONFIG_FIELDS = frozenset({
     "prompt",
     "prompt_review",
     "base_branch",
+    # Issue #139: the active Milestone claim scope (optional string).
+    "active_milestone",
     "max_concurrency",
     "skills",
     "context_files",

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -65,6 +65,8 @@ KNOWN_CONFIG_FIELDS = frozenset({
     "prompt",
     "prompt_review",
     "base_branch",
+    # Issue #139: the active Milestone claim scope (optional string).
+    "active_milestone",
     "max_concurrency",
     "skills",
     "context_files",

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -646,7 +646,7 @@ def test_pick_next_delivery_stops_when_scene_is_malformed(
     monkeypatch.setattr(runner, "pick_resumable_delivery", broken)
     monkeypatch.setattr(
         runner, "pick_issue",
-        lambda repo: calls.append(("ready", repo)) or {"number": 10},
+        lambda repo, active_milestone=None: calls.append(("ready", repo)) or {"number": 10},
     )
     with pytest.raises(ValueError, match="no 'Muyan Pilot opened PR' comment"):
         runner.pick_next_delivery(
@@ -671,7 +671,7 @@ def test_pick_next_delivery_prefers_resumable_delivery_over_ready(
     )
     monkeypatch.setattr(
         runner, "pick_issue",
-        lambda repo: calls.append(("ready", repo)) or ready,
+        lambda repo, active_milestone=None: calls.append(("ready", repo)) or ready,
     )
     result = runner.pick_next_delivery(
         ["owner/repo"], tmp_path / "slots", 1,
@@ -699,7 +699,7 @@ def test_pick_next_delivery_falls_back_to_ready_when_no_resumable(
     )
     monkeypatch.setattr(
         runner, "pick_issue",
-        lambda repo: calls.append(("ready", repo)) or ready,
+        lambda repo, active_milestone=None: calls.append(("ready", repo)) or ready,
     )
     result = runner.pick_next_delivery(
         ["owner/repo"], tmp_path / "slots", 1,
@@ -726,7 +726,7 @@ def test_pick_next_delivery_scans_sources_in_order(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         runner, "pick_issue",
-        lambda repo: calls.append(("ready", repo)) or ready,
+        lambda repo, active_milestone=None: calls.append(("ready", repo)) or ready,
     )
     result = runner.pick_next_delivery(
         ["owner/first", "owner/second"], tmp_path / "slots", 1,
@@ -748,7 +748,7 @@ def test_pick_next_delivery_returns_none_when_nothing_to_do(
         runner, "pick_in_progress_issue",
         lambda repo, slot_dir, max_concurrency: None,
     )
-    monkeypatch.setattr(runner, "pick_issue", lambda repo: None)
+    monkeypatch.setattr(runner, "pick_issue", lambda repo, active_milestone=None: None)
     assert runner.pick_next_delivery(
         ["owner/repo"], tmp_path / "slots", 1,
     ) is None
@@ -812,7 +812,7 @@ def test_main_resumes_resumable_delivery_before_claiming_new(monkeypatch, tmp_pa
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "owner/repo", issue, scene
         ),
     )
@@ -853,7 +853,7 @@ def test_main_still_claims_new_issue_when_no_resumable(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
             "owner/repo", issue, None
         ),
     )


### PR DESCRIPTION
Fixes #139

<!-- muyan-pilot:run=cc746c35 -->
run_id=cc746c35

## What changed

The Runner now claims `ai-ready` Issues only from the configured active
GitHub Milestone — an explicit version scope, never a guessed one.

- New optional config field `active_milestone` (a Milestone TITLE, e.g.
  `v0.2.0`), parsed and validated in `load_config`: absent → `None`
  (pre-#139 behavior, byte-identical scans — compat); present → must be a
  non-empty string, otherwise the start fails fast.
- New `ready_searches(active_milestone)` builds the three ready scans
  (p0, bug, plain) in pickup order. With a configured Milestone every
  scan carries the `milestone:"<title>"` qualifier in the gh search query
  (the quoted form — milestone titles may contain spaces/special
  characters), so an Issue of another Milestone or of no Milestone never
  enters the queue, and a Milestone Issue without `ai-ready` never does
  either: `ai-ready` stays the execution switch, the Milestone is only
  the version scope.
- `pick_issue` / `pick_next_issue` / `pick_next_delivery` / `main` thread
  the scope through. The scope is query-layer only: the `is_epic`
  code-layer skip and the blockedBy skip are the unchanged second layer,
  and a failed scan still fails open (never a silent claim of the wrong
  version).
- Explicit decision: **P0 does NOT cross milestones** — the active
  Milestone is the claim scope of every fresh claim; `p0` only orders
  the pickup inside it (one uniform rule, no special case).
- Explicit decision: **resume states are never gated** — the opened-PR
  resume scan and the in-flight restart scan run work to completion
  regardless of Milestone changes.

## Files

- `bootstrap_runner.py` — config field, `ready_searches`, scoped scans,
  wiring through `main`
- `tests/test_bootstrap_runner.py` — config parse/validation, the exact
  scoped gh queries (all three scans), P0 scan order + scope, compat
  scans, fail-open scan failure, `pick_next_issue`/`pick_next_delivery`
  wiring, `main` passing the config value
- `tests/test_resume_pr.py` — mock signatures for the new parameters
- `.muyan-pilot.example.toml`, `docs/getting-started.mdx`,
  `docs/zh/getting-started.mdx`, `tests/test_docs_site.py`,
  `tests/test_docs_i18n.py`, `AGENTS.md`, `README.md` — the config
  contract and the claim-scope rule

## Verification

- Full suite: 1011 + 12 = 1023 passed, 100% line and branch coverage
  (see `test.log` in the task worktree).
- Live contract (read-only gh calls against the real repo): the exact
  scoped query shapes are accepted by the API — `milestone:"v0.2.0"`
  returns the 4 open `ai-ready` v0.2.0 Issues (157, 119, 98, 48), the
  p0-scoped variant returns `[]` (no p0+ai-ready in v0.2.0 now), and
  `milestone:"v0.3.0"` returns a different (empty) queue — v0.2.0 Issues
  never leak across the scope.
- Base advanced twice while working (PRs #165, #166); both merged into
  the task branch with no conflicts and the full suite rerun green.