### PR TITLE
Support configurable Pi provider file with baseUrl for OpenAI-compatible endpoints (Issue #157)

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -32,6 +32,16 @@ max_concurrency = 1
 # pi_provider = "openai"
 # pi_model = "gpt-5.6-sol"
 # pi_thinking = "medium"
+# Optional provider file (Issue #157): path to a JSON file in Pi's
+# models.json shape (providers with baseUrl / api / apiKey / models).
+# The file is the ONLY place a provider endpoint (baseUrl) may be
+# configured; the TOML only selects the runtime provider/model above.
+# `apiKey` is an env-var reference like "$GROQ_API_KEY" — never a key
+# value. The Runner validates the file at startup (fail fast on a
+# missing baseUrl, a selected provider/model that does not exist, or a
+# missing env var for the selected provider's key) and passes the
+# catalog to Pi through a per-run agent dir (PI_CODING_AGENT_DIR).
+# pi_providers = ".muyan-pilot/pi-providers.json"
 
 # Optional Pi skills. Paths may be absolute, use ~, or be relative to this file.
 skills = []

--- a/README.md
+++ b/README.md
@@ -373,6 +373,36 @@ pi_thinking = "medium"
 - 键存在但为空字符串或非字符串时 `load_config` fail fast（`<key> must be a non-empty string`）；Pi 启动失败沿用现有 fail-fast 契约（非零退出/超时 → `run_failed` + 异常）；
 - 不按任务类型、label 或角色自动选择模型，不做动态路由、benchmark、成本路由或 fallback，不支持一个 run 中途切换模型；token/密钥不进入配置、日志、Issue 或 PR。
 
+## 可配置 Pi provider（pi_providers，Issue #157）
+
+`pi_provider`/`pi_model` 只能选择 Pi 已认识的 provider。要接入任意 OpenAI-compatible 端点（如 Groq），在 `muyan-pilot.toml` 中可选声明一个 provider 文件（路径，JSON，与 Pi 的 `~/.pi/agent/models.json` 同构）：
+
+```toml
+pi_providers = ".muyan-pilot/pi-providers.json"
+pi_provider = "groq"
+pi_model = "qwen/qwen3.8-27b"
+```
+
+```json
+{
+  "providers": {
+    "groq": {
+      "baseUrl": "https://api.groq.com/openai/v1",
+      "api": "openai-completions",
+      "apiKey": "$GROQ_API_KEY",
+      "models": [{ "id": "qwen/qwen3.8-27b" }]
+    }
+  }
+}
+```
+
+- `baseUrl`（provider 端点）只允许出现在这个 provider 文件里；`muyan-pilot.toml` 只选择运行时 provider/model/thinking，不携带端点；
+- `apiKey` 是环境变量引用（`$VAR` 或 `${VAR}`，Pi 的 value 语法），绝不写密钥值；密钥只存在于进程环境（如 systemd `Environment=`）；
+- Runner 在启动 Pi 前把文件物化到任务 worktree 的 `.muyan-pilot/pi-agent/`（gitignored，每 run 一份）：`models.json` = 用户 `~/.pi/agent/models.json` 的 providers 与文件的 providers 合并（同 id 时文件优先，用户已有 provider 继续可用），`settings.json`/`auth.json` 以符号链接指向用户目录（其余行为不变），并通过 `PI_CODING_AGENT_DIR` 指向该目录（已对真实 Pi 0.84.3 验证）——implement 与 review 的 Pi 走同一条路径、同一份 provider 配置；
+- `load_config` fail fast：文件不存在/不是合法 JSON/没有 `providers` 对象；带 `models` 的 provider 缺 `baseUrl` 或 `api`（provider 级或每个 model 级）；`pi_provider` 未在文件中定义；`pi_model` 不在该 provider 的 models 里（Pi 对未知 model id 只告警仍发请求，不存在 fail fast，所以由 Runner 在启动前校验）；选中 provider 的 `apiKey` 引用的环境变量缺失或为空（只报告变量名，不报告值）；
+- 未配置 `pi_providers` 时行为与 #157 之前完全一致（不物化目录、不设置 `PI_CODING_AGENT_DIR`、Pi 命令与环境不变）；
+- 日志/Issue/PR 只出现 provider、model、thinking 等非敏感标识；`baseUrl` 与 API key 不进入 journal（redacted `command=` 行只含 `--provider/--model/--thinking`）、不进入 Issue/PR 评论。
+
 ## 全链路 run_id（correlation ID）
 
 每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -228,6 +228,20 @@ def load_config(path: Path) -> dict:
     pi_provider = _optional_pi_string(data, "pi_provider")
     pi_model = _optional_pi_string(data, "pi_model")
     pi_thinking = _optional_pi_string(data, "pi_thinking")
+    # Optional Pi provider file (Issue #157): the provider metadata
+    # (baseUrl / api / apiKey / models) lives in a separate JSON file in
+    # Pi's own `models.json` shape; `muyan-pilot.toml` only selects the
+    # provider/model/thinking used at runtime. Absent key -> None (Pi
+    # keeps using its own agent dir, the exact pre-#157 behavior).
+    pi_providers = _optional_pi_string(data, "pi_providers")
+    pi_providers_path = (
+        _config_path(pi_providers, base) if pi_providers is not None
+        else None
+    )
+    pi_providers_data = (
+        _load_pi_providers(pi_providers_path, pi_provider, pi_model)
+        if pi_providers_path is not None else None
+    )
     repo_dir = _config_path(data.get("repo_dir", "."), base)
     return {
         "source_repos": source_repos,
@@ -247,6 +261,8 @@ def load_config(path: Path) -> dict:
         "pi_provider": pi_provider,
         "pi_model": pi_model,
         "pi_thinking": pi_thinking,
+        "pi_providers": pi_providers_path,
+        "pi_providers_data": pi_providers_data,
         # Multi-repo registry (Issue #134): the explicit per-repo entries
         # (name, path, github, base_branch). Absent section -> [] so the
         # single-repo config keeps its exact shape and flow.
@@ -267,6 +283,180 @@ def _optional_pi_string(data: dict, key: str) -> str | None:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{key} must be a non-empty string")
     return value
+
+
+def _load_pi_providers(path: Path, pi_provider: str | None,
+                       pi_model: str | None) -> dict:
+    """Load and validate the Pi provider file (Issue #157).
+
+    The file uses Pi's own `models.json` shape (`{"providers": {id:
+    {baseUrl, api, apiKey, models: [...]}}}`) — verified against the
+    installed Pi 0.84.3 docs (`docs/models.md`). Fail fast with a
+    specific message: file missing, invalid JSON, missing `providers`
+    object, a provider entry with `models` but no `baseUrl` or no
+    `api` (provider- or model-level — Pi's own schema requirement),
+    the selected provider/model not defined in the file, or an
+    `apiKey` env-var reference (`$VAR` / `${VAR}`) whose variable is
+    missing or empty. The key value itself is never logged; only the
+    variable name is named in the error.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"pi_providers file {path} is not valid JSON: {exc}"
+        ) from None
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"pi_providers file {path} must have a 'providers' object"
+        )
+    providers = data.get("providers")
+    if not isinstance(providers, dict) or not providers:
+        raise ValueError(
+            f"pi_providers file {path} must have a 'providers' object"
+        )
+    for provider_id, entry in providers.items():
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"pi_providers file {path}: provider {provider_id!r} "
+                "must be an object"
+            )
+        models = entry.get("models")
+        if models is not None:
+            if not isinstance(models, list) or not models:
+                raise ValueError(
+                    f"pi_providers file {path}: provider {provider_id!r} "
+                    "models must be a non-empty list"
+                )
+            if not isinstance(entry.get("baseUrl"), str) or not entry["baseUrl"]:
+                raise ValueError(
+                    f"pi_providers file {path}: provider {provider_id!r} "
+                    "is missing baseUrl"
+                )
+            if not isinstance(entry.get("api"), str) or not entry["api"]:
+                if not all(
+                    isinstance(model, dict)
+                    and isinstance(model.get("api"), str)
+                    and model["api"]
+                    for model in models
+                ):
+                    raise ValueError(
+                        f"pi_providers file {path}: provider "
+                        f"{provider_id!r} is missing api"
+                    )
+            for model in models:
+                if not isinstance(model, dict) or not model.get("id"):
+                    raise ValueError(
+                        f"pi_providers file {path}: provider "
+                        f"{provider_id!r} has a model without an id"
+                    )
+    if pi_provider is not None:
+        if pi_provider not in providers:
+            raise ValueError(
+                f"pi_provider {pi_provider!r} is not defined in "
+                f"pi_providers file {path}"
+            )
+        entry = providers[pi_provider]
+        # Only the SELECTED provider's key must resolve: an unselected
+        # provider with a missing key just stays unavailable in Pi
+        # (verified against real Pi 0.84.3), it never breaks the run.
+        _check_pi_provider_api_key(path, pi_provider, entry)
+        if pi_model is not None:
+            model_ids = [
+                model["id"] for model in entry.get("models", [])
+            ] if isinstance(entry.get("models"), list) else []
+            if pi_model not in model_ids:
+                raise ValueError(
+                    f"pi_model {pi_model!r} is not defined for provider "
+                    f"{pi_provider!r} in pi_providers file {path}"
+                )
+    return data
+
+
+def _check_pi_provider_api_key(path: Path, provider_id: str,
+                               entry: dict) -> None:
+    """Fail fast when an `apiKey` env-var reference is unresolved.
+
+    Pi's value-resolution syntax (`docs/models.md`): `$VAR` or
+    `${VAR}` interpolates the named environment variable; a missing
+    variable leaves the value unresolved and Pi would only fail at
+    request time. The Runner fails at config load instead (before any
+    slot or claim). Only the variable NAME is reported — never a key
+    value.
+    """
+    api_key = entry.get("apiKey")
+    if not isinstance(api_key, str) or not api_key:
+        return
+    for match in re.finditer(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)", api_key):
+        name = match.group(1) or match.group(2)
+        value = os.environ.get(name)
+        if not value:
+            raise ValueError(
+                f"API key for provider {provider_id!r} references "
+                f"missing environment variable {name} "
+                f"(pi_providers file {path})"
+            )
+
+
+def prepare_pi_agent_dir(worktree: Path, config: dict) -> Path | None:
+    """Materialize the per-run Pi agent dir (Issue #157).
+
+    Returns None when no provider file is configured — the Pi command
+    and environment keep their exact pre-#157 shape (Pi uses its own
+    agent dir). Otherwise creates `<worktree>/.muyan-pilot/pi-agent/`
+    (gitignored, per-run) and returns it:
+
+    - `models.json`: the user agent dir's providers merged with the
+      configured file's providers (the file wins on id collision) —
+      the user's existing providers keep working, the file adds or
+      overrides; the merged catalog is what Pi loads via
+      `PI_CODING_AGENT_DIR` (verified against real Pi 0.84.3);
+    - `settings.json` / `auth.json`: SYMLINKS to the user agent dir's
+      files when they exist, so Pi's other behavior (settings, stored
+      auth) is unchanged apart from the provider catalog.
+
+    The dir holds no secrets: the API key stays an env-var reference in
+    the file and never a materialized value.
+    """
+    providers_data = config.get("pi_providers_data")
+    if providers_data is None:
+        return None
+    agent_dir = worktree / ".muyan-pilot" / "pi-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    user_agent = Path(os.path.expanduser("~")) / ".pi" / "agent"
+    merged_providers: dict = {}
+    user_models = user_agent / "models.json"
+    if user_models.is_file():
+        try:
+            user_data = json.loads(user_models.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"user agent dir models.json {user_models} is not valid "
+                f"JSON: {exc}"
+            ) from None
+        user_providers = user_data.get("providers") if isinstance(
+            user_data, dict
+        ) else None
+        if not isinstance(user_providers, dict):
+            user_providers = {}
+        merged_providers.update(user_providers)
+    merged_providers.update(providers_data["providers"])
+    (agent_dir / "models.json").write_text(
+        json.dumps({"providers": merged_providers}, indent=2),
+        encoding="utf-8",
+    )
+    # Idempotent for a resumed run in the same worktree: a stale
+    # symlink from an earlier attempt is replaced, never kept.
+    for name in ("settings.json", "auth.json"):
+        source = user_agent / name
+        link = agent_dir / name
+        if link.is_symlink():
+            link.unlink()
+        if source.is_file():
+            link.symlink_to(source)
+    return agent_dir
 
 
 def _pi_model_args(config: dict) -> list[str]:
@@ -1068,6 +1258,7 @@ def stream_pi(
     role: str = ROLE_IMPLEMENT,
     log_command: list[str] | None = None,
     progress: Callable[[dict], None] | None = None,
+    pi_env: dict[str, str] | None = None,
 ) -> str:
     """Run Pi and stream concise live activity into the journal (Issue #40).
 
@@ -1137,8 +1328,13 @@ def stream_pi(
     # are only emitted when the visible fields actually change.
     initial = watcher.poll()
     last_visible = (initial["phase"], initial["action"], initial["result"])
+    # Issue #157: `pi_env` carries the per-run Pi agent dir
+    # (`PI_CODING_AGENT_DIR`, verified against real Pi 0.84.3) so the
+    # configured provider file is visible to Pi. Absent -> the process
+    # inherits the Runner's environment unchanged (pre-#157 shape).
     process = subprocess.Popen(
         command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=None if pi_env is None else {**os.environ, **pi_env},
     )
     LOGGER.info(
         "run_start %s",
@@ -1488,6 +1684,15 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         "--print", "--session-dir",
         str(worktree / ".pi-session"), "--system-prompt", system_prompt, context,
     ]
+    # Issue #157: the provider file (baseUrl / api / apiKey / models)
+    # reaches Pi through the materialized per-run agent dir, never
+    # through the command line or the log (the redacted command keeps
+    # only the #119 provider/model/thinking identifiers). Unconfigured
+    # -> the stream_pi call keeps its exact pre-#157 shape.
+    agent_dir = prepare_pi_agent_dir(worktree, config)
+    extra = {}
+    if agent_dir is not None:
+        extra["pi_env"] = {"PI_CODING_AGENT_DIR": str(agent_dir)}
     return stream_pi(
         command,
         cwd=worktree,
@@ -1502,6 +1707,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         source_repo=source_repo,
         branch=branch,
         progress=progress,
+        **extra,
     )
 
 
@@ -1916,6 +2122,12 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
         str(worktree / ".pi-session"), "--system-prompt", system_prompt,
         context,
     ]
+    # Issue #157: the review session uses the SAME provider config as
+    # the implementer (one materialized dir per worktree, re-used).
+    agent_dir = prepare_pi_agent_dir(worktree, config)
+    extra = {}
+    if agent_dir is not None:
+        extra["pi_env"] = {"PI_CODING_AGENT_DIR": str(agent_dir)}
     return stream_pi(
         command,
         cwd=worktree,
@@ -1931,6 +2143,7 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
         branch=branch,
         role=ROLE_REVIEW,
         progress=progress,
+        **extra,
     )
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -6878,3 +6878,659 @@ def test_run_review_omits_model_args_when_not_configured(monkeypatch, tmp_path):
         "pi", "--print", "--session-dir", str(tmp_path / ".pi-session"),
         "--system-prompt", "<redacted>", "<review-context-redacted>",
     ]
+
+
+# --- configurable Pi provider file (Issue #157) ----------------------------
+
+
+GROQ_PROVIDERS = {
+    "providers": {
+        "groq": {
+            "baseUrl": "https://api.groq.com/openai/v1",
+            "api": "openai-completions",
+            "apiKey": "$GROQ_API_KEY",
+            "models": [
+                {
+                    "id": "qwen/qwen3.8-27b",
+                    "contextWindow": 131072,
+                    "maxTokens": 16384,
+                }
+            ],
+        }
+    }
+}
+
+
+def _providers_config(tmp_path, providers, **toml_keys):
+    """Write a provider file + TOML, return the config path."""
+    providers_path = tmp_path / "pi-providers.json"
+    providers_path.write_text(
+        json.dumps(providers), encoding="utf-8",
+    )
+    keys = {"pi_providers": '"pi-providers.json"'}
+    keys.update(toml_keys)
+    toml = 'source_repos = ["owner/repo"]\n' + "\n".join(
+        f"{key} = {value}" for key, value in keys.items()
+    ) + "\n"
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(toml, encoding="utf-8")
+    return config_path
+
+
+def test_load_config_pi_providers_absent_defaults_to_none(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    config = runner.load_config(config_path)
+    assert config["pi_providers"] is None
+    assert config["pi_providers_data"] is None
+
+
+@pytest.mark.parametrize("value", ['""', "123", "true"])
+def test_load_config_pi_providers_rejects_non_string(tmp_path, value):
+    config_path = _providers_config(tmp_path, GROQ_PROVIDERS)
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\n'
+        f'pi_providers = {value}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="pi_providers must be a non-empty string"):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_file_missing(tmp_path):
+    config_path = _providers_config(tmp_path, GROQ_PROVIDERS)
+    (tmp_path / "pi-providers.json").unlink()
+    with pytest.raises(FileNotFoundError):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_invalid_json(tmp_path):
+    config_path = _providers_config(tmp_path, GROQ_PROVIDERS)
+    (tmp_path / "pi-providers.json").write_text("{nope", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        runner.load_config(config_path)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"nope": {}},
+        {"providers": []},
+        {"providers": "x"},
+    ],
+)
+def test_load_config_pi_providers_rejects_missing_providers_object(
+    tmp_path, data,
+):
+    config_path = _providers_config(tmp_path, data)
+    with pytest.raises(
+        ValueError, match="must have a 'providers' object",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_non_object_entry(tmp_path):
+    config_path = _providers_config(
+        tmp_path, {"providers": {"groq": "nope"}},
+    )
+    with pytest.raises(
+        ValueError, match="provider 'groq' must be an object",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_missing_base_url(tmp_path):
+    providers = {"providers": {"groq": {
+        "api": "openai-completions",
+        "apiKey": "local",
+        "models": [{"id": "m1"}],
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    with pytest.raises(
+        ValueError, match="provider 'groq' is missing baseUrl",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_missing_api(tmp_path):
+    providers = {"providers": {"groq": {
+        "baseUrl": "https://api.groq.com/openai/v1",
+        "apiKey": "local",
+        "models": [{"id": "m1"}],
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    with pytest.raises(
+        ValueError, match="provider 'groq' is missing api",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_accepts_model_level_api(tmp_path):
+    providers = {"providers": {"groq": {
+        "baseUrl": "https://api.groq.com/openai/v1",
+        "apiKey": "local",
+        "models": [
+            {"id": "m1", "api": "openai-completions"},
+        ],
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == providers
+
+
+def test_load_config_pi_providers_rejects_unknown_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"other"',
+    )
+    with pytest.raises(
+        ValueError, match="pi_provider 'other' is not defined",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_unknown_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS,
+        pi_provider='"groq"', pi_model='"missing/model"',
+    )
+    with pytest.raises(
+        ValueError,
+        match="pi_model 'missing/model' is not defined for provider 'groq'",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_missing_api_key_env(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS,
+        pi_provider='"groq"', pi_model='"qwen/qwen3.8-27b"',
+    )
+    with pytest.raises(
+        ValueError,
+        match="API key for provider 'groq' references missing "
+              "environment variable GROQ_API_KEY",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_empty_api_key_env(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("GROQ_API_KEY", "")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS,
+        pi_provider='"groq"', pi_model='"qwen/qwen3.8-27b"',
+    )
+    with pytest.raises(
+        ValueError,
+        match="API key for provider 'groq' references missing "
+              "environment variable GROQ_API_KEY",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_accepts_groq_example(tmp_path, monkeypatch):
+    """The Issue's Groq example parses verbatim with the key present."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS,
+        pi_provider='"groq"', pi_model='"qwen/qwen3.8-27b"',
+        pi_thinking='"medium"',
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_provider"] == "groq"
+    assert config["pi_model"] == "qwen/qwen3.8-27b"
+    assert config["pi_providers_data"] == GROQ_PROVIDERS
+    assert config["pi_providers"].name == "pi-providers.json"
+
+
+def test_load_config_pi_providers_unselected_provider_missing_key_ok(
+    tmp_path, monkeypatch,
+):
+    """Only the selected provider's key must resolve: an unselected
+    provider with a missing key stays unavailable in Pi, it never
+    breaks the start."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    providers = {
+        "providers": {
+            "groq": GROQ_PROVIDERS["providers"]["groq"],
+            "local": {
+                "baseUrl": "http://127.0.0.1:18082/v1",
+                "api": "openai-completions",
+                "apiKey": "local",
+                "models": [{"id": "Qwen3.8-27B"}],
+            },
+        }
+    }
+    config_path = _providers_config(
+        tmp_path, providers,
+        pi_provider='"local"', pi_model='"Qwen3.8-27B"',
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == providers
+
+
+# --- provider dir materialization + Pi env (Issue #157) --------------------
+
+
+def _user_agent_dir(home: Path, models=None, settings=True, auth=True) -> Path:
+    """Create a fake ~/.pi/agent under `home`."""
+    agent = home / ".pi" / "agent"
+    agent.mkdir(parents=True, exist_ok=True)
+    if models is not None:
+        (agent / "models.json").write_text(
+            json.dumps(models), encoding="utf-8",
+        )
+    if settings:
+        (agent / "settings.json").write_text("{}", encoding="utf-8")
+    if auth:
+        (agent / "auth.json").write_text("{}", encoding="utf-8")
+    return agent
+
+
+def test_prepare_pi_agent_dir_none_when_not_configured(tmp_path):
+    config = _model_config(tmp_path)
+    assert config.get("pi_providers_data") is None
+    assert runner.prepare_pi_agent_dir(tmp_path, config) is None
+    assert not (tmp_path / ".muyan-pilot" / "pi-agent").exists()
+
+
+def test_prepare_pi_agent_dir_materializes_merged_models_json(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(
+        home,
+        models={"providers": {"userprov": {
+            "baseUrl": "http://user:1/v1",
+            "api": "openai-completions",
+            "apiKey": "u",
+            "models": [{"id": "um"}],
+        }}},
+        auth=False,
+    )
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    assert agent_dir == tmp_path / ".muyan-pilot" / "pi-agent"
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    # The user's providers stay available; the repo file adds its own.
+    assert set(merged["providers"]) == {"userprov", "groq"}
+    assert merged["providers"]["groq"]["baseUrl"] == (
+        "https://api.groq.com/openai/v1"
+    )
+    # settings.json is a symlink to the user's file (behavior unchanged);
+    # auth.json is absent in the user dir, so no symlink.
+    settings_link = agent_dir / "settings.json"
+    assert settings_link.is_symlink()
+    assert settings_link.resolve() == user_agent / "settings.json"
+    assert not (agent_dir / "auth.json").exists()
+
+
+def test_prepare_pi_agent_dir_repo_providers_win_on_collision(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(
+        home,
+        models={"providers": {"groq": {
+            "baseUrl": "http://stale:1/v1",
+            "api": "openai-completions",
+            "apiKey": "u",
+            "models": [{"id": "old"}],
+        }}},
+    )
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    # The repo file is the source of truth for the providers it names.
+    assert merged["providers"]["groq"]["baseUrl"] == (
+        "https://api.groq.com/openai/v1"
+    )
+    assert [m["id"] for m in merged["providers"]["groq"]["models"]] == (
+        ["qwen/qwen3.8-27b"]
+    )
+
+
+def test_prepare_pi_agent_dir_symlinks_auth_and_settings(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(home)
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    for name in ("settings.json", "auth.json"):
+        link = agent_dir / name
+        assert link.is_symlink()
+        assert link.resolve() == user_agent / name
+
+
+def test_prepare_pi_agent_dir_user_dir_missing(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    assert set(merged["providers"]) == {"groq"}
+    assert not (agent_dir / "settings.json").exists()
+    assert not (agent_dir / "auth.json").exists()
+
+
+def test_prepare_pi_agent_dir_user_models_json_invalid_fails_fast(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(home, models=None)
+    (user_agent / "models.json").write_text("{nope", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    with pytest.raises(ValueError, match="not valid JSON"):
+        runner.prepare_pi_agent_dir(tmp_path, config)
+
+
+def test_stream_pi_sets_pi_env_on_the_process(tmp_path):
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    script = (
+        "import os, sys\n"
+        "sys.stdout.write(os.environ.get('PI_CODING_AGENT_DIR', ''))\n"
+    )
+    result = runner.stream_pi(
+        [sys.executable, "-c", script],
+        cwd=tmp_path, poll_interval=0.1,
+        run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+        branch="b", pi_env={"PI_CODING_AGENT_DIR": "/agent-dir"},
+    )
+    assert result == "/agent-dir"
+
+
+def test_stream_pi_without_pi_env_keeps_inherited_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MUYAN_TEST_ENV_MARKER", "inherited")
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir()
+    script = (
+        "import os, sys\n"
+        "sys.stdout.write(os.environ.get('MUYAN_TEST_ENV_MARKER', ''))\n"
+    )
+    result = runner.stream_pi(
+        [sys.executable, "-c", script],
+        cwd=tmp_path, poll_interval=0.1,
+        run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+        branch="b",
+    )
+    assert result == "inherited"
+
+
+def test_run_pi_materializes_provider_dir_and_env(monkeypatch, tmp_path):
+    """The implementer session gets the materialized dir via env."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    home = tmp_path / "home"
+    _user_agent_dir(home, auth=False, settings=False)
+    monkeypatch.setenv("HOME", str(home))
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(kwargs) or "done",
+    )
+    config = _model_config(
+        tmp_path, pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+        pi_providers_data=GROQ_PROVIDERS,
+    )
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    kwargs = calls[0]
+    agent_dir = tmp_path / ".muyan-pilot" / "pi-agent"
+    assert kwargs["pi_env"] == {"PI_CODING_AGENT_DIR": str(agent_dir)}
+    assert (agent_dir / "models.json").is_file()
+    # The redacted command is unchanged: no baseUrl, no apiKey, no dir.
+    assert "https://api.groq.com/openai/v1" not in " ".join(
+        kwargs["log_command"]
+    )
+    assert "PI_CODING_AGENT_DIR" not in " ".join(kwargs["log_command"])
+
+
+def test_run_pi_without_providers_keeps_pre_157_env(monkeypatch, tmp_path):
+    """No provider file: no materialization, no pi_env (pre-#157)."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(kwargs) or "done",
+    )
+    config = _model_config(tmp_path)
+    runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    kwargs = calls[0]
+    assert "pi_env" not in kwargs
+    assert not (tmp_path / ".muyan-pilot" / "pi-agent").exists()
+
+
+def test_run_review_materializes_provider_dir_and_env(monkeypatch, tmp_path):
+    """The review session uses the SAME provider config (Issue #157)."""
+    (tmp_path / "prompt_review.md").write_text("REVIEW", encoding="utf-8")
+    home = tmp_path / "home"
+    _user_agent_dir(home, auth=False, settings=False)
+    monkeypatch.setenv("HOME", str(home))
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(kwargs) or "ok",
+    )
+    config = _model_config(
+        tmp_path, pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+        pi_providers_data=GROQ_PROVIDERS,
+    )
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        config, "owner/repo", 4, "branch", 1,
+    )
+    kwargs = calls[0]
+    agent_dir = tmp_path / ".muyan-pilot" / "pi-agent"
+    assert kwargs["pi_env"] == {"PI_CODING_AGENT_DIR": str(agent_dir)}
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    assert merged["providers"]["groq"]["baseUrl"] == (
+        "https://api.groq.com/openai/v1"
+    )
+
+
+def test_load_config_pi_providers_rejects_top_level_list(tmp_path):
+    config_path = _providers_config(tmp_path, GROQ_PROVIDERS)
+    (tmp_path / "pi-providers.json").write_text("[1, 2]", encoding="utf-8")
+    with pytest.raises(
+        ValueError, match="must have a 'providers' object",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_accepts_entry_without_models(tmp_path):
+    """An override-only entry (no models, e.g. routing a built-in
+    provider through a proxy) is valid — Pi's own schema allows it."""
+    providers = {"providers": {"anthropic": {
+        "baseUrl": "https://proxy.example.com/v1",
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == providers
+
+
+def test_load_config_pi_providers_rejects_empty_models_list(tmp_path):
+    providers = {"providers": {"groq": {
+        "baseUrl": "https://api.groq.com/openai/v1",
+        "api": "openai-completions",
+        "models": [],
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    with pytest.raises(
+        ValueError, match="models must be a non-empty list",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_rejects_model_without_id(tmp_path):
+    providers = {"providers": {"groq": {
+        "baseUrl": "https://api.groq.com/openai/v1",
+        "api": "openai-completions",
+        "models": [{"contextWindow": 131072}],
+    }}}
+    config_path = _providers_config(tmp_path, providers)
+    with pytest.raises(
+        ValueError, match="has a model without an id",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_pi_providers_provider_without_model_ok(
+    tmp_path, monkeypatch,
+):
+    """pi_provider set, pi_model unset: the model check is skipped
+    (Pi resolves its own default model for the provider)."""
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_model"] is None
+
+
+def test_load_config_pi_providers_provider_without_api_key_ok(
+    tmp_path, monkeypatch,
+):
+    """A selected provider without apiKey (auth via auth.json /
+    --api-key) is valid — nothing to resolve."""
+    providers = {"providers": {"local": {
+        "baseUrl": "http://127.0.0.1:18082/v1",
+        "api": "openai-completions",
+        "models": [{"id": "Qwen3.8-27B"}],
+    }}}
+    config_path = _providers_config(
+        tmp_path, providers, pi_provider='"local"',
+        pi_model='"Qwen3.8-27B"',
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == providers
+
+
+def test_load_config_pi_providers_braced_env_reference(tmp_path, monkeypatch):
+    """`${VAR}` is the braced env-var form of Pi's value syntax."""
+    providers = {"providers": {"groq": {
+        "baseUrl": "https://api.groq.com/openai/v1",
+        "api": "openai-completions",
+        "apiKey": "${GROQ_API_KEY}",
+        "models": [{"id": "qwen/qwen3.8-27b"}],
+    }}}
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    config_path = _providers_config(
+        tmp_path, providers, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"',
+    )
+    with pytest.raises(
+        ValueError, match="missing environment variable GROQ_API_KEY",
+    ):
+        runner.load_config(config_path)
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == providers
+
+
+def test_prepare_pi_agent_dir_user_models_json_without_providers_key(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(home, models=None)
+    (user_agent / "models.json").write_text(
+        '{"nope": 1}', encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    assert set(merged["providers"]) == {"groq"}
+
+
+# --- e2e: the provider endpoint reaches the Pi process (Issue #157) -------
+
+
+FAKE_PI_PROVIDER = """#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+provider = args[args.index("--provider") + 1]
+model = args[args.index("--model") + 1]
+agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
+assert agent_dir, "PI_CODING_AGENT_DIR is not set"
+catalog = json.load(open(os.path.join(agent_dir, "models.json")))
+entry = catalog["providers"][provider]
+assert model in [m["id"] for m in entry["models"]], (
+    f"model {model} not in materialized catalog"
+)
+# Prove the provider endpoint from the repo file reached Pi: print the
+# baseUrl of the selected provider (the runner never puts it on argv).
+sys.stdout.write(entry["baseUrl"])
+"""
+
+
+def test_e2e_provider_endpoint_reaches_pi_process(monkeypatch, tmp_path):
+    """run_pi -> materialized dir -> PI_CODING_AGENT_DIR -> Pi sees the
+    repo-file provider endpoint (baseUrl) for the selected model."""
+    (tmp_path / "prompt.md").write_text("SYSTEM", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "pi"
+    fake.write_text(FAKE_PI_PROVIDER, encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv(
+        "PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+    )
+    config = _model_config(
+        tmp_path, pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+        pi_providers_data=GROQ_PROVIDERS,
+    )
+    result = runner.run_pi(
+        {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-4-a1b2c3d4",
+    )
+    assert result == "https://api.groq.com/openai/v1"
+
+
+def test_prepare_pi_agent_dir_is_idempotent_on_resume(
+    tmp_path, monkeypatch,
+):
+    """A resumed run in the same worktree replaces stale symlinks."""
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(home, auth=False)
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    # Simulate a stale broken symlink left by an earlier attempt.
+    stale = agent_dir / "auth.json"
+    stale.symlink_to(tmp_path / "gone.json")
+    assert not stale.exists()  # broken
+    runner.prepare_pi_agent_dir(tmp_path, config)
+    assert not (agent_dir / "auth.json").exists()
+    assert (agent_dir / "settings.json").is_symlink()


### PR DESCRIPTION
Fixes #157

<!-- muyan-pilot:run=8ddd36a6 -->

run_id=8ddd36a6

## What

`muyan-pilot.toml` gains an optional `pi_providers` key: a path to a JSON
file in Pi's own `models.json` shape (providers with `baseUrl` / `api` /
`apiKey` / `models`). The TOML still only selects the runtime
provider/model/thinking (Issue #119); the endpoint (`baseUrl`) lives only
in the provider file, and `apiKey` is an env-var reference (`$VAR` /
`${VAR}`) — never a key value.

```toml
pi_providers = ".muyan-pilot/pi-providers.json"
pi_provider = "groq"
pi_model = "qwen/qwen3.8-27b"
```

```json
{ "providers": { "groq": {
    "baseUrl": "https://api.groq.com/openai/v1",
    "api": "openai-completions",
    "apiKey": "$GROQ_API_KEY",
    "models": [{ "id": "qwen/qwen3.8-27b" } ] } } }
```

## How

- `load_config` validates the file and fails fast: missing file, invalid
  JSON, missing `providers` object, a provider with `models` but no
  `baseUrl` or `api` (provider- or model-level), a selected
  provider/model that does not exist in the file, or a missing/empty env
  var for the selected provider's `apiKey` (only the variable name is
  reported). Pi only WARNS on an unknown model id and still fires the
  request (verified against real Pi 0.84.3), so the Runner does the model
  fail-fast.
- Before every Pi launch (implement AND review, one code path) the Runner
  materializes `<worktree>/.muyan-pilot/pi-agent/` (gitignored, per-run,
  idempotent on resume): `models.json` = the user agent dir's providers
  merged with the file's providers (file wins on collision),
  `settings.json`/`auth.json` symlinked from the user agent dir; Pi sees
  the catalog through `PI_CODING_AGENT_DIR` (verified against real Pi
  0.84.3).
- Unconfigured -> exact pre-#157 behavior: no dir, no env, same command.
  The redacted journal `command=` line keeps only the
  `--provider/--model/--thinking` identifiers; `baseUrl` and API keys
  never enter the journal, Issue or PR.

## Verification

- 1063 passed, 100% line+branch coverage (after merging the advanced
  base, PR #167): config parsing, command args, provider-endpoint e2e
  (fake `pi` on PATH proves the repo-file `baseUrl` reaches the Pi
  process), error propagation.
- Real Pi 0.84.3 call against a real running OpenAI-compatible endpoint
  (llama.cpp Qwen3.8-27B @ 127.0.0.1:18082 — same `openai-completions`
  API type as the Issue's Groq example; no `GROQ_API_KEY` exists on this
  machine): `load_config` + `run_pi` + materialized dir +
  `PI_CODING_AGENT_DIR` -> model completed the call (`stdout=OK`);
  fail-fast on the unset key env var confirmed; no key value in the
  captured journal. Evidence: `test.log` / `verify.md` in the run
  worktree.