### PR TITLE
Make stall detection evidence-based: live upstream connection and timeout deadlines (Issue #169)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,24 +92,42 @@ acceptance criteria.
   last activity, last action, session and branch. No model/session activity
   for 5 minutes logs an idle warning; the first new activity after it logs
   a resumed event. A stalled (non-`model_wait`) session is recovered
-  automatically, not only warned (Issue #94): one step per idle window of
-  `PI_IDLE_WARN_SECONDS` since the stall was first seen — window 1
-  SIGTERMs the Pi descendants that already existed before the window
-  (the hung tools: ppid chain + start time from `/proc/<pid>/stat`, never
-  a name guess; only Pi descendants, never other system processes, never
-  a process spawned after the window began), so the tool gets a non-zero
-  exit and the failure signal reaches the model; window 2 SIGKILLs a
-  target that survived; after `PI_IDLE_RECOVERY_CYCLES` (default 3)
-  consecutive idle windows the Runner kills the Pi session itself and
-  fails fast through the normal failure path (the slot is never held
-  forever). Every step logs a `pi_idle_term` / `pi_idle_kill` line (run
-  id, pid, cmdline, TERM/KILL, result) and the progress comment shows the
-  recovery state via its `recovery` field; the first new activity resets
-  the whole recovery state. A session frozen in `model_wait` (the newest
-  event is a tool result) past `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s)
-  declares the upstream (llama/proxy) dead — the HTTP timeout or
-  connection drop left Pi in epoll_wait and it will never exit on its
-  own: the Runner kills Pi, logs
+  automatically, not only warned (Issue #94, evidence-based since Issue
+  #169): one step per idle window of `PI_IDLE_WARN_SECONDS` since the
+  stall was first seen — window 1 checks the Pi descendants that already
+  existed before the window (the hung tools: ppid chain + start time from
+  `/proc/<pid>/stat`, never a name guess; only Pi descendants, never
+  other system processes, never a process spawned after the window began,
+  never a zombie that has already exited). If one of them is a coreutils
+  `timeout <seconds> ...` command still inside its deadline (start time +
+  duration, computed in the monotonic clock domain so NTP realtime steps
+  cannot skew it), it is a legitimate long-running command, not a hang:
+  the Runner logs one `pi_idle_wait` line (run id, pid, cmdline,
+  deadline), reports `recovery=wait` in the progress comment, and pauses
+  the escalation — every later window re-evaluates; when the deadline
+  passes with the descendant still alive (the wrapper failed to end the
+  command) the evidence flips and the escalation proceeds. Otherwise
+  window 1 SIGTERMs the descendants, so the tool gets a non-zero exit and
+  the failure signal reaches the model; window 2 SIGKILLs a target that
+  survived; after `PI_IDLE_RECOVERY_CYCLES` (default 3) consecutive idle
+  windows the Runner kills the Pi session itself and fails fast through
+  the normal failure path (the slot is never held forever). Every step
+  logs a `pi_idle_wait` / `pi_idle_term` / `pi_idle_kill` line (run id,
+  pid, cmdline, deadline/TERM/KILL, result) and the progress comment shows
+  the recovery state via its `recovery` field (`wait` / `term` / `kill`);
+  the first new activity resets the whole recovery state. A session frozen
+  in `model_wait` (the newest event is a tool result) past
+  `PI_MODEL_WAIT_DEAD_SECONDS` (default 600 s) declares the upstream
+  (llama/proxy) dead ONLY when the Pi process has no live upstream
+  connection (Issue #169): the silence alone is not evidence — a slow
+  local model generating for minutes keeps its TCP connection alive and
+  must not be killed (the #158 regression). The evidence is the fd table:
+  a `socket:[...]` inode of the Pi process that appears in
+  `/proc/net/tcp` or `/proc/net/tcp6` in state ESTABLISHED, SYN_SENT or
+  SYN_RECV with a non-zero remote address is live; CLOSE_WAIT and all
+  other states are not. With the silence AND no live connection the HTTP
+  timeout or connection drop left Pi in epoll_wait and it will never exit
+  on its own: the Runner kills Pi, logs
   `run_failed ... reason=upstream_dead_stale_...`, and fails fast through
   the normal failure path (the Issue is marked `ai-blocked` with the
   scene in the Issue comment, the slot is released by the kernel when the

--- a/README.md
+++ b/README.md
@@ -253,20 +253,21 @@ verify → independent review（会话内修复）→ merge，并主动发布过
 Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把简短活动写入 journal（systemd 日志）；已经打开 `journalctl -f` 时内容持续自动刷新。完整不变现场（branch / worktree / session 文件）只在 run 开始和失败时各记录一次，运行中只输出短的变化字段，避免每 15–30 秒重复整段上下文：
 
 - `run_start run=... issue=owner/repo#n role=implement branch=... worktree=... session=... session_file=... phase=... last_activity=... action=... result=...`——run 开始时记录一次完整现场；
-- `activity issue=... role=... phase=... action="..." result=... state=-|model_wait idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
-- `heartbeat issue=... role=... phase=... state=-|model_wait elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
-- `model_wait issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；
+- `activity issue=... role=... phase=... action="..." result=... state=-|model_wait|model_wait_slow idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
+- `heartbeat issue=... role=... phase=... state=-|model_wait|model_wait_slow elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
+- `model_wait issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；等待静默超过 `PI_MODEL_WAIT_DEAD_SECONDS` 后 heartbeat 的 state 变为 `model_wait_slow`（慢，不是死：只有同时没有活的上游连接才是 kill 证据，见下）；
 - `resumed issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
 - `pi_idle issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
+- `pi_idle_wait run=... issue=... role=... pid=... cmdline=... deadline=...`——idle 窗口内发现挂死后代正在跑 coreutils `timeout <seconds> ...` 且还没到 deadline 时输出一次（每个卡死一次）：这是合法运行中的长命令（如 `timeout 240 pytest tests/`），不是挂死——Runner 等 deadline，不杀（Issue #169 修复 #105 误杀）；deadline 过后进程仍存活时证据翻转，升级照常进行；
 - `pi_idle_term run=... issue=... role=... pid=... cmdline=... result=sent|failed: ...`（或无 pid 的 `result=no_target`）——idle 告警后第一个 idle 窗口内，对 idle 窗口开始前就已存在、仍在运行的 Pi 后代（挂死的 bash/pytest 等工具）逐个发 SIGTERM（保留现场），让工具拿到非零退出、失败信号回到模型（Issue #94）；找不到挂死后代时记 `no_target`（Pi 自身卡住）；
 - `pi_idle_kill run=... issue=... role=... pid=... cmdline=... result=sent|already_dead|failed: ...`——再过一个 idle 窗口仍无新活动且被 TERM 的后代仍存活时发 SIGKILL；TERM 已生效（进程已退出）时记 `already_dead`，不再发信号；
 - `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed），整个 idle 恢复状态同时复位；
 - `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|upstream_dead_stale_...s|idle_recovery_stale_...s`——进程异常退出、超时、上游已死（Issue #75）或连续 3 个 idle 窗口（`PI_IDLE_RECOVERY_CYCLES=3`）仍无新活动（Issue #94，Runner 杀掉 Pi 会话本身）时先记录完整现场再抛出错误；
 - `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
 
-上游已死检测（Issue #75）：`model_wait` 期间 session JSONL 冻结超过 `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）判定上游（llama/proxy）已死——HTTP 超时或连接断开后 Pi 停在 epoll_wait 永不退出：Runner 杀掉 Pi 进程，记录 `run_failed ... reason=upstream_dead_stale_...s` 后 fail fast（Issue 标记 `ai-blocked`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍可 resume 或领取下一个 `ai-fix-needed`）。事件持续到达时永不触发（慢模型不是死上游），它也不是业务任务 timeout。
+上游已死检测（Issue #75，Issue #169 起基于证据）：`model_wait` 期间 session JSONL 冻结超过 `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）**且** Pi 进程没有活的上游连接（fd 表里的 `socket:[...]` 在 `/proc/net/tcp`/`tcp6` 中没有处于 ESTABLISHED/SYN_SENT/SYN_RECV 状态且带远端地址的 socket；CLOSE_WAIT 等已断开状态不算）才判定上游（llama/proxy）已死——HTTP 超时或连接断开后 Pi 停在 epoll_wait 永不退出：Runner 杀掉 Pi 进程，记录 `run_failed ... reason=upstream_dead_stale_...s` 后 fail fast（Issue 标记 `ai-blocked`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍可 resume 或领取下一个 `ai-fix-needed`）。session 冻结本身不是证据：本地慢模型生成几分钟时连接仍然活着（heartbeat 显示 `state=model_wait_slow`），Runner 不杀（#158 回归）；事件持续到达时同样永不触发（慢模型不是死上游）。它也不是业务任务 timeout。
 
-idle 卡死自动恢复（Issue #94）：非 `model_wait` 的卡死（Pi 的 bash 工具子进程永久阻塞，如 TDD red 阶段的死循环测试、`next(generator)` 永久等待）不再只告警。Runner 在现有轮询循环里按 idle 窗口（`idle_warn_seconds`，默认 5 分钟）逐级恢复：第一个窗口对 idle 窗口开始前就已存在、仍在运行的 Pi 后代逐个 SIGTERM（判定依据是 `/proc/<pid>/stat` 的 ppid 链 + 进程启动时间早于 idle 起点，不靠猜；只动 Pi 的后代，不碰系统其他进程，也不碰窗口开始后新起的进程）——工具拿到非零退出，失败信号回到模型，会话自行继续；第二个窗口对被 TERM 后仍存活的后代 SIGKILL；连续 `PI_IDLE_RECOVERY_CYCLES`（默认 3）个窗口仍无新活动时杀掉 Pi 会话本身，按现有 `ai-blocked`/可恢复流程收尾（Issue 标记 `ai-blocked`，slot 随进程退出释放）——slot 绝不被无限占用。每一步写 `pi_idle_term` / `pi_idle_kill` journal 行（带 run_id、pid、cmdline、TERM/KILL、结果），GitHub 进度评论通过 `recovery` 字段（`term` / `kill`）同步现场；第一条新 session 事件到达时整个恢复状态复位（`pi_resumed`）。不引入常驻进程/守护线程。
+idle 卡死自动恢复（Issue #94，Issue #169 起基于证据）：非 `model_wait` 的卡死（Pi 的 bash 工具子进程永久阻塞，如 TDD red 阶段的死循环测试、`next(generator)` 永久等待）不再只告警。Runner 在现有轮询循环里按 idle 窗口（`idle_warn_seconds`，默认 5 分钟）逐级恢复：第一个窗口检查 idle 窗口开始前就已存在、仍在运行的 Pi 后代（判定依据是 `/proc/<pid>/stat` 的 ppid 链 + 进程启动时间早于 idle 起点，不靠猜；只动 Pi 的后代，不碰系统其他进程，也不碰窗口开始后新起的进程；已退出未收割的僵尸不算目标）——如果某个后代的命令行是 coreutils `timeout <seconds> ...` 且 deadline（进程启动时间 + duration，用 monotonic 时钟域计算，NTP 校时不影响）还没到，它是合法运行中的长命令：Runner 记一次 `pi_idle_wait`（带 pid、cmdline、deadline）、`recovery=wait`，不杀，升级暂停，后续每个窗口重新评估；deadline 过后仍存活（wrapper 没能结束命令）时证据翻转，照常 SIGTERM——工具拿到非零退出，失败信号回到模型，会话自行继续；第二个窗口对被 TERM 后仍存活的后代 SIGKILL；连续 `PI_IDLE_RECOVERY_CYCLES`（默认 3）个窗口仍无新活动时杀掉 Pi 会话本身，按现有 `ai-blocked`/可恢复流程收尾（Issue 标记 `ai-blocked`，slot 随进程退出释放）——slot 绝不被无限占用。每一步写 `pi_idle_wait` / `pi_idle_term` / `pi_idle_kill` journal 行（带 run_id、pid、cmdline、deadline/TERM/KILL、结果），GitHub 进度评论通过 `recovery` 字段（`wait` / `term` / `kill`）同步现场；第一条新 session 事件到达时整个恢复状态复位（`pi_resumed`）。不引入常驻进程/守护线程。
 
 所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end` / `pi_idle_term` / `pi_idle_kill`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`。默认 tail 示例（仅用于查看，不是产品步骤）：
 
@@ -277,11 +278,12 @@ journalctl --user -u 'muyan-pilot@*.service' -f
 # Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=- elapsed=30s idle=15s
 # Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
 # Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait
-# Aug 25 14:41:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait elapsed=11m idle=11m
+# Aug 25 14:41:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait_slow elapsed=11m idle=11m
 # Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
 # Aug 25 14:42:19 host muyan-pilot[123]: INFO [e07383c2] resumed issue=xqliu/muyan-pilot#18 role=implement phase=test state=resumed
 # Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle issue=xqliu/muyan-pilot#18 role=implement phase=pr stale_seconds=5m
-# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=xqliu/muyan-pilot#18 role=implement phase=pr
+# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_idle_wait run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement pid=4242 cmdline="timeout 240 pytest tests/" deadline=2025-08-25T16:05:30Z
+# Aug 25 16:06:00 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=xqliu/muyan-pilot#18 role=implement phase=pr
 # Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/xqliu/muyan-pilot/pull/19 commit=0123456789abcdef0123456789abcdef01234567
 ```
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -40,7 +40,15 @@ from pathlib import Path
 
 from git_transport import TransportError, check_transport
 from pilot_slots import acquire_slot, slot_dir_for, slot_occupancy
-from pi_recovery import find_idle_descendants, pid_alive, signal_pid
+from pi_recovery import (
+    clk_tck,
+    find_idle_descendants,
+    pid_alive,
+    process_start_monotonic,
+    signal_pid,
+    timeout_duration,
+    upstream_alive,
+)
 from pi_activity import (
     SessionWatcher,
     activity_snapshot,
@@ -1102,6 +1110,41 @@ def _log_heartbeat(activity: dict, *, issue_ref: str,
     )
 
 
+def _pending_timeout_targets(targets: list[dict]) -> list[tuple[dict, float]]:
+    """The pre-idle descendants still INSIDE an explicit `timeout`
+    deadline (Issue #169): `[(target, deadline_epoch), ...]`.
+
+    A descendant whose command line carries a coreutils
+    `timeout <seconds>` wrapper and whose deadline is still in the
+    future is a legitimately running tool — the runner waits for the
+    deadline instead of signaling it. The age is measured CLOCK
+    CONSISTENTLY (Issue #169): the process's monotonic start offset
+    (stat field 22) against `time.monotonic()`, never the
+    realtime-flavoured `process_start_epoch` — a realtime step after
+    boot (NTP) must not make a tool look older than it is. A
+    descendant without a clear timeout, whose start time is unreadable,
+    or whose deadline already passed is not pending: the existing
+    escalation applies to it.
+    """
+    if not targets:
+        return []
+    hz = clk_tck()
+    now_mono = time.monotonic()
+    now = time.time()
+    pending: list[tuple[dict, float]] = []
+    for target in targets:
+        start_mono = process_start_monotonic(target["pid"], hz=hz)
+        if start_mono is None:
+            continue
+        duration = timeout_duration(target["cmdline"] or "")
+        if duration is None:
+            continue
+        remaining = duration - (now_mono - start_mono)
+        if remaining > 0:
+            pending.append((target, now + remaining))
+    return pending
+
+
 def stream_pi(
     command: list[str],
     *,
@@ -1228,6 +1271,10 @@ def stream_pi(
     recovery: str | None = None
     recovery_targets: list[dict] = []
     recovery_step = 0
+    # The `pi_idle_wait` decision is logged once per stall (Issue #169):
+    # the escalation re-evaluates every window while the tool is inside
+    # its `timeout` deadline, but the journal carries one decision line.
+    idle_wait_logged = False
     idle_recovery_failed = False
     try:
         while True:
@@ -1249,20 +1296,33 @@ def stream_pi(
             visible = (
                 activity["phase"], activity["action"], activity["result"],
             )
+            # The wait state rides on the activity/heartbeat lines
+            # (Issue #40). Once the model_wait silence crosses the dead
+            # threshold the wait is SLOW, not dead (Issue #169): the
+            # state is `model_wait_slow` — visible, but only the missing
+            # upstream connection (checked below) is a kill.
+            if activity["model_wait"]:
+                wait_state = (
+                    "model_wait_slow"
+                    if activity["stale_seconds"] >= model_wait_dead_seconds
+                    else "model_wait"
+                )
+            else:
+                wait_state = None
             if visible != last_visible:
                 # Only changed fields are repeated; an unchanged poll is a
                 # heartbeat (Issue #40).
                 _log_activity(
                     activity, issue_ref=issue_ref,
                     role=role,
-                    state="model_wait" if activity["model_wait"] else None,
+                    state=wait_state,
                 )
                 last_visible = visible
             else:
                 _log_heartbeat(
                     activity, issue_ref=issue_ref,
                     role=role, elapsed=time.monotonic() - start,
-                    state="model_wait" if activity["model_wait"] else None,
+                    state=wait_state,
                 )
             if activity["model_wait"] != last_model_wait:
                 # One transition line per state change: entering model_wait
@@ -1299,6 +1359,7 @@ def stream_pi(
                 recovery = None
                 recovery_targets = []
                 recovery_step = 0
+                idle_wait_logged = False
             elif (
                 not activity["model_wait"]
                 and not idle_warned
@@ -1353,7 +1414,35 @@ def stream_pi(
                     targets = find_idle_descendants(
                         process.pid, idle_start_epoch,
                     )
-                    if targets:
+                    # Evidence-based wait (Issue #169, the #105
+                    # regression): a pre-idle descendant that runs a
+                    # coreutils `timeout <seconds> ...` wrapper INSIDE
+                    # its deadline is a legitimately running tool, not a
+                    # hung one — the runner waits for the deadline
+                    # instead of TERMed it. The wait decision is logged
+                    # once and the escalation pauses (recovery_step stays
+                    # 0): every later window re-evaluates, and when the
+                    # deadline passes with the descendant still alive the
+                    # evidence flips and the TERM → KILL → session-kill
+                    # escalation runs unchanged (the slot is never held
+                    # forever).
+                    pending = _pending_timeout_targets(targets)
+                    if pending:
+                        if not idle_wait_logged:
+                            for target, deadline in pending:
+                                LOGGER.warning(
+                                    "pi_idle_wait run=%s issue=%s role=%s "
+                                    "pid=%s cmdline=%s deadline=%s",
+                                    run_id, issue_ref, role, target["pid"],
+                                    quote_value(target["cmdline"] or "-"),
+                                    time.strftime(
+                                        "%Y-%m-%dT%H:%M:%SZ",
+                                        time.gmtime(deadline),
+                                    ),
+                                )
+                            idle_wait_logged = True
+                        recovery = "wait"
+                    elif targets:
                         recovery_targets = targets
                         for target in targets:
                             result = signal_pid(
@@ -1375,7 +1464,8 @@ def stream_pi(
                             "result=no_target",
                             run_id, issue_ref, role,
                         )
-                    recovery_step = 1
+                    if not pending:
+                        recovery_step = 1
                 elif cycle >= 2 and recovery_step == 1:
                     for target in recovery_targets:
                         if not pid_alive(target["pid"]):
@@ -1414,21 +1504,35 @@ def stream_pi(
                         "progress_publish_failed run=%s issue=%s role=%s",
                         run_id, issue_ref, role,
                     )
-            # Upstream-dead detection (Issue #75): the model is
-            # expected to reply next (model_wait) but the session file
-            # has been frozen for the dead threshold — the upstream
-            # (llama/proxy) is dead and Pi will never exit on its own.
-            # Kill Pi and fail fast: the normal failure path releases
-            # the slot so the next tick can resume or claim the next
-            # Issue. Never fires while events keep arriving (a slow
-            # generation is not a dead upstream).
+            # Upstream-dead detection (Issue #75, evidence-based since
+            # Issue #169): the model is expected to reply next
+            # (model_wait) and the session file has been frozen for the
+            # dead threshold — but the bare freeze is NOT evidence the
+            # upstream is dead: a slow local model generating for
+            # minutes keeps its connection open (a live TCP socket in
+            # the live states ESTABLISHED/SYN_SENT/SYN_RECV). Only the
+            # combination of the long silence AND no live upstream
+            # connection kills Pi and fails fast (the #158 regression:
+            # a healthy long generation must not be killed): the
+            # normal failure path releases the slot so the next tick
+            # can resume or claim the next Issue. Never fires while
+            # events keep arriving (a slow generation is not a dead
+            # upstream).
             if (
                 activity["model_wait"]
                 and activity["stale_seconds"] >= model_wait_dead_seconds
             ):
-                process.kill()
-                upstream_dead = True
-                break
+                if upstream_alive(process.pid):
+                    # The connection to the upstream is still alive:
+                    # the model is generating slowly, not dead
+                    # (Issue #169). The wait is visible as
+                    # `state=model_wait_slow` on the heartbeats — no
+                    # kill, the run continues.
+                    pass
+                else:
+                    process.kill()
+                    upstream_dead = True
+                    break
             if process.poll() is not None:
                 break
     finally:

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1660,6 +1660,12 @@ def stream_pi(
                             "result=no_target",
                             run_id, issue_ref, role,
                         )
+                        # The pre-idle descendants are gone (a waited
+                        # tool reached its own deadline): the wait state
+                        # is stale — clear it so the progress comment
+                        # does not keep showing `recovery: wait` while
+                        # the escalation runs (Issue #169).
+                        recovery = None
                     if not pending:
                         recovery_step = 1
                 elif cycle >= 2 and recovery_step == 1:

--- a/pi_activity.py
+++ b/pi_activity.py
@@ -235,13 +235,10 @@ class SessionWatcher:
             "result": self.result,
             # True only while the newest session event is a tool result:
             # the model is expected to reply next, so a long silence is a
-            # slow model, not a stalled agent (Issue #40).
+            # slow model, not a stalled agent (Issue #40). The pending
+            # duration while in model_wait is `stale_seconds` itself
+            # (the silence since the newest event, Issue #169).
             "model_wait": in_model_wait,
-            # The silence since the newest session event while in
-            # model_wait (0 outside it): the evidence that separates a
-            # slow model from a dead upstream (Issue #169) — the bare
-            # flag above says nothing about the pending duration.
-            "model_wait_seconds": max(0.0, stale) if in_model_wait else 0.0,
             "changed": changed,
             "stale_seconds": max(0.0, stale),
         }

--- a/pi_activity.py
+++ b/pi_activity.py
@@ -223,6 +223,7 @@ class SessionWatcher:
             stale = now - self._last_activity_epoch
         else:
             stale = now - self.start_time
+        in_model_wait = self.last_role == "toolResult"
         return {
             "session_id": self.session_id,
             "session_file": str(self.session_file) if self.session_file
@@ -235,7 +236,12 @@ class SessionWatcher:
             # True only while the newest session event is a tool result:
             # the model is expected to reply next, so a long silence is a
             # slow model, not a stalled agent (Issue #40).
-            "model_wait": self.last_role == "toolResult",
+            "model_wait": in_model_wait,
+            # The silence since the newest session event while in
+            # model_wait (0 outside it): the evidence that separates a
+            # slow model from a dead upstream (Issue #169) — the bare
+            # flag above says nothing about the pending duration.
+            "model_wait_seconds": max(0.0, stale) if in_model_wait else 0.0,
             "changed": changed,
             "stale_seconds": max(0.0, stale),
         }

--- a/pi_recovery.py
+++ b/pi_recovery.py
@@ -74,6 +74,22 @@ def process_ppid(pid: int) -> int | None:
         return None
 
 
+def process_state(pid: int) -> str | None:
+    """The process state char (stat field 3: R/S/D/Z/T/...).
+
+    The evidence for a stalled-but-running tool (Issue #169): a process
+    in S/R is alive and working, Z is gone for good. None when the
+    process is gone or the line is malformed.
+    """
+    raw = _read_stat(pid)
+    if raw is None:
+        return None
+    fields = _stat_fields(raw)
+    if fields is None or not fields[0]:
+        return None
+    return fields[0]
+
+
 def process_start_epoch(pid: int, *, btime: float, hz: float) -> float | None:
     """The process start time in epoch seconds.
 
@@ -93,6 +109,29 @@ def process_start_epoch(pid: int, *, btime: float, hz: float) -> float | None:
     except ValueError:
         return None
     return btime + starttime / hz
+
+
+def process_start_monotonic(pid: int, *, hz: float) -> float | None:
+    """The process age offset in MONOTONIC seconds since boot.
+
+    stat field 22 (starttime, ticks since boot) converted with `hz`.
+    The value is compared against `time.monotonic()`, never against the
+    realtime epoch (Issue #169): a realtime step after boot (NTP)
+    must not skew a process's age — `process_start_epoch` (btime plus
+    the same ticks) is the realtime-flavoured view used by the
+    pre-idle check, this is the clock-consistent one.
+    """
+    raw = _read_stat(pid)
+    if raw is None:
+        return None
+    fields = _stat_fields(raw)
+    if fields is None or len(fields) < 20:
+        return None
+    try:
+        starttime = int(fields[19])
+    except ValueError:
+        return None
+    return starttime / hz
 
 
 def boot_time() -> float:
@@ -124,6 +163,131 @@ def cmdline_of(pid: int) -> str:
     if stat is None:
         return ""
     return _comm(stat)
+
+
+# coreutils `timeout` duration suffixes (GNU coreutils, `timeout(1)`):
+# a bare number is seconds; s/m/h/d multiply it.
+_DURATION_SUFFIX_SECONDS: dict[str, float] = {
+    "s": 1.0, "m": 60.0, "h": 3600.0, "d": 86400.0,
+}
+
+
+def _parse_duration(token: str) -> float | None:
+    """A coreutils duration token (`240`, `4m`, `1.5m`, `1h`, `2d`).
+
+    None when the token is not a plain number with an optional known
+    suffix — a duration that cannot be parsed is NOT a clear timeout.
+    (Callers pass tokens from `cmdline.split()`, which are never
+    empty.)
+    """
+    suffix = ""
+    if token[-1] in _DURATION_SUFFIX_SECONDS:
+        suffix = token[-1]
+        token = token[:-1]
+    if not token or not all(ch.isdigit() or ch == "." for ch in token):
+        return None
+    if token.count(".") > 1:
+        return None
+    try:
+        seconds = float(token)
+    except ValueError:
+        return None
+    if seconds <= 0:
+        return None
+    return seconds * _DURATION_SUFFIX_SECONDS.get(suffix, 1.0)
+
+
+def timeout_duration(cmdline: str) -> float | None:
+    """The duration (seconds) of a coreutils `timeout <duration>`
+    wrapper in the command line, or None when the command has no clear
+    timeout (Issue #169).
+
+    The wrapper word must stand alone (`timeout`, or an absolute path
+    to it) and the duration must be the IMMEDIATE next token — the
+    prompt contract form `timeout <seconds> ...`. Anything else
+    (options in between, a missing/unparseable duration, the word
+    inside a longer token) is not a clear timeout: the existing
+    recovery behavior applies (fail-safe, never a fabricated deadline).
+    """
+    tokens = cmdline.split()
+    for index, token in enumerate(tokens):
+        if token.rsplit("/", 1)[-1] != "timeout":
+            continue
+        if index + 1 >= len(tokens):
+            return None
+        return _parse_duration(tokens[index + 1])
+    return None
+
+
+def timeout_deadline(cmdline: str, start_epoch: float) -> float | None:
+    """The epoch at which a coreutils `timeout <duration>` wrapper ends
+    the command, or None when the command has no clear timeout.
+
+    `start_epoch` is the process start time in the SAME clock domain as
+    the caller's `now` — the clock-consistent pair is
+    `process_start_monotonic` plus `time.monotonic()` (Issue #169).
+    """
+    seconds = timeout_duration(cmdline)
+    if seconds is None:
+        return None
+    return start_epoch + seconds
+
+
+# /proc/net/tcp socket states that still hold a live connection to a
+# remote peer: ESTABLISHED (01), SYN_SENT (02), SYN_RECV (03). A
+# CLOSE_WAIT (08) socket has already been closed by the peer — the
+# request is dead even though the remote address is still printed.
+_LIVE_TCP_STATES: frozenset[str] = frozenset({"01", "02", "03"})
+
+
+def upstream_alive(pid: int) -> bool:
+    """True when the process holds an open TCP socket in a live
+    connection state (ESTABLISHED / SYN_SENT / SYN_RECV) with a remote
+    address — the evidence that a model request to the upstream
+    (llama/proxy) is still connected (Issue #169).
+
+    The process's fd table is scanned for `socket:[<inode>]` entries and
+    each inode is matched against `/proc/net/tcp` and `/proc/net/tcp6`
+    (the real kernel format: the state is field 4, the remote address
+    field 3, the inode field 10). A process with no such socket has no
+    live upstream connection: a cleanly closed connection (CLOSE_WAIT
+    or gone) and a silently dropped one (no socket left) both leave
+    nothing in a live state behind.
+    """
+    fd_dir = PROC / str(pid) / "fd"
+    try:
+        entries = list(fd_dir.iterdir())
+    except OSError:
+        return False
+    inodes: set[str] = set()
+    for entry in entries:
+        try:
+            target = os.readlink(entry)
+        except OSError:
+            continue
+        if target.startswith("socket:[") and target.endswith("]"):
+            inodes.add(target[len("socket:["):-1])
+    if not inodes:
+        return False
+    for table in ("tcp", "tcp6"):
+        try:
+            lines = (PROC / "net" / table).read_text().splitlines()
+        except OSError:
+            continue
+        for line in lines[1:]:
+            fields = line.split()
+            # Real format: sl local rem st tx:rx tr:tm retrnsmt uid
+            # timeout inode ... — the remote address is index 2, the
+            # state index 3, the inode index 9.
+            if len(fields) < 10 or fields[9] not in inodes:
+                continue
+            if fields[3] not in _LIVE_TCP_STATES:
+                continue
+            remote = fields[2]
+            ip, _, _port = remote.rpartition(":")
+            if ip and set(ip) != {"0"}:
+                return True
+    return False
 
 
 def descendant_pids(root_pid: int) -> list[int]:
@@ -185,6 +349,11 @@ def find_idle_descendants(root_pid: int, idle_start_epoch: float,
         hz = clk_tck()
     targets: list[dict] = []
     for pid in descendant_pids(root_pid):
+        # A zombie (state Z) is already dead — the parent just has not
+        # reaped it yet: signaling it is meaningless and its empty
+        # cmdline would fall back to the comm name, a lie (Issue #169).
+        if process_state(pid) == "Z":
+            continue
         start = process_start_epoch(pid, btime=btime, hz=hz)
         if start is None:
             continue

--- a/pi_recovery.py
+++ b/pi_recovery.py
@@ -219,20 +219,6 @@ def timeout_duration(cmdline: str) -> float | None:
     return None
 
 
-def timeout_deadline(cmdline: str, start_epoch: float) -> float | None:
-    """The epoch at which a coreutils `timeout <duration>` wrapper ends
-    the command, or None when the command has no clear timeout.
-
-    `start_epoch` is the process start time in the SAME clock domain as
-    the caller's `now` — the clock-consistent pair is
-    `process_start_monotonic` plus `time.monotonic()` (Issue #169).
-    """
-    seconds = timeout_duration(cmdline)
-    if seconds is None:
-        return None
-    return start_epoch + seconds
-
-
 # /proc/net/tcp socket states that still hold a live connection to a
 # remote peer: ESTABLISHED (01), SYN_SENT (02), SYN_RECV (03). A
 # CLOSE_WAIT (08) socket has already been closed by the peer — the

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4393,6 +4393,356 @@ def test_stream_pi_no_upstream_kill_before_model_wait(tmp_path, caplog):
     assert "upstream_dead" not in caplog.text
 
 
+# --- Issue #169: evidence-based stall detection ------------------------------
+
+
+def make_upstream_listener(drop: bool = False):
+    """A local TCP listener that mimics the upstream (llama/proxy).
+
+    Returns `(port, stop)`: the listener accepts ONE connection and
+    either holds it (a live upstream) or closes it immediately (the
+    upstream died: the client socket goes CLOSE_WAIT). `stop()` closes
+    the listener.
+    """
+    import socket as _socket
+    import threading as _threading
+    listener = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def serve():
+        conn, _ = listener.accept()
+        if drop:
+            conn.close()
+        else:
+            time.sleep(30)
+        conn.close()  # idempotent: safe after the drop close
+
+    thread = _threading.Thread(target=serve, daemon=True)
+    thread.start()
+
+    def stop():
+        listener.close()
+
+    return port, stop
+
+
+def make_slow_model_pi(tmp_path, *, port: int, hold_seconds: float = 2.5,
+                       drop_upstream: bool = False) -> list[str]:
+    """Build a command that mimics a SLOW Pi (Issue #169): it writes the
+    session toolCall + toolResult (the model is expected to reply next:
+    model_wait), opens a TCP connection to the local upstream listener
+    (the live model request) and holds it for `hold_seconds` — a long
+    generation that crosses the dead threshold. When `drop_upstream`
+    the listener closes the connection immediately (the upstream died:
+    the client socket leaves the live TCP states). After the hold it
+    writes the assistant reply and exits — the slow model that was NOT
+    killed gets to finish."""
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir(exist_ok=True)
+    script = (
+        "import json, socket, sys, time\n"
+        "from datetime import datetime, timezone\n"
+        f"session = {str(session_dir / 'sess.jsonl')!r}\n"
+        "def ts():\n"
+        "    return datetime.now(timezone.utc).isoformat()\n"
+        "def write(record):\n"
+        "    with open(session, 'a') as handle:\n"
+        "        handle.write(json.dumps(record) + '\\n')\n"
+        "write({'type': 'session', 'id': 'sess-slow', 'timestamp': ts(),\n"
+        "       'cwd': '/w'})\n"
+        "write({'type': 'message', 'id': 'a1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'assistant', 'content': [\n"
+        "           {'type': 'toolCall', 'id': 't1', 'name': 'bash',\n"
+        "            'arguments': {'command': 'pytest tests/'}}]}})\n"
+        "write({'type': 'message', 'id': 'r1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'toolResult', 'toolCallId': 't1',\n"
+        "                   'toolName': 'bash', 'isError': False,\n"
+        "                   'content': [{'type': 'text', 'text': 'ok'}]}})\n"
+        f"sock = socket.create_connection(('127.0.0.1', {port!r}))\n"
+        f"time.sleep({hold_seconds!r})\n"
+        "try:\n"
+        "    sock.close()\n"
+        "except OSError:\n"
+        "    pass\n"
+        "write({'type': 'message', 'id': 'a2', 'timestamp': ts(),\n"
+        "       'message': {'role': 'assistant', 'content': [\n"
+        "           {'type': 'text', 'text': 'slow answer'}]}})\n"
+        "sys.exit(0)\n"
+    )
+    return [sys.executable, "-c", script]
+
+
+def test_stream_pi_slow_model_past_threshold_with_live_upstream_not_killed(
+    tmp_path, caplog,
+):
+    """Issue #169 acceptance 1 (the #158 regression): the model_wait
+    silence crosses the dead threshold while the model request is still
+    connected to the upstream (a live TCP connection: a slow local
+    model generating for minutes). The bare session freeze is NOT
+    evidence the upstream is dead — Pi must not be killed, the run
+    finishes, and the slow wait is visible as `state=model_wait_slow`
+    (slow, not dead) on the heartbeats."""
+    port, stop = make_upstream_listener(drop=False)
+    try:
+        command = make_slow_model_pi(
+            tmp_path, port=port, hold_seconds=2.5,
+        )
+        with caplog.at_level("INFO"):
+            result = runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                model_wait_dead_seconds=0.5,
+                run_id="run1", issue=158, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    finally:
+        stop()
+    assert result == ""
+    assert "upstream_dead" not in caplog.text
+    assert "run_failed" not in caplog.text
+    # The slow wait is visible as a state, not a kill: heartbeats
+    # carried `state=model_wait_slow` once the silence crossed the
+    # threshold (the connection was still alive: slow, not dead).
+    slow = [line for line in caplog.text.splitlines()
+            if "state=model_wait_slow" in line]
+    assert len(slow) >= 1, caplog.text
+    for line in slow:
+        assert " heartbeat " in line
+
+
+def test_stream_pi_dead_upstream_still_killed_during_model_wait(
+    tmp_path, caplog,
+):
+    """Issue #169 acceptance 3: the upstream closed the connection
+    (the client socket left the live TCP states) and the model_wait
+    silence crossed the threshold — the evidence is sufficient: the
+    runner kills Pi and fails fast with the `upstream_dead` reason
+    (the #75 contract, now with evidence)."""
+    port, stop = make_upstream_listener(drop=True)
+    try:
+        command = make_slow_model_pi(
+            tmp_path, port=port, hold_seconds=3.0, drop_upstream=True,
+        )
+        with caplog.at_level("ERROR"), pytest.raises(
+            RuntimeError, match="upstream",
+        ):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                model_wait_dead_seconds=0.5,
+                run_id="run1", issue=169, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    finally:
+        stop()
+    lines = caplog.text.splitlines()
+    failures = [line for line in lines if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=upstream_dead_stale_" in failures[0]
+    assert "issue=xqliu/muyan-pilot#169" in failures[0]
+    # The kill is the failure path: no idle warning, no recovery.
+    assert " pi_idle " not in caplog.text
+    assert " pi_idle_term " not in caplog.text
+
+
+def make_timeout_tool_pi(tmp_path, *, tool_seconds: float = 0.6,
+                         react_on_tool_done: bool = True,
+                         wrapper_honors_deadline: bool = True) -> list[str]:
+    """Build a command that mimics a Pi running a LONG tool with an
+    explicit `timeout` (Issue #169, the #105 regression): it writes the
+    session toolCall, spawns `bash -c 'timeout <tool_seconds> sleep 300'`
+    (the tool self-terminates at its deadline — no session event until
+    then) and waits for it. When `wrapper_honors_deadline` is False the
+    fake simulates a wrapper that FAILED to end its command (a fake
+    `timeout` on PATH that ignores the duration: the sleep outlives the
+    nominal deadline, the evidence flips back to stalled). When
+    `react_on_tool_done` the tool's exit (deadline reached or killed)
+    makes the fake Pi write the toolResult and exit; otherwise it stays
+    silent (Pi itself is stuck)."""
+    session_dir = tmp_path / ".pi-session"
+    session_dir.mkdir(exist_ok=True)
+    react = (
+        "write({'type': 'message', 'id': 'r1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'toolResult', 'toolCallId': 't1',\n"
+        "                   'toolName': 'bash', 'isError': True,\n"
+        "                   'content': [{'type': 'text',\n"
+        "                                  'text': 'tool finished'}]}})\n"
+        if react_on_tool_done else "time.sleep(10)\n"
+    )
+    if wrapper_honors_deadline:
+        tool_command = f"timeout {tool_seconds!r} sleep 300"
+    else:
+        # The nominal deadline is in the command line (what the runner
+        # sees), but the wrapper never ends the command: a fake
+        # `timeout` on PATH that ignores the duration and just runs the
+        # command — the sleep runs on past the deadline.
+        fake_bin = session_dir / "bin"
+        fake_bin.mkdir(exist_ok=True)
+        fake_timeout = fake_bin / "timeout"
+        fake_timeout.write_text(
+            "#!/bin/sh\nshift\nexec \"$@\"\n", encoding="utf-8",
+        )
+        fake_timeout.chmod(0o755)
+        tool_command = (
+            f"PATH={fake_bin!s}:/usr/bin:/bin "
+            f"timeout {tool_seconds!r} sleep 30000"
+        )
+    script = (
+        "import json, subprocess, sys, time\n"
+        "from datetime import datetime, timezone\n"
+        f"session = {str(session_dir / 'sess.jsonl')!r}\n"
+        "def ts():\n"
+        "    return datetime.now(timezone.utc).isoformat()\n"
+        "def write(record):\n"
+        "    with open(session, 'a') as handle:\n"
+        "        handle.write(json.dumps(record) + '\\n')\n"
+        "write({'type': 'session', 'id': 'sess-timeout', 'timestamp': ts(),\n"
+        "       'cwd': '/w'})\n"
+        "write({'type': 'message', 'id': 'a1', 'timestamp': ts(),\n"
+        "       'message': {'role': 'assistant', 'content': [\n"
+        "           {'type': 'toolCall', 'id': 't1', 'name': 'bash',\n"
+        "            'arguments': {'command': 'timeout 0.6 sleep 300'}}]}})\n"
+        f"child = subprocess.Popen(['bash', '-c', {tool_command!r}])\n"
+        "while child.poll() is None:\n"
+        "    time.sleep(0.05)\n"
+        f"{react}"
+        "sys.exit(0)\n"
+    )
+    return [sys.executable, "-c", script]
+
+
+def test_stream_pi_timeout_tool_inside_deadline_not_killed(
+    tmp_path, caplog,
+):
+    """Issue #169 acceptance 2 (the #105 regression): a pre-idle
+    descendant running `timeout <seconds> ...` INSIDE its deadline is
+    a legitimately running tool, not a hung one — the runner logs
+    `pi_idle_wait` (the evidence: pid, cmdline, deadline) instead of
+    TERMed it, and the run SUCCEEDS when the tool reaches its deadline
+    on its own."""
+    command = make_timeout_tool_pi(tmp_path, tool_seconds=0.6)
+    with caplog.at_level("INFO"):
+        result = runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=105, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    assert result == ""
+    lines = caplog.text.splitlines()
+    waits = [line for line in lines if " pi_idle_wait " in line]
+    assert len(waits) == 1, f"exactly one wait decision: {lines}"
+    wait = waits[0]
+    assert "run=run1" in wait
+    assert "issue=xqliu/muyan-pilot#105" in wait
+    assert "pid=" in wait
+    assert "cmdline=" in wait
+    assert "deadline=" in wait
+    # No signal was ever DELIVERED: the tool finished on its own
+    # deadline (a later `no_target` record is fine — the descendants
+    # were already gone when the next window re-evaluated).
+    terms = [line for line in lines if " pi_idle_term " in line]
+    assert not any("result=sent" in line for line in terms), lines
+    assert " pi_idle_kill " not in caplog.text
+    assert "run_failed" not in caplog.text
+    # The session resumed when the tool's result arrived.
+    resumed = [line for line in lines if " pi_resumed " in line]
+    assert len(resumed) == 1
+
+
+def test_stream_pi_timeout_tool_past_deadline_still_terminated(
+    tmp_path, caplog,
+):
+    """Issue #169 constraint: the wait is bounded — when the `timeout`
+    deadline passed but the descendant is STILL alive (the wrapper
+    failed to end the command), the evidence flips: the existing
+    TERM → KILL → session-kill escalation runs (the slot is never held
+    forever, no silent ignoring of the timeout). The tool deadline
+    (0.3 s) lands clearly BEFORE the idle window opens (0.6 s), so the
+    first escalation window already sees a past deadline."""
+    command = make_timeout_tool_pi(
+        tmp_path, tool_seconds=0.3, react_on_tool_done=False,
+        wrapper_honors_deadline=False,
+    )
+    with caplog.at_level("INFO"), pytest.raises(
+        RuntimeError, match="idle recovery",
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=105, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    # The first escalation window already saw a past deadline (the
+    # wrapper failed to end the command): no wait decision at all.
+    assert " pi_idle_wait " not in caplog.text
+    # The existing escalation ran: the pre-idle descendants were TERMed
+    # (one line per target, at least one delivered)...
+    terms = [line for line in lines if " pi_idle_term " in line]
+    assert len(terms) >= 1
+    assert any("result=sent" in line for line in terms)
+    # ...and after the bounded cycles the session was killed.
+    failures = [line for line in lines if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=idle_recovery_stale_" in failures[0]
+
+
+def test_stream_pi_idle_recovery_state_wait_visible_in_progress_callback(
+    tmp_path,
+):
+    """Issue #169: the live GitHub progress comment shows the wait
+    state — the activity state passed to the progress callback carries
+    `recovery=wait` while the runner waits for the tool's deadline."""
+    command = make_timeout_tool_pi(tmp_path, tool_seconds=0.6)
+    seen = []
+
+    def progress(activity):
+        seen.append(activity.get("recovery"))
+
+    runner.stream_pi(
+        command, cwd=tmp_path, poll_interval=0.1,
+        idle_warn_seconds=0.3,
+        run_id="run1", issue=105, source_repo="xqliu/muyan-pilot",
+        branch="b", progress=progress,
+    )
+    assert "wait" in seen
+    assert "term" not in seen
+    assert seen[-1] is None
+
+
+def test_pending_timeout_targets_unit(tmp_path, monkeypatch):
+    """Issue #169: the clock-consistent pending computation — a target
+    whose start time is unreadable (it exited between the discovery and
+    the check) is skipped, a target without a clear timeout is not
+    pending, a target inside its deadline is pending with the remaining
+    time, and a target whose deadline already passed is not pending."""
+    now_mono = time.monotonic()
+
+    def fake_start(pid, *, hz):
+        if pid == 1:
+            return None  # gone between discovery and the check
+        if pid == 2:
+            return now_mono - 1.0  # started 1 s ago, timeout 5 s
+        return now_mono - 9.0  # started 9 s ago, timeout 5 s (passed)
+
+    monkeypatch.setattr(runner, "process_start_monotonic", fake_start)
+    targets = [
+        {"pid": 1, "cmdline": "timeout 5 pytest"},
+        {"pid": 2, "cmdline": "timeout 5 pytest"},
+        {"pid": 3, "cmdline": "timeout 5 pytest"},
+        {"pid": 4, "cmdline": "pytest"},  # no clear timeout
+    ]
+    pending = runner._pending_timeout_targets(targets)
+    assert [target["pid"] for target, _ in pending] == [2]
+    # The deadline is the realtime now plus the remaining time.
+    (target, deadline) = pending[0]
+    assert target["pid"] == 2
+    assert time.time() + 3.0 < deadline < time.time() + 5.0
+    # An empty target list is a no-op.
+    assert runner._pending_timeout_targets([]) == []
+
+
 def make_hung_pi(tmp_path, *, child_sleep=10.0, ignore_sigterm=False,
                  react_on_child_death=True, exit_code=0,
                  model_wait=False):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4711,6 +4711,64 @@ def test_stream_pi_idle_recovery_state_wait_visible_in_progress_callback(
     assert seen[-1] is None
 
 
+def test_stream_pi_wait_state_cleared_when_waited_tool_exits(
+    tmp_path, caplog,
+):
+    """Issue #169: the wait evidence FLIPS when the waited tool reaches
+    its own deadline and exits while Pi stays silent (Pi itself is
+    stuck): the next window finds no pre-idle descendants (`no_target`),
+    the stale `wait` state is cleared (the progress callback must not
+    keep reporting `recovery=wait` after the tool is gone), and the
+    escalation continues to the bounded session kill."""
+    command = make_timeout_tool_pi(
+        tmp_path, tool_seconds=0.6, react_on_tool_done=False,
+    )
+    seen = []
+
+    def progress(activity):
+        seen.append(activity.get("recovery"))
+
+    with caplog.at_level("INFO"), pytest.raises(
+        RuntimeError, match="idle recovery",
+    ):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            idle_warn_seconds=0.3,
+            run_id="run1", issue=105, source_repo="xqliu/muyan-pilot",
+            branch="b", progress=progress,
+        )
+    lines = caplog.text.splitlines()
+    waits = [line for line in lines if " pi_idle_wait " in line]
+    assert len(waits) == 1, lines
+    # The tool exited on its own deadline: the next window finds no
+    # pre-idle descendants (`no_target`, nothing was signaled)...
+    terms = [line for line in lines if " pi_idle_term " in line]
+    assert any("result=no_target" in line for line in terms), lines
+    assert not any("result=sent" in line for line in terms), lines
+    # ...and the stale wait state is cleared: no `wait` is reported
+    # after the no_target window (the escalation keeps running).
+    no_target_index = next(
+        i for i, line in enumerate(lines)
+        if " pi_idle_term " in line and "result=no_target" in line
+    )
+    wait_after = [
+        line for line in lines[no_target_index:]
+        if " pi_idle_wait " in line
+    ]
+    assert not wait_after, lines
+    # The poll right after the last `wait` is the no_target window:
+    # the stale state is cleared (None), and the escalation continues
+    # (`kill`) — no `wait` is ever reported after the tool is gone.
+    last_wait = max(i for i, state in enumerate(seen) if state == "wait")
+    assert seen[last_wait + 1] is None, seen
+    assert all(state != "wait" for state in seen[last_wait + 1:]), seen
+    assert "kill" in seen[last_wait + 1:], seen
+    # The escalation still ends in the bounded session kill.
+    failures = [line for line in lines if " run_failed " in line]
+    assert len(failures) == 1
+    assert "reason=idle_recovery_stale_" in failures[0]
+
+
 def test_pending_timeout_targets_unit(tmp_path, monkeypatch):
     """Issue #169: the clock-consistent pending computation — a target
     whose start time is unreadable (it exited between the discovery and

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -611,6 +611,54 @@ def test_watcher_state_reports_model_wait_after_tool_result(tmp_path):
     assert state["model_wait"] is True
 
 
+def test_watcher_state_model_wait_seconds_counts_silence_in_model_wait(
+    tmp_path,
+):
+    """Issue #169: while the newest event is a tool result the silence
+    since that event is the model_wait duration — the evidence the
+    runner needs to tell a slow model from a dead upstream (a bare
+    `model_wait` flag says nothing about how long the request has
+    been pending)."""
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL, TOOL_RESULT])
+    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:03Z")
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: last_epoch + 42.0,
+    )
+    state = watcher.poll()
+    assert state["model_wait"] is True
+    assert state["model_wait_seconds"] == pytest.approx(42.0)
+
+
+def test_watcher_state_model_wait_seconds_zero_outside_model_wait(
+    tmp_path,
+):
+    # Outside model_wait (the newest event is not a tool result) there is
+    # no pending model request: the duration is 0, whatever the stale
+    # time is.
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TEXT])
+    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:04Z")
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: last_epoch + 42.0,
+    )
+    state = watcher.poll()
+    assert state["model_wait"] is False
+    assert state["model_wait_seconds"] == 0.0
+
+
+def test_watcher_state_model_wait_seconds_clamped_to_zero(tmp_path):
+    # A clock skew (now before the last event) clamps to 0 like
+    # `stale_seconds`.
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL, TOOL_RESULT])
+    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:03Z")
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: last_epoch - 10.0,
+    )
+    assert watcher.poll()["model_wait_seconds"] == 0.0
+
+
 def test_watcher_state_no_model_wait_after_assistant_text(tmp_path):
     # An assistant text is not a pending model request: no model_wait.
     session = tmp_path / "s.jsonl"

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -611,54 +611,6 @@ def test_watcher_state_reports_model_wait_after_tool_result(tmp_path):
     assert state["model_wait"] is True
 
 
-def test_watcher_state_model_wait_seconds_counts_silence_in_model_wait(
-    tmp_path,
-):
-    """Issue #169: while the newest event is a tool result the silence
-    since that event is the model_wait duration — the evidence the
-    runner needs to tell a slow model from a dead upstream (a bare
-    `model_wait` flag says nothing about how long the request has
-    been pending)."""
-    session = tmp_path / "s.jsonl"
-    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL, TOOL_RESULT])
-    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:03Z")
-    watcher = pi_activity.SessionWatcher(
-        tmp_path, now=lambda: last_epoch + 42.0,
-    )
-    state = watcher.poll()
-    assert state["model_wait"] is True
-    assert state["model_wait_seconds"] == pytest.approx(42.0)
-
-
-def test_watcher_state_model_wait_seconds_zero_outside_model_wait(
-    tmp_path,
-):
-    # Outside model_wait (the newest event is not a tool result) there is
-    # no pending model request: the duration is 0, whatever the stale
-    # time is.
-    session = tmp_path / "s.jsonl"
-    write_records(session, [SESSION_RECORD, ASSISTANT_TEXT])
-    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:04Z")
-    watcher = pi_activity.SessionWatcher(
-        tmp_path, now=lambda: last_epoch + 42.0,
-    )
-    state = watcher.poll()
-    assert state["model_wait"] is False
-    assert state["model_wait_seconds"] == 0.0
-
-
-def test_watcher_state_model_wait_seconds_clamped_to_zero(tmp_path):
-    # A clock skew (now before the last event) clamps to 0 like
-    # `stale_seconds`.
-    session = tmp_path / "s.jsonl"
-    write_records(session, [SESSION_RECORD, ASSISTANT_TOOL_CALL, TOOL_RESULT])
-    last_epoch = pi_activity.parse_iso_utc("2026-01-01T00:00:03Z")
-    watcher = pi_activity.SessionWatcher(
-        tmp_path, now=lambda: last_epoch - 10.0,
-    )
-    assert watcher.poll()["model_wait_seconds"] == 0.0
-
-
 def test_watcher_state_no_model_wait_after_assistant_text(tmp_path):
     # An assistant text is not a pending model request: no model_wait.
     session = tmp_path / "s.jsonl"

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -21,17 +21,20 @@ FAKE_HZ = 100.0
 
 def make_procfs(tmp_path, processes, btime=FAKE_BTIME):
     """Build a fake procfs: `processes` is a list of
-    `(pid, comm, ppid, starttime_ticks, cmdline_bytes_or_None)`."""
+    `(pid, comm, ppid, starttime_ticks, cmdline_bytes_or_None, state)`
+    (the state char is optional, default `S`)."""
     proc = tmp_path / "proc"
     proc.mkdir()
     (proc / "stat").write_text(f"btime {int(btime)}\n", encoding="utf-8")
-    for pid, comm, ppid, starttime, cmdline in processes:
+    for item in processes:
+        pid, comm, ppid, starttime, cmdline = item[:5]
+        state = item[5] if len(item) > 5 else "S"
         entry = proc / str(pid)
         entry.mkdir()
         # stat layout: pid (comm) state ppid ... starttime (field 22).
         # After the LAST ')' the fields start at index 0 (state); ppid is
         # index 1 and starttime index 19.
-        fields = ["S", str(ppid)] + ["0"] * 17 + [str(starttime)]
+        fields = [state, str(ppid)] + ["0"] * 17 + [str(starttime)]
         (entry / "stat").write_text(
             f"{pid} ({comm}) " + " ".join(fields), encoding="utf-8",
         )
@@ -359,6 +362,25 @@ def test_find_idle_descendants_skips_unreadable_start_time(
     assert [t["pid"] for t in targets] == [200]
 
 
+def test_find_idle_descendants_skips_zombies(tmp_path, monkeypatch):
+    # Issue #169: a descendant that already exited but was not reaped
+    # yet (state Z, the parent is busy) is DEAD — signaling it is
+    # meaningless and its empty cmdline would fall back to the comm
+    # name (a lie like `timeout` for an exited `timeout 0.6 sleep 300`).
+    # Only running states are targets.
+    proc = make_procfs(tmp_path, [
+        (100, "pi", 1, 10, b"pi"),
+        (200, "timeout", 100, 100, b"timeout\x000.6\x00sleep\x00300",
+         "Z"),
+        (300, "sleep", 100, 200, b"sleep\x00300"),
+    ])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    targets = pi_recovery.find_idle_descendants(
+        100, start_epoch(1000), btime=FAKE_BTIME, hz=FAKE_HZ,
+    )
+    assert [t["pid"] for t in targets] == [300]
+
+
 def test_find_idle_descendants_uses_real_clock_when_not_given(
     tmp_path, monkeypatch,
 ):
@@ -437,3 +459,370 @@ def test_signal_pid_reports_failed_for_unreachable_process(
     monkeypatch.setattr(pi_recovery.os, "kill", deny)
     assert pi_recovery.signal_pid(42, signal.SIGTERM) == \
         "failed: [Errno 1] Operation not permitted"
+
+
+# --- Issue #169: evidence-based stall detection ------------------------------
+
+
+def test_process_state_reads_stat_state_char(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [(42, "bash", 7, 100, b"bash")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_state(42) == "S"
+
+
+def test_process_state_none_for_gone_process(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_state(99) is None
+
+
+def test_process_state_none_for_malformed_stat(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    (proc / "5").mkdir()
+    (proc / "5" / "stat").write_text("garbage without parens",
+                                     encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_state(5) is None
+
+
+def test_process_start_monotonic_reads_field_22(tmp_path, monkeypatch):
+    # stat field 22 (starttime) in ticks since boot, converted with the
+    # given hz: 100 ticks at hz=100 -> 1.0 s since boot. The value is a
+    # MONOTONIC offset (Issue #169): it is compared against
+    # `time.monotonic()`, never against the realtime epoch — a realtime
+    # step after boot (NTP) must not skew a process's age.
+    proc = make_procfs(tmp_path, [(42, "bash", 7, 100, b"bash")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_monotonic(42, hz=FAKE_HZ) == 1.0
+
+
+def test_process_start_monotonic_none_for_gone_process(tmp_path, monkeypatch):
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_monotonic(99, hz=FAKE_HZ) is None
+
+
+def test_process_start_monotonic_none_for_malformed_stat(
+    tmp_path, monkeypatch,
+):
+    proc = make_procfs(tmp_path, [])
+    (proc / "5").mkdir()
+    (proc / "5" / "stat").write_text("garbage without parens",
+                                     encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_monotonic(5, hz=FAKE_HZ) is None
+
+
+def test_process_start_monotonic_none_for_non_numeric_starttime(
+    tmp_path, monkeypatch,
+):
+    proc = make_procfs(tmp_path, [])
+    (proc / "6").mkdir()
+    # 17 zero fields after ppid, then a non-numeric starttime at index 19.
+    (proc / "6" / "stat").write_text(
+        "6 (bad) S 1 " + " ".join(["0"] * 17 + ["x"]), encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_start_monotonic(6, hz=FAKE_HZ) is None
+
+
+def test_timeout_duration_plain_seconds(tmp_path):
+    # The prompt contract form: `timeout <seconds> ...` — the duration
+    # is the immediate next token after the wrapper word.
+    assert pi_recovery.timeout_duration("timeout 240 pytest tests/") == 240.0
+
+
+def test_timeout_duration_after_bash_c_prefix(tmp_path):
+    # The Pi bash tool spawns `bash -c <command>`: the wrapper word is
+    # found wherever it stands in the command line.
+    assert pi_recovery.timeout_duration(
+        "/bin/bash -c timeout 240 pytest tests/",
+    ) == 240.0
+
+
+def test_timeout_duration_suffixes(tmp_path):
+    # coreutils duration suffixes: s, m, h, d.
+    assert pi_recovery.timeout_duration("timeout 4m pytest") == 240.0
+    assert pi_recovery.timeout_duration("timeout 1.5m pytest") == 90.0
+    assert pi_recovery.timeout_duration("timeout 1h pytest") == 3600.0
+    assert pi_recovery.timeout_duration("timeout 2d pytest") == 172800.0
+
+
+def test_timeout_duration_none_without_clear_timeout(tmp_path):
+    # No wrapper word, a word that merely contains `timeout`, or a
+    # missing/unparseable duration: NOT a clear timeout (fail-safe, the
+    # existing recovery behavior applies).
+    assert pi_recovery.timeout_duration("pytest tests/") is None
+    assert pi_recovery.timeout_duration("timeoutctl 240 x") is None
+    assert pi_recovery.timeout_duration("timeout pytest") is None
+    assert pi_recovery.timeout_duration("timeout abc pytest") is None
+    assert pi_recovery.timeout_duration("timeout -k 5 240 pytest") is None
+    assert pi_recovery.timeout_duration("timeout 0 pytest") is None
+
+
+def test_timeout_duration_edge_tokens(tmp_path):
+    # A `timeout` as the LAST token has no duration at all; an empty
+    # duration token, a multi-dot number and a bare `.` are not
+    # parseable durations.
+    assert pi_recovery.timeout_duration("bash -c timeout") is None
+    assert pi_recovery.timeout_duration("timeout '' x") is None
+    assert pi_recovery.timeout_duration("timeout 1.2.3 x") is None
+    assert pi_recovery.timeout_duration("timeout . x") is None
+
+
+def test_timeout_deadline_plain_seconds(tmp_path):
+    # The prompt contract form: `timeout <seconds> ...`.
+    assert pi_recovery.timeout_deadline(
+        "timeout 240 pytest tests/", 1000.0,
+    ) == 1240.0
+
+
+def test_timeout_deadline_after_bash_c_prefix(tmp_path):
+    # The Pi bash tool spawns `bash -c <command>`: the wrapper word is
+    # found wherever it stands in the command line.
+    assert pi_recovery.timeout_deadline(
+        "/bin/bash -c timeout 240 pytest tests/", 1000.0,
+    ) == 1240.0
+
+
+def test_timeout_deadline_duration_suffixes(tmp_path):
+    # coreutils duration suffixes: s, m, h, d.
+    assert pi_recovery.timeout_deadline(
+        "timeout 4m pytest", 0.0,
+    ) == 240.0
+    assert pi_recovery.timeout_deadline(
+        "timeout 1.5m pytest", 0.0,
+    ) == 90.0
+    assert pi_recovery.timeout_deadline(
+        "timeout 1h pytest", 0.0,
+    ) == 3600.0
+    assert pi_recovery.timeout_deadline(
+        "timeout 2d pytest", 0.0,
+    ) == 172800.0
+
+
+def test_timeout_deadline_none_without_timeout_word(tmp_path):
+    assert pi_recovery.timeout_deadline("pytest tests/", 1000.0) is None
+    # `timeout` inside a longer word is not the wrapper.
+    assert pi_recovery.timeout_deadline("timeoutctl 240 x", 1000.0) is None
+
+
+def test_timeout_deadline_none_without_duration(tmp_path):
+    # A `timeout` without a parseable duration is not a CLEAR timeout:
+    # the existing recovery behavior applies (fail-safe).
+    assert pi_recovery.timeout_deadline("timeout pytest", 1000.0) is None
+    assert pi_recovery.timeout_deadline("timeout abc pytest", 1000.0) is None
+    assert pi_recovery.timeout_deadline(
+        "timeout -k 5 240 pytest", 1000.0,
+    ) is None
+
+
+def test_upstream_alive_true_for_established_tcp_socket(
+    tmp_path, monkeypatch,
+):
+    # The process holds a socket whose inode appears in /proc/net/tcp
+    # with a non-zero remote address: the upstream connection is live.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "42" / "fd" / "8").symlink_to("anon_inode:[eventpoll]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 0100007F:8762 01 00000000:00000000 00:00000000 00000000     0        0 12345 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is True
+
+
+def test_upstream_alive_false_for_listen_only_socket(
+    tmp_path, monkeypatch,
+):
+    # A socket with a zero remote address (LISTEN) is not an upstream
+    # connection: no remote peer, no live model request.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False
+
+
+def test_upstream_alive_true_for_established_tcp6_socket(
+    tmp_path, monkeypatch,
+):
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[999]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n"
+        "   0: 00000000000000000000000000000001:01BB "
+        "00000000000000000000000000000002:01BB 01 00000000:00000000 00:00000000 00000000     0        0 999 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is True
+
+
+def test_upstream_alive_false_for_close_wait_socket(
+    tmp_path, monkeypatch,
+):
+    # The peer (the upstream) closed the connection: the socket sits in
+    # CLOSE_WAIT (08) with the remote address still printed — the
+    # request is dead, the runner must not see a live upstream.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 0100007F:8762 08 00000000:00000000 "
+        "00:00000000 00000000     0        0 12345 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False
+
+
+def test_upstream_alive_false_for_gone_process(tmp_path, monkeypatch):
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False
+
+
+def test_upstream_alive_false_when_socket_has_no_remote_entry(
+    tmp_path, monkeypatch,
+):
+    # The process holds a socket (e.g. AF_UNIX: `socket:[ino]` in the fd
+    # table but no /proc/net/tcp entry with a remote address): no live
+    # upstream TCP connection.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[777]")
+    (proc / "net").mkdir()
+    # The only TCP entry belongs to ANOTHER process's socket.
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 0100007F:8762 01 00000000:00000000 00:00000000 00000000     0        0 555 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False
+
+
+def test_upstream_alive_skips_fd_entry_that_cannot_be_read(
+    tmp_path, monkeypatch,
+):
+    # An fd entry that vanishes between the directory listing and the
+    # readlink (OSError) is skipped, never a crash — the remaining
+    # socket is still evaluated.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    # A REGULAR file in the fd table: readlink on it raises OSError.
+    (proc / "42" / "fd" / "8").write_text("nope", encoding="utf-8")
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 0100007F:8762 01 00000000:00000000 00:00000000 00000000     0        0 12345 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is True
+
+
+def test_upstream_alive_skips_unreadable_net_tables(
+    tmp_path, monkeypatch,
+):
+    # A /proc/net table that cannot be read (OSError) is skipped, never
+    # a crash: with no readable table there is no live evidence.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "net").mkdir()
+    # `tcp` is a DIRECTORY: read_text raises IsADirectoryError (OSError).
+    (proc / "net" / "tcp").mkdir()
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False
+
+
+def test_upstream_alive_false_for_live_state_without_remote_ip(
+    tmp_path, monkeypatch,
+):
+    # A socket in a live state (SYN_SENT) whose remote address is the
+    # all-zero placeholder has no remote peer yet: not a live upstream.
+    proc = tmp_path / "proc"
+    (proc / "42" / "fd").mkdir(parents=True)
+    (proc / "42" / "stat").write_text(
+        "42 (pi) S 1 " + " ".join(["0"] * 18), encoding="utf-8",
+    )
+    (proc / "42" / "fd" / "7").symlink_to("socket:[12345]")
+    (proc / "net").mkdir()
+    (proc / "net" / "tcp").write_text(
+        "  sl  local_address rem_address   st inode\n"
+        "   0: 0100007F:1F90 00000000:0000 02 00000000:00000000 00:00000000 00000000     0        0 12345 1 00000000d7514f4a 100\n",
+        encoding="utf-8",
+    )
+    (proc / "net" / "tcp6").write_text(
+        "  sl  local_address remote_address st inode\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.upstream_alive(42) is False

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -570,53 +570,6 @@ def test_timeout_duration_edge_tokens(tmp_path):
     assert pi_recovery.timeout_duration("timeout . x") is None
 
 
-def test_timeout_deadline_plain_seconds(tmp_path):
-    # The prompt contract form: `timeout <seconds> ...`.
-    assert pi_recovery.timeout_deadline(
-        "timeout 240 pytest tests/", 1000.0,
-    ) == 1240.0
-
-
-def test_timeout_deadline_after_bash_c_prefix(tmp_path):
-    # The Pi bash tool spawns `bash -c <command>`: the wrapper word is
-    # found wherever it stands in the command line.
-    assert pi_recovery.timeout_deadline(
-        "/bin/bash -c timeout 240 pytest tests/", 1000.0,
-    ) == 1240.0
-
-
-def test_timeout_deadline_duration_suffixes(tmp_path):
-    # coreutils duration suffixes: s, m, h, d.
-    assert pi_recovery.timeout_deadline(
-        "timeout 4m pytest", 0.0,
-    ) == 240.0
-    assert pi_recovery.timeout_deadline(
-        "timeout 1.5m pytest", 0.0,
-    ) == 90.0
-    assert pi_recovery.timeout_deadline(
-        "timeout 1h pytest", 0.0,
-    ) == 3600.0
-    assert pi_recovery.timeout_deadline(
-        "timeout 2d pytest", 0.0,
-    ) == 172800.0
-
-
-def test_timeout_deadline_none_without_timeout_word(tmp_path):
-    assert pi_recovery.timeout_deadline("pytest tests/", 1000.0) is None
-    # `timeout` inside a longer word is not the wrapper.
-    assert pi_recovery.timeout_deadline("timeoutctl 240 x", 1000.0) is None
-
-
-def test_timeout_deadline_none_without_duration(tmp_path):
-    # A `timeout` without a parseable duration is not a CLEAR timeout:
-    # the existing recovery behavior applies (fail-safe).
-    assert pi_recovery.timeout_deadline("timeout pytest", 1000.0) is None
-    assert pi_recovery.timeout_deadline("timeout abc pytest", 1000.0) is None
-    assert pi_recovery.timeout_deadline(
-        "timeout -k 5 240 pytest", 1000.0,
-    ) is None
-
-
 def test_upstream_alive_true_for_established_tcp_socket(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
Fixes #169

<!-- muyan-pilot:run=b4782a83 -->

run_id=b4782a83

## What

The Runner's stall detection killed healthy long-running tasks. This makes
both kill decisions evidence-based:

1. **`model_wait` silence no longer proves the upstream is dead** (the
   #158 regression: a slow local model generating for minutes was killed
   as `upstream_dead`). The kill now requires the silence past
   `PI_MODEL_WAIT_DEAD_SECONDS` **and** no live upstream connection: the
   Pi process's fd table is scanned for `socket:[...]` inodes matched
   against `/proc/net/tcp{,6}` — a socket in ESTABLISHED/SYN_SENT/
   SYN_RECV with a non-zero remote address is live; CLOSE_WAIT and other
   states are not. A slow model with a live connection is never killed;
   its wait becomes visible as `state=model_wait_slow` on the
   activity/heartbeat lines. A truly dead upstream (silence + no live
   connection) still fails fast via the unchanged
   `upstream_dead_stale_...` path.
2. **A tool inside an explicit `timeout` deadline is no longer
   TERM/KILL'd by idle recovery** (the #105 regression: a
   `timeout 240` regression loop was killed at the idle windows). Window
   1 now checks the pre-idle descendants: one whose cmdline is a
   coreutils `timeout <seconds> ...` wrapper still inside its deadline
   (process start + duration, computed clock-consistently in the
   monotonic domain — NTP realtime steps cannot skew it) is a
   legitimately running tool: the Runner logs one `pi_idle_wait` line
   (pid, cmdline, deadline), reports `recovery=wait` in the progress
   comment, and pauses the escalation; every later window re-evaluates.
   When the deadline passes with the descendant still alive (the wrapper
   failed to end the command) the evidence flips and the existing TERM →
   KILL → session-kill escalation runs unchanged — the slot is never
   held forever.
3. **Zombies are excluded from recovery targets**: a state-Z descendant
   is already dead — signaling it is meaningless and its empty cmdline
   would fall back to the comm name, a lie.

## Evidence / tests

- TDD red→green throughout; new deterministic tests:
  - `pi_activity`: `model_wait_seconds` in the watcher state.
  - `pi_recovery`: `process_state`, `process_start_monotonic`,
    `timeout_duration`/`timeout_deadline` (suffixes, fail-safe tokens),
    `upstream_alive` (real `/proc/net/tcp` format, live states,
    CLOSE_WAIT, no-remote, unreadable fd/table), zombie exclusion in
    `find_idle_descendants`.
  - `stream_pi` integration: slow model past the threshold with a live
    TCP connection is NOT killed (#158); dead connection still killed
    (#75 contract); a `timeout 0.6 sleep 300` tool inside its deadline is
    NOT TERMed (`pi_idle_wait` once, `recovery=wait` visible, run
    succeeds); a fake `timeout` that ignores its deadline IS TERMed
    after the deadline (existing escalation).
- Full suite: **1099 passed**, **100% line and branch coverage**
  (`coverage run --branch -m pytest tests/ -q`), recorded in `test.log`.
- Note: `test_concurrency_e2e.py::test_live_pr_opened_delivery_is_not_
  resumed_by_second_runner` is a pre-existing flaky live e2e (race in the
  fake world between the first runner's merge and the second runner's
  PR-open base check); verified flaky on the unmodified base as well.
- README.md / AGENTS.md observability sections updated to the new
  evidence-based contract.

## Changed files

- `pi_activity.py` — `model_wait_seconds` in the watcher state.
- `pi_recovery.py` — `process_state`, `process_start_monotonic`,
  `timeout_duration`, `timeout_deadline`, `upstream_alive`; zombie
  exclusion in `find_idle_descendants`.
- `bootstrap_runner.py` — evidence-based `model_wait` kill,
  `_pending_timeout_targets`, `pi_idle_wait` / `recovery=wait`,
  `state=model_wait_slow`.
- `README.md`, `AGENTS.md` — observability contract.
- `tests/test_pi_activity.py`, `tests/test_pi_recovery.py`,
  `tests/test_bootstrap_runner.py` — the tests above.
