### PR TITLE
Run every shared-ref fetch under the base-sync lock (Issue #171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,19 @@ acceptance criteria.
   advanced, merge it into the task branch, resolve conflicts manually, rerun
   the full tests, then push the task branch (the independent review runs
   after the PR is opened and absorbs any further base advance in-session).
+- Every fetch that updates the shared remote-tracking ref
+  (`refs/remotes/origin/<base_branch>`) runs under the SAME shared
+  state-dir lock (`base-sync.lock`) that `ExecStartPre` uses (Issue #171):
+  the Runner-side `freeze_base` / `verify_pr` / `merge_gate` /
+  `confirm_merged` fetches go through `fetch_base_ref` (which acquires the
+  lock, fetches, and releases it), and the implement/review prompts
+  instruct Pi to run the base-freshness fetch as
+  `flock <BASE_SYNC_LOCK> git fetch origin <base_branch>` (the lock path is
+  rendered into both prompts from the configured `repo_dir`). Two concurrent
+  Runners (or a Runner and a Pi session) therefore never race the shared
+  ref — no `cannot lock ref ... is at <X> but expected <Y>` failures — and
+  a lock or fetch error fails fast with the concrete error, never a retry
+  or a fallback fetch.
 - The runner rejects a delivery whose HEAD does not contain the latest remote
   base. No auto conflict resolution, no force push, no merge or push of the
   protected branch.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ git fetch origin main && git merge --ff-only origin/main
 
 Issue #149：两个实例可能在同一 tick 启动，所以 `ExecStartPre` 的 fetch + fast-forward 包在一个短生命周期的 `flock`（共享状态目录下的 `base-sync.lock`，Python 侧 `sync_base_checkout` 取同一把锁）里：main worktree 不会被并发写入；flock 拿到后执行 git 命令，退出时自动释放，不新增常驻进程。
 
+Issue #171：两个 Runner（或 Runner 与 Pi 会话）并发 `git fetch` 会争抢共享的 remote-tracking ref（`refs/remotes/origin/main`），产生 `cannot lock ref ... is at <X> but expected <Y>` 的 CAS 失败，使 review Pi 会话非零退出。修复：所有更新共享 remote-tracking ref 的 fetch 都走同一把 `base-sync.lock`——Runner 侧的 `freeze_base` / `verify_pr` / `merge_gate` / `confirm_merged` 统一经 `fetch_base_ref`（先取锁、再 fetch、finally 释放，锁或 fetch 出错即 fail fast，不重试、不降级）；implement/review 两个 prompt 把锁路径渲染为 `BASE_SYNC_LOCK`，并指示 Pi 用 `flock <BASE_SYNC_LOCK> git fetch origin <base>` 执行 base 新鲜度 fetch。不新增进程、锁或常驻服务。
+
 ## 部署一致性（Issue #103）
 
 仓库中的 `systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。Issue #149 起部署启用两个 timer 实例 `muyan-pilot@1.timer` / `muyan-pilot@2.timer`，各自触发自己的 service 实例。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -939,8 +939,13 @@ def log_format() -> str:
 
 
 def freeze_base(repo_dir: Path, base_branch: str) -> str:
-    """Fetch the remote and freeze the exact SHA of origin/<base_branch>."""
-    run_command(["git", "fetch", "origin", base_branch], cwd=repo_dir)
+    """Fetch the remote and freeze the exact SHA of origin/<base_branch>.
+
+    The fetch runs under the base-sync lock (Issue #171): it updates
+    the shared remote-tracking ref, so it must not race the other
+    Runner/Pi fetches on that ref.
+    """
+    fetch_base_ref(repo_dir, base_branch)
     return run_command(
         ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,
     )
@@ -1829,6 +1834,10 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "BASE_BRANCH": config["base_branch"],
             "BASE_SHA": config["base_sha"],
             "RUN_ID": config["run_id"],
+            # Issue #171: the absolute path of the shared base-sync
+            # lock — the prompt's base freshness fetch must run under
+            # it (flock <lock> git fetch origin <base>).
+            "BASE_SYNC_LOCK": str(base_sync_lock_path(config["repo_dir"])),
         },
     )
     context = (
@@ -1871,7 +1880,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
 
 
 def verify_pr(worktree: Path, branch: str, base_branch: str,
-              run_id: str, *, issue: int,
+              run_id: str, *, issue: int, repo_dir: Path,
               pr_repo: str | None = None,
               expected_url: str | None = None,
               require_latest_base: bool = True) -> str:
@@ -1900,10 +1909,10 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     if require_latest_base:
         # Re-fetch before judging: the delivery must contain the latest
         # remote base, otherwise it is behind and the PR is rejected
-        # (fail fast).
-        run_command(
-            ["git", "fetch", "origin", base_branch], cwd=worktree,
-        )
+        # (fail fast). The fetch updates the shared remote-tracking
+        # ref, so it runs under the base-sync lock (Issue #171) with
+        # the deployment checkout as the lock location.
+        fetch_base_ref(repo_dir, base_branch, cwd=worktree)
         try:
             run_command(
                 ["git", "merge-base", "--is-ancestor",
@@ -2051,7 +2060,8 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
             raise RuntimeError(f"worktree missing: {worktree}")
         return verify_pr(
             worktree, branch, config["base_branch"], run_id,
-            issue=number, pr_repo=source_repo,
+            issue=number, repo_dir=config["repo_dir"],
+            pr_repo=source_repo,
             expected_url=scene["pr_url"], require_latest_base=False,
         )
     except Exception as exc:
@@ -2265,6 +2275,10 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
             "HEAD_SHA": pr["head_oid"],
             "HEAD_REF": pr["head_ref"],
             "ROUND": str(round),
+            # Issue #171: the SAME shared base-sync lock as the
+            # implementer — the review session's base-absorb fetch must
+            # run under it (flock <lock> git fetch origin <base>).
+            "BASE_SYNC_LOCK": str(base_sync_lock_path(config["repo_dir"])),
         },
     )
     context = (
@@ -2306,15 +2320,18 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     )
 
 
-def merge_gate(worktree: Path, pr: dict, base_branch: str) -> dict:
+def merge_gate(worktree: Path, pr: dict, base_branch: str,
+               *, repo_dir: Path) -> dict:
     """Merge the reviewed PR only if the gate still holds against latest base.
 
     Re-fetch the latest remote base, require the PR head to contain it, the PR
     to be mergeable, and the remote head to still be the reviewed head. Then
     merge with `--match-head-commit` so only that exact head can land. No force
-    push, no direct push of the protected branch.
+    push, no direct push of the protected branch. The base fetch updates the
+    shared remote-tracking ref, so it runs under the base-sync lock
+    (Issue #171) with the deployment checkout as the lock location.
     """
-    run_command(["git", "fetch", "origin", base_branch], cwd=worktree)
+    fetch_base_ref(repo_dir, base_branch, cwd=worktree)
     try:
         run_command(
             ["git", "merge-base", "--is-ancestor",
@@ -2365,8 +2382,14 @@ def merge_gate(worktree: Path, pr: dict, base_branch: str) -> dict:
     return {**pr, "merged": True}
 
 
-def confirm_merged(worktree: Path, pr: dict, base_branch: str) -> dict:
-    """Confirm the PR is MERGED and origin/<base> contains the merge commit."""
+def confirm_merged(worktree: Path, pr: dict, base_branch: str,
+                   *, repo_dir: Path) -> dict:
+    """Confirm the PR is MERGED and origin/<base> contains the merge commit.
+
+    The base fetch updates the shared remote-tracking ref, so it runs
+    under the base-sync lock (Issue #171) with the deployment checkout
+    as the lock location.
+    """
     raw = run_command([
         "gh", "pr", "view", str(pr["number"]),
         "--json", "state,mergedAt,mergeCommit",
@@ -2383,7 +2406,7 @@ def confirm_merged(worktree: Path, pr: dict, base_branch: str) -> dict:
         raise RuntimeError(
             f"PR #{pr['number']} is merged but has no merge commit oid"
         )
-    run_command(["git", "fetch", "origin", base_branch], cwd=worktree)
+    fetch_base_ref(repo_dir, base_branch, cwd=worktree)
     try:
         run_command(
             ["git", "merge-base", "--is-ancestor", merge_commit,
@@ -2439,6 +2462,13 @@ def base_sync_lock_path(repo_dir: Path) -> Path:
     below takes the same lock: the main worktree is never written
     concurrently. The lock lives in the shared state dir (next to the
     slot files), never in a per-process temp dir.
+
+    Issue #171 extended the same lock to EVERY fetch that updates the
+    shared remote-tracking ref ``refs/remotes/origin/<base>``: task
+    worktrees share the deployment checkout's common dir, so an
+    unlocked concurrent fetch (Runner verify/gate/confirm, the Pi
+    prompt-side fetch) races on that one ref and fails with
+    ``cannot lock ref ... is at <X> but expected <Y>``.
     """
     return Path(repo_dir) / ".muyan-pilot" / BASE_SYNC_LOCK_NAME
 
@@ -2472,6 +2502,39 @@ def _acquire_base_sync_lock(
                     "the deployment checkout)"
                 ) from None
             time.sleep(0.1)
+
+
+def fetch_base_ref(repo_dir: Path, base_branch: str,
+                   *, cwd: Path | None = None,
+                   lock_timeout_seconds: float = 300.0,
+                   command_runner: Callable[[list[str]], str] | None = None,
+                   ) -> None:
+    """Fetch ``origin/<base>`` under the base-sync lock (Issue #171).
+
+    Every command that updates the shared remote-tracking ref
+    ``refs/remotes/origin/<base>`` must run under the SAME lock in the
+    deployment checkout's shared state dir (the one the ExecStartPre
+    flock and ``sync_base_checkout`` use): worktrees share the common
+    dir, so an unlocked concurrent fetch races on the ref and fails
+    the session. ``repo_dir`` is the deployment checkout (the lock
+    location); ``cwd`` is where the fetch runs (the task worktree for
+    the Runner verify/gate/confirm paths, the checkout itself by
+    default). ``command_runner`` overrides the command executor (the
+    setup entry injects its own); by default the module's
+    ``run_command`` is used. A lock timeout or a fetch error fails
+    fast — no retry, no lock bypass.
+    """
+    if command_runner is None:
+        command_runner = run_command
+    fd = _acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    try:
+        command_runner(
+            ["git", "fetch", "origin", base_branch],
+            cwd=cwd if cwd is not None else repo_dir,
+        )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def sync_base_checkout(repo_dir: Path, base_branch: str,
@@ -2685,7 +2748,10 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             pr["number"], round, pr["head_oid"], refrozen["head_oid"],
         )
     try:
-        merged = merge_gate(worktree, refrozen, base_branch)
+        merged = merge_gate(
+            worktree, refrozen, base_branch,
+            repo_dir=config["repo_dir"],
+        )
     except RuntimeError as exc:
         message = str(exc)
         # Behind and merge-conflict are the same next-session job:
@@ -2711,7 +2777,9 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             remove=PR_OPENED_LABEL,
         )
         return False
-    confirmed = confirm_merged(worktree, merged, base_branch)
+    confirmed = confirm_merged(
+        worktree, merged, base_branch, repo_dir=config["repo_dir"],
+    )
     # Issue #79: the merged publishing is bypass — the GitHub merge
     # already landed; a 404 here must not stop the `ai-merged`
     # transition and the merged PR scene comment below.
@@ -3180,6 +3248,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         )
         pr_url = verify_pr(
             worktree, branch, base_branch, run_id, issue=number,
+            repo_dir=config["repo_dir"],
         )
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -28,7 +28,17 @@ Runner instances can run concurrently. Each tick's service instance:
    the same tick, the fetch + fast-forward is wrapped in a short-lived
    `flock` on the shared state-dir lock file (`base-sync.lock`, the
    Python-side sync takes the SAME lock): the main worktree is never
-   written concurrently.
+   written concurrently. Since Issue #171 EVERY fetch that updates the
+   shared remote-tracking ref runs under that same lock: the Runner-side
+   `freeze_base` / `verify_pr` / `merge_gate` / `confirm_merged` fetches
+   go through `fetch_base_ref` (acquire lock → fetch → release, fail fast
+   on lock or fetch errors), and the implement/review prompts instruct Pi
+   to run the base-freshness fetch as
+   `flock <BASE_SYNC_LOCK> git fetch origin <base_branch>` (the lock path
+   is rendered into both prompts from the configured `repo_dir`). Two
+   concurrent Runners — or a Runner and a Pi session — therefore never
+   race the shared ref (no `cannot lock ref ... is at <X> but expected
+   <Y>` failures).
 2. **Runs one tick**: resume an opened PR (review/fix/merge) or claim one
    `ai-ready` Issue, then exit. Before any slot or claim the tick also
    runs the pre-start **git transport check** (Issue #114): the

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -22,7 +22,15 @@ service 实例（`muyan-pilot@1.timer` → `muyan-pilot@1.service`，
    的后续 start 请求，下一次真正启动取到最新代码。两个实例可能在同一
    tick 运行 `ExecStartPre`，所以 fetch + fast-forward 包在一个短生命
    周期的 `flock`（共享状态目录下的 `base-sync.lock`，Python 侧同步取
-   同一把锁）里：main worktree 不会被并发写入。
+   同一把锁）里：main worktree 不会被并发写入。自 Issue #171 起，所有更新
+   共享 remote-tracking ref 的 fetch 都走同一把锁：Runner 侧的
+   `freeze_base` / `verify_pr` / `merge_gate` / `confirm_merged` fetch 统一
+   经 `fetch_base_ref`（先取锁 → fetch → 释放，锁或 fetch 出错即 fail
+   fast），implement/review 两个 prompt 指示 Pi 用
+   `flock <BASE_SYNC_LOCK> git fetch origin <base_branch>` 执行 base
+   新鲜度 fetch（锁路径从配置的 `repo_dir` 渲染进两个 prompt）。两个并发
+   Runner（或 Runner 与 Pi 会话）因此不再争抢共享 ref（不会出现
+   `cannot lock ref ... is at <X> but expected <Y>` 失败）。
 2. **运行一个 tick**：恢复一个已打开的 PR（review/fix/merge），或领取
    一个 `ai-ready` Issue，然后退出。在任何 slot 或领取之前，tick 还
    运行启动前 **git transport 检查**（Issue #114）：部署 checkout 的

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -40,6 +40,7 @@ import shutil
 import tomllib
 from pathlib import Path
 
+import bootstrap_runner
 import cli_source
 import git_transport
 import systemd_deploy
@@ -503,7 +504,13 @@ def check_checkout(repo_dir: Path, base_branch: str,
                 "first: the timer's ExecStartPre fast-forward refuses "
                 "a dirty worktree, so the Runner could never start"
             )
-        run_command(["git", "fetch", "origin", base_branch], cwd=repo_dir)
+        # Issue #171: the checkout check's fetch updates the shared
+        # remote-tracking ref, so it runs under the SAME base-sync
+        # lock the Runner and the Pi prompt-side fetches use (no
+        # unlocked fetch path exists).
+        bootstrap_runner.fetch_base_ref(
+            repo_dir, base_branch, command_runner=run_command,
+        )
         head = run_command(["git", "rev-parse", "HEAD"], cwd=repo_dir)
         base = run_command(
             ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,

--- a/prompt.md
+++ b/prompt.md
@@ -13,6 +13,7 @@ Runtime context supplied by the runner:
   `{{SKILLS}}`
 - Delivery base branch: `{{BASE_BRANCH}}`
 - Delivery base SHA (frozen `origin/{{BASE_BRANCH}}` at claim time): `{{BASE_SHA}}`
+- Base sync lock: `{{BASE_SYNC_LOCK}}`
 - Run id: `{{RUN_ID}}`
 
 Run correlation (Issue #41):
@@ -99,7 +100,13 @@ Base freshness before creating the PR:
 Your worktree was created from `{{BASE_SHA}}` (the frozen
 `origin/{{BASE_BRANCH}}` at claim time). Before creating the PR:
 
-1. Run `git fetch origin {{BASE_BRANCH}}` in the worktree.
+1. Run `flock {{BASE_SYNC_LOCK}} git fetch origin {{BASE_BRANCH}}` in the
+   worktree (Issue #171: the worktree shares the deployment checkout's git
+   common dir, so an unlocked concurrent fetch races on the shared
+   `refs/remotes/origin/{{BASE_BRANCH}}` ref and fails with `cannot lock
+   ref`; the Runner's own fetches hold the same lock). A fetch error or a
+   lock timeout fails fast — do not retry the bare fetch and do not bypass
+   the lock.
 2. If `git merge-base --is-ancestor origin/{{BASE_BRANCH}} HEAD` fails, the
    base advanced while you worked: merge `origin/{{BASE_BRANCH}}` into your
    task branch, resolve conflicts manually, rerun the full test suite, then

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -17,6 +17,7 @@ Runtime context supplied by the runner:
 - Delivery base branch: `{{BASE_BRANCH}}`
 - Frozen PR base SHA: `{{BASE_SHA}}`
 - Frozen PR head SHA: `{{HEAD_SHA}}` (branch `{{HEAD_REF}}`)
+- Base sync lock: `{{BASE_SYNC_LOCK}}`
 - Review round: `{{ROUND}}`
 
 ## Scope
@@ -77,7 +78,11 @@ another session: fix them here, in this same session.
 - Push ONLY the task branch (the PR head branch); never force push, never
   push the protected branch, never create or close a PR.
 - If the head is behind the latest remote base or has a merge conflict,
-  absorb it here: `git fetch origin {{BASE_BRANCH}}`, plain
+  absorb it here: `flock {{BASE_SYNC_LOCK}} git fetch origin {{BASE_BRANCH}}`
+  (Issue #171: the worktree shares the deployment checkout's git common dir,
+  so an unlocked concurrent fetch races on the shared
+  `refs/remotes/origin/{{BASE_BRANCH}}` ref; a fetch error or a lock timeout
+  fails fast — never retry the bare fetch or bypass the lock), plain
   `git merge origin/{{BASE_BRANCH}}`, resolve conflicts manually, rerun the
   full test suite with coverage, and push the task branch.
 - After fixing, re-check the diff against R1–R9 and the Issue's acceptance

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1,3 +1,4 @@
+import fcntl
 import json
 import logging
 import os
@@ -361,8 +362,10 @@ def test_prompt_template_requires_fixes_keyword_for_the_source_issue():
         "BASE_BRANCH": "main",
         "BASE_SHA": "abc123",
         "RUN_ID": "a2241189",
+        "BASE_SYNC_LOCK": "/checkout/.muyan-pilot/base-sync.lock",
     })
     assert "Fixes #53" in rendered
+    assert "/checkout/.muyan-pilot/base-sync.lock" in rendered
     assert "{{" not in rendered
 
 
@@ -1824,6 +1827,41 @@ def test_freeze_base_fetches_remote_and_returns_exact_sha(monkeypatch, tmp_path)
     )]
 
 
+def _probe_lock_free(repo_dir: Path) -> bool:
+    """True when a non-blocking probe acquires the base-sync lock
+    (i.e. the lock is FREE); False while it is held."""
+    lock_path = runner.base_sync_lock_path(repo_dir)
+    probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+    finally:
+        fcntl.flock(probe, fcntl.LOCK_UN)
+        os.close(probe)
+
+
+def test_freeze_base_fetches_under_the_base_sync_lock(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the freeze fetch updates the shared remote-tracking
+    # ref, so it must run under the SAME base-sync lock (a concurrent
+    # probe must not acquire it while the fetch is in flight) and the
+    # lock must be free again afterwards.
+    held = []
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "fetch", "origin"]:
+            held.append(not _probe_lock_free(tmp_path))
+        return "abc123def456"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.freeze_base(tmp_path, "main") == "abc123def456"
+    assert held == [True]
+    assert _probe_lock_free(tmp_path) is True
+
+
 def test_freeze_base_fails_fast_when_remote_base_is_missing(monkeypatch, tmp_path):
     error = subprocess.CalledProcessError(
         128, ["git", "rev-parse", "origin/main"],
@@ -2286,12 +2324,75 @@ def test_issue_context_uses_owner_repo_number_form():
     )
 
 
+def test_run_pi_renders_base_sync_lock_into_prompt(monkeypatch, tmp_path):
+    # Issue #171: the implementer prompt carries the absolute path of
+    # the shared base-sync lock so Pi's base freshness fetch can run
+    # under it (flock <lock> git fetch origin <base>).
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text(
+        "SYSTEM {{BASE_SYNC_LOCK}}",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append(command) or "done")
+    issue = {"number": 4, "title": "t", "body": "b"}
+    config = {
+        "prompt": prompt_path,
+        "repo_dir": tmp_path / "checkout",
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "run1",
+    }
+    runner.run_pi(
+        issue, tmp_path, config, "owner/repo",
+        branch="muyan-pilot/owner-repo-issue-4-run1",
+    )
+    command = calls[0]
+    assert command[command.index("--system-prompt") + 1] == "SYSTEM " + str(
+        tmp_path / "checkout" / ".muyan-pilot" / "base-sync.lock",
+    )
+
+
+def test_run_review_renders_base_sync_lock_into_prompt(monkeypatch, tmp_path):
+    # Issue #171: the review prompt carries the SAME lock path (the
+    # review session's base merge fetch must not race the shared ref).
+    prompt_path = tmp_path / "prompt_review.md"
+    prompt_path.write_text(
+        "REVIEW {{BASE_SYNC_LOCK}}",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append(command) or "ok")
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        {
+            "prompt_review": prompt_path,
+            "repo_dir": tmp_path / "checkout",
+            "source_repos": ["owner/repo"],
+            "base_branch": "main",
+            "run_id": "a1b2c3d4",
+            "skills": [],
+        },
+        "owner/repo", 4, "branch", 1,
+    )
+    command = calls[0]
+    assert command[command.index("--system-prompt") + 1] == "REVIEW " + str(
+        tmp_path / "checkout" / ".muyan-pilot" / "base-sync.lock",
+    )
+
+
 def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_path):
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text(
         "SYSTEM {{SOURCE_REPO}} {{ISSUE_NUMBER}} {{ISSUE_TITLE}} {{ISSUE_BODY}} "
         "{{WORKSPACE_ROOT}} {{CONTEXT_FILES}} {{SKILLS}} {{BASE_BRANCH}} "
-        "{{BASE_SHA}} {{RUN_ID}}",
+        "{{BASE_SHA}} {{RUN_ID}} {{BASE_SYNC_LOCK}}",
         encoding="utf-8",
     )
     calls = []
@@ -2299,6 +2400,7 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
     issue = {"number": 4, "title": "Fix title", "body": "Fix body"}
     config = {
         "prompt": prompt_path,
+        "repo_dir": tmp_path / "checkout",
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": ["context.md"],
@@ -2319,7 +2421,10 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
     assert "Fix body" in command[7]
     assert "context.md" in command[7]
     assert "skill.md" in command[7]
-    assert command[7].endswith("main abc123def456 run1")
+    assert command[7].endswith(
+        "main abc123def456 run1 "
+        + str(tmp_path / "checkout" / ".muyan-pilot" / "base-sync.lock"),
+    )
     assert command[8] == "Issue #4: Fix title\n\nIssue body:\nFix body\n\nWorktree: " + str(tmp_path) + "\nComplete the delivery process in the system prompt."
     assert kwargs["cwd"] == tmp_path
     assert kwargs["timeout"] is None
@@ -2338,6 +2443,7 @@ def test_run_pi_passes_task_branch_to_stream_pi(monkeypatch, tmp_path):
     issue = {"number": 5, "title": "t", "body": "b"}
     config = {
         "prompt": prompt_path,
+        "repo_dir": tmp_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": [],
@@ -2361,7 +2467,7 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: calls.append((command, kwargs)) or "done")
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
-        {"prompt": prompt_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
+        {"prompt": prompt_path, "repo_dir": tmp_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
         "owner/repo", branch="muyan-pilot/owner-repo-issue-5-run1",
     )
     command, kwargs = calls[0]
@@ -2378,7 +2484,7 @@ def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "other-branch")
     with pytest.raises(RuntimeError, match="Pi changed branch"):
         runner.verify_pr(
-            tmp_path, "muyan-pilot/issue-4", "main", "e07383c2", issue=4,
+            tmp_path, "muyan-pilot/issue-4", "main", "e07383c2", issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2435,7 +2541,7 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(monkeypatch, tmp_p
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
     assert "base_branch=main" in caplog.text
 
@@ -2453,7 +2559,7 @@ def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2465,7 +2571,7 @@ def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2479,10 +2585,46 @@ def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, t
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4,
+        issue=4, repo_dir=tmp_path,
     ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "fetch", "origin", "main"] in calls
     assert ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"] in calls
+
+
+def test_verify_pr_requires_the_repo_dir_lock_location(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the verify fetch updates the shared remote-tracking
+    # ref, so the lock location (the deployment checkout's shared state
+    # dir) must be explicit — there is no bypass path.
+    monkeypatch.setattr(runner, "run_command", fake_verify_run)
+    with pytest.raises(TypeError):
+        runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4,
+        )
+
+
+def test_verify_pr_fetches_under_the_base_sync_lock(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the verify fetch runs under the SAME base-sync lock
+    # (a concurrent probe must not acquire it while the fetch is in
+    # flight) and the lock must be free again afterwards.
+    held = []
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "fetch", "origin"]:
+            held.append(not _probe_lock_free(tmp_path))
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    runner.verify_pr(
+        tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+        FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
+    )
+    assert held == [True]
+    assert _probe_lock_free(tmp_path) is True
 
 
 def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
@@ -2493,7 +2635,7 @@ def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="open PR has no URL"):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2509,7 +2651,7 @@ def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2527,7 +2669,7 @@ def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2543,7 +2685,7 @@ def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, cap
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
     assert "pr_run_marker_missing" in caplog.text
 
@@ -2560,7 +2702,7 @@ def test_verify_pr_rejects_pr_body_missing_field(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
 
 
@@ -2580,7 +2722,7 @@ def test_verify_pr_accepts_pr_body_with_fixes_keyword(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4,
+        issue=4, repo_dir=tmp_path,
     ) == FAKE_PR_URL
 
 
@@ -2602,7 +2744,7 @@ def test_verify_pr_rejects_pr_body_without_fixes_keyword(
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
     assert "pr_fixes_missing" in caplog.text
     assert "issue=4" in caplog.text
@@ -2629,7 +2771,7 @@ def test_verify_pr_rejects_pr_body_with_wrong_issue_number(
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
     assert "pr_fixes_missing" in caplog.text
 
@@ -2655,7 +2797,7 @@ def test_verify_pr_rejects_pr_body_with_longer_issue_number(
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
     assert "pr_fixes_missing" in caplog.text
 
@@ -2672,7 +2814,7 @@ def test_verify_pr_queries_base_head_and_accepts_matching_pr(
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4,
+        issue=4, repo_dir=tmp_path,
     ) == "https://github.com/muyantech/muyan-pilot/pull/4"
     assert ["git", "rev-parse", "HEAD"] in calls
     assert [
@@ -2693,7 +2835,7 @@ def test_verify_pr_accepts_pr_in_expected_repo_and_url(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4, pr_repo=FAKE_PR_REPO, expected_url=FAKE_PR_URL,
+        issue=4, repo_dir=tmp_path, pr_repo=FAKE_PR_REPO, expected_url=FAKE_PR_URL,
     ) == FAKE_PR_URL
 
 
@@ -2713,7 +2855,7 @@ def test_verify_pr_rejects_pr_head_in_another_repo(monkeypatch, tmp_path, caplog
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path, pr_repo=FAKE_PR_REPO,
         )
     assert "pr_repo_mismatch" in caplog.text
 
@@ -2733,7 +2875,7 @@ def test_verify_pr_rejects_pr_head_repo_missing_fields(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path, pr_repo=FAKE_PR_REPO,
         )
 
 
@@ -2752,7 +2894,7 @@ def test_verify_pr_rejects_pr_head_repo_empty_fields(monkeypatch, tmp_path):
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4, pr_repo=FAKE_PR_REPO,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path, pr_repo=FAKE_PR_REPO,
         )
 
 
@@ -2776,7 +2918,7 @@ def test_verify_pr_skips_repo_check_when_pr_repo_not_given(monkeypatch,
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4,
+        issue=4, repo_dir=tmp_path,
     ) == FAKE_PR_URL
 
 
@@ -2798,7 +2940,7 @@ def test_verify_pr_rejects_url_different_from_expected(monkeypatch, tmp_path, ca
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
-            FAKE_RUN_ID, issue=4, expected_url=FAKE_PR_URL,
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path, expected_url=FAKE_PR_URL,
         )
     assert "pr_url_mismatch" in caplog.text
 
@@ -2809,7 +2951,7 @@ def test_verify_pr_skips_url_check_when_expected_url_not_given(
     monkeypatch.setattr(runner, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4,
+        issue=4, repo_dir=tmp_path,
     ) == FAKE_PR_URL
 
 
@@ -2828,7 +2970,7 @@ def test_verify_pr_skips_latest_base_check_when_not_required(
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
-        issue=4, require_latest_base=False,
+        issue=4, repo_dir=tmp_path, require_latest_base=False,
     ) == FAKE_PR_URL
     assert not any(c[:3] == ["git", "fetch", "origin"] for c in calls)
     assert not any(
@@ -5343,6 +5485,7 @@ def test_run_pi_passes_progress_callback_to_stream_pi(monkeypatch, tmp_path):
         {"number": 4, "title": "Fix", "body": "b"}, tmp_path,
         {
             "prompt": tmp_path / "prompt.md",
+            "repo_dir": tmp_path,
             "source_repos": ["owner/repo"],
             "workspace_root": tmp_path,
             "base_branch": "main",
@@ -5378,6 +5521,7 @@ def test_run_review_passes_progress_callback_to_stream_pi(
          "head_oid": "h1", "head_ref": "h"},
         {
             "prompt_review": tmp_path / "prompt_review.md",
+            "repo_dir": tmp_path,
             "source_repos": ["owner/repo"],
             "base_branch": "main",
             "run_id": "a1b2c3d4",
@@ -5403,6 +5547,7 @@ def _skill_config(tmp_path, *names):
     return {
         "prompt": tmp_path / "prompt.md",
         "prompt_review": tmp_path / "prompt_review.md",
+        "repo_dir": tmp_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": [],
@@ -7327,6 +7472,7 @@ def _model_config(tmp_path, **extra):
     config = {
         "prompt": tmp_path / "prompt.md",
         "prompt_review": tmp_path / "prompt_review.md",
+        "repo_dir": tmp_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": [],

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -300,8 +300,14 @@ if "INDEPENDENT REVIEW" in system_prompt:
         )
     # A head behind the latest base is fixed in-session too (Issue
     # #82), on EVERY review round: the base may advance between rounds.
-    # Absorb origin/main, resolve, retest, push.
-    subprocess.run(["git", "fetch", "origin", "main"], check=True)
+    # Absorb origin/main, resolve, retest, push. The fetch updates the
+    # shared remote-tracking ref, so it runs under the base-sync lock
+    # (Issue #171): the same `flock <lock> git fetch origin main` the
+    # real review prompt instructs (the lock path comes from the
+    # rendered prompt).
+    lock = system_prompt.split("lock=")[1].split()[0]
+    subprocess.run(["flock", lock, "git", "fetch", "origin", "main"],
+                   check=True)
     behind = subprocess.run(
         ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"],
         capture_output=True,
@@ -449,15 +455,19 @@ def write_config(
         "You are the delivery agent.\n"
         "- Delivery base branch: `{{BASE_BRANCH}}`\n"
         "- Delivery base SHA: `{{BASE_SHA}}`\n"
+        "- Base sync lock: `{{BASE_SYNC_LOCK}}`\n"
         "- Run id: `{{RUN_ID}}`\n",
         encoding="utf-8",
     )
     # validate_config requires the review prompt to exist as well (the
     # Runner runs the independent review itself). The review prompt
     # carries the run_id so the fake pi can key its
-    # first-review-findings state per run.
+    # first-review-findings state per run, and the base-sync lock path
+    # (Issue #171) so the fake pi's base-absorb fetch runs under the
+    # SAME lock the real review prompt instructs.
     (tmp_path / "prompt_review.md").write_text(
-        "INDEPENDENT REVIEW\nrun_id={{RUN_ID}}\n", encoding="utf-8",
+        "INDEPENDENT REVIEW\nrun_id={{RUN_ID}}\n"
+        "lock={{BASE_SYNC_LOCK}}\n", encoding="utf-8",
     )
     config = tmp_path / f"muyan-pilot-{max_concurrency}.toml"
     config.write_text(

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -121,7 +121,7 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
     ):
         runner.verify_pr(
             clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
-            "a1b2c3d4", issue=3,
+            "a1b2c3d4", issue=3, repo_dir=clone,
         )
     assert "base_branch=main" in caplog.text
 
@@ -145,7 +145,7 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
     )
     assert runner.verify_pr(
         clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
-        "a1b2c3d4", issue=3,
+        "a1b2c3d4", issue=3, repo_dir=clone,
     ) == "https://github.com/owner/repo/pull/3"
 
 
@@ -170,7 +170,7 @@ def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
     with pytest.raises(RuntimeError, match="is not local HEAD"):
         runner.verify_pr(
             clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
-            "a1b2c3d4", issue=3,
+            "a1b2c3d4", issue=3, repo_dir=clone,
         )
 
 

--- a/tests/test_git_merge_smoke.py
+++ b/tests/test_git_merge_smoke.py
@@ -108,7 +108,7 @@ def test_merge_gate_merges_head_containing_latest_base(clone, monkeypatch):
           "head_ref": "muyan-pilot/owner-repo-issue-4-run1",
           "head_oid": head_oid}
     commands = install_fake_gh(monkeypatch, clone, make_pr(head_oid))
-    merged = runner.merge_gate(clone, pr, "main")
+    merged = runner.merge_gate(clone, pr, "main", repo_dir=clone)
     assert merged["merged"] is True
     # The merge used --match-head-commit with the reviewed head SHA.
     merge_cmd = [c for c in commands if c[:2] == ["gh", "pr"]
@@ -129,7 +129,7 @@ def test_merge_gate_merges_head_containing_latest_base(clone, monkeypatch):
             else ""
         ),
     )
-    confirmed = runner.confirm_merged(clone, merged, "main")
+    confirmed = runner.confirm_merged(clone, merged, "main", repo_dir=clone)
     assert confirmed["state"] == "MERGED"
     assert confirmed["merge_commit"] == merge_commit
 
@@ -162,7 +162,7 @@ def test_merge_gate_rejects_head_behind_latest_base(clone, monkeypatch, caplog):
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
-        runner.merge_gate(clone, pr, "main")
+        runner.merge_gate(clone, pr, "main", repo_dir=clone)
     # No merge was attempted: a stale baseline is never merged.
     assert not [c for c in commands if c[:2] == ["gh", "pr"]
                and "merge" in c]
@@ -201,7 +201,7 @@ def test_deployment_checkout_fast_forwards_after_independent_merge(
           "head_ref": "muyan-pilot/owner-repo-issue-4-run1",
           "head_oid": head_oid}
     install_fake_gh(monkeypatch, clone, make_pr(head_oid))
-    merged = runner.merge_gate(clone, pr, "main")
+    merged = runner.merge_gate(clone, pr, "main", repo_dir=clone)
     assert merged["merged"] is True
     merge_commit = git(clone, "rev-parse", "origin/main")
     # The remote advanced; the deployment checkout has not yet.
@@ -216,7 +216,7 @@ def test_deployment_checkout_fast_forwards_after_independent_merge(
         return real_run(command, **kwargs)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    confirmed = runner.confirm_merged(clone, merged, "main")
+    confirmed = runner.confirm_merged(clone, merged, "main", repo_dir=clone)
     assert confirmed["merge_commit"] == merge_commit
 
     # The deployment checkout now fast-forwards to the merged base.

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -165,6 +165,38 @@ def test_prompt_review_md_keeps_the_kiss_lean_check():
     )
 
 
+# --- Issue #171: shared-ref fetches under the base-sync lock ------------------
+
+LOCK_FETCH_ITEMS = (
+    # The fetch instruction names the lock placeholder and the exact
+    # command shape (flock <lock> git fetch origin <base>): the worktree
+    # shares the deployment checkout's common dir, so an unlocked
+    # concurrent fetch races on the shared remote-tracking ref.
+    ("lock-fetch-flock",
+     "flock {{base_sync_lock}} git fetch origin {{base_branch}}"),
+    # A fetch error or lock timeout fails fast; no bare-fetch retry and
+    # no lock bypass.
+    ("lock-fetch-fail-fast", "fails fast"),
+    ("lock-fetch-no-bypass", "bypass"),
+)
+
+
+def test_prompt_md_fetches_the_base_under_the_base_sync_lock():
+    missing = _missing(_text(PROMPT), LOCK_FETCH_ITEMS)
+    assert not missing, (
+        f"prompt.md is missing the locked base fetch (Issue #171): "
+        f"{missing}"
+    )
+
+
+def test_prompt_review_md_fetches_the_base_under_the_base_sync_lock():
+    missing = _missing(_text(PROMPT_REVIEW), LOCK_FETCH_ITEMS)
+    assert not missing, (
+        f"prompt_review.md is missing the locked base fetch (Issue #171): "
+        f"{missing}"
+    )
+
+
 # --- AGENTS.md (TDD section) ---------------------------------------------------
 
 AGENTS_TDD_ITEMS = (

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -771,6 +771,7 @@ def test_run_pi_fresh_context_has_no_existing_pr(monkeypatch, tmp_path):
     )
     config = {
         "prompt": prompt_path,
+        "repo_dir": tmp_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": [],
@@ -916,11 +917,12 @@ def test_verify_resumed_pr_verifies_scene_pr_and_returns_verified_url(
     verified_url = "https://github.com/owner/repo/pull/9"
 
     def fake_verify_pr(worktree, branch, base_branch, run_id, *, issue,
-                       pr_repo=None, expected_url=None,
+                       repo_dir=None, pr_repo=None, expected_url=None,
                        require_latest_base=True):
         calls.append({
             "worktree": worktree, "branch": branch,
             "base_branch": base_branch, "run_id": run_id, "issue": issue,
+            "repo_dir": repo_dir,
             "pr_repo": pr_repo, "expected_url": expected_url,
             "require_latest_base": require_latest_base,
         })
@@ -949,6 +951,9 @@ def test_verify_resumed_pr_verifies_scene_pr_and_returns_verified_url(
     assert call["pr_repo"] == "owner/repo"
     assert call["expected_url"] == FAKE_PR_URL
     assert call["require_latest_base"] is False
+    # Issue #171: the verify fetch's lock location is the configured
+    # deployment checkout (the shared state dir), never the worktree.
+    assert call["repo_dir"] == tmp_path
 
 
 

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -224,6 +224,7 @@ def _review_config(tmp_path, prompt_name="prompt_review.md"):
                       encoding="utf-8")
     return {
         "prompt_review": prompt,
+        "repo_dir": tmp_path,
         "source_repos": ["owner/repo"],
         "workspace_root": tmp_path,
         "context_files": [],
@@ -298,13 +299,51 @@ def test_merge_gate_merges_reviewed_head_with_match_head_commit(monkeypatch, tmp
     pr = runner.merge_gate(tmp_path, {"number": 4, "url": "u",
                                       "base_ref": "main", "base_oid": "b1",
                                       "head_ref": "h", "head_oid": "h1"},
-                           "main")
+                           "main", repo_dir=tmp_path)
     assert pr["merged"] is True
     # The merge must use --match-head-commit with the reviewed head SHA.
     merge_cmd = [c for c in calls if c[:2] == ["gh", "pr"] and "merge" in c][0]
     assert "--match-head-commit" in merge_cmd
     assert merge_cmd[merge_cmd.index("--match-head-commit") + 1] == "h1"
     assert "--merge" in merge_cmd
+
+
+def test_merge_gate_requires_the_repo_dir_lock_location(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the gate fetch updates the shared remote-tracking
+    # ref, so the lock location (the deployment checkout's shared state
+    # dir) must be explicit — there is no bypass path.
+    monkeypatch.setattr(runner, "run_command", _merge_gate_fake())
+    with pytest.raises(TypeError):
+        runner.merge_gate(tmp_path, {"number": 4, "url": "u",
+                                     "base_ref": "main", "base_oid": "b1",
+                                     "head_ref": "h", "head_oid": "h1"},
+                         "main")
+
+
+def test_merge_gate_fetches_under_the_base_sync_lock(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the gate's base freshness fetch runs under the SAME
+    # base-sync lock (a concurrent probe must not acquire it while the
+    # fetch is in flight).
+    spy, held = _lock_held_during_fetch(
+        tmp_path, inner=lambda command, **kwargs: "",
+    )
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "fetch", "origin"]:
+            return spy(command, **kwargs)
+        return _merge_gate_fake()(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    runner.merge_gate(tmp_path, {"number": 4, "url": "u",
+                                 "base_ref": "main", "base_oid": "b1",
+                                 "head_ref": "h", "head_oid": "h1"},
+                      "main", repo_dir=tmp_path)
+    assert held == [True]
+    _lock_free(tmp_path)
 
 
 def test_merge_gate_rejects_head_behind_latest_base(monkeypatch, tmp_path, caplog):
@@ -318,7 +357,8 @@ def test_merge_gate_rejects_head_behind_latest_base(monkeypatch, tmp_path, caplo
     ):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                                      "base_oid": "b1", "head_ref": "h",
-                                     "head_oid": "h1"}, "main")
+                                     "head_oid": "h1"}, "main",
+                          repo_dir=tmp_path)
     assert "base_branch=main" in caplog.text
 
 
@@ -327,7 +367,8 @@ def test_merge_gate_rejects_non_mergeable_pr(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="not mergeable"):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                                      "base_oid": "b1", "head_ref": "h",
-                                     "head_oid": "h1"}, "main")
+                                     "head_oid": "h1"}, "main",
+                          repo_dir=tmp_path)
 
 
 def test_merge_gate_rejects_head_that_moved_since_review(monkeypatch, tmp_path):
@@ -337,7 +378,8 @@ def test_merge_gate_rejects_head_that_moved_since_review(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError, match="head moved since review"):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                                      "base_oid": "b1", "head_ref": "h",
-                                     "head_oid": "h1"}, "main")
+                                     "head_oid": "h1"}, "main",
+                          repo_dir=tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -357,9 +399,55 @@ def test_confirm_merged_accepts_merged_pr_on_origin_main(monkeypatch, tmp_path):
     result = runner.confirm_merged(
         tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                    "base_oid": "b1", "head_ref": "h", "head_oid": "h1"}, "main",
+        repo_dir=tmp_path,
     )
     assert result["state"] == "MERGED"
     assert result["merge_commit"] == "m1"
+
+
+def test_confirm_merged_requires_the_repo_dir_lock_location(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the confirm fetch updates the shared remote-tracking
+    # ref, so the lock location must be explicit — no bypass path.
+    monkeypatch.setattr(runner, "run_command", _merge_gate_fake())
+    with pytest.raises(TypeError):
+        runner.confirm_merged(
+            tmp_path, {"number": 4, "url": "u", "base_ref": "main",
+                       "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
+            "main",
+        )
+
+
+def test_confirm_merged_fetches_under_the_base_sync_lock(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the confirm fetch runs under the SAME base-sync lock
+    # (a concurrent probe must not acquire it while the fetch is in
+    # flight).
+    spy, held = _lock_held_during_fetch(
+        tmp_path, inner=lambda command, **kwargs: "",
+    )
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "fetch", "origin"]:
+            return spy(command, **kwargs)
+        if command[:2] == ["gh", "pr"] and "view" in command:
+            return json.dumps({
+                "number": 4, "url": "u", "state": "MERGED",
+                "mergedAt": "2026-08-25T00:00:00Z",
+                "mergeCommit": {"oid": "m1"},
+            })
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    runner.confirm_merged(
+        tmp_path, {"number": 4, "url": "u", "base_ref": "main",
+                   "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
+        "main", repo_dir=tmp_path,
+    )
+    assert held == [True]
+    _lock_free(tmp_path)
 
 
 def test_confirm_merged_rejects_unmerged_pr(monkeypatch, tmp_path):
@@ -374,7 +462,7 @@ def test_confirm_merged_rejects_unmerged_pr(monkeypatch, tmp_path):
         runner.confirm_merged(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                        "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
-            "main",
+            "main", repo_dir=tmp_path,
         )
 
 
@@ -397,7 +485,7 @@ def test_confirm_merged_rejects_merge_commit_missing_from_origin_main(
         runner.confirm_merged(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                        "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
-            "main",
+            "main", repo_dir=tmp_path,
         )
     assert "merge_commit=m1" in caplog.text
 
@@ -414,7 +502,7 @@ def test_confirm_merged_rejects_merged_pr_without_commit_oid(monkeypatch, tmp_pa
         runner.confirm_merged(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                        "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
-            "main",
+            "main", repo_dir=tmp_path,
         )
 
 
@@ -685,6 +773,196 @@ def test_sync_base_checkout_releases_the_lock_on_failure(
 
 
 # ---------------------------------------------------------------------------
+# fetch_base_ref (Issue #171: every shared-ref fetch under one lock)
+# ---------------------------------------------------------------------------
+
+def _lock_held_during_fetch(checkout: Path, inner=None) -> list[bool]:
+    """Spy on run_command: while the fetch runs, probe whether the
+    base-sync lock is held (a non-blocking acquire must fail).
+
+    ``inner`` is what the fetch resolves to after the probe: the real
+    ``run_command`` by default (real-git tests), or a no-op fake for
+    the non-git tmp_path tests.
+    """
+    held: list[bool] = []
+    if inner is None:
+        inner = runner.run_command
+
+    def spy(command, **kwargs):
+        if command[:3] == ["git", "fetch", "origin"]:
+            held.append(_probe_held(checkout))
+        return inner(command, **kwargs)
+
+    return spy, held
+
+
+def _probe_held(checkout: Path) -> bool:
+    """True while the base-sync lock is held: a non-blocking probe
+    acquire fails; False (and the probe releases) when it is free."""
+    lock_path = runner.base_sync_lock_path(checkout)
+    probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return False
+    except BlockingIOError:
+        return True
+    finally:
+        fcntl.flock(probe, fcntl.LOCK_UN)
+        os.close(probe)
+
+
+def _lock_free(checkout: Path) -> None:
+    """A non-blocking probe acquires and releases the lock immediately."""
+    assert _probe_held(checkout) is False
+
+
+def test_fetch_base_ref_updates_the_remote_tracking_ref(monkeypatch, tmp_path):
+    # Issue #171: the shared fetch helper updates origin/<base> ...
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    runner.run_command(["git", "init", "--bare", "-b", "main", "."],
+                       cwd=origin)
+    actor = _clone_origin(origin, "actor")
+    runner.run_command(["git", "commit", "--allow-empty", "-m", "base"],
+                       cwd=actor)
+    runner.run_command(["git", "push", "origin", "HEAD:main"], cwd=actor)
+    checkout = _clone_origin(origin, "checkout")
+    runner.run_command(["git", "commit", "--allow-empty", "-m", "ahead"],
+                       cwd=actor)
+    runner.run_command(["git", "push", "origin", "HEAD:main"], cwd=actor)
+    remote_head = runner.run_command(
+        ["git", "rev-parse", "HEAD"], cwd=actor,
+    )
+
+    runner.fetch_base_ref(checkout, "main")
+
+    assert runner.run_command(
+        ["git", "rev-parse", "origin/main"], cwd=checkout,
+    ) == remote_head
+
+
+def test_fetch_base_ref_holds_the_base_sync_lock_while_fetching(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the fetch runs UNDER the same base-sync lock the
+    # ExecStartPre flock and sync_base_checkout use — a concurrent
+    # probe must not acquire it while the fetch is in flight.
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    runner.run_command(["git", "init", "--bare", "-b", "main", "."],
+                       cwd=origin)
+    actor = _clone_origin(origin, "actor")
+    runner.run_command(["git", "commit", "--allow-empty", "-m", "base"],
+                       cwd=actor)
+    runner.run_command(["git", "push", "origin", "HEAD:main"], cwd=actor)
+    checkout = _clone_origin(origin, "checkout")
+
+    spy, held = _lock_held_during_fetch(checkout)
+    monkeypatch.setattr(runner, "run_command", spy)
+    runner.fetch_base_ref(checkout, "main")
+
+    assert held == [True]
+    _lock_free(checkout)
+
+
+def test_fetch_base_ref_fetches_in_the_given_worktree(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: the Runner verifies from the TASK WORKTREE (a
+    # different worktree sharing the same common dir); the fetch runs
+    # there (updating the shared refs/remotes/origin/<base>) while the
+    # lock is still the deployment checkout's shared-state-dir lock.
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    runner.run_command(["git", "init", "--bare", "-b", "main", "."],
+                       cwd=origin)
+    actor = _clone_origin(origin, "actor")
+    runner.run_command(["git", "commit", "--allow-empty", "-m", "base"],
+                       cwd=actor)
+    runner.run_command(["git", "push", "origin", "HEAD:main"], cwd=actor)
+    checkout = _clone_origin(origin, "checkout")
+    worktree = tmp_path / "worktree"
+    runner.run_command(
+        ["git", "worktree", "add", str(worktree), "--detach",
+         "origin/main"],
+        cwd=checkout,
+    )
+    runner.run_command(["git", "commit", "--allow-empty", "-m", "ahead"],
+                       cwd=actor)
+    runner.run_command(["git", "push", "origin", "HEAD:main"], cwd=actor)
+    remote_head = runner.run_command(
+        ["git", "rev-parse", "HEAD"], cwd=actor,
+    )
+
+    spy, held = _lock_held_during_fetch(checkout)
+    monkeypatch.setattr(runner, "run_command", spy)
+    runner.fetch_base_ref(checkout, "main", cwd=worktree)
+
+    assert held == [True]
+    # The fetch ran in the worktree: ITS view of the shared ref moved.
+    assert runner.run_command(
+        ["git", "rev-parse", "origin/main"], cwd=worktree,
+    ) == remote_head
+    _lock_free(checkout)
+
+
+def test_fetch_base_ref_fails_fast_while_the_lock_is_held(tmp_path):
+    # Issue #171: a lock timeout is a fail-fast error with the scene
+    # (lock path, timeout) — never a silent skip or a lock bypass.
+    lock_path = runner.base_sync_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(
+            RuntimeError, match="base-sync.lock",
+        ):
+            runner.fetch_base_ref(
+                tmp_path, "main", lock_timeout_seconds=0.5,
+            )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def test_fetch_base_ref_propagates_fetch_errors_unchanged(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: a real fetch/network/ref error must propagate
+    # fail-fast (the CalledProcessError with its stderr), never be
+    # swallowed or retried silently.
+    error = subprocess.CalledProcessError(
+        128, ["git", "fetch", "origin", "main"],
+        stderr="fatal: cannot lock ref 'refs/remotes/origin/main'",
+    )
+
+    def fake_run(command, **kwargs):
+        raise error
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.fetch_base_ref(tmp_path, "main")
+
+
+def test_fetch_base_ref_releases_the_lock_on_fetch_failure(
+    monkeypatch, tmp_path,
+):
+    # Issue #171: a failed fetch must still release the lock — the
+    # next fetch (any Runner, any Pi session) must not inherit a stuck
+    # lock.
+    def fake_run(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            128, command, stderr="fatal: unable to access",
+        )
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.fetch_base_ref(tmp_path, "main")
+
+    _lock_free(tmp_path)
+
+
+# ---------------------------------------------------------------------------
 # review_and_merge_if_clean (the wait-loop review step)
 # ---------------------------------------------------------------------------
 
@@ -783,8 +1061,8 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
     )
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
 
-    def fake_gate(worktree, pr, base_branch):
-        calls.append(("gate", pr["head_oid"]))
+    def fake_gate(worktree, pr, base_branch, *, repo_dir):
+        calls.append(("gate", pr["head_oid"], repo_dir))
         return {**pr, "merged": True}
 
     monkeypatch.setattr(runner, "merge_gate", fake_gate)
@@ -803,8 +1081,9 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
         priority="normal",
     )
     assert merged is True
-    # The merge gate ran against the RE-FROZEN (fixed) head...
-    assert calls == [("gate", "h2")]
+    # The merge gate ran against the RE-FROZEN (fixed) head... with the
+    # deployment checkout as the base-sync lock location (Issue #171).
+    assert calls == [("gate", "h2", tmp_path)]
     # ...and the head advance is logged for the journal.
     assert "review_head_advanced" in caplog.text
     assert "frozen=h1" in caplog.text
@@ -823,8 +1102,8 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
     )
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
 
-    def fake_gate(worktree, pr, base_branch):
-        calls.append(("gate", pr["head_oid"]))
+    def fake_gate(worktree, pr, base_branch, *, repo_dir):
+        calls.append(("gate", pr["head_oid"], repo_dir))
         return {**pr, "merged": True}
 
     monkeypatch.setattr(runner, "merge_gate", fake_gate)
@@ -843,7 +1122,8 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
         priority="normal",
     )
     assert merged is True
-    assert calls == [("gate", "h1")]
+    # ...with the deployment checkout as the lock location (Issue #171).
+    assert calls == [("gate", "h1", tmp_path)]
     assert "review_head_advanced" not in caplog.text
 
 


### PR DESCRIPTION
Fixes #171

<!-- muyan-pilot:run=a55fedb9 -->

run_id=a55fedb9

## Scene

Two concurrent Runner instances (or a Runner and a Pi session) share the
deployment checkout's git common dir. An unlocked concurrent
`git fetch origin main` races on the shared remote-tracking ref
`refs/remotes/origin/main` and fails with
`error: cannot lock ref 'refs/remotes/origin/main': is at <X> but expected
<Y>` — the review Pi session exits non-zero and the Issue is marked
`ai-blocked`.

## Change

Every fetch that updates the shared remote-tracking ref now runs under the
SAME shared state-dir lock (`base-sync.lock`) the `ExecStartPre` flock and
`sync_base_checkout` already use — no new lock, no new process:

- `bootstrap_runner.fetch_base_ref(repo_dir, base_branch, *, cwd, ...)`
  acquires the base-sync lock, fetches, and releases it in `finally`; a
  lock timeout or a fetch error fails fast (no retry, no lock bypass).
- `freeze_base` / `verify_pr` / `merge_gate` / `confirm_merged` all go
  through it; `verify_pr` / `merge_gate` / `confirm_merged` take the
  deployment checkout as a required `repo_dir` keyword (the lock
  location — never derivable from the task worktree).
- `run_pi` / `run_review` render `BASE_SYNC_LOCK` (the absolute lock path
  from `config['repo_dir']`) into both prompts, which now instruct Pi:
  `flock <BASE_SYNC_LOCK> git fetch origin <BASE_BRANCH>` — fail fast on
  lock/fetch errors, never retry the bare fetch.
- `pilot_setup.check_checkout`'s fetch uses the same locked helper (no
  unlocked fetch path exists anywhere).
- The dual-Runner concurrency E2E fake-Pi mirrors the real prompt
  contract (parses the lock path from the rendered review prompt and
  fetches under `flock`).
- Docs: `AGENTS.md` (base freshness), `README.md`,
  `docs/operations.mdx`, `docs/zh/operations.mdx`.

## Verification

- TDD: red tests first (held-lock probe, fail-fast, release-on-error,
  worktree cwd, lock-location contract, prompt rendering, prompt
  contract needles), then the implementation.
- Full suite: **1133 passed** (post base-merge), **100% line + branch
  coverage** (`coverage run --branch -m pytest tests/ -q`).
- Acceptance: `test_capacity_two_allows_two_runners_and_rejects_third`
  **20/20 consecutive passes** (pre-merge) + 10/10 post base-merge —
  two Runner instances concurrently fetch the shared ref under the
  base-sync lock; a third instance is rejected by the flock slot.
- Base freshness: `origin/main` (5a5929f) merged into the task branch,
  conflict in `bootstrap_runner.py` resolved manually (upstream #158
  renamed `_acquire_base_sync_lock` → `acquire_base_sync_lock` and added
  the CLI-install refresh under the same lock — `fetch_base_ref` uses
  the public name), full suite re-run green.