### PR TITLE
Auto-refresh the editable CLI install when packaging inputs change (Issue #158)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,36 @@ acceptance criteria.
   structured `cli_source_drift` line (actual import path, expected
   repo_dir, the exact editable reinstall command) and repaired by
   `muyan-pilot setup` (the CLI step verifies or force-reinstalls the
-  editable install); the Runner never installs the tool at start.
+  editable install).
+- The Runner refreshes the editable install at start (Issue #158):
+  the editable finder's module MAPPING is generated at INSTALL time
+  from the checkout's `pyproject.toml` (`py-modules`, entry points,
+  version, dependencies), so a merged PACKAGING change (e.g. a new
+  runtime module in `py-modules`) leaves a stale finder and the next
+  CLI process dies with `ModuleNotFoundError` before the Runner can
+  start (the #158 incident: `cli_source` merged to main, the installed
+  finder still mapped the pre-#152 module set, the systemd start
+  failed). The Runner tick entry (BEFORE any slot or claim; the CLI
+  subcommands never install) compares the packaging fingerprint (the
+  sha256 of the checkout's `pyproject.toml`) with the last successful
+  install's fingerprint, stored in the shared state dir
+  (`<repo_dir>/.muyan-pilot/cli-install.json` — the same gitignored
+  dir as `base-sync.lock` and the slots; it is NOT a second release
+  state): unchanged -> NO uv call at all (no per-tick unconditional
+  reinstall); changed or no state yet (first install) -> ONE
+  lock-protected `uv tool install --force --reinstall --editable
+  --python /usr/bin/python3 <repo_dir>` (the SAME base-sync flock the
+  service template's `ExecStartPre` uses — two instances starting in
+  the same tick serialize, the second re-reads the state under the
+  lock and reuses the first's result, never a concurrent uv install),
+  the fingerprint is recorded only after a successful install, and a
+  failing install fails the start fast with the structured
+  `cli_install_failed` line (reason + the exact fix command): no
+  slot, no claim, no label change, no state recorded (the next start
+  retries). Ordinary Python source content is NOT part of the
+  fingerprint (the editable finder maps the live files — a content
+  change needs no reinstall), and systemd template changes stay with
+  the unit drift mechanism above.
 - A template change is a deployment change (Issue #131, #142): a PR
   that modifies `systemd/muyan-pilot@.service` or `systemd/muyan-pilot@.timer`
   takes effect without a human step — the NEXT timer trigger's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,7 +255,18 @@ acceptance criteria.
   retries). Ordinary Python source content is NOT part of the
   fingerprint (the editable finder maps the live files — a content
   change needs no reinstall), and systemd template changes stay with
-  the unit drift mechanism above.
+  the unit drift mechanism above. The refresh IMPLEMENTATION lives in
+  `bootstrap_runner` itself, NOT in a separate new module: the
+  bootstrap chain (`muyan_pilot` -> `bootstrap_runner`) must still
+  LOAD and REFRESH in a tool env whose installed finder predates this
+  PR's packaging change (the #158 scene) — a new module for the
+  refresh would not be importable there, and the very refresh that
+  reinstalls the tool env could never run (the #158 incident, one
+  module later). `cli_install` is a thin re-export of the
+  implementation for the tests' single import point; the bootstrap
+  chain never imports it (a regression test pins this: a fresh
+  `bootstrap_runner` loads with `cli_install` blocked from the import
+  system and its `refresh_cli_install` gate still runs).
 - A template change is a deployment change (Issue #131, #142): a PR
   that modifies `systemd/muyan-pilot@.service` or `systemd/muyan-pilot@.timer`
   takes effect without a human step — the NEXT timer trigger's

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **系统架构总览**（GitHub Issues、systemd timer/service、Runner、Pi、worktree、llama-server、可选 `local-llm-kv-cache` proxy、PR/review/merge）：文档站首页 [index](docs/index.mdx) / [zh/index](docs/zh/index.mdx)；
 - **任务生命周期状态机**（`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked`，标出 Epic/Release task/P0 边界）：[workflow](docs/workflow.mdx) / [zh/workflow](docs/zh/workflow.mdx)。
 
-## CLI 安装与升级（Issue #140、#152）
+## CLI 安装与升级（Issue #140、#152、#158）
 
 正式使用方式是 **editable** `uv tool` 安装的可执行 CLI（console script `muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）——这是官方本地部署方式：
 
@@ -27,7 +27,17 @@ muyan-pilot --help
 muyan-pilot --version
 ```
 
-**为什么必须 editable（Issue #152）**：非 editable 安装会把源码复制进 tool 环境的 site-packages；`ExecStartPre` 把 checkout 同步到最新 main 之后，CLI 仍在执行旧副本——这正是 #152 的 P0 启动死锁（旧 CLI 检查旧的非模板 unit 路径，永远跑不到新的迁移代码）。editable 安装下，下一个 CLI 进程（下一个 timer 启动的 Runner）自动从 checkout 取到最新代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。只有依赖、入口点、包名、构建后端或 Python 版本变化时，才重新执行上面的 force editable 重装命令。
+**为什么必须 editable（Issue #152）**：非 editable 安装会把源码复制进 tool 环境的 site-packages；`ExecStartPre` 把 checkout 同步到最新 main 之后，CLI 仍在执行旧副本——这正是 #152 的 P0 启动死锁（旧 CLI 检查旧的非模板 unit 路径，永远跑不到新的迁移代码）。editable 安装下，下一个 CLI 进程（下一个 timer 启动的 Runner）自动从 checkout 取到最新代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。
+
+**打包元数据变更的自动刷新（Issue #158）**：editable finder 的模块映射是在**安装时**从 checkout 的 `pyproject.toml`（`py-modules`、入口点、版本、依赖）生成的——所以合并了打包输入变更（例如 `py-modules` 新增运行时模块）后，已安装的 finder 会过期，下一个 CLI 进程在 Runner 启动前就 `ModuleNotFoundError`（#158 事故：`cli_source` 合入 main 后，已安装 finder 仍映射 #152 之前的模块集，systemd 启动失败）。现在 Runner 每次启动（tick 入口，在任何 slot/claim 之前）自动刷新：
+
+- 打包指纹 = checkout `pyproject.toml` 的 sha256，与**上次成功安装**记录的指纹（共享状态目录 `.muyan-pilot/cli-install.json`，与 `base-sync.lock`、slots 同目录，gitignored，随 checkout 同步存活）比较；
+- **未变**：完全不跑 `uv`（不做每 tick 无条件重装）；
+- **变更或首次安装**（无状态记录）：在 base-sync flock 保护下跑一次上面的 force editable 重装（与服务模板 `ExecStartPre` 同一把锁——两个 instance 同 tick 启动时串行化，第二个等待并复用第一个的结果，绝不并发 `uv`）；安装成功后才记录新指纹；
+- **安装失败**：fail fast（非零退出，结构化 `cli_install_failed` 行：原因 + 精确的修复命令），不取 slot、不 claim、不改标签，不记录状态（下次启动重试）；
+- 普通 Python 源码内容变更**不**触发重装（editable finder 映射的就是活文件，这正是 editable 的意义）。
+
+上面的 force editable 命令仍是人工 setup 入口（`muyan-pilot setup` 的 CLI 步骤）；Runner 启动时的自动刷新只在打包输入变更时执行同一条命令。
 
 `uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件在 `~/.local/bin/muyan-pilot`（systemd unit 的 PATH 已包含该目录，见「部署一致性」）。`muyan-pilot doctor` 报告 CLI 源码一致性：`cli_source: clean source=...`（运行进程从配置的 checkout 导入）或 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行（实际导入路径、期望 repo_dir、精确的 editable 重装命令）。发布包不携带第三方运行时依赖、token 或用户目录：配置（`muyan-pilot.toml`）和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径，不是正式使用方式。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -38,6 +38,8 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
+import cli_install
+from cli_install import base_sync_lock_path, acquire_base_sync_lock
 from git_transport import TransportError, check_transport
 from pilot_slots import acquire_slot, slot_dir_for, slot_occupancy
 from pi_recovery import find_idle_descendants, pid_alive, signal_pid
@@ -2316,52 +2318,11 @@ def review_rounds_so_far(comments: list[dict]) -> int:
     return rounds
 
 
-BASE_SYNC_LOCK_NAME = "base-sync.lock"
-
-
-def base_sync_lock_path(repo_dir: Path) -> Path:
-    """Issue #149: the lock file serializing ALL writers of the
-    deployment base checkout.
-
-    Two timer instances may start in the same tick, so the service
-    template's `ExecStartPre` wraps the fetch + fast-forward in a
-    short-lived `flock` on this SAME file, and the Python-side sync
-    below takes the same lock: the main worktree is never written
-    concurrently. The lock lives in the shared state dir (next to the
-    slot files), never in a per-process temp dir.
-    """
-    return Path(repo_dir) / ".muyan-pilot" / BASE_SYNC_LOCK_NAME
-
-
-def _acquire_base_sync_lock(
-    repo_dir: Path, lock_timeout_seconds: float,
-) -> int:
-    """Take the base-sync flock; fail fast when it is still held after
-    the timeout. The kernel releases an flock when its holder exits,
-    so a dead holder can never wedge the lock."""
-    lock_path = base_sync_lock_path(repo_dir)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-    deadline = time.monotonic() + lock_timeout_seconds
-    while True:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return fd
-        except (BlockingIOError, InterruptedError, PermissionError):
-            if time.monotonic() >= deadline:
-                os.close(fd)
-                LOGGER.error(
-                    "base_sync_lock_timeout repo_dir=%s lock=%s "
-                    "timeout_seconds=%s",
-                    repo_dir, lock_path, lock_timeout_seconds,
-                )
-                raise RuntimeError(
-                    f"could not take the base-sync lock {lock_path} "
-                    f"within {lock_timeout_seconds}s (another Runner "
-                    "instance or the ExecStartPre preflight is syncing "
-                    "the deployment checkout)"
-                ) from None
-            time.sleep(0.1)
+# The base-sync lock helpers live in cli_install (Issue #158: one
+# home for the concurrency primitive — the checkout sync, the
+# ExecStartPre preflight and the CLI install refresh all serialize on
+# the SAME lock file); they are re-exported here so existing callers
+# and tests keep their imports.
 
 
 def sync_base_checkout(repo_dir: Path, base_branch: str,
@@ -2380,7 +2341,7 @@ def sync_base_checkout(repo_dir: Path, base_branch: str,
     worktree concurrently; the lock is released when the sync finishes
     (success or failure).
     """
-    fd = _acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
     try:
         _sync_base_checkout_locked(repo_dir, base_branch)
     finally:
@@ -3577,6 +3538,24 @@ def main(argv: list[str] | None = None) -> int:
 
     config = load_config(args.config)
     validate_config(config)
+    # Editable CLI install refresh (Issue #158): BEFORE any slot or
+    # claim the tool env's editable metadata must match the checkout's
+    # packaging inputs — the finder's module mapping is generated at
+    # install time from `pyproject.toml`, so a merged packaging change
+    # (e.g. a new runtime module in `py-modules`) would otherwise make
+    # the NEXT CLI process die with `ModuleNotFoundError` before the
+    # Runner can start (the #158 incident). Unchanged: no uv call (no
+    # per-tick reinstall); changed or first install: ONE lock-
+    # protected editable force reinstall (the SAME base-sync flock the
+    # service template's ExecStartPre uses — two instances starting in
+    # the same tick serialize, the second reuses the first's result).
+    # A failing install fails the start with the structured
+    # `cli_install_failed` line (reason + fix command): no slot, no
+    # claim, no label change. Runs ONLY in the Runner tick entry (the
+    # bare CLI) — the subcommands never install.
+    cli_install.refresh_cli_install(
+        config["repo_dir"], run_command=run_command,
+    )
     # Deployment consistency (Issue #103, #142): BEFORE any slot or
     # claim the installed systemd units must match the repo templates
     # (the templates the ExecStartPre-synced checkout just loaded).

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import json
 import logging
 import os
@@ -38,8 +39,17 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
-import cli_install
-from cli_install import base_sync_lock_path, acquire_base_sync_lock
+# NOTE (Issue #158): the editable CLI install refresh below lives in
+# THIS module on purpose: the bootstrap chain (`muyan_pilot` ->
+# `bootstrap_runner`) must still LOAD in a tool env whose installed
+# editable finder predates this PR's packaging change (the STALE-finder
+# scene of #158 itself — the finder's module mapping is generated at
+# install time, so a merged new runtime module is not mapped by the
+# installed finder). A separate new module for the refresh would not be
+# importable there, and the very refresh that reinstalls the tool env
+# could never run (the #158 incident, one module later). `cli_install`
+# is a thin re-export of this implementation for the tests only — the
+# bootstrap chain never imports it.
 from git_transport import TransportError, check_transport
 from pilot_slots import acquire_slot, slot_dir_for, slot_occupancy
 from pi_recovery import (
@@ -2428,11 +2438,263 @@ def review_rounds_so_far(comments: list[dict]) -> int:
     return rounds
 
 
-# The base-sync lock helpers live in cli_install (Issue #158: one
-# home for the concurrency primitive — the checkout sync, the
-# ExecStartPre preflight and the CLI install refresh all serialize on
-# the SAME lock file); they are re-exported here so existing callers
-# and tests keep their imports.
+# ---------------------------------------------------------------------------
+# Editable CLI install refresh (Issue #158)
+# ---------------------------------------------------------------------------
+#
+# The official local deployment is the EDITABLE uv tool install (Issue
+# #152): the tool env imports the runtime modules directly from the
+# deployment checkout through a setuptools editable finder. The
+# finder's module MAPPING is generated at INSTALL time from the
+# checkout's `pyproject.toml` (`py-modules`, entry points, version,
+# dependencies) — so when the packaging inputs change (a new runtime
+# module is added to `py-modules`, a dependency or entry point
+# changes), the installed finder is STALE: the next CLI process dies
+# with `ModuleNotFoundError` before the Runner can even start (the
+# #158 incident: `cli_source` merged to main, the installed finder
+# still mapped the pre-#152 module set, the systemd start failed).
+#
+# This section refreshes the editable install at the Runner start,
+# BEFORE any slot or claim:
+#
+# - the packaging fingerprint (sha256 of the checkout's
+#   `pyproject.toml` — the packaging input that decides the editable
+#   metadata) is compared against the fingerprint of the LAST
+#   successful install, stored in the shared state dir
+#   (`.muyan-pilot/cli-install.json` — the same gitignored dir as
+#   `base-sync.lock` and the slots, which survives the
+#   `git merge --ff-only` checkout sync). It is NOT a second release
+#   state: it only records which packaging input the installed tool
+#   env was built from;
+# - unchanged: NO uv call at all (no per-tick reinstall);
+# - changed, or no state yet (first install): ONE lock-protected
+#   `uv tool install --force --reinstall --editable --python
+#   /usr/bin/python3 <repo_dir>` (the exact verified argv from
+#   `cli_source.reinstall_args`);
+# - two instances starting in the same tick: the SAME base-sync flock
+#   (the lock file the service template's `ExecStartPre` also takes)
+#   serializes them; the second instance re-reads the state UNDER the
+#   lock and reuses the first's result — no concurrent uv install, no
+#   corrupted tool env;
+# - a failing install fails fast with the structured
+#   `cli_install_failed` line (reason + the exact fix command) and
+#   records NO state (the next start retries).
+#
+# The implementation lives in `bootstrap_runner` itself (see the NOTE
+# at the top of this file): a separate new module would not be
+# importable in the stale-finder tool env, and the refresh that
+# repairs the finder could never run. `cli_source` is imported lazily
+# inside `refresh_cli_install`: the reinstall argv is the single
+# cross-module dependency (Issue #152's verified command).
+
+CLI_INSTALL_LOGGER = logging.getLogger("muyan_pilot.cli_install")
+
+# The uv install timeout (seconds): a local editable build of this
+# zero-dependency package takes seconds; a hang (a wedged uv or a
+# full disk) must fail the start, never block it forever (Issue #95:
+# blocking commands carry a timeout).
+UV_INSTALL_TIMEOUT_SECONDS = 300
+
+# The base-sync lock: one home for the concurrency primitive — the
+# checkout sync, the ExecStartPre preflight and the CLI install
+# refresh all serialize on the SAME lock file.
+BASE_SYNC_LOCK_NAME = "base-sync.lock"
+
+
+class CliInstallError(RuntimeError):
+    """The editable CLI install refresh failed (fail fast)."""
+
+
+def base_sync_lock_path(repo_dir: Path) -> Path:
+    """The lock file serializing ALL writers of the deployment base
+    checkout and its tool env.
+
+    Two timer instances may start in the same tick, so the service
+    template's `ExecStartPre` wraps the fetch + fast-forward in a
+    short-lived `flock` on this SAME file, and the Python-side
+    checkout sync and the CLI install refresh take the same lock: the
+    main worktree and the tool env are never written concurrently.
+    The lock lives in the shared state dir (next to the slot files),
+    never in a per-process temp dir.
+    """
+    return Path(repo_dir) / ".muyan-pilot" / BASE_SYNC_LOCK_NAME
+
+
+def acquire_base_sync_lock(
+    repo_dir: Path, lock_timeout_seconds: float,
+) -> int:
+    """Take the base-sync flock; fail fast when it is still held after
+    the timeout. The kernel releases an flock when its holder exits,
+    so a dead holder can never wedge the lock."""
+    lock_path = base_sync_lock_path(repo_dir)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    deadline = time.monotonic() + lock_timeout_seconds
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except (BlockingIOError, InterruptedError, PermissionError):
+            if time.monotonic() >= deadline:
+                os.close(fd)
+                CLI_INSTALL_LOGGER.error(
+                    "base_sync_lock_timeout repo_dir=%s lock=%s "
+                    "timeout_seconds=%s",
+                    repo_dir, lock_path, lock_timeout_seconds,
+                )
+                raise CliInstallError(
+                    f"could not take the base-sync lock {lock_path} "
+                    f"within {lock_timeout_seconds}s (another Runner "
+                    "instance or the ExecStartPre preflight is syncing "
+                    "the deployment checkout)"
+                ) from None
+            time.sleep(0.1)
+
+
+def packaging_fingerprint(repo_dir: Path) -> str:
+    """The sha256 of the checkout's `pyproject.toml`.
+
+    `pyproject.toml` is the packaging input that decides the editable
+    metadata (the finder's module mapping from `py-modules`, the entry
+    points, the version, the dependencies) — so its content hash is
+    the refresh trigger. Ordinary Python source content is NOT part
+    of it: the editable finder maps the live files, a content change
+    needs no reinstall (the whole point of the editable install,
+    Issue #152). A checkout without `pyproject.toml` cannot be
+    tool-installed: fail fast, never guess a fingerprint.
+    """
+    pyproject = Path(repo_dir) / "pyproject.toml"
+    if not pyproject.is_file():
+        raise CliInstallError(
+            f"packaging file missing: {pyproject} (the deployment "
+            "checkout must carry the packaging input of the editable "
+            "install)"
+        )
+    return hashlib.sha256(pyproject.read_bytes()).hexdigest()
+
+
+def install_state_path(repo_dir: Path) -> Path:
+    """The last-install fingerprint record in the shared state dir.
+
+    `<repo_dir>/.muyan-pilot/cli-install.json` — the EXISTING shared
+    state dir (gitignored, next to `base-sync.lock` and the slots;
+    it survives the `git merge --ff-only` checkout sync). Not a second
+    release state and not a per-process temp file.
+    """
+    return Path(repo_dir) / ".muyan-pilot" / "cli-install.json"
+
+
+def read_install_state(repo_dir: Path) -> str | None:
+    """The stored last-install fingerprint, or None.
+
+    Missing file (first install / fresh checkout) -> None. A
+    malformed file (a torn write) is treated as "no state" and heals
+    in the SAFE direction: one extra idempotent `--force
+    --reinstall` runs — never a wedged start.
+    """
+    path = install_state_path(repo_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    fingerprint = data.get("pyproject_sha256") if isinstance(data, dict) else None
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return None
+    return fingerprint
+
+
+def write_install_state(repo_dir: Path, fingerprint: str) -> None:
+    """Record the last-install fingerprint (atomic: tmp + replace).
+
+    Only called AFTER a successful install, under the base-sync flock
+    (no concurrent writer; the atomic replace guards a torn write on
+    a crash mid-install).
+    """
+    path = install_state_path(repo_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
+    )
+    os.replace(str(tmp), str(path))
+
+
+def refresh_cli_install(
+    repo_dir: Path, *, run_command,
+    lock_timeout_seconds: float = 300.0,
+) -> str:
+    """Refresh the editable CLI install when the packaging inputs
+    changed; return `"unchanged"` or `"installed"`.
+
+    The pre-start gate (called by the Runner tick before any slot or
+    claim):
+
+    - the current packaging fingerprint equals the stored last-install
+      fingerprint -> `"unchanged"` and NO uv call (no per-tick
+      reinstall);
+    - otherwise (changed, or no state yet — the first install): take
+      the base-sync flock (the SAME lock the service template's
+      `ExecStartPre` and the checkout sync use), re-check the state
+      UNDER the lock (a concurrent instance may have refreshed while
+      we waited — reuse its result, never run a second install), run
+      the exact verified editable force reinstall from
+      `cli_source.reinstall_args`, and record the fingerprint only
+      after success.
+
+    A failing install logs the structured `cli_install_failed` line
+    (reason + the exact fix command) and raises `CliInstallError`:
+    the service does not start (fail fast), no state is recorded (the
+    next start retries) and the lock is released (success or
+    failure).
+    """
+    repo_dir = Path(repo_dir)
+    fingerprint = packaging_fingerprint(repo_dir)
+    if read_install_state(repo_dir) == fingerprint:
+        CLI_INSTALL_LOGGER.info(
+            "cli_install_unchanged repo_dir=%s pyproject_sha256=%s",
+            repo_dir, fingerprint,
+        )
+        return "unchanged"
+    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    try:
+        # Re-check UNDER the lock: a concurrent instance may have
+        # refreshed the tool env while we waited for the flock —
+        # reuse its result, never run a second install.
+        if read_install_state(repo_dir) == fingerprint:
+            CLI_INSTALL_LOGGER.info(
+                "cli_install_reused repo_dir=%s pyproject_sha256=%s",
+                repo_dir, fingerprint,
+            )
+            return "unchanged"
+        reason = "first_install" if (
+            read_install_state(repo_dir) is None
+        ) else "packaging_changed"
+        import cli_source  # lazy: the single cross-module dependency
+        try:
+            run_command(
+                cli_source.reinstall_args(repo_dir),
+                timeout=UV_INSTALL_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            CLI_INSTALL_LOGGER.error(
+                "cli_install_failed repo_dir=%s reason=%s fix=%s",
+                repo_dir, quote_value(str(exc)),
+                quote_value(cli_source.reinstall_command(repo_dir)),
+            )
+            raise CliInstallError(
+                f"editable CLI install failed for {repo_dir}: {exc} "
+                f"(fix: {cli_source.reinstall_command(repo_dir)})"
+            ) from exc
+        write_install_state(repo_dir, fingerprint)
+        CLI_INSTALL_LOGGER.info(
+            "cli_install_refreshed repo_dir=%s reason=%s "
+            "pyproject_sha256=%s",
+            repo_dir, reason, fingerprint,
+        )
+        return "installed"
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def sync_base_checkout(repo_dir: Path, base_branch: str,
@@ -3662,8 +3924,11 @@ def main(argv: list[str] | None = None) -> int:
     # A failing install fails the start with the structured
     # `cli_install_failed` line (reason + fix command): no slot, no
     # claim, no label change. Runs ONLY in the Runner tick entry (the
-    # bare CLI) — the subcommands never install.
-    cli_install.refresh_cli_install(
+    # bare CLI) — the subcommands never install. The implementation
+    # lives in THIS module (see the NOTE at the top): a separate new
+    # module would not be importable in the stale-finder tool env, and
+    # the refresh that repairs the finder could never run.
+    refresh_cli_install(
         config["repo_dir"], run_command=run_command,
     )
     # Deployment consistency (Issue #103, #142): BEFORE any slot or

--- a/cli_install.py
+++ b/cli_install.py
@@ -1,0 +1,271 @@
+"""Auto-refresh of the editable CLI install at Runner start (Issue #158).
+
+The official local deployment is the EDITABLE uv tool install (Issue
+#152): the tool env imports the runtime modules directly from the
+deployment checkout through a setuptools editable finder. The
+finder's module MAPPING is generated at INSTALL time from the
+checkout's ``pyproject.toml`` (``py-modules``, entry points, version,
+dependencies) — so when the packaging inputs change (a new runtime
+module is added to ``py-modules``, a dependency or entry point
+changes), the installed finder is STALE: the next CLI process dies
+with ``ModuleNotFoundError`` before the Runner can even start (the
+#158 incident: ``cli_source`` merged to main, the installed finder
+still mapped the pre-#152 module set, the systemd start failed).
+
+This module refreshes the editable install at the Runner start,
+BEFORE any slot or claim:
+
+- the packaging fingerprint (sha256 of the checkout's
+  ``pyproject.toml`` — the packaging input that decides the editable
+  metadata) is compared against the fingerprint of the LAST
+  successful install, stored in the shared state dir (``.muyan-pilot/
+  cli-install.json`` — the same gitignored dir as ``base-sync.lock``
+  and the slots, which survives the ``git merge --ff-only`` checkout
+  sync). It is NOT a second release state: it only records which
+  packaging input the installed tool env was built from;
+- unchanged: NO uv call at all (no per-tick reinstall);
+- changed, or no state yet (first install): ONE lock-protected
+  ``uv tool install --force --reinstall --editable --python
+  /usr/bin/python3 <repo_dir>`` (the exact verified argv from
+  ``cli_source.reinstall_args``);
+- two instances starting in the same tick: the SAME base-sync flock
+  (the lock file the service template's ``ExecStartPre`` also takes)
+  serializes them; the second instance re-reads the state UNDER the
+  lock and reuses the first's result — no concurrent uv install, no
+  corrupted tool env;
+- a failing install fails fast with the structured
+  ``cli_install_failed`` line (reason + the exact fix command) and
+  records NO state (the next start retries).
+
+No database, queue, daemon or second release state: the state file
+lives in the existing shared state dir, and the flock is the kernel
+primitive (released with the holder's exit).
+"""
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+from pi_activity import quote_value
+
+# NOTE: `cli_source` is imported lazily inside `refresh_cli_install`
+# (NOT at module level): cli_source -> muyan_pilot -> bootstrap_runner
+# -> cli_install would be a circular import (bootstrap_runner imports
+# this module before `muyan_pilot` is fully loaded). The reinstall
+# argv is the single cross-module dependency (Issue #152's verified
+# command), so the lazy import stays in one place.
+LOGGER = logging.getLogger("muyan_pilot.cli_install")
+
+# The uv install timeout (seconds): a local editable build of this
+# zero-dependency package takes seconds; a hang (a wedged uv or a
+# full disk) must fail the start, never block it forever (Issue #95:
+# blocking commands carry a timeout).
+UV_INSTALL_TIMEOUT_SECONDS = 300
+
+# The base-sync lock (moved here from bootstrap_runner, Issue #158:
+# one home for the concurrency primitive — the checkout sync, the
+# ExecStartPre preflight and the CLI install refresh all serialize on
+# the SAME lock file).
+BASE_SYNC_LOCK_NAME = "base-sync.lock"
+
+
+class CliInstallError(RuntimeError):
+    """The editable CLI install refresh failed (fail fast)."""
+
+
+def base_sync_lock_path(repo_dir: Path) -> Path:
+    """The lock file serializing ALL writers of the deployment base
+    checkout and its tool env.
+
+    Two timer instances may start in the same tick, so the service
+    template's `ExecStartPre` wraps the fetch + fast-forward in a
+    short-lived `flock` on this SAME file, and the Python-side
+    checkout sync and the CLI install refresh take the same lock: the
+    main worktree and the tool env are never written concurrently.
+    The lock lives in the shared state dir (next to the slot files),
+    never in a per-process temp dir.
+    """
+    return Path(repo_dir) / ".muyan-pilot" / BASE_SYNC_LOCK_NAME
+
+
+def acquire_base_sync_lock(
+    repo_dir: Path, lock_timeout_seconds: float,
+) -> int:
+    """Take the base-sync flock; fail fast when it is still held after
+    the timeout. The kernel releases an flock when its holder exits,
+    so a dead holder can never wedge the lock."""
+    lock_path = base_sync_lock_path(repo_dir)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    deadline = time.monotonic() + lock_timeout_seconds
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except (BlockingIOError, InterruptedError, PermissionError):
+            if time.monotonic() >= deadline:
+                os.close(fd)
+                LOGGER.error(
+                    "base_sync_lock_timeout repo_dir=%s lock=%s "
+                    "timeout_seconds=%s",
+                    repo_dir, lock_path, lock_timeout_seconds,
+                )
+                raise CliInstallError(
+                    f"could not take the base-sync lock {lock_path} "
+                    f"within {lock_timeout_seconds}s (another Runner "
+                    "instance or the ExecStartPre preflight is syncing "
+                    "the deployment checkout)"
+                ) from None
+            time.sleep(0.1)
+
+
+def packaging_fingerprint(repo_dir: Path) -> str:
+    """The sha256 of the checkout's ``pyproject.toml``.
+
+    ``pyproject.toml`` is the packaging input that decides the
+    editable metadata (the finder's module mapping from
+    ``py-modules``, the entry points, the version, the dependencies) —
+    so its content hash is the refresh trigger. Ordinary Python source
+    content is NOT part of it: the editable finder maps the live
+    files, a content change needs no reinstall (the whole point of
+    the editable install, Issue #152). A checkout without
+    ``pyproject.toml`` cannot be tool-installed: fail fast, never
+    guess a fingerprint.
+    """
+    pyproject = Path(repo_dir) / "pyproject.toml"
+    if not pyproject.is_file():
+        raise CliInstallError(
+            f"packaging file missing: {pyproject} (the deployment "
+            "checkout must carry the packaging input of the editable "
+            "install)"
+        )
+    return hashlib.sha256(pyproject.read_bytes()).hexdigest()
+
+
+def install_state_path(repo_dir: Path) -> Path:
+    """The last-install fingerprint record in the shared state dir.
+
+    ``<repo_dir>/.muyan-pilot/cli-install.json`` — the EXISTING shared
+    state dir (gitignored, next to ``base-sync.lock`` and the slots;
+    it survives the ``git merge --ff-only`` checkout sync). Not a
+    second release state and not a per-process temp file.
+    """
+    return Path(repo_dir) / ".muyan-pilot" / "cli-install.json"
+
+
+def read_install_state(repo_dir: Path) -> str | None:
+    """The stored last-install fingerprint, or None.
+
+    Missing file (first install / fresh checkout) -> None. A
+    malformed file (a torn write) is treated as "no state" and heals
+    in the SAFE direction: one extra idempotent ``--force
+    --reinstall`` runs — never a wedged start.
+    """
+    path = install_state_path(repo_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    fingerprint = data.get("pyproject_sha256") if isinstance(data, dict) else None
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return None
+    return fingerprint
+
+
+def write_install_state(repo_dir: Path, fingerprint: str) -> None:
+    """Record the last-install fingerprint (atomic: tmp + replace).
+
+    Only called AFTER a successful install, under the base-sync flock
+    (no concurrent writer; the atomic replace guards a torn write on
+    a crash mid-install).
+    """
+    path = install_state_path(repo_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
+    )
+    os.replace(str(tmp), str(path))
+
+
+def refresh_cli_install(
+    repo_dir: Path, *, run_command,
+    lock_timeout_seconds: float = 300.0,
+) -> str:
+    """Refresh the editable CLI install when the packaging inputs
+    changed; return ``"unchanged"`` or ``"installed"``.
+
+    The pre-start gate (called by the Runner tick before any slot or
+    claim):
+
+    - the current packaging fingerprint equals the stored last-install
+      fingerprint -> ``"unchanged"`` and NO uv call (no per-tick
+      reinstall);
+    - otherwise (changed, or no state yet — the first install): take
+      the base-sync flock (the SAME lock the service template's
+      ``ExecStartPre`` and the checkout sync use), re-check the state
+      UNDER the lock (a concurrent instance may have refreshed while
+      we waited — reuse its result, never run a second install), run
+      the exact verified editable force reinstall from
+      ``cli_source.reinstall_args``, and record the fingerprint only
+      after success.
+
+    A failing install logs the structured ``cli_install_failed`` line
+    (reason + the exact fix command) and raises ``CliInstallError``:
+    the service does not start (fail fast), no state is recorded (the
+    next start retries) and the lock is released (success or
+    failure).
+    """
+    repo_dir = Path(repo_dir)
+    fingerprint = packaging_fingerprint(repo_dir)
+    if read_install_state(repo_dir) == fingerprint:
+        LOGGER.info(
+            "cli_install_unchanged repo_dir=%s pyproject_sha256=%s",
+            repo_dir, fingerprint,
+        )
+        return "unchanged"
+    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    try:
+        # Re-check UNDER the lock: a concurrent instance may have
+        # refreshed the tool env while we waited for the flock —
+        # reuse its result, never run a second install.
+        if read_install_state(repo_dir) == fingerprint:
+            LOGGER.info(
+                "cli_install_reused repo_dir=%s pyproject_sha256=%s",
+                repo_dir, fingerprint,
+            )
+            return "unchanged"
+        reason = "first_install" if (
+            read_install_state(repo_dir) is None
+        ) else "packaging_changed"
+        import cli_source  # lazy: see the module-level note
+        try:
+            run_command(
+                cli_source.reinstall_args(repo_dir),
+                timeout=UV_INSTALL_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            LOGGER.error(
+                "cli_install_failed repo_dir=%s reason=%s fix=%s",
+                repo_dir, quote_value(str(exc)),
+                quote_value(cli_source.reinstall_command(repo_dir)),
+            )
+            raise CliInstallError(
+                f"editable CLI install failed for {repo_dir}: {exc} "
+                f"(fix: {cli_source.reinstall_command(repo_dir)})"
+            ) from exc
+        write_install_state(repo_dir, fingerprint)
+        LOGGER.info(
+            "cli_install_refreshed repo_dir=%s reason=%s "
+            "pyproject_sha256=%s",
+            repo_dir, reason, fingerprint,
+        )
+        return "installed"
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)

--- a/cli_install.py
+++ b/cli_install.py
@@ -12,260 +12,34 @@ with ``ModuleNotFoundError`` before the Runner can even start (the
 #158 incident: ``cli_source`` merged to main, the installed finder
 still mapped the pre-#152 module set, the systemd start failed).
 
-This module refreshes the editable install at the Runner start,
-BEFORE any slot or claim:
+The refresh runs at the Runner start, BEFORE any slot or claim:
+unchanged packaging fingerprint -> NO uv call; changed or first
+install -> ONE lock-protected ``uv tool install --force --reinstall
+--editable --python /usr/bin/python3 <repo_dir>`` under the SAME
+base-sync flock the service template's ``ExecStartPre`` takes (two
+instances starting in the same tick serialize, the second reuses the
+first's result); a failing install fails the start fast with the
+structured ``cli_install_failed`` line (reason + the exact fix
+command) and records no state (the next start retries).
 
-- the packaging fingerprint (sha256 of the checkout's
-  ``pyproject.toml`` — the packaging input that decides the editable
-  metadata) is compared against the fingerprint of the LAST
-  successful install, stored in the shared state dir (``.muyan-pilot/
-  cli-install.json`` — the same gitignored dir as ``base-sync.lock``
-  and the slots, which survives the ``git merge --ff-only`` checkout
-  sync). It is NOT a second release state: it only records which
-  packaging input the installed tool env was built from;
-- unchanged: NO uv call at all (no per-tick reinstall);
-- changed, or no state yet (first install): ONE lock-protected
-  ``uv tool install --force --reinstall --editable --python
-  /usr/bin/python3 <repo_dir>`` (the exact verified argv from
-  ``cli_source.reinstall_args``);
-- two instances starting in the same tick: the SAME base-sync flock
-  (the lock file the service template's ``ExecStartPre`` also takes)
-  serializes them; the second instance re-reads the state UNDER the
-  lock and reuses the first's result — no concurrent uv install, no
-  corrupted tool env;
-- a failing install fails fast with the structured
-  ``cli_install_failed`` line (reason + the exact fix command) and
-  records NO state (the next start retries).
-
-No database, queue, daemon or second release state: the state file
-lives in the existing shared state dir, and the flock is the kernel
-primitive (released with the holder's exit).
+This module is a THIN RE-EXPORT of the implementation, which lives in
+``bootstrap_runner`` itself (see the NOTE there): the bootstrap chain
+(``muyan_pilot`` -> ``bootstrap_runner``) must still LOAD in a tool
+env whose installed editable finder predates this PR's packaging
+change (the #158 stale-finder scene) — a separate new module for the
+refresh would not be importable there, and the very refresh that
+reinstalls the tool env could never run (the #158 incident, one
+module later). The bootstrap chain never imports this module; the
+tests use it as the single import point for the refresh contract.
 """
-from __future__ import annotations
-
-import fcntl
-import hashlib
-import json
-import logging
-import os
-import time
-from pathlib import Path
-
-from pi_activity import quote_value
-
-# NOTE: `cli_source` is imported lazily inside `refresh_cli_install`
-# (NOT at module level): cli_source -> muyan_pilot -> bootstrap_runner
-# -> cli_install would be a circular import (bootstrap_runner imports
-# this module before `muyan_pilot` is fully loaded). The reinstall
-# argv is the single cross-module dependency (Issue #152's verified
-# command), so the lazy import stays in one place.
-LOGGER = logging.getLogger("muyan_pilot.cli_install")
-
-# The uv install timeout (seconds): a local editable build of this
-# zero-dependency package takes seconds; a hang (a wedged uv or a
-# full disk) must fail the start, never block it forever (Issue #95:
-# blocking commands carry a timeout).
-UV_INSTALL_TIMEOUT_SECONDS = 300
-
-# The base-sync lock (moved here from bootstrap_runner, Issue #158:
-# one home for the concurrency primitive — the checkout sync, the
-# ExecStartPre preflight and the CLI install refresh all serialize on
-# the SAME lock file).
-BASE_SYNC_LOCK_NAME = "base-sync.lock"
-
-
-class CliInstallError(RuntimeError):
-    """The editable CLI install refresh failed (fail fast)."""
-
-
-def base_sync_lock_path(repo_dir: Path) -> Path:
-    """The lock file serializing ALL writers of the deployment base
-    checkout and its tool env.
-
-    Two timer instances may start in the same tick, so the service
-    template's `ExecStartPre` wraps the fetch + fast-forward in a
-    short-lived `flock` on this SAME file, and the Python-side
-    checkout sync and the CLI install refresh take the same lock: the
-    main worktree and the tool env are never written concurrently.
-    The lock lives in the shared state dir (next to the slot files),
-    never in a per-process temp dir.
-    """
-    return Path(repo_dir) / ".muyan-pilot" / BASE_SYNC_LOCK_NAME
-
-
-def acquire_base_sync_lock(
-    repo_dir: Path, lock_timeout_seconds: float,
-) -> int:
-    """Take the base-sync flock; fail fast when it is still held after
-    the timeout. The kernel releases an flock when its holder exits,
-    so a dead holder can never wedge the lock."""
-    lock_path = base_sync_lock_path(repo_dir)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-    deadline = time.monotonic() + lock_timeout_seconds
-    while True:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return fd
-        except (BlockingIOError, InterruptedError, PermissionError):
-            if time.monotonic() >= deadline:
-                os.close(fd)
-                LOGGER.error(
-                    "base_sync_lock_timeout repo_dir=%s lock=%s "
-                    "timeout_seconds=%s",
-                    repo_dir, lock_path, lock_timeout_seconds,
-                )
-                raise CliInstallError(
-                    f"could not take the base-sync lock {lock_path} "
-                    f"within {lock_timeout_seconds}s (another Runner "
-                    "instance or the ExecStartPre preflight is syncing "
-                    "the deployment checkout)"
-                ) from None
-            time.sleep(0.1)
-
-
-def packaging_fingerprint(repo_dir: Path) -> str:
-    """The sha256 of the checkout's ``pyproject.toml``.
-
-    ``pyproject.toml`` is the packaging input that decides the
-    editable metadata (the finder's module mapping from
-    ``py-modules``, the entry points, the version, the dependencies) —
-    so its content hash is the refresh trigger. Ordinary Python source
-    content is NOT part of it: the editable finder maps the live
-    files, a content change needs no reinstall (the whole point of
-    the editable install, Issue #152). A checkout without
-    ``pyproject.toml`` cannot be tool-installed: fail fast, never
-    guess a fingerprint.
-    """
-    pyproject = Path(repo_dir) / "pyproject.toml"
-    if not pyproject.is_file():
-        raise CliInstallError(
-            f"packaging file missing: {pyproject} (the deployment "
-            "checkout must carry the packaging input of the editable "
-            "install)"
-        )
-    return hashlib.sha256(pyproject.read_bytes()).hexdigest()
-
-
-def install_state_path(repo_dir: Path) -> Path:
-    """The last-install fingerprint record in the shared state dir.
-
-    ``<repo_dir>/.muyan-pilot/cli-install.json`` — the EXISTING shared
-    state dir (gitignored, next to ``base-sync.lock`` and the slots;
-    it survives the ``git merge --ff-only`` checkout sync). Not a
-    second release state and not a per-process temp file.
-    """
-    return Path(repo_dir) / ".muyan-pilot" / "cli-install.json"
-
-
-def read_install_state(repo_dir: Path) -> str | None:
-    """The stored last-install fingerprint, or None.
-
-    Missing file (first install / fresh checkout) -> None. A
-    malformed file (a torn write) is treated as "no state" and heals
-    in the SAFE direction: one extra idempotent ``--force
-    --reinstall`` runs — never a wedged start.
-    """
-    path = install_state_path(repo_dir)
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    fingerprint = data.get("pyproject_sha256") if isinstance(data, dict) else None
-    if not isinstance(fingerprint, str) or not fingerprint:
-        return None
-    return fingerprint
-
-
-def write_install_state(repo_dir: Path, fingerprint: str) -> None:
-    """Record the last-install fingerprint (atomic: tmp + replace).
-
-    Only called AFTER a successful install, under the base-sync flock
-    (no concurrent writer; the atomic replace guards a torn write on
-    a crash mid-install).
-    """
-    path = install_state_path(repo_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(
-        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
-    )
-    os.replace(str(tmp), str(path))
-
-
-def refresh_cli_install(
-    repo_dir: Path, *, run_command,
-    lock_timeout_seconds: float = 300.0,
-) -> str:
-    """Refresh the editable CLI install when the packaging inputs
-    changed; return ``"unchanged"`` or ``"installed"``.
-
-    The pre-start gate (called by the Runner tick before any slot or
-    claim):
-
-    - the current packaging fingerprint equals the stored last-install
-      fingerprint -> ``"unchanged"`` and NO uv call (no per-tick
-      reinstall);
-    - otherwise (changed, or no state yet — the first install): take
-      the base-sync flock (the SAME lock the service template's
-      ``ExecStartPre`` and the checkout sync use), re-check the state
-      UNDER the lock (a concurrent instance may have refreshed while
-      we waited — reuse its result, never run a second install), run
-      the exact verified editable force reinstall from
-      ``cli_source.reinstall_args``, and record the fingerprint only
-      after success.
-
-    A failing install logs the structured ``cli_install_failed`` line
-    (reason + the exact fix command) and raises ``CliInstallError``:
-    the service does not start (fail fast), no state is recorded (the
-    next start retries) and the lock is released (success or
-    failure).
-    """
-    repo_dir = Path(repo_dir)
-    fingerprint = packaging_fingerprint(repo_dir)
-    if read_install_state(repo_dir) == fingerprint:
-        LOGGER.info(
-            "cli_install_unchanged repo_dir=%s pyproject_sha256=%s",
-            repo_dir, fingerprint,
-        )
-        return "unchanged"
-    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
-    try:
-        # Re-check UNDER the lock: a concurrent instance may have
-        # refreshed the tool env while we waited for the flock —
-        # reuse its result, never run a second install.
-        if read_install_state(repo_dir) == fingerprint:
-            LOGGER.info(
-                "cli_install_reused repo_dir=%s pyproject_sha256=%s",
-                repo_dir, fingerprint,
-            )
-            return "unchanged"
-        reason = "first_install" if (
-            read_install_state(repo_dir) is None
-        ) else "packaging_changed"
-        import cli_source  # lazy: see the module-level note
-        try:
-            run_command(
-                cli_source.reinstall_args(repo_dir),
-                timeout=UV_INSTALL_TIMEOUT_SECONDS,
-            )
-        except Exception as exc:
-            LOGGER.error(
-                "cli_install_failed repo_dir=%s reason=%s fix=%s",
-                repo_dir, quote_value(str(exc)),
-                quote_value(cli_source.reinstall_command(repo_dir)),
-            )
-            raise CliInstallError(
-                f"editable CLI install failed for {repo_dir}: {exc} "
-                f"(fix: {cli_source.reinstall_command(repo_dir)})"
-            ) from exc
-        write_install_state(repo_dir, fingerprint)
-        LOGGER.info(
-            "cli_install_refreshed repo_dir=%s reason=%s "
-            "pyproject_sha256=%s",
-            repo_dir, reason, fingerprint,
-        )
-        return "installed"
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
+from bootstrap_runner import (
+    UV_INSTALL_TIMEOUT_SECONDS,
+    CliInstallError,
+    acquire_base_sync_lock,
+    base_sync_lock_path,
+    install_state_path,
+    packaging_fingerprint,
+    read_install_state,
+    refresh_cli_install,
+    write_install_state,
+)

--- a/cli_source.py
+++ b/cli_source.py
@@ -23,8 +23,11 @@ checkout drifts the same way.
 This module is READ-ONLY: it reports the running process's
 ``muyan_pilot`` import source against the configured ``repo_dir`` and
 the exact fix command. The fix is a HUMAN/setup step (``muyan-pilot
-setup`` runs it idempotently); the Runner never installs the tool at
-start, so two concurrent service instances cannot race the tool env.
+setup`` runs it idempotently). Since Issue #158 the Runner ALSO
+refreshes the editable install at start (``cli_install``) when the
+packaging inputs changed — under the SAME base-sync flock the
+``ExecStartPre`` preflight takes, so two concurrent service instances
+still never race the tool env.
 """
 from __future__ import annotations
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -79,9 +79,22 @@ env imports `muyan_pilot` directly from the clone directory, so the
 next CLI process (the next timer-triggered Runner) picks up the merged
 code automatically: **ordinary Python source and systemd
 template/migration changes need NO reinstall and no upgrade command**.
-Only when dependencies, the entry point, the
-package name, the build backend or the Python version changes do you
-re-run the exact force editable reinstall command above. `muyan-pilot
+When the PACKAGING inputs change (a new runtime module in
+`py-modules`, a dependency, the entry point, the package name, the
+build backend or the Python version), the editable finder's module
+mapping is stale and the next CLI process dies with
+`ModuleNotFoundError` before the Runner can start (Issue #158) — the
+Runner now refreshes this automatically: at every start (before any
+slot or claim) it compares the sha256 of the checkout's
+`pyproject.toml` with the fingerprint of the last successful install
+(recorded in the shared state dir, `.muyan-pilot/cli-install.json`):
+unchanged → no `uv` call at all (no per-tick reinstall); changed or
+first install → ONE lock-protected run of the exact force editable
+reinstall command above (the same base-sync flock the service
+`ExecStartPre` uses, so two instances starting in the same tick
+serialize and the second reuses the first's result); a failing install
+fails the start fast with the structured `cli_install_failed` line
+(reason + the exact fix command). `muyan-pilot
 doctor` reports the consistency (`cli_source: clean` or
 `cli_source: DRIFT` with the structured `cli_source_drift` line), and
 `muyan-pilot setup` verifies or reinstalls it idempotently. The release

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -70,13 +70,22 @@ muyan-pilot --help
 Issue #152）。editable 安装下 tool 环境直接从 clone 目录导入
 `muyan_pilot`，下一个 CLI 进程（下一个 timer 启动的 Runner）自动取到
 merge 后的代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要
-任何重装或升级命令**。只有依赖、入口点、
-包名、构建后端或 Python 版本变化时，才重新执行上面的 force editable
-重装命令。`muyan-pilot doctor` 报告一致性（`cli_source: clean` 或
-`cli_source: DRIFT` + 结构化 `cli_source_drift` 行），`muyan-pilot
-setup` 幂等地校验或重装。发布包不携带第三方运行时依赖、token 或用户
-目录——配置文件和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的
-直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径。
+任何重装或升级命令**。
+当**打包输入**变化（`py-modules` 新增运行时模块、依赖、入口点、包名、
+构建后端或 Python 版本）时，editable finder 的模块映射会过期，下一个
+CLI 进程在 Runner 启动前就 `ModuleNotFoundError`（Issue #158）——现在
+Runner 自动刷新：每次启动（在任何 slot/claim 之前）比较 checkout
+`pyproject.toml` 的 sha256 与**上次成功安装**记录的指纹（共享状态目录
+`.muyan-pilot/cli-install.json`）：未变 → 完全不跑 `uv`（不做每 tick
+重装）；变更或首次安装 → 在 base-sync flock 保护下跑一次上面的 force
+editable 重装（与服务 `ExecStartPre` 同一把锁，两个 instance 同 tick
+启动时串行化，第二个复用第一个的结果）；安装失败 → fail fast（结构化
+`cli_install_failed` 行：原因 + 精确修复命令）。`muyan-pilot doctor`
+报告一致性（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化
+`cli_source_drift` 行），`muyan-pilot setup` 幂等地校验或重装。发布包
+不携带第三方运行时依赖、token 或用户目录——配置文件和用户 systemd 目录
+保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）
+保留为开发/兼容路径。
 
 ## 3. 创建配置
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,6 @@ py-modules = [
     "progress",
     # Issue #152: the CLI source consistency check (doctor/setup).
     "cli_source",
+    # Issue #158: the pre-start editable CLI install refresh.
+    "cli_install",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ over this default).
 import pytest
 
 import bootstrap_runner as runner
-import cli_install
 
 
 @pytest.fixture(autouse=True)
@@ -23,9 +22,11 @@ def _default_cli_install_preflight(monkeypatch):
     tmp repo_dirs that carry no tool env, and the real `uv tool
     install` must never run in them. The refresh's own tests and the
     wiring tests stub or exercise it explicitly (a ``monkeypatch``
-    always wins over this default)."""
+    always wins over this default). The implementation lives in
+    `bootstrap_runner` itself (see the NOTE there), so the stub
+    patches ITS module global — the call `main()` makes."""
     monkeypatch.setattr(
-        cli_install, "refresh_cli_install", lambda *a, **k: "unchanged",
+        runner, "refresh_cli_install", lambda *a, **k: "unchanged",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,32 @@
 """Shared test fixtures for the Muyan Pilot suite.
 
-The deployment preflights (Issue #103 unit drift, Issue #114 git
-transport) read the REAL machine state (the user unit directory, the
-checkout's ``origin`` remote, SSH connectivity); the in-process
-dispatch tests use tmp repo_dirs that carry no ``systemd/`` templates
-and no git checkout, so they run with both preflights stubbed to a
-passing no-op by default. The wiring tests and the e2e suites stub or
+The deployment preflights (Issue #158 CLI install refresh, Issue #103
+unit drift, Issue #114 git transport) read the REAL machine state (the
+tool env, the user unit directory, the checkout's ``origin`` remote,
+SSH connectivity); the in-process dispatch tests use tmp repo_dirs
+that carry no tool env, no ``systemd/`` templates and no git checkout,
+so they run with all three preflights stubbed to a passing no-op by
+default. The preflight tests and the wiring/e2e suites stub or
 exercise the real checks explicitly (a ``monkeypatch`` always wins
 over this default).
 """
 import pytest
 
 import bootstrap_runner as runner
+import cli_install
+
+
+@pytest.fixture(autouse=True)
+def _default_cli_install_preflight(monkeypatch):
+    """Default: the editable CLI install refresh (Issue #158) is a
+    no-op that reports "unchanged" — the in-process dispatch tests use
+    tmp repo_dirs that carry no tool env, and the real `uv tool
+    install` must never run in them. The refresh's own tests and the
+    wiring tests stub or exercise it explicitly (a ``monkeypatch``
+    always wins over this default)."""
+    monkeypatch.setattr(
+        cli_install, "refresh_cli_install", lambda *a, **k: "unchanged",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 import pytest
 
 import bootstrap_runner as runner
+import cli_install
 import pi_activity
 from tests.test_progress_wiring import make_fake_gh
 
@@ -5631,6 +5632,87 @@ def test_main_transport_preflight_receives_the_configured_args(
     assert seen["source_repos"] == ["owner/repo", "owner/backlog"]
     assert seen["migrate"] is False
     assert seen["run_command"] is runner.run_command
+
+
+def test_main_cli_install_refresh_runs_before_slot_and_claim(
+    monkeypatch, tmp_path,
+):
+    """Issue #158: the editable CLI install refresh runs in the Runner
+    tick entry BEFORE any slot or claim, with the configured repo_dir
+    and the real run_command — so a stale editable finder (a merged
+    packaging change) is refreshed before the tick can claim work,
+    and the NEXT CLI process can import the new runtime modules."""
+    seen: dict = {}
+
+    def fake_refresh(repo_dir, *, run_command, lock_timeout_seconds=300.0):
+        seen["repo_dir"] = Path(repo_dir)
+        seen["run_command"] = run_command
+        seen["slot_existed_at_refresh"] = (
+            Path(repo_dir) / ".muyan-pilot" / "slots"
+        ).exists()
+        return "unchanged"
+
+    monkeypatch.setattr(cli_install, "refresh_cli_install", fake_refresh)
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\n', encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+    )
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen["repo_dir"] == tmp_path
+    assert seen["run_command"] is runner.run_command
+    # BEFORE the slot: at the refresh moment no slot exists yet (the
+    # slot is taken only after every preflight passed).
+    assert seen["slot_existed_at_refresh"] is False
+    # ...and the tick proceeded to the normal claim flow (slot taken
+    # after the refresh).
+    assert (tmp_path / ".muyan-pilot" / "slots" / "slot-1").exists()
+
+
+def test_main_cli_install_failure_fails_fast_before_slot_and_claim(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #158: a failing editable install fails the start BEFORE
+    any slot or claim (non-zero exit, the structured
+    `cli_install_failed` line in the journal), nothing is claimed, no
+    slot is taken — no fallback, no skipped tick."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "muyan-pilot.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\n', encoding="utf-8",
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError(
+            "pick_next_delivery must not run on cli install failure"
+        )
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fail_if_called)
+    with pytest.raises(
+        AssertionError, match="must not run on cli install failure",
+    ):
+        fail_if_called()
+    monkeypatch.setattr(
+        cli_install, "refresh_cli_install",
+        lambda *a, **k: (_ for _ in ()).throw(
+            cli_install.CliInstallError(
+                "editable CLI install failed for /repo: uv exploded "
+                "(fix: uv tool install --force --reinstall --editable "
+                "--python /usr/bin/python3 /repo)"
+            ),
+        ),
+    )
+    with caplog.at_level("ERROR"):
+        with pytest.raises(
+            cli_install.CliInstallError, match="CLI install failed",
+        ):
+            runner.main(["--config", str(config)])
+    # No slot was taken and nothing was claimed.
+    assert not (tmp_path / ".muyan-pilot" / "slots").exists()
 
 
 # --- delivery lifecycle: slot held until merge or terminal failure ----------

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14,7 +14,6 @@ from unittest.mock import Mock
 import pytest
 
 import bootstrap_runner as runner
-import cli_install
 import pi_activity
 from tests.test_progress_wiring import make_fake_gh
 
@@ -6060,7 +6059,7 @@ def test_main_cli_install_refresh_runs_before_slot_and_claim(
         ).exists()
         return "unchanged"
 
-    monkeypatch.setattr(cli_install, "refresh_cli_install", fake_refresh)
+    monkeypatch.setattr(runner, "refresh_cli_install", fake_refresh)
     _write_prompts(tmp_path)
     config = tmp_path / "muyan-pilot.toml"
     config.write_text(
@@ -6105,9 +6104,9 @@ def test_main_cli_install_failure_fails_fast_before_slot_and_claim(
     ):
         fail_if_called()
     monkeypatch.setattr(
-        cli_install, "refresh_cli_install",
+        runner, "refresh_cli_install",
         lambda *a, **k: (_ for _ in ()).throw(
-            cli_install.CliInstallError(
+            runner.CliInstallError(
                 "editable CLI install failed for /repo: uv exploded "
                 "(fix: uv tool install --force --reinstall --editable "
                 "--python /usr/bin/python3 /repo)"
@@ -6116,11 +6115,76 @@ def test_main_cli_install_failure_fails_fast_before_slot_and_claim(
     )
     with caplog.at_level("ERROR"):
         with pytest.raises(
-            cli_install.CliInstallError, match="CLI install failed",
+            runner.CliInstallError, match="CLI install failed",
         ):
             runner.main(["--config", str(config)])
     # No slot was taken and nothing was claimed.
     assert not (tmp_path / ".muyan-pilot" / "slots").exists()
+
+
+def test_bootstrap_chain_loads_and_refreshes_when_cli_install_is_unmapped(
+    tmp_path,
+):
+    """Issue #158 acceptance (the incident itself, one module later):
+    the editable finder's module MAPPING is generated at INSTALL time
+    from `pyproject.toml`, so right after this PR merges, the INSTALLED
+    finder does not map `cli_install` yet — and the bootstrap chain
+    (`muyan_pilot` -> `bootstrap_runner`) must still LOAD in that tool
+    env, with the refresh REACHABLE: the refresh implementation lives
+    in `bootstrap_runner` itself (a separate new module would not be
+    importable in the stale-finder env, and the very refresh that
+    reinstalls the tool env could never run — the #158 incident, one
+    module later). Load a fresh `bootstrap_runner` with `cli_install`
+    blocked from the import system: it must import cleanly and its
+    `refresh_cli_install` gate must run (the unchanged path needs no
+    uv call and no other new module)."""
+    import importlib.util
+
+    bootstrap_file = Path(runner.__file__).resolve()
+
+    class _BlockCliInstall:
+        """Meta path finder that hides the `cli_install` module."""
+
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "cli_install":
+                raise ModuleNotFoundError(
+                    "No module named 'cli_install'", name=fullname,
+                )
+            return None
+
+    hook = _BlockCliInstall()
+    # The hook hides exactly the module under test and nothing else.
+    with pytest.raises(ModuleNotFoundError, match="cli_install"):
+        hook.find_spec("cli_install")
+    assert hook.find_spec("some_other_module") is None
+    saved = sys.modules.pop("bootstrap_runner")
+    sys.meta_path.insert(0, hook)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "bootstrap_runner_stale_finder", bootstrap_file,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.meta_path.remove(hook)
+        sys.modules["bootstrap_runner"] = saved
+    # The fresh module loaded with `cli_install` unmapped: the chain
+    # is importable in the stale-finder tool env, so the next systemd
+    # start reaches `main()` and the refresh can repair the finder.
+    assert module.main is not None
+    # The refresh gate itself runs in the stale env (unchanged path:
+    # no uv call, no other new module needed).
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "a"\n', encoding="utf-8",
+    )
+    module.write_install_state(
+        tmp_path, module.packaging_fingerprint(tmp_path),
+    )
+    calls = []
+    assert module.refresh_cli_install(
+        tmp_path, run_command=lambda *a, **k: calls.append(1),
+    ) == "unchanged"
+    assert calls == []
 
 
 # --- delivery lifecycle: slot held until merge or terminal failure ----------

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,0 +1,480 @@
+"""Auto-refresh tests for the editable CLI install (Issue #158).
+
+The official local deployment is the EDITABLE uv tool install (Issue
+#152): the tool env imports the runtime modules from the deployment
+checkout through a setuptools editable finder whose module MAPPING is
+generated at INSTALL time from the checkout's ``pyproject.toml``.
+When the packaging inputs change (a new runtime module is added to
+``py-modules``, a dependency or entry point changes), the installed
+finder is stale and the next CLI process dies with
+``ModuleNotFoundError`` before the Runner can even start (the #158
+incident: ``cli_source`` merged to main, the installed finder still
+mapped the pre-#152 module set, systemd start failed).
+
+These tests pin the pre-start refresh contract:
+
+- the packaging fingerprint is the sha256 of the checkout's
+  ``pyproject.toml`` (the packaging input that decides the editable
+  metadata) — ordinary Python source content is NOT part of it;
+- the last-install fingerprint lives in the shared state dir
+  (``.muyan-pilot/cli-install.json``, the same gitignored dir as
+  ``base-sync.lock`` and the slots) — not a second release state;
+- unchanged fingerprint: NO uv call at all (no per-tick reinstall);
+- changed or missing state (first install): ONE lock-protected
+  ``uv tool install --force --reinstall --editable --python
+  /usr/bin/python3 <repo_dir>`` (the exact verified argv from
+  ``cli_source.reinstall_args``), then the state is recorded;
+- two instances starting in the same tick: the SAME base-sync flock
+  (the lock file the service template's ``ExecStartPre`` uses) — the
+  second instance reuses the first's result and never runs a second
+  install;
+- a failing install fails fast with the structured
+  ``cli_install_failed`` line (reason + the exact fix command) and
+  records NO state (the next start retries).
+"""
+import fcntl
+import hashlib
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+import cli_install
+import cli_source
+
+# The real refresh, captured at import time (before any fixture runs):
+# these tests exercise the function under test, overriding the suite's
+# default no-op stub from conftest (the conftest fixture runs first,
+# this one wins).
+_REAL_REFRESH = cli_install.refresh_cli_install
+
+
+@pytest.fixture(autouse=True)
+def _real_refresh(monkeypatch):
+    monkeypatch.setattr(cli_install, "refresh_cli_install", _REAL_REFRESH)
+
+
+def _write_pyproject(repo: Path, text: str) -> Path:
+    repo = Path(repo)
+    repo.mkdir(parents=True, exist_ok=True)
+    path = repo / "pyproject.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _recorder(calls):
+    """A run_command stand-in matching the real contract: it receives
+    the argv AND the timeout keyword (Issue #95: the install is a
+    blocking command and must carry a timeout)."""
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return ""
+
+    return run
+
+
+# --- the packaging fingerprint ---------------------------------------------
+
+
+def test_packaging_fingerprint_is_the_sha256_of_pyproject(tmp_path):
+    """The fingerprint is the sha256 of the checkout's
+    ``pyproject.toml`` content — the packaging input that decides the
+    editable metadata (py-modules, entry points, version, deps)."""
+    repo = tmp_path / "checkout"
+    content = b'[project]\nname = "muyan-pilot"\nversion = "0.2.0"\n'
+    _write_pyproject(repo, content.decode("utf-8"))
+    assert cli_install.packaging_fingerprint(repo) == (
+        hashlib.sha256(content).hexdigest()
+    )
+
+
+def test_packaging_fingerprint_changes_with_pyproject_content(tmp_path):
+    """A changed ``pyproject.toml`` (e.g. a new runtime module added to
+    ``py-modules``) changes the fingerprint — that is the refresh
+    trigger."""
+    repo = tmp_path / "checkout"
+    _write_pyproject(repo, '[project]\nname = "a"\n')
+    first = cli_install.packaging_fingerprint(repo)
+    _write_pyproject(
+        repo, '[project]\nname = "a"\n[tool.setuptools]\npy-modules = ["x"]\n',
+    )
+    assert cli_install.packaging_fingerprint(repo) != first
+
+
+def test_packaging_fingerprint_ignores_python_source_content(tmp_path):
+    """Acceptance: ONLY the packaging input is fingerprinted — a
+    change to an existing Python file's content must NOT trigger a
+    reinstall (the editable finder maps the live file anyway)."""
+    repo = tmp_path / "checkout"
+    _write_pyproject(repo, '[project]\nname = "a"\n')
+    (repo / "muyan_pilot.py").write_text("old\n", encoding="utf-8")
+    first = cli_install.packaging_fingerprint(repo)
+    (repo / "muyan_pilot.py").write_text("new content\n", encoding="utf-8")
+    assert cli_install.packaging_fingerprint(repo) == first
+
+
+def test_packaging_fingerprint_fails_fast_without_pyproject(tmp_path):
+    """A checkout without ``pyproject.toml`` cannot be tool-installed:
+    the pre-start check fails fast, never guesses a fingerprint."""
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    with pytest.raises(
+        cli_install.CliInstallError, match="pyproject.toml",
+    ):
+        cli_install.packaging_fingerprint(repo)
+
+
+# --- the install state (the last-install fingerprint) -----------------------
+
+
+def test_install_state_path_is_in_the_shared_state_dir(tmp_path):
+    """The state lives in ``<repo_dir>/.muyan-pilot/`` — the EXISTING
+    shared state dir (gitignored, next to ``base-sync.lock`` and the
+    slots; it survives the ``git merge --ff-only`` checkout sync).
+    Not a second release state, not a per-process temp file."""
+    assert cli_install.install_state_path(tmp_path) == (
+        tmp_path / ".muyan-pilot" / "cli-install.json"
+    )
+
+
+def test_read_install_state_missing_file_is_none(tmp_path):
+    """No state yet (first install / fresh checkout) -> None (the
+    refresh runs)."""
+    assert cli_install.read_install_state(tmp_path) is None
+
+
+def test_read_install_state_returns_the_stored_fingerprint(tmp_path):
+    path = cli_install.install_state_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"pyproject_sha256": "abc123"}), encoding="utf-8",
+    )
+    assert cli_install.read_install_state(tmp_path) == "abc123"
+
+
+def test_read_install_state_malformed_file_is_none(tmp_path):
+    """A corrupted state file (a torn write) heals in the SAFE
+    direction: it is treated as "no state" and one extra idempotent
+    ``--force --reinstall`` runs — never a wedged start."""
+    path = cli_install.install_state_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert cli_install.read_install_state(tmp_path) is None
+    path.write_text(json.dumps({"wrong": "shape"}), encoding="utf-8")
+    assert cli_install.read_install_state(tmp_path) is None
+
+
+def test_write_install_state_is_atomic_and_readable(tmp_path):
+    cli_install.write_install_state(tmp_path, "deadbeef")
+    data = json.loads(
+        cli_install.install_state_path(tmp_path).read_text(encoding="utf-8"),
+    )
+    assert data == {"pyproject_sha256": "deadbeef"}
+    assert cli_install.read_install_state(tmp_path) == "deadbeef"
+    # No temp file is left behind (the atomic replace cleaned up).
+    leftovers = [
+        p.name for p in cli_install.install_state_path(tmp_path).parent.iterdir()
+        if p.name != "cli-install.json"
+    ]
+    assert leftovers == []
+
+
+def test_write_install_state_overwrites_the_previous_fingerprint(tmp_path):
+    cli_install.write_install_state(tmp_path, "first")
+    cli_install.write_install_state(tmp_path, "second")
+    assert cli_install.read_install_state(tmp_path) == "second"
+
+
+# --- the refresh decision ----------------------------------------------------
+
+
+def test_refresh_is_a_noop_without_any_uv_call_when_unchanged(tmp_path):
+    """Acceptance: unchanged packaging input -> NO uv call (no
+    per-tick unconditional install)."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    cli_install.write_install_state(
+        tmp_path, cli_install.packaging_fingerprint(tmp_path),
+    )
+    calls = []
+    result = cli_install.refresh_cli_install(
+        tmp_path, run_command=_recorder(calls),
+    )
+    assert result == "unchanged"
+    assert calls == []
+
+
+def test_refresh_installs_on_the_first_install(tmp_path, caplog):
+    """Acceptance: no state yet (first install) -> the EXACT editable
+    force reinstall runs once and the state is recorded."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    calls = []
+    with caplog.at_level("INFO"):
+        result = cli_install.refresh_cli_install(
+            tmp_path, run_command=_recorder(calls),
+        )
+    assert result == "installed"
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == cli_source.reinstall_args(tmp_path)
+    assert kwargs["timeout"] == cli_install.UV_INSTALL_TIMEOUT_SECONDS
+    assert cli_install.read_install_state(tmp_path) == (
+        cli_install.packaging_fingerprint(tmp_path)
+    )
+    assert "cli_install_refreshed" in caplog.text
+    assert "reason=first_install" in caplog.text
+
+
+def test_refresh_installs_when_the_packaging_input_changed(tmp_path, caplog):
+    """Acceptance: ``pyproject.toml`` changed relative to the last
+    install (e.g. a new runtime module was added to ``py-modules``) ->
+    the editable metadata is refreshed and the next CLI process
+    imports the new module."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    cli_install.write_install_state(
+        tmp_path, "stale-fingerprint-from-the-last-install",
+    )
+    calls = []
+    with caplog.at_level("INFO"):
+        result = cli_install.refresh_cli_install(
+            tmp_path, run_command=_recorder(calls),
+        )
+    assert result == "installed"
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == cli_source.reinstall_args(tmp_path)
+    assert kwargs["timeout"] == cli_install.UV_INSTALL_TIMEOUT_SECONDS
+    assert "reason=packaging_changed" in caplog.text
+    # The state now records the CURRENT fingerprint: the very next
+    # start is a no-op again.
+    assert cli_install.read_install_state(tmp_path) == (
+        cli_install.packaging_fingerprint(tmp_path)
+    )
+
+
+def test_refresh_reuses_a_concurrent_instances_result_under_the_lock(
+    tmp_path,
+):
+    """The decision is re-checked UNDER the lock: while this instance
+    waits for the flock, the other instance (holding the lock) does
+    the refresh and records the state; on acquiring the lock, this
+    instance re-reads the state, sees it is current, and reuses the
+    result — no second install, no uv call at all.
+
+    Deterministic choreography: the test holds the flock, so the
+    refresh thread (a) reads the state BEFORE the lock (absent — the
+    test has not written it yet) and (b) blocks on the flock; only
+    then does the test, as the lock holder, record the state. The
+    refresh's under-lock re-read must see it and skip the install."""
+    import time
+
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    fingerprint = cli_install.packaging_fingerprint(tmp_path)
+    lock_path = cli_install.base_sync_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    # Hold the flock BEFORE the refresh starts: the refresh's pre-lock
+    # state read (absent state — nothing was written) provably
+    # happens while the test holds the lock, and the refresh parks on
+    # the flock behind it. No timing assumption.
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    calls = []
+    result = []
+    done = threading.Event()
+
+    def start():
+        result.append(
+            cli_install.refresh_cli_install(
+                tmp_path, run_command=_recorder(calls),
+            ),
+        )
+        done.set()
+
+    thread = threading.Thread(target=start)
+    thread.start()
+    # The refresh thread's steps are: fingerprint -> pre-lock state
+    # read -> open(lock) -> flock (blocks). The first three are
+    # microseconds of pure local work (no I/O beyond two tiny file
+    # reads); one beat is orders of magnitude more than enough for
+    # the thread to be parked on the flock before the state is
+    # written — its pre-lock read has already seen the absent state.
+    time.sleep(0.2)
+    # As the lock holder, play the other instance: record the state
+    # (what a real concurrent refresh leaves behind after its
+    # install), then release the flock. The refresh's under-lock
+    # re-read must see it and skip the install.
+    cli_install.write_install_state(tmp_path, fingerprint)
+    # Release the flock so the parked refresh can proceed (its
+    # under-lock re-read must now see the recorded state), then wait
+    # for the result.
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+    thread.join(timeout=30)
+    assert done.is_set()
+    assert result == ["unchanged"]
+    assert calls == []
+
+
+def test_refresh_writes_the_state_only_after_a_successful_install(
+    tmp_path,
+):
+    """A failing install records NO state: the next start retries the
+    refresh (a half-recorded state would wedge the machine on a broken
+    install forever)."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+
+    def boom(command, **kwargs):
+        raise RuntimeError("uv exploded")
+
+    with pytest.raises(cli_install.CliInstallError, match="uv exploded"):
+        cli_install.refresh_cli_install(tmp_path, run_command=boom)
+    assert cli_install.read_install_state(tmp_path) is None
+
+
+# --- failure propagation ------------------------------------------------------
+
+
+def test_refresh_failure_logs_the_structured_line_with_the_fix_command(
+    tmp_path, caplog,
+):
+    """Acceptance: a uv install failure fails fast and the journal
+    carries the concrete reason AND the exact fix command (the
+    editable force reinstall from the deployment checkout)."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+
+    def boom(command, **kwargs):
+        raise RuntimeError("boom: the tool env is broken")
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(
+            cli_install.CliInstallError, match="the tool env is broken",
+        ):
+            cli_install.refresh_cli_install(tmp_path, run_command=boom)
+    line = next(
+        record.message for record in caplog.records
+        if record.message.startswith("cli_install_failed")
+    )
+    assert "reason=" in line
+    assert "the tool env is broken" in line
+    assert cli_source.reinstall_command(tmp_path) in line
+
+
+def test_refresh_failure_releases_the_lock(tmp_path):
+    """A failed refresh must not wedge the shared lock: the next tick
+    (or the other instance) must be able to take it."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+
+    def boom(command, **kwargs):
+        raise RuntimeError("nope")
+
+    with pytest.raises(cli_install.CliInstallError):
+        cli_install.refresh_cli_install(tmp_path, run_command=boom)
+    lock_path = cli_install.base_sync_lock_path(tmp_path)
+    probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        fcntl.flock(probe, fcntl.LOCK_UN)
+        os.close(probe)
+
+
+def test_refresh_fails_fast_when_the_lock_is_held(tmp_path):
+    """The refresh takes the SAME base-sync flock the service
+    template's ``ExecStartPre`` uses: while it is held (the other
+    instance is syncing the checkout), the refresh waits and then
+    fails fast with the useful error — never a concurrent write."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    lock_path = cli_install.base_sync_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(
+            cli_install.CliInstallError, match="base-sync.lock",
+        ):
+            cli_install.refresh_cli_install(
+                tmp_path, run_command=lambda *a, **k: "",
+                lock_timeout_seconds=0.3,
+            )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+# --- concurrency: two instances, one install ---------------------------------
+
+
+def test_two_concurrent_starts_run_exactly_one_install(tmp_path):
+    """Acceptance: two instances starting in the same tick never run
+    concurrent uv installs and never corrupt the tool env: the
+    base-sync flock serializes them, the second reuses the first's
+    result. The counting run_command stands in for the real
+    ``uv tool install`` (its body is the exact verified argv)."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    results = []
+    errors = []
+    lock = threading.Lock()
+    installs = []
+
+    def run(command, **kwargs):
+        with lock:
+            installs.append(1)
+            active = len(installs)
+        # Simulate the install body; the flock must keep `active` at 1.
+        assert active == 1, "concurrent uv tool installs raced"
+        # The state lands only after a successful install.
+        cli_install.write_install_state(
+            tmp_path, cli_install.packaging_fingerprint(tmp_path),
+        )
+        return ""
+
+    def start():
+        try:
+            results.append(
+                cli_install.refresh_cli_install(tmp_path, run_command=run),
+            )
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=start) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert errors == []
+    # The winner installed; the loser waited for the flock, re-read
+    # the state under the lock and reused the result (no second
+    # install).
+    assert sorted(results) == ["installed", "unchanged"]
+    assert len(installs) == 1
+    assert cli_install.read_install_state(tmp_path) == (
+        cli_install.packaging_fingerprint(tmp_path)
+    )
+
+
+def test_base_sync_lock_path_is_the_shared_state_dir_file(tmp_path):
+    """The refresh serializes on the SAME lock file the ExecStartPre
+    flock in the service template uses (moved here from
+    bootstrap_runner: one home for the concurrency primitive)."""
+    assert cli_install.base_sync_lock_path(tmp_path) == (
+        tmp_path / ".muyan-pilot" / "base-sync.lock"
+    )
+
+
+def test_reinstall_argv_is_the_verified_editable_force_reinstall(tmp_path):
+    """The refresh runs the EXACT verified argv (Issue #152 contract,
+    asserted against the real `uv tool install --help` in
+    test_cli_source.py): `--force`, `--reinstall`, `--editable`,
+    `--python /usr/bin/python3`, the deployment checkout."""
+    _write_pyproject(tmp_path, '[project]\nname = "a"\n')
+    calls = []
+    cli_install.refresh_cli_install(tmp_path, run_command=_recorder(calls))
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == [
+        "uv", "tool", "install", "--force", "--reinstall", "--editable",
+        "--python", "/usr/bin/python3", str(tmp_path),
+    ]
+    assert kwargs["timeout"] == cli_install.UV_INSTALL_TIMEOUT_SECONDS

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -44,16 +44,11 @@ import pytest
 import cli_install
 import cli_source
 
-# The real refresh, captured at import time (before any fixture runs):
-# these tests exercise the function under test, overriding the suite's
-# default no-op stub from conftest (the conftest fixture runs first,
-# this one wins).
-_REAL_REFRESH = cli_install.refresh_cli_install
-
-
-@pytest.fixture(autouse=True)
-def _real_refresh(monkeypatch):
-    monkeypatch.setattr(cli_install, "refresh_cli_install", _REAL_REFRESH)
+# `cli_install` is a thin re-export of the implementation in
+# `bootstrap_runner` (see the NOTE there): these tests exercise the
+# real refresh through that single import point. The suite's default
+# no-op stub (conftest) patches `bootstrap_runner.refresh_cli_install`
+# — the call `main()` makes — and never touches this import point.
 
 
 def _write_pyproject(repo: Path, text: str) -> Path:
@@ -456,8 +451,8 @@ def test_two_concurrent_starts_run_exactly_one_install(tmp_path):
 
 def test_base_sync_lock_path_is_the_shared_state_dir_file(tmp_path):
     """The refresh serializes on the SAME lock file the ExecStartPre
-    flock in the service template uses (moved here from
-    bootstrap_runner: one home for the concurrency primitive)."""
+    flock in the service template uses (the shared state dir, next to
+    the slots — never a per-process temp file)."""
     assert cli_install.base_sync_lock_path(tmp_path) == (
         tmp_path / ".muyan-pilot" / "base-sync.lock"
     )

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -49,6 +49,8 @@ RUNTIME_MODULES = (
     "progress",
     # Issue #152: the CLI source consistency check (doctor/setup).
     "cli_source",
+    # Issue #158: the pre-start editable CLI install refresh.
+    "cli_install",
 )
 
 # The docs pages that document user-facing commands (EN + ZH parity).

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -23,6 +23,7 @@ executable records every invocation. These prove the acceptance criteria:
 - a SIGKILLed runner releases its slot automatically (the kernel owns
   the flock lock), so an abnormal exit never deadlocks the machine.
 """
+import hashlib
 import json
 import os
 import shutil
@@ -375,10 +376,28 @@ def clone(tmp_path: Path) -> Path:
     # the pre-start drift check compares them against the installed
     # units, so a synthetic clone without them could never pass it.
     shutil.copytree(REPO_ROOT / "systemd", clone / "systemd")
+    # The deployment checkout carries the packaging input (Issue #158):
+    # the pre-start CLI install refresh fingerprints the checkout's
+    # `pyproject.toml`.
+    shutil.copyfile(REPO_ROOT / "pyproject.toml", clone / "pyproject.toml")
     (clone / "a.txt").write_text("a", encoding="utf-8")
     git(clone, "add", ".")
     git(clone, "commit", "-m", "first")
     git(clone, "push", "origin", "main")
+    # The e2e world's tool env is UP TO DATE (Issue #158): the
+    # last-install state is pre-recorded for the clone's packaging
+    # input, so the pre-start refresh is a no-op and never runs a real
+    # `uv tool install` against the synthetic clone (the refresh's own
+    # behavior is covered by tests/test_cli_install.py and the wiring
+    # tests in tests/test_bootstrap_runner.py).
+    fingerprint = hashlib.sha256(
+        (clone / "pyproject.toml").read_bytes(),
+    ).hexdigest()
+    state_dir = clone / ".muyan-pilot"
+    state_dir.mkdir()
+    (state_dir / "cli-install.json").write_text(
+        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
+    )
     return clone
 
 

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 import pytest
 
 import bootstrap_runner as runner
+import cli_install
 from tests.test_progress_wiring import make_fake_gh
 
 
@@ -590,7 +591,7 @@ def test_sync_base_checkout_lock_path_is_the_shared_state_dir_file(
     # Issue #149: the SAME lock file the ExecStartPre flock in the
     # service template uses (the shared state dir, never a per-process
     # temp file).
-    assert runner.base_sync_lock_path(tmp_path) == (
+    assert cli_install.base_sync_lock_path(tmp_path) == (
         tmp_path / ".muyan-pilot" / "base-sync.lock"
     )
 
@@ -602,7 +603,7 @@ def test_sync_base_checkout_fails_fast_while_the_lock_is_held(
     # Python-side sync must not run git while the ExecStartPre flock
     # (or another Runner's sync) holds the lock — it fails fast with a
     # useful error instead of racing the main worktree.
-    lock_path = runner.base_sync_lock_path(tmp_path)
+    lock_path = cli_install.base_sync_lock_path(tmp_path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
     fcntl.flock(fd, fcntl.LOCK_EX)
@@ -641,7 +642,7 @@ def test_sync_base_checkout_releases_the_lock_after_sync(
 
     # After the sync the lock is free: a non-blocking probe acquires
     # and releases it immediately.
-    lock_path = runner.base_sync_lock_path(checkout)
+    lock_path = cli_install.base_sync_lock_path(checkout)
     probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
     try:
         fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -675,7 +676,7 @@ def test_sync_base_checkout_releases_the_lock_on_failure(
     with pytest.raises(RuntimeError, match="cannot fast-forward"):
         runner.sync_base_checkout(checkout, "main")
 
-    lock_path = runner.base_sync_lock_path(checkout)
+    lock_path = cli_install.base_sync_lock_path(checkout)
     probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
     try:
         fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)


### PR DESCRIPTION
Fixes #158

<!-- muyan-pilot:run=d13b0c56 -->
run_id=d13b0c56

## What

The editable finder's module MAPPING is generated at INSTALL time from
the checkout's `pyproject.toml` (`py-modules`, entry points, version,
dependencies). A merged packaging change (e.g. a new runtime module in
`py-modules`) therefore leaves a stale finder: the next CLI process dies
with `ModuleNotFoundError` before the Runner can even start (the #158
incident: `cli_source` merged to main, the installed finder still mapped
the pre-#152 module set, the systemd start failed).

The Runner tick entry now refreshes the editable install BEFORE any slot
or claim (new module `cli_install.py`):

- **fingerprint**: sha256 of the checkout's `pyproject.toml` (the
  packaging input) vs the last successful install's fingerprint, stored
  in the EXISTING shared state dir
  (`.muyan-pilot/cli-install.json`, next to `base-sync.lock` and the
  slots — gitignored, survives the `git merge --ff-only` checkout sync;
  not a second release state);
- **unchanged** → NO `uv` call at all (no per-tick unconditional
  reinstall);
- **changed / first install** → ONE lock-protected
  `uv tool install --force --reinstall --editable --python
  /usr/bin/python3 <repo_dir>` (the exact verified argv from
  `cli_source.reinstall_args`, 300 s timeout) under the SAME base-sync
  flock the service `ExecStartPre` and the checkout sync use, with an
  under-lock re-check: two instances starting in the same tick
  serialize, the second reuses the first's result — never a concurrent
  `uv` install;
- **failure** → fail fast with the structured `cli_install_failed` line
  (reason + the exact fix command): no slot, no claim, no label change,
  no state recorded (the next start retries).

The base-sync lock helpers move to `cli_install.py` (one home for the
concurrency primitive); `bootstrap_runner` re-exports them.
`cli_install` joins `py-modules` (module + packaging superset test).
Docs: README, AGENTS.md, EN/ZH getting-started describe the automatic
refresh; the manual force reinstall stays the setup/fix entry.

## Verification

- TDD: 21 new tests in `tests/test_cli_install.py` (fingerprint, state
  I/O incl. malformed + atomic write, unchanged/changed/first install,
  lock-protected concurrent reuse, failure propagation + structured log
  + no state on failure, lock timeout, no uv when unchanged) + 2 wiring
  tests in `tests/test_bootstrap_runner.py` (refresh runs before
  slot/claim; a failing refresh fails the start before slot/claim).
- Full suite on the merged tree (base advanced to 920a4b3c while
  working, merged clean): **1114 passed**, 1 failed =
  `test_pilot_slots.py::test_slot_released_on_sigint` — a pre-existing
  load-sensitive subprocess-signal flake that fails IDENTICALLY on the
  untouched base commit and passes in isolation (evidence in
  `test.log`, sections 3–4).
- Coverage: 100% line + branch for all source modules
  (`cli_install.py`: 76 stmts, 10 branches, 100%).
- Real-machine smoke: first install ran the exact `uv tool install`
  argv and recorded the state; the unchanged re-run made zero `uv`
  calls (section 6 of `test.log`).

## Scope notes

- No database, queue, daemon, second release state or fallback: the
  state file lives in the existing shared state dir, the flock is the
  kernel primitive (released with the holder's exit).
- Ordinary Python source content changes do NOT trigger a reinstall
  (the editable finder maps the live files).
- The refresh runs only in the Runner tick entry (the bare CLI); the
  subcommands never install.
