### PR TITLE
Fix per-run Pi provider settings

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -449,8 +449,34 @@ def prepare_pi_agent_dir(worktree: Path, config: dict) -> Path | None:
       files when they exist, so Pi's other behavior (settings, stored
       auth) is unchanged apart from the provider catalog.
 
-    The dir holds no secrets: the API key stays an env-var reference in
-    the file and never a materialized value.
+    The per-run `settings.json` is a REAL file (Issue #172), consistent
+    with the per-run catalog:
+
+    - base: the user agent dir's settings when it exists (the user's
+      other settings are preserved), `{}` otherwise — the user's global
+      `~/.pi/agent/settings.json` is never modified;
+    - `pi_provider`/`pi_model` configured: `defaultProvider` /
+      `defaultModel` point at the selected provider/model and
+      `enabledModels` is exactly that model, so the initial model
+      selection (CLI flags, then scoped models, then settings defaults)
+      can only land on a model of the merged catalog;
+    - not configured: `enabledModels` keeps only the patterns that
+      resolve in the merged catalog (Pi's exact reference match:
+      canonical `provider/modelId` or unambiguous bare model id,
+      case-insensitive); a pattern that resolves to nothing would make
+      Pi warn `No models match pattern` at startup and could steer the
+      initial model to a provider the run cannot use — an empty result
+      drops the key entirely (Pi falls back to the full catalog);
+    - a user `httpIdleTimeoutMs` of `0` (Pi's documented "disabled")
+      is dropped: with it, a first response that never arrives hangs
+      forever; without the key Pi applies its built-in default (300s)
+      and the request fails with a concrete timeout error instead.
+
+    `auth.json` stays a SYMLINK to the user agent dir's file when it
+    exists: stored auth for providers present in the merged catalog is
+    still valid. The dir holds no secrets: the API key stays an
+    env-var reference in the provider file and never a materialized
+    value.
     """
     providers_data = config.get("pi_providers_data")
     if providers_data is None:
@@ -479,16 +505,97 @@ def prepare_pi_agent_dir(worktree: Path, config: dict) -> Path | None:
         json.dumps({"providers": merged_providers}, indent=2),
         encoding="utf-8",
     )
-    # Idempotent for a resumed run in the same worktree: a stale
-    # symlink from an earlier attempt is replaced, never kept.
-    for name in ("settings.json", "auth.json"):
-        source = user_agent / name
-        link = agent_dir / name
-        if link.is_symlink():
-            link.unlink()
-        if source.is_file():
-            link.symlink_to(source)
+    # Per-run settings.json (Issue #172): a real file consistent with
+    # the merged catalog above, never a symlink to the user's global
+    # settings (whose defaults/enabledModels may reference models this
+    # run's catalog cannot resolve). Idempotent for a resumed run in
+    # the same worktree: a stale file or symlink from an earlier
+    # attempt is replaced, never kept.
+    user_settings = user_agent / "settings.json"
+    base_settings: dict = {}
+    if user_settings.is_file():
+        try:
+            loaded = json.loads(user_settings.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"user agent dir settings.json {user_settings} is not "
+                f"valid JSON: {exc}"
+            ) from None
+        if not isinstance(loaded, dict):
+            raise ValueError(
+                f"user agent dir settings.json {user_settings} must be "
+                f"a JSON object"
+            )
+        base_settings = loaded
+    settings = dict(base_settings)
+    pi_provider = config.get("pi_provider")
+    pi_model = config.get("pi_model")
+    if pi_provider is not None and pi_model is not None:
+        settings["defaultProvider"] = pi_provider
+        settings["defaultModel"] = pi_model
+        settings["enabledModels"] = [f"{pi_provider}/{pi_model}"]
+    else:
+        patterns = settings.get("enabledModels")
+        if isinstance(patterns, list):
+            resolved = _resolve_enabled_models(patterns, merged_providers)
+            if resolved:
+                settings["enabledModels"] = resolved
+            else:
+                settings.pop("enabledModels", None)
+    if settings.get("httpIdleTimeoutMs") == 0:
+        settings.pop("httpIdleTimeoutMs")
+    stale = agent_dir / "settings.json"
+    if stale.is_symlink() or stale.is_file():
+        stale.unlink()
+    stale.write_text(
+        json.dumps(settings, indent=2), encoding="utf-8",
+    )
+    # auth.json keeps its pre-#172 shape: a symlink to the user's
+    # stored auth (valid for the merged catalog's providers).
+    auth_source = user_agent / "auth.json"
+    auth_link = agent_dir / "auth.json"
+    if auth_link.is_symlink():
+        auth_link.unlink()
+    if auth_source.is_file():
+        auth_link.symlink_to(auth_source)
     return agent_dir
+
+
+def _resolve_enabled_models(patterns: list, providers: dict) -> list:
+    """Filter `enabledModels` patterns to the merged catalog (Issue #172).
+
+    Mirrors Pi's exact reference match (`model-resolver.js`
+    `findExactModelReferenceMatch`, verified against Pi 0.84.3): the
+    canonical `provider/modelId` form, or a bare model id that is
+    unambiguous across the catalog — case-insensitive. A pattern that
+    resolves to nothing would make Pi warn `No models match pattern`
+    at startup and could steer the initial model selection to a model
+    the run cannot use, so the per-run settings.json keeps only what
+    the per-run models.json can resolve.
+    """
+    canonical: set = set()
+    bare_counts: dict = {}
+    for provider_id, entry in providers.items():
+        models = entry.get("models") if isinstance(entry, dict) else None
+        if not isinstance(models, list):
+            continue
+        for model in models:
+            model_id = model.get("id") if isinstance(model, dict) else None
+            if not isinstance(model_id, str) or not model_id:
+                continue
+            canonical.add(f"{provider_id}/{model_id}".lower())
+            key = model_id.lower()
+            bare_counts[key] = bare_counts.get(key, 0) + 1
+    resolved = []
+    for pattern in patterns:
+        if not isinstance(pattern, str) or not pattern.strip():
+            continue
+        reference = pattern.strip().lower()
+        if reference in canonical:
+            resolved.append(pattern)
+        elif bare_counts.get(reference, 0) == 1:
+            resolved.append(pattern)
+    return resolved
 
 
 def _pi_model_args(config: dict) -> list[str]:

--- a/systemd/muyan-pilot@.service
+++ b/systemd/muyan-pilot@.service
@@ -8,6 +8,13 @@ Type=simple
 WorkingDirectory=%h/Documents/muyan/muyan-pilot
 Environment="PATH=%h/.npm-global/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="MUYAN_PILOT_CONFIG=%h/Documents/muyan/muyan-pilot/muyan-pilot.toml"
+# Issue #172: the provider file may reference API keys as environment
+# variables (e.g. $GROQ_API_KEY). The user-local env file in the
+# gitignored state dir (next to base-sync.lock) carries them; the `-`
+# prefix keeps deployments without provider files working. The key
+# lives only in that local file — never in this template, the repo, or
+# the journal.
+EnvironmentFile=-%h/Documents/muyan/muyan-pilot/.muyan-pilot/env
 # Deployment adapter only: disable systemd's default startup kill limit.
 TimeoutStartSec=infinity
 # Issue #52: before the Runner starts, fast-forward the local main

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -8109,11 +8109,14 @@ def test_prepare_pi_agent_dir_materializes_merged_models_json(
     assert merged["providers"]["groq"]["baseUrl"] == (
         "https://api.groq.com/openai/v1"
     )
-    # settings.json is a symlink to the user's file (behavior unchanged);
-    # auth.json is absent in the user dir, so no symlink.
-    settings_link = agent_dir / "settings.json"
-    assert settings_link.is_symlink()
-    assert settings_link.resolve() == user_agent / "settings.json"
+    # Issue #172: settings.json is a REAL per-run file consistent with
+    # the merged catalog (a symlink to the global file would keep its
+    # defaults/enabledModels pointing at models absent from this run's
+    # catalog). The user's `{}` base stays `{}`. auth.json is absent in
+    # the user dir, so no symlink.
+    settings = agent_dir / "settings.json"
+    assert not settings.is_symlink()
+    assert json.loads(settings.read_text(encoding="utf-8")) == {}
     assert not (agent_dir / "auth.json").exists()
 
 
@@ -8145,7 +8148,7 @@ def test_prepare_pi_agent_dir_repo_providers_win_on_collision(
     )
 
 
-def test_prepare_pi_agent_dir_symlinks_auth_and_settings(
+def test_prepare_pi_agent_dir_auth_symlink_settings_real_file(
     tmp_path, monkeypatch,
 ):
     home = tmp_path / "home"
@@ -8153,10 +8156,297 @@ def test_prepare_pi_agent_dir_symlinks_auth_and_settings(
     monkeypatch.setenv("HOME", str(home))
     config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
     agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
-    for name in ("settings.json", "auth.json"):
-        link = agent_dir / name
-        assert link.is_symlink()
-        assert link.resolve() == user_agent / name
+    # auth.json stays a symlink (stored auth for the merged catalog's
+    # providers is still valid); settings.json is a real per-run file
+    # (Issue #172), never a link to the user's global settings.
+    auth_link = agent_dir / "auth.json"
+    assert auth_link.is_symlink()
+    assert auth_link.resolve() == user_agent / "auth.json"
+    settings = agent_dir / "settings.json"
+    assert not settings.is_symlink()
+    assert settings.is_file()
+
+
+# --- per-run settings consistency (Issue #172) ----------------------------
+
+
+def _user_settings(home: Path, settings: dict) -> Path:
+    agent = home / ".pi" / "agent"
+    agent.mkdir(parents=True, exist_ok=True)
+    (agent / "settings.json").write_text(
+        json.dumps(settings), encoding="utf-8",
+    )
+    return agent
+
+
+def test_prepare_pi_agent_dir_settings_points_at_selected_provider_model(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    user_agent = _user_agent_dir(
+        home,
+        models={"providers": {"local-qwen": {
+            "baseUrl": "http://127.0.0.1:18082/v1",
+            "api": "openai-completions",
+            "apiKey": "local",
+            "models": [{"id": "qwen3.8:27b"}],
+        }}},
+        settings=False,
+    )
+    _user_settings(home, {
+        "defaultProvider": "openai",
+        "defaultModel": "gpt-5.6-sol",
+        "enabledModels": [
+            "openai/gpt-5.6-sol",
+            "openrouter/stealth/ox-alpha",
+        ],
+        "httpIdleTimeoutMs": 0,
+        "theme": "light/dark",
+        "packages": ["npm:pi-mcp-adapter"],
+    })
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(
+        tmp_path, pi_providers_data=GROQ_PROVIDERS,
+        pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+    )
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # The runtime defaults and enabled models point at the SELECTED
+    # provider/model (which exists in the merged catalog) — never at a
+    # model the per-run catalog cannot resolve.
+    assert settings["defaultProvider"] == "groq"
+    assert settings["defaultModel"] == "qwen/qwen3.8-27b"
+    assert settings["enabledModels"] == ["groq/qwen/qwen3.8-27b"]
+    # The user's disabled (0) HTTP idle timeout is dropped: Pi falls
+    # back to its built-in default so a first response that never
+    # arrives fails with a concrete timeout instead of hanging.
+    assert "httpIdleTimeoutMs" not in settings
+    # The user's other settings are preserved.
+    assert settings["theme"] == "light/dark"
+    assert settings["packages"] == ["npm:pi-mcp-adapter"]
+    # The global file is never modified.
+    global_settings = json.loads(
+        (user_agent / "settings.json").read_text(encoding="utf-8"),
+    )
+    assert global_settings["defaultProvider"] == "openai"
+    assert global_settings["httpIdleTimeoutMs"] == 0
+
+
+def test_prepare_pi_agent_dir_settings_filters_enabled_models_to_catalog(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(
+        home,
+        models={"providers": {"userprov": {
+            "baseUrl": "http://user:1/v1",
+            "api": "openai-completions",
+            "apiKey": "u",
+            "models": [{"id": "um"}],
+        }}},
+        settings=False,
+    )
+    _user_settings(home, {
+        "enabledModels": [
+            "userprov/um",
+            "openai/gpt-5.6-sol",
+            "bogus/none",
+        ],
+    })
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # Without a selected provider/model only the patterns that resolve
+    # in the merged catalog (user providers + repo file) survive.
+    assert settings["enabledModels"] == ["userprov/um"]
+
+
+def test_prepare_pi_agent_dir_settings_bare_model_id_resolves_when_unambiguous(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(
+        home,
+        models={"providers": {
+            "provA": {
+                "baseUrl": "http://a:1/v1",
+                "api": "openai-completions",
+                "apiKey": "a",
+                "models": [{"id": "shared"}, {"id": "only-a"}],
+            },
+            "provB": {
+                "baseUrl": "http://b:1/v1",
+                "api": "openai-completions",
+                "apiKey": "b",
+                "models": [{"id": "shared"}],
+            },
+        }},
+        settings=False,
+    )
+    _user_settings(home, {
+        "enabledModels": ["only-a", "shared", ""],
+    })
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # Pi's exact match: an unambiguous bare id resolves, an ambiguous
+    # one (same id on two providers) does not, an empty pattern never
+    # does.
+    assert settings["enabledModels"] == ["only-a"]
+
+
+def test_prepare_pi_agent_dir_settings_ignores_malformed_catalog_entries(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(
+        home,
+        models={"providers": {
+            "nomodels": {"baseUrl": "http://n:1/v1", "api": "x"},
+            "badmodel": {
+                "baseUrl": "http://b:1/v1",
+                "api": "x",
+                "models": [{"name": "no id"}],
+            },
+            "good": {
+                "baseUrl": "http://g:1/v1",
+                "api": "x",
+                "models": [{"id": "gm"}],
+            },
+        }},
+        settings=False,
+    )
+    _user_settings(home, {"enabledModels": ["good/gm", "nomodels/x"]})
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # Malformed user catalog entries are skipped, never a crash: the
+    # resolvable pattern survives.
+    assert settings["enabledModels"] == ["good/gm"]
+
+
+def test_prepare_pi_agent_dir_settings_user_file_not_object_fails_fast(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(home, models=None, settings=False)
+    (home / ".pi" / "agent" / "settings.json").write_text(
+        "[1, 2]", encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        runner.prepare_pi_agent_dir(tmp_path, config)
+
+
+def test_prepare_pi_agent_dir_settings_drops_unresolvable_enabled_models(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(home, models=None, settings=False)
+    _user_settings(home, {"enabledModels": ["openai/gpt-5.6-sol"]})
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # Nothing resolves: the key is dropped entirely (Pi falls back to
+    # the full catalog) — an empty list would scope the run to zero
+    # models.
+    assert "enabledModels" not in settings
+
+
+def test_prepare_pi_agent_dir_settings_keeps_nonzero_http_idle_timeout(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(home, models=None, settings=False)
+    _user_settings(home, {"httpIdleTimeoutMs": 60000})
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    # A real (non-disabled) timeout is the user's explicit choice and
+    # stays.
+    assert settings["httpIdleTimeoutMs"] == 60000
+
+
+def test_prepare_pi_agent_dir_settings_user_file_missing(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(
+        tmp_path, pi_providers_data=GROQ_PROVIDERS,
+        pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+    )
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    assert settings == {
+        "defaultProvider": "groq",
+        "defaultModel": "qwen/qwen3.8-27b",
+        "enabledModels": ["groq/qwen/qwen3.8-27b"],
+    }
+
+
+def test_prepare_pi_agent_dir_settings_user_file_invalid_fails_fast(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(home, models=None, settings=False)
+    (home / ".pi" / "agent" / "settings.json").write_text(
+        "{nope", encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
+    with pytest.raises(ValueError, match="not valid JSON"):
+        runner.prepare_pi_agent_dir(tmp_path, config)
+
+
+def test_prepare_pi_agent_dir_selected_model_not_in_catalog_fails_fast(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / "home"
+    _user_agent_dir(home, models=None, settings=False)
+    monkeypatch.setenv("HOME", str(home))
+    config = _model_config(
+        tmp_path, pi_providers_data=GROQ_PROVIDERS,
+        pi_provider="groq", pi_model="qwen/qwen3.8-27b",
+    )
+    # The selected provider/model is validated against the provider
+    # file at config load (load_config); prepare_pi_agent_dir receives
+    # the same validated config, so the per-run settings can always
+    # point at a model that exists in the merged catalog.
+    agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    merged = json.loads(
+        (agent_dir / "models.json").read_text(encoding="utf-8"),
+    )
+    model_ids = [
+        f"{pid}/{m['id']}"
+        for pid, entry in merged["providers"].items()
+        for m in entry.get("models", [])
+    ]
+    assert settings["enabledModels"][0] in model_ids
 
 
 def test_prepare_pi_agent_dir_user_dir_missing(tmp_path, monkeypatch):
@@ -8169,7 +8459,13 @@ def test_prepare_pi_agent_dir_user_dir_missing(tmp_path, monkeypatch):
         (agent_dir / "models.json").read_text(encoding="utf-8"),
     )
     assert set(merged["providers"]) == {"groq"}
-    assert not (agent_dir / "settings.json").exists()
+    # Issue #172: the per-run settings.json is always written (an empty
+    # base when the user has none) — the run never inherits the global
+    # file's defaults through a symlink.
+    settings = json.loads(
+        (agent_dir / "settings.json").read_text(encoding="utf-8"),
+    )
+    assert settings == {}
     assert not (agent_dir / "auth.json").exists()
 
 
@@ -8464,16 +8760,22 @@ def test_e2e_provider_endpoint_reaches_pi_process(monkeypatch, tmp_path):
 def test_prepare_pi_agent_dir_is_idempotent_on_resume(
     tmp_path, monkeypatch,
 ):
-    """A resumed run in the same worktree replaces stale symlinks."""
+    """A resumed run in the same worktree replaces stale files."""
     home = tmp_path / "home"
     user_agent = _user_agent_dir(home, auth=False)
     monkeypatch.setenv("HOME", str(home))
     config = _model_config(tmp_path, pi_providers_data=GROQ_PROVIDERS)
     agent_dir = runner.prepare_pi_agent_dir(tmp_path, config)
-    # Simulate a stale broken symlink left by an earlier attempt.
+    # Simulate stale leftovers from an earlier attempt: a broken auth
+    # symlink and a settings symlink (the pre-#172 shape).
     stale = agent_dir / "auth.json"
     stale.symlink_to(tmp_path / "gone.json")
     assert not stale.exists()  # broken
+    settings = agent_dir / "settings.json"
+    settings.unlink()
+    settings.symlink_to(user_agent / "settings.json")
     runner.prepare_pi_agent_dir(tmp_path, config)
     assert not (agent_dir / "auth.json").exists()
-    assert (agent_dir / "settings.json").is_symlink()
+    # The stale settings symlink is replaced by the real per-run file.
+    assert not settings.is_symlink()
+    assert json.loads(settings.read_text(encoding="utf-8")) == {}

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -115,6 +115,21 @@ def test_service_keeps_running_task_without_duration_limit():
     assert section["ExecStart"] == ["%h/.local/bin/muyan-pilot"]
 
 
+def test_service_loads_optional_provider_env_file():
+    """Issue #172: the systemd-launched Runner must be able to obtain
+    the provider API keys referenced by the provider file. The service
+    loads the user-local env file from the gitignored state dir
+    (`.muyan-pilot/env`, next to `base-sync.lock`) with the `-` optional
+    prefix: a deployment without provider files starts unchanged, and
+    the key itself lives only in that local file — never in the
+    template, the repo, or the journal."""
+    service = parse_unit(SERVICE_FILE)
+    section = service["Service"]
+    assert section["EnvironmentFile"] == [
+        "-%h/Documents/muyan/muyan-pilot/.muyan-pilot/env"
+    ]
+
+
 def test_service_fast_forwards_main_before_runner_starts():
     """Issue #52: the service must fast-forward the local main checkout
     to the latest origin/main BEFORE the Runner starts (ExecStartPre,


### PR DESCRIPTION
Fixes #172

## Summary
- materialize a per-run `settings.json` aligned with the merged Pi provider catalog;
- filter stale `enabledModels` and remove disabled HTTP idle timeout settings;
- load provider API-key environment variables from the user-local systemd environment file.

## Verification
- `74 passed, 284 deselected` for the provider/settings/systemd targeted tests.

## Review note
The systemd template consumes `.muyan-pilot/env`; setup/bootstrap creation and population of that file are not included in this PR and remain an end-to-end follow-up boundary.
