### PR TITLE
Keep AI-recoverable failures in the automatic fix loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,12 +442,18 @@ acceptance criteria.
 - After a PR is opened the Issue is in a recoverable review state, not
   done: `ai-pr-opened` means awaiting review. `ai-fix-needed` marks a
   delivery whose head is not mergeable yet (the review found a finding
-  the session could not fix, or the PR is behind the latest base / has a
-  merge conflict): the NEXT tick resumes the same run on the same
-  feature branch, worktree and PR number and runs the next independent
-  review session, which merges the latest `origin/<base>` into the
-  branch IN-SESSION, resolves any conflict, re-runs the full suite and
-  re-emits the verdict. Both opened-PR states are scanned (Issue #70).
+  the session could not fix, the PR is behind the latest base / has a
+  merge conflict, or an AI-recoverable failure of the existing run/PR
+  — a Pi execution failure, a verification failure, an unpushed local
+  commit (the #158 scene: the local commit is preserved and the next
+  review session pushes the task branch on the same PR), or a missing
+  worktree — Issue #50): the NEXT tick resumes the SAME run_id, branch,
+  worktree and PR and runs the next independent review session, which
+  merges the latest `origin/<base>` into the branch IN-SESSION, resolves
+  any conflict, re-runs the full suite and re-emits the verdict. A
+  recoverable failure is reported on the Issue AND the PR with the full
+  scene (run_id, PR, branch, worktree, session, phase, last activity and
+  the concrete error). Both opened-PR states are scanned (Issue #70).
   The `ai-pr-opened` scan exists because the delivery that opened the
   PR can be gone (a killed runner, or the progress failure behind Issue
   #70 that used to block the Issue before the review started): without
@@ -477,10 +483,22 @@ acceptance criteria.
   re-frozen head; `gh pr merge --match-head-commit` then lands exactly
   that head. No auto conflict resolution by the Runner, no `--abort`,
   no force push, no merge or push of the protected branch.
-- An unresolvable review (Pi failure, exhausted review rounds, a
-  finding the session could not fix) keeps the PR, branch and worktree
-  intact and marks the Issue `ai-blocked` (removing the opened-PR
-  state) with the concrete finding.
+- A RECOVERABLE failure of the existing run/PR (Issue #50: a Pi
+  execution failure, a verification failure, an unpushed local commit,
+  a missing worktree, a finding the session could not fix) keeps the PR,
+  branch and worktree intact and marks the Issue `ai-fix-needed` (the
+  opened-PR state label is removed) with the failure comment on the
+  Issue AND the PR carrying the full scene (run_id, PR, branch,
+  worktree, session, phase, last activity, concrete error); the next
+  tick resumes the same run, branch, worktree and PR — no replacement
+  PR, no re-claim, never `ai-blocked`.
+- An UNRECOVERABLE failure (Issue #50: an external precondition the AI
+  cannot safely judge or fix — an unrecoverable scene, a base-branch
+  config change, an exhausted review round budget, a PR closed without
+  merge) keeps the PR, branch and worktree intact and marks the Issue
+  `ai-blocked` ALONE (the opened-PR state label is removed, and a
+  leftover `ai-fix-needed` too) with the explicit reason why automatic
+  recovery is impossible.
 
 ## Run correlation
 
@@ -533,10 +551,16 @@ acceptance criteria.
   reviewed head. A PR behind the latest base is rejected, never
   merged. The Runner confirms the PR is MERGED and the merge commit is on the
   protected branch before marking the Issue `ai-merged`.
-- A review finding is not `ai-blocked`: it is fixed in the review session
-  (or in the next review session on the same PR). Only command failure, an
-  unavailable environment, or a review that cannot be verified fails fast and
-  marks `ai-blocked`.
+- A review finding or an AI-recoverable failure of the existing run/PR
+  (Issue #50: a Pi execution failure, a verification failure, an unpushed
+  local commit, a missing worktree) is NOT `ai-blocked`: it is fixed in
+  the next review session on the same PR (the Issue stays `ai-fix-needed`
+  and the next tick resumes the same run, branch, worktree and PR).
+  Only an unrecoverable external precondition (an exhausted review round
+  budget, an unrecoverable scene, a base-branch config change, a PR
+  closed without merge) fails fast and marks `ai-blocked` — and the
+  blocked comment must state the explicit reason why automatic recovery
+  is impossible.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ gh label list --repo xqliu/muyan-pilot
 |---|---|---|---|
 | `ai-ready` | 明确派发给 Pilot 的新任务（允许 AI 领取） | `muyan-pilot add` 创建时自动添加，或人工 `gh issue edit --add-label ai-ready` | 领取时加 `ai-in-progress`（`ai-ready` 保留）；成功合并后保留（与 `ai-merged` 共存，表示已交付） |
 | `ai-in-progress` | Runner 已领取、正在执行 | 领取 `ai-ready` Issue 时由 Runner 添加 | 开出 PR 时移除（转 `ai-pr-opened`）；失败时移除（转 `ai-blocked`）；Runner 被杀时残留，由下一 tick 的重启恢复扫描接回 |
-| `ai-pr-opened` | PR 已创建，当前等待 review；不会自动再次启动 Fixer | `verify_pr` 验收通过后由 Runner 添加（同时移除 `ai-in-progress`） | clean verdict 合并后移除（转 `ai-merged`）；review finding / base 冲突时移除（转 `ai-fix-needed`）；终态失败时移除（转 `ai-blocked`） |
-| `ai-fix-needed` | 已有 PR 需要在原 branch/worktree/PR 上继续修复；定时 Runner 自动拾取 | 审查会话未能修复的 finding，或 PR 落后最新 base / merge conflict | 下一个审查会话（同一 PR）clean verdict 合并后移除（转 `ai-merged`）；超轮 / 无法修复时移除（转 `ai-blocked`） |
+| `ai-pr-opened` | PR 已创建，当前等待 review；不会自动再次启动 Fixer | `verify_pr` 验收通过后由 Runner 添加（同时移除 `ai-in-progress`） | clean verdict 合并后移除（转 `ai-merged`）；review finding / base 冲突 / **可恢复失败**（Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）时移除（转 `ai-fix-needed`）；只有**不可恢复失败**（Issue #50）时移除（转 `ai-blocked`） |
+| `ai-fix-needed` | 已有 PR 需要在原 branch/worktree/PR 上继续修复；定时 Runner 自动拾取 | 审查会话未能修复的 finding，或 PR 落后最新 base / merge conflict，或已有 run/PR 的**可恢复失败**（Issue #50：失败 comment 写入 Issue 和 PR，带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误） | 下一个审查会话（同一 PR，同一 run_id/branch/worktree）clean verdict 合并后移除（转 `ai-merged`）；审查超轮（`MAX_REVIEW_ROUNDS`）时移除（转 `ai-blocked`，超轮是人工决策） |
 | `ai-merged` | 成功终态：Runner 已合并 PR 并确认 merge commit 落在保护分支 | Runner 合并并确认后添加（替代 `ai-pr-opened`） | 终态，不再自动变更；PR body 的 `Fixes #N` 在 merge 时自动关闭 Issue |
-| `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | 命令失败、现场无法恢复、审查超轮等 fail fast 场景 | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
+| `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | **只用于 AI 无法安全判断或修复的外部前置条件**（Issue #50）：无可恢复的 opened-PR 现场（缺少/不可信 `Muyan Pilot opened PR` 评论）、base 分支变更、审查超轮、PR 未合并被关闭；进入时 comment 必须写明为什么不能自动恢复。已有 run/PR 的可恢复失败**不**进入此状态（转 `ai-fix-needed`，见上） | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
 | `p0` | 紧急优先级（**不是交付状态**）：只改变领取顺序，不改变 Issue 粒度、交付状态或终态语义 | 人工加 label（生产链路出现高优先级故障时） | 人工移除；Runner 从不增删该 label |
 | `ai-epic` | Epic 协调 Issue（发布清单/多任务聚合，**不是可执行任务、不是交付状态**）：只负责聚合与发布门禁 | 人工加 label（创建 Epic 时） | 人工移除（Epic 完成并关闭时）；Runner 从不增删该 label，也从不领取带它的 Issue |
 
@@ -365,7 +365,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 
 本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是正整数，缺失时默认 1（本地 AI/GPU 只能稳定服务一个任务）；非整数、布尔值、0 或负数启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
 
-- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与 Pi 活动轮询同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding 或 base 冲突）时，**下一个 tick 在同一 run、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
+- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与 Pi 活动轮询同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding、base 冲突，或已有 run/PR 的**可恢复失败**——Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）时，**下一个 tick 在同一 run_id、同一 branch、同一 worktree、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
 - 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
 - 达到 `max_concurrency` 时，新 Runner 不领取 Issue、不修改标签、不调用 Pi，记录结构化日志 `capacity_full max_concurrency=... slot_dir=...` 后正常退出（退出码 0），等 systemd timer 下次触发；
 - slot 锁由打开的文件描述符持有：进程正常结束、SIGTERM/SIGINT（systemd stop / Ctrl+C）或被 SIGKILL 时，内核自动释放锁——活着的持有者永远不会因为时间或 PID 检查丢失 slot，死掉的持有者永远不会占住 slot，异常退出不会造成永久锁死；slot 文件本身保留（它是锁目标，不是令牌），`status` 按锁的实际状态报告占用；
@@ -507,7 +507,8 @@ PR 创建后任务没有结束：Issue 进入可恢复的 review 状态。`ai-pr
 - 每个 tick 先按顺序扫描 source repos 中两个 opened-PR 状态的 open Issue（Issue #70）：`ai-fix-needed`（finding 或 base 冲突 → 同一 PR 的下一个审查会话）和 `ai-pr-opened`（等待 review → 同一 PR 的独立审查）。`ai-pr-opened` 被扫描是因为开 PR 的那次 delivery 可能已经不在（Runner 被杀，或 Issue #70 背后的进度 PATCH 404 曾把已交付的 Issue 在审查开始前就标成 `ai-blocked`）：没有这个扫描，一个有效的 MERGEABLE PR 会永远没有 owner。`ai-blocked` 的 Issue 被排除（先要人工决策），`ai-merged` 和 `ai-in-progress` 同样被排除；找到时，Runner 只信任由维护者（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的最新 `Muyan Pilot opened PR:` 评论（公开评论永远不可信），从中恢复 run 现场（`run_id`、base_branch、base_sha、PR URL），branch 和 worktree 由配置的 repo、Issue 编号和 run_id **推导**（绝不从评论读取，评论无法指定任意本地路径），在**原 worktree、原 branch、同一 PR** 上继续（`ai-fix-needed` 与 `ai-pr-opened` 都直接进入审查等待），而不是领取新 Issue。现场无法恢复（评论缺少完整现场、无可信评论）时 fail fast：Issue 标记 `ai-blocked` 并写明具体原因，本 tick 停止，不做猜测，也不让新任务插队。任何 git/Pi 变更前，Runner 先校验配置的 base 和 open PR（head repo、head branch、base、run marker、精确 URL）。
 - 审查会话（journal 中 `role=review`）在会话内完成修复：修改代码、重跑完整测试与 100% 行/分支覆盖率、commit 并**只 push 原 task branch**，然后对修复后的 head 重新输出 `REVIEW_VERDICT`。PR 头分支前进，**PR number 保持不变**。
 - 审查会话无法修复的 finding（或 PR 落后最新 base / merge conflict）：Issue 标记 `ai-fix-needed`，等待下一个 tick 的下一个审查会话（会话内 `git merge origin/<base>` 吸收最新 base、解决冲突、全量回归后重新输出 verdict）。Runner 自己不自动解决冲突、不 `--abort`、不 force push、不 push 保护分支。
-- 审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）：超轮仍有 Blocker/Major、审查 Pi 失败或无法验证时，Issue 标记 `ai-blocked`（移除 opened-PR 状态），评论写明具体失败和完整现场；PR、branch、worktree 原样保留，不删除、不关闭、不重建。
+- **可恢复失败留在自动修复循环**（Issue #50）：审查 Pi 执行失败、验证失败、未推送本地 commit（#158 场景：本地 commit 保留，下一次审查会话在同一 PR 上继续 push 和验证）、worktree 缺失等已有 run/PR 的失败**不**是终态——Issue 标记 `ai-fix-needed`（移除 opened-PR 状态），失败 comment 同时写入 Issue 和 PR，带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误；下一个 tick 自动拾取并在同一 run、branch、worktree、PR 上继续。PR、branch、worktree 原样保留，不删除、不关闭、不重建，也不重新创建 PR。
+- 审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）：**只有**超轮仍有 Blocker/Major 时 Issue 才标记 `ai-blocked`（移除 opened-PR 状态，超轮是人工决策），评论写明为什么不能自动恢复和完整现场；`ai-blocked` 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50）。
 - Runner/服务重启后，仅凭 Issue 标签、评论 marker、PR head、branch 和 worktree 即可恢复该循环；implement/review/merge 串行占用同一个并发 slot，不会为同一个 run 启动第二个 Pi。
 
 状态语义：
@@ -526,7 +527,7 @@ Pi 不直接 push 保护分支。实现 Agent 只 push feature branch 并创建 
 2. **独立审查（同时是修复者，Issue #82）**：启动一个独立的 Review Agent（code-review R1–R9，不附加 `review-fix-loop`/`tdd-dev` skill），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implementer 一样通过 live activity 管道输出（journal 中 `role=review`）。审查者**可以修改代码**：发现 Blocker/Major 时在同一会话内修复、重跑完整测试与 100% 行/分支覆盖率、commit 并只 push task branch，然后对修复后的 head 重新输出 verdict——没有冷启动 Fixer，也没有第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；`pass` 表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，绝不当作通过。
 3. **重新冻结并合并门禁**：clean verdict 后 Runner 重新冻结 PR（审查者可能已 push 修复，head 前进），重新 fetch 最新 `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，只有被审查的 head 能落地。
 4. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动 CLOSED（见上方「PR body 契约」）。
-5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。审查循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；超轮仍有 Blocker/Major、审查 Pi 失败或无法验证时 fail fast 并标记 `ai-blocked`。
+5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。已有 run/PR 的**可恢复失败**（审查 Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）同样标记 `ai-fix-needed`：失败 comment 写入 Issue 和 PR（带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误），下一个 tick 在同一 run、branch、worktree、PR 上继续，不重新创建 PR、不重复领取。审查循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；**只有**超轮仍有 Blocker/Major 时 fail fast 并标记 `ai-blocked`（超轮是人工决策，comment 写明为什么不能自动恢复）。
 
 成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是在同一 PR 的审查会话内修复（或交给下一个审查会话）。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -4247,6 +4247,13 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     config["repo_dir"], source_repo, number,
                     scene["run_id"],
                 )
+                # Derived from the same trusted inputs (never read from
+                # a comment) BEFORE the worktree check: a missing
+                # worktree is a recoverable failure whose comment must
+                # carry the full scene including the branch (Issue
+                # #50), so the branch must be set even when the
+                # directory does not exist.
+                branch = task_branch(source_repo, number, scene["run_id"])
                 # Issue #90 + #50: the worktree is derived from the
                 # configured repo_dir, source repo, Issue number and
                 # run id (never read from a comment). A missing
@@ -4258,7 +4265,6 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 # preserved.
                 if not worktree.is_dir():
                     raise RuntimeError(f"worktree missing: {worktree}")
-                branch = task_branch(source_repo, number, scene["run_id"])
                 review_config = {
                     **config,
                     "base_sha": scene["base_sha"],

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -180,6 +180,38 @@ TRUSTED_COMMENT_ASSOCIATIONS = frozenset({
 })
 
 
+class UnrecoverableDeliveryError(RuntimeError):
+    """A delivery failure that is an EXTERNAL precondition the AI cannot
+    safely judge or fix (Issue #50).
+
+    `ai-blocked` is not the result of "one run failed": it is the
+    terminal state the Runner reaches only after reading the full task
+    context (code, logs, existing artifacts) and deciding that it cannot
+    safely continue. The message carries the explicit reason why
+    automatic recovery is impossible (missing external resource/permission/
+    credential, a human decision, or a bounded loop the AI may not exceed);
+    the failure comment renders it so a human sees exactly what to do.
+    Every other delivery failure is recoverable and stays in the automatic
+    fix loop (`ai-fix-needed`, the next timer resumes the same run, branch,
+    worktree and PR).
+    """
+
+
+def is_unrecoverable_failure(exc: BaseException) -> bool:
+    """Issue #50: classify one delivery failure.
+
+    True ONLY for an explicit `UnrecoverableDeliveryError` (an external
+    precondition the AI cannot safely judge or fix). Every other
+    failure — Pi execution failure (pi exit, upstream dead, idle
+    recovery), timeout, runner exception, missing/malformed verdict,
+    missing worktree, unpushed local commit, gate failure — is
+    recoverable: the Issue goes to `ai-fix-needed` and the next timer
+    resumes the same run, branch, worktree and PR. A single failure
+    must never permanently stop an Issue.
+    """
+    return isinstance(exc, UnrecoverableDeliveryError)
+
+
 class RunIdFilter(logging.Filter):
     """Prefix every log message with the current `[run_id]`, if bound."""
 
@@ -1152,11 +1184,25 @@ def block_scene_failure(issue: dict, error: ValueError, repo: str,
         edit_issue(
             number, repo=repo, add=BLOCKED_LABEL, remove=FIX_NEEDED_LABEL,
         )
+        # Issue #50: a scene that cannot be recovered is an external
+        # precondition the AI cannot fix by itself (the runner cannot
+        # derive run_id, branch, worktree or PR without the trusted
+        # scene comment, so it cannot start a review session): the
+        # comment states the EXPLICIT reason why automatic recovery is
+        # impossible plus the human next step (restore the scene or
+        # relabel).
         comment_issue(
             number, repo=repo,
             body=(
                 f"{marker}\n" if marker else ""
-            ) + f"Muyan Pilot failed: {error}",
+            ) + (
+                f"Muyan Pilot failed: {error}; this is an external "
+                "precondition the AI cannot safely judge or fix, so "
+                "it cannot be recovered automatically (the Issue "
+                "stays ai-blocked until a human decides) — restore "
+                "the trusted 'Muyan Pilot opened PR' scene comment or "
+                "relabel the Issue ai-fix-needed to resume this same PR"
+            ),
         )
     except Exception:
         LOGGER.exception("issue=%s failure reporting failed", number)
@@ -1901,8 +1947,11 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     Checks, in order: current branch, latest remote base ancestry (unless
     `require_latest_base` is False — the resume pre-validation runs
     before the base merge, when being behind is the expected state),
-    exactly one open PR for the head branch, PR base, PR head == local
-    HEAD, the run marker in the PR body, and the `Fixes #<issue>`
+    exactly one open PR for the head branch, PR base, PR head vs local
+    HEAD (a local HEAD AHEAD of the PR head is the #158 unpushed-commit
+    scene, Issue #50: it is logged and passed through — the next review
+    session pushes the task branch on the same PR; a diverged head is a
+    failure), the run marker in the PR body, and the `Fixes #<issue>`
     keyword in the PR body (Issue #53: GitHub closes the source Issue
     natively only when the body carries the keyword, so a PR without it
     would leave the Issue open after the merge). When `pr_repo` is
@@ -1980,13 +2029,44 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
         )
     head_oid = prs[0].get("headRefOid")
     if head_oid != local_head:
-        LOGGER.error(
-            "pr_head_mismatch pr_head=%s local_head=%s branch=%s",
+        # Issue #50 (the #158 `d13b0c56` scene): the local HEAD may be
+        # AHEAD of the remote PR head — a commit made by a killed
+        # session (implementer or reviewer) that was never pushed. The
+        # local commit, branch, worktree and PR stay intact and the
+        # state is RECOVERABLE: failing here would re-raise on every
+        # tick and the review session — which pushes the task branch
+        # before its verdict (prompt_review.md) — could never run. Log
+        # the exact heads (the commit/push phase the journal must
+        # carry) and continue the verification: the next review round
+        # pushes the task branch on the same PR and the merge gate
+        # re-freezes the advanced head. A remote head that is NOT an
+        # ancestor of the local HEAD (diverged) is still a failure: a
+        # plain push would be rejected and only a force push or a
+        # human decision could continue it.
+        try:
+            run_command(
+                ["git", "merge-base", "--is-ancestor", head_oid,
+                 "HEAD"],
+                cwd=worktree,
+            )
+        except subprocess.CalledProcessError:
+            LOGGER.error(
+                "pr_head_diverged pr_head=%s local_head=%s branch=%s",
+                head_oid, local_head, branch,
+            )
+            raise RuntimeError(
+                f"PR head {head_oid} is not local HEAD {local_head} "
+                "and is not an ancestor of it (the branch diverged); "
+                "a plain push would be rejected and a force push is "
+                "forbidden, so the resume must not continue on this "
+                "branch"
+            ) from None
+        LOGGER.info(
+            "local_head_ahead_of_pr_head pr_head=%s local_head=%s "
+            "branch=%s; the unpushed local commit is preserved and the "
+            "next review session pushes the task branch on the same PR "
+            "(Issue #50)",
             head_oid, local_head, branch,
-        )
-        raise RuntimeError(
-            f"PR head {head_oid} is not local HEAD {local_head}; the "
-            "verified commit was not pushed, push the reviewed commit and retry"
         )
     marker = run_marker(run_id)
     body = prs[0].get("body")
@@ -2046,12 +2126,19 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
     delivery wait only ever sees verified URLs, never the comment
     string.
 
-    Any failure is terminal: the Issue is marked `ai-blocked` ALONE
+    A failure is classified (Issue #50): a RECOVERABLE failure
+    (unpushed local commit, runner exception, ...) keeps the Issue in
+    the automatic fix loop — `ai-fix-needed` with a run-marked failure
+    comment carrying the full scene (run_id, PR, branch, worktree,
+    session, phase, last activity, concrete error) on Issue AND PR —
+    while an explicit `UnrecoverableDeliveryError` (an external
+    precondition the AI cannot safely judge or fix, e.g. a base-branch
+    config change) is terminal: the Issue is marked `ai-blocked` ALONE
     (the opened-PR state label is removed, and a leftover
-    `ai-fix-needed` too) with a run-marked failure comment, the blocked
-    milestone and the blocked progress scene, and the error is
-    re-raised so the tick stops — no review Pi is started, nothing is
-    merged, and the PR, branch and worktree stay intact.
+    `ai-fix-needed` too) with the explicit reason why automatic
+    recovery is impossible. Either way the error is re-raised so the
+    tick stops — no review Pi is started, nothing is merged, and the
+    PR, branch and worktree stay intact.
     """
     number = int(issue["number"])
     run_id = scene["run_id"]
@@ -2061,14 +2148,25 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
     )
     try:
         if scene["base_branch"] != config["base_branch"]:
-            raise ValueError(
+            # Issue #91 + #50: a base-branch change is a human
+            # decision: the runner must not auto-retry a PR frozen on
+            # another base, so the handler below marks the Issue
+            # ai-blocked with the explicit reason and both base values
+            # named.
+            raise UnrecoverableDeliveryError(
                 f"resume scene base_branch={scene['base_branch']} "
                 f"differs from configured base_branch="
                 f"{config['base_branch']}; the PR is frozen on a "
                 "different base and must not be resumed against the "
-                "configured one"
+                "configured one — a base change is a human decision, "
+                "so auto-retrying would keep failing on the same "
+                "mismatch"
             )
         if not worktree.is_dir():
+            # Issue #90 + #50: a missing worktree is a RECOVERABLE
+            # failure (the branch still exists on the remote and the
+            # worktree can be recreated on the next resume), so the
+            # handler below keeps the Issue in the automatic fix loop.
             raise RuntimeError(f"worktree missing: {worktree}")
         return verify_pr(
             worktree, branch, config["base_branch"], run_id,
@@ -2081,64 +2179,150 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
             "issue=%s resume_pr_verification_failed pr=%s branch=%s",
             number, scene["pr_url"], branch,
         )
+        detail = _failure_detail(exc)
         try:
-            edit_issue(
-                number, repo=source_repo, add=BLOCKED_LABEL,
-                remove=PR_OPENED_LABEL,
-            )
-            # A resume that fails while the Issue awaits the next
-            # review session (`ai-fix-needed`) leaves that label
-            # behind: remove it too, so the terminal state is
-            # `ai-blocked` alone (Issue #82 routes both opened-PR
-            # states into the same resume).
-            if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
+            if is_unrecoverable_failure(exc):
+                # Issue #50: an external precondition the AI cannot
+                # safely judge or fix is terminal: `ai-blocked` ALONE
+                # (the opened-PR state label is removed, and a leftover
+                # `ai-fix-needed` too) with the explicit reason why
+                # automatic recovery is impossible.
                 edit_issue(
-                    number, repo=source_repo, remove=FIX_NEEDED_LABEL,
+                    number, repo=source_repo, add=BLOCKED_LABEL,
+                    remove=PR_OPENED_LABEL,
                 )
-            body = (
-                f"Muyan Pilot failed: the resume verification of "
-                f"PR {scene['pr_url']} failed: {exc}; the PR, branch "
-                f"{branch} and worktree {worktree} are preserved"
-            )
+                if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
+                    edit_issue(
+                        number, repo=source_repo, remove=FIX_NEEDED_LABEL,
+                    )
+                body = (
+                    f"Muyan Pilot failed: the resume verification of "
+                    f"PR {scene['pr_url']} failed: {detail}; this is an "
+                    "external precondition the AI cannot safely judge "
+                    "or fix, so it cannot be recovered automatically "
+                    "(the Issue stays ai-blocked until a human "
+                    "decides); the PR, branch "
+                    f"{branch} and worktree {worktree} are preserved"
+                )
+            else:
+                # Issue #50: a RECOVERABLE failure (the #158 `d13b0c56`
+                # scene: the reviewer committed a fix locally but was
+                # killed before `git push`, so the remote PR head is
+                # still the old one) keeps the Issue in the automatic
+                # fix loop: `ai-fix-needed` (the next timer pushes the
+                # local commit and continues on the same PR), never
+                # `ai-blocked`. The failure comment carries the full
+                # scene and is written to the Issue AND the PR.
+                edit_issue(
+                    number, repo=source_repo, add=FIX_NEEDED_LABEL,
+                    remove=PR_OPENED_LABEL,
+                )
+                body = (
+                    f"Muyan Pilot needs a fix: the resume verification "
+                    f"of PR {scene['pr_url']} failed: {detail}; the "
+                    "Issue stays ai-fix-needed and the next tick "
+                    "resumes the same run, branch, worktree and PR"
+                )
+                # The session fields are '-' when no session file
+                # exists yet (the Pi never started or the dir is
+                # gone); a snapshot read failure is logged and
+                # reported as "no session yet" (best-effort
+                # observability, never a second failure).
+                snapshot = None
+                try:
+                    snapshot = activity_snapshot(worktree / ".pi-session")
+                except Exception:
+                    LOGGER.exception(
+                        "issue=%s activity scene failed", number,
+                    )
+                if snapshot is None:
+                    snapshot = {
+                        "session_id": None, "session_file": None,
+                        "phase": "starting",
+                        "last_activity": None, "action": None,
+                        "result": None,
+                    }
+                body += "\n" + format_run_scene(
+                    snapshot,
+                    run_id=run_id, issue=issue_context(
+                        source_repo, number,
+                    ),
+                    role=ROLE_REVIEW, branch=branch,
+                    worktree=str(worktree),
+                )
             if current_run_id():
                 body = f"{run_marker(current_run_id())}\n{body}"
             comment_issue(number, repo=source_repo, body=body)
+            comment_pr(_pr_number(scene["pr_url"]), body=body)
             bound_run_id = current_run_id()
             if bound_run_id:
-                # Issue #79: the blocked-scene progress publishing is
-                # bypass — a 404 here must not abort the failure
-                # reporting (the `ai-blocked` transition and the
+                # Issue #79: the fix-needed/blocked-scene progress
+                # publishing is bypass — a 404 here must not abort the
+                # failure reporting (the label transition and the
                 # failure comment above already completed, and the
                 # original error is re-raised below either way).
-                _safe_publish(
-                    run_id=bound_run_id, issue=number,
-                    source_repo=source_repo, role=ROLE_REVIEW,
-                    action=lambda: ProgressPublisher(
-                        number, source_repo, bound_run_id,
-                        run_command=run_command,
-                    ).milestone(
-                        f"blocked: the resume verification of "
-                        f"PR {scene['pr_url']} failed: {exc}"
-                    ),
-                )
-                _safe_publish(
-                    run_id=bound_run_id, issue=number,
-                    source_repo=source_repo, role=ROLE_REVIEW,
-                    action=lambda: _finish_blocked_progress(
-                        number, bound_run_id, source_repo, worktree,
-                        branch, scene["pr_url"],
-                        f"the resume verification of PR "
-                        f"{scene['pr_url']} failed: {exc}",
-                        "fix the resume verification failure above "
-                        "and resume the delivery of this same PR",
-                        title=issue["title"],
-                        role=ROLE_REVIEW,
-                        review_round=review_rounds_so_far(
-                            issue_comments(number, repo=source_repo),
+                if is_unrecoverable_failure(exc):
+                    _safe_publish(
+                        run_id=bound_run_id, issue=number,
+                        source_repo=source_repo, role=ROLE_REVIEW,
+                        action=lambda: ProgressPublisher(
+                            number, source_repo, bound_run_id,
+                            run_command=run_command,
+                        ).milestone(
+                            f"blocked: the resume verification of "
+                            f"PR {scene['pr_url']} failed: {sanitize(detail)}"
                         ),
-                        priority=issue_priority(issue),
-                    ),
-                )
+                    )
+                    _safe_publish(
+                        run_id=bound_run_id, issue=number,
+                        source_repo=source_repo, role=ROLE_REVIEW,
+                        action=lambda: _finish_blocked_progress(
+                            number, bound_run_id, source_repo, worktree,
+                            branch, scene["pr_url"],
+                            f"the resume verification of PR "
+                            f"{scene['pr_url']} failed: {detail}; this "
+                            "is an external precondition the AI cannot "
+                            "safely judge or fix, so it cannot be "
+                            "recovered automatically (the Issue stays "
+                            "ai-blocked until a human decides)",
+                            "fix the precondition above (see the "
+                            "reason) and relabel the Issue "
+                            "ai-fix-needed to resume this same PR",
+                            title=issue["title"],
+                            role=ROLE_REVIEW,
+                            review_round=review_rounds_so_far(
+                                issue_comments(number, repo=source_repo),
+                            ),
+                            priority=issue_priority(issue),
+                        ),
+                    )
+                else:
+                    _safe_publish(
+                        run_id=bound_run_id, issue=number,
+                        source_repo=source_repo, role=ROLE_REVIEW,
+                        action=lambda: ProgressPublisher(
+                            number, source_repo, bound_run_id,
+                            run_command=run_command,
+                        ).milestone(
+                            f"fix needed: the resume verification of "
+                            f"PR {scene['pr_url']} failed: {sanitize(detail)}"
+                        ),
+                    )
+                    _safe_publish(
+                        run_id=bound_run_id, issue=number,
+                        source_repo=source_repo, role=ROLE_REVIEW,
+                        action=lambda: _finish_fix_needed_progress(
+                            number, bound_run_id, source_repo, worktree,
+                            branch, scene["pr_url"],
+                            f"the resume verification of PR "
+                            f"{scene['pr_url']} failed: {detail}",
+                            title=issue["title"],
+                            review_round=review_rounds_so_far(
+                                issue_comments(number, repo=source_repo),
+                            ),
+                            priority=issue_priority(issue),
+                        ),
+                    )
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)
         raise
@@ -2853,8 +3037,13 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
       a merge conflict -> label the Issue `ai-fix-needed` with the
       absorb-base finding (the next review session absorbs the latest
       base in-session); returns False;
-    - missing/malformed verdict or an exhausted round budget -> raise;
-      the caller marks the Issue `ai-blocked`.
+    - missing/malformed verdict -> raise; the caller keeps the Issue in
+      the automatic fix loop (`ai-fix-needed`, Issue #50: the next review
+      session re-runs the same review on the same PR);
+    - an exhausted round budget -> raise `UnrecoverableDeliveryError`
+      (Issue #50: the bounded loop is a human decision, not a
+      recoverable failure); the caller marks the Issue `ai-blocked`
+      with the explicit reason.
     """
     marker = run_marker(config["run_id"])
     comments = issue_comments(number, repo=source_repo)
@@ -2864,9 +3053,14 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             "review_rounds_exhausted issue=%s rounds=%s",
             number, rounds,
         )
-        raise RuntimeError(
+        # Issue #50: the loop is bounded by MAX_REVIEW_ROUNDS on purpose
+        # — after 5 rounds without a clean verdict the remaining findings
+        # need a human decision, so the AI cannot safely continue this PR
+        # (the explicit reason the blocked comment must carry).
+        raise UnrecoverableDeliveryError(
             f"review/fix loop exhausted after {MAX_REVIEW_ROUNDS} rounds "
-            "without a clean verdict; needs human review"
+            "without a clean verdict; the bounded loop is a human "
+            "decision, so the AI cannot safely continue this PR"
         )
     round = rounds + 1
     pr = freeze_pr(worktree, branch, base_branch)
@@ -3607,6 +3801,11 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         raise
 
 
+def _pr_number(pr_url: str) -> int:
+    """Extract the PR number from its URL (the last path segment)."""
+    return int(pr_url.rstrip("/").rsplit("/", 1)[-1])
+
+
 def pr_state(pr_url: str) -> str:
     """Return the GitHub state of one PR: `OPEN`, `MERGED` or `CLOSED`.
 
@@ -3615,9 +3814,9 @@ def pr_state(pr_url: str) -> str:
     `CLOSED` ends the slot hold. Anything else is a corrupted state and
     fails fast.
     """
-    number = pr_url.rstrip("/").rsplit("/", 1)[-1]
+    number = _pr_number(pr_url)
     raw = run_command([
-        "gh", "pr", "view", number, "--json", "state",
+        "gh", "pr", "view", str(number), "--json", "state",
     ])
     data = json.loads(raw)
     if not isinstance(data, dict):
@@ -3687,6 +3886,47 @@ def _finish_blocked_progress(
         "**Muyan Pilot blocked**\n\n"
         f"failure: {detail}\n"
         f"next step: {next_step}"
+    )))
+
+
+def _finish_fix_needed_progress(
+    number: int, run_id: str | None, source_repo: str,
+    worktree: Path | None, branch: str | None, pr_url: str,
+    detail: str, title: str,
+    review_round: int = 0, priority: str = "normal",
+) -> None:
+    """Finish the tracked progress comment with the fix-needed scene
+    (Issue #50).
+
+    The contract (Issue #18): on a RECOVERABLE failure the progress
+    comment becomes the fix-needed scene with the next-step reason —
+    the Issue stays in the automatic fix loop (`ai-fix-needed`) and the
+    next timer resumes the same run, branch, worktree and PR. `ensure`
+    finds the run's existing progress comment by its hidden marker
+    (PATCHing it in place) or creates it when the run never reached
+    one; either way the fix-needed scene is the final state of this
+    tick. `title` is required — the GitHub issue data contract
+    guarantees a non-empty string title (every runner scan fetches it),
+    never fabricated. `review_round` and `priority` are the actual
+    completed review rounds and pickup priority of the run (the caller
+    derives them from the Issue's trusted review-round comments and
+    labels), so the scene never shows a stale hardcoded value.
+    """
+    if run_id is None:
+        return
+    publisher = ProgressPublisher(
+        number, source_repo, run_id, run_command=run_command,
+    )
+    publisher.ensure(_progress_body(_progress_state(
+        issue=number, title=title, run_id=run_id, role=ROLE_REVIEW,
+        branch=branch or "-", worktree=worktree or Path("-"),
+        started=time.monotonic(), pr_url=pr_url,
+        review_round=review_round, priority=priority,
+    ), outcome=(
+        "**Muyan Pilot fix needed**\n\n"
+        f"failure: {detail}\n"
+        "next step: the next tick resumes the same run, branch, "
+        "worktree and PR automatically (the Issue stays ai-fix-needed)"
     )))
 
 
@@ -3835,46 +4075,80 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
             # True (terminal); unfixed findings or a behind/conflict
             # gate label the Issue `ai-fix-needed` and the next
             # iteration re-runs the same independent review. A review
-            # that cannot run (unrecoverable scene, missing worktree,
-            # missing/malformed verdict, exhausted rounds) is a real
-            # failure: the Issue is marked `ai-blocked` ALONE (the
-            # opened-PR state label, `ai-pr-opened` or `ai-fix-needed`,
-            # is removed) so it is never stranded in an opened-PR state
-            # without an owner.
+            # that cannot run is classified (Issue #50): a RECOVERABLE
+            # failure (Pi execution failure, model wait, runner
+            # exception, missing/malformed verdict, missing worktree,
+            # unpushed local commit) keeps the Issue in the automatic
+            # fix loop — `ai-fix-needed` with the full scene (run_id,
+            # PR, branch, worktree, session, phase, last activity,
+            # concrete error) on Issue AND PR, and the next timer
+            # resumes the same run, branch, worktree and PR. Only an
+            # explicit `UnrecoverableDeliveryError` (an external
+            # precondition the AI cannot safely judge or fix: an
+            # unrecoverable scene, a base-branch config change,
+            # exhausted rounds) is terminal: the Issue is marked
+            # `ai-blocked` ALONE (the opened-PR state label,
+            # `ai-pr-opened` or `ai-fix-needed`, is removed) with the
+            # explicit reason why automatic recovery is impossible.
             worktree = None
             branch = None
             try:
-                scene = resume_scene(
-                    issue_comments(number, repo=source_repo),
-                )
-                # Issue #91: the scene freezes the base the PR was
-                # opened against. The config may have moved on (or the
-                # comment is stale): reviewing or merging a PR frozen on
-                # another base against the configured one would run the
-                # freeze/merge gate on the wrong base, so fail fast
-                # before any git/Pi mutation instead of silently
-                # switching bases. The handler below marks the Issue
-                # ai-blocked with both base values named.
+                try:
+                    scene = resume_scene(
+                        issue_comments(number, repo=source_repo),
+                    )
+                except ValueError as scene_exc:
+                    # Issue #50: without the trusted scene the runner
+                    # cannot derive run_id, branch, worktree or PR and
+                    # cannot start a review session — an external
+                    # precondition the AI cannot fix by itself (the
+                    # same terminal state as the scan-time
+                    # `block_scene_failure`), so the handler below
+                    # marks the Issue ai-blocked with the explicit
+                    # reason.
+                    raise UnrecoverableDeliveryError(
+                        f"the resume scene is unrecoverable "
+                        f"({scene_exc}); the runner cannot derive "
+                        "run_id, branch, worktree or PR without the "
+                        "trusted 'Muyan Pilot opened PR' comment, so "
+                        "it cannot start a review session; a human "
+                        "must restore the scene comment or relabel "
+                        "the Issue"
+                    ) from scene_exc
+                # Issue #91 + #50: the scene freezes the base the PR
+                # was opened against. The config may have moved on (or
+                # the comment is stale): reviewing or merging a PR
+                # frozen on another base against the configured one
+                # would run the freeze/merge gate on the wrong base,
+                # so fail fast before any git/Pi mutation instead of
+                # silently switching bases. A base-branch change is a
+                # human decision (Issue #50): the runner must not
+                # auto-retry a PR frozen on another base, so the
+                # handler below marks the Issue ai-blocked with the
+                # explicit reason and both base values named.
                 if scene["base_branch"] != config["base_branch"]:
-                    raise ValueError(
+                    raise UnrecoverableDeliveryError(
                         f"resume scene base_branch={scene['base_branch']} "
                         f"differs from configured base_branch="
                         f"{config['base_branch']}; the PR is frozen on a "
                         "different base and must not be reviewed or "
-                        "merged against the configured one"
+                        "merged against the configured one — a base "
+                        "change is a human decision, so auto-retrying "
+                        "would keep failing on the same mismatch"
                     )
                 worktree = worktree_path(
                     config["repo_dir"], source_repo, number,
                     scene["run_id"],
                 )
-                # Issue #90: the worktree is derived from the
+                # Issue #90 + #50: the worktree is derived from the
                 # configured repo_dir, source repo, Issue number and
                 # run id (never read from a comment). A missing
-                # directory means the scene cannot be resumed: fail
-                # fast BEFORE any git/Pi mutation (no freeze_pr, no
-                # review Pi) — the handler below marks the Issue
-                # ai-blocked ALONE with the PR and branch preserved
-                # (the pre-#82 resume_delivery fail-fast, restored).
+                # directory is a RECOVERABLE failure: the branch still
+                # exists on the remote and the worktree can be
+                # recreated (git worktree add) on the next resume, so
+                # the handler below keeps the Issue in the automatic
+                # fix loop (ai-fix-needed) with the PR and branch
+                # preserved.
                 if not worktree.is_dir():
                     raise RuntimeError(f"worktree missing: {worktree}")
                 branch = task_branch(source_repo, number, scene["run_id"])
@@ -3892,30 +4166,150 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                 LOGGER.exception(
                     "issue=%s delivery_review_failed pr=%s", number, pr_url,
                 )
+                detail = _failure_detail(exc)
+                if is_unrecoverable_failure(exc):
+                    # Issue #50: the ONLY opened-PR failure that leaves
+                    # the automatic loop is an external precondition
+                    # the AI cannot safely judge or fix: the Issue is
+                    # marked ai-blocked ALONE (the opened-PR state
+                    # label, `ai-pr-opened` or `ai-fix-needed`, is
+                    # removed) and the failure comment states the
+                    # explicit reason why automatic recovery is
+                    # impossible.
+                    edit_issue(
+                        number, repo=source_repo, add=BLOCKED_LABEL,
+                        remove=PR_OPENED_LABEL,
+                    )
+                    # A failure while the Issue is in `ai-fix-needed`
+                    # (awaiting the next review session) leaves that
+                    # label behind: remove it too, so the terminal
+                    # state is `ai-blocked` alone (Issue #82 routes
+                    # both opened-PR states into the same review).
+                    if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
+                        edit_issue(
+                            number, repo=source_repo,
+                            remove=FIX_NEEDED_LABEL,
+                        )
+                    body = (
+                        f"Muyan Pilot failed: the independent review of "
+                        f"PR {pr_url} failed: {detail}; this is an "
+                        "external precondition the AI cannot safely "
+                        "judge or fix, so it cannot be recovered "
+                        "automatically (the Issue stays ai-blocked "
+                        "until a human decides)"
+                    )
+                    if marker:
+                        body = f"{marker}\n{body}"
+                    comment_issue(number, repo=source_repo, body=body)
+                    if run_id:
+                        # Issue #79: the blocked-scene progress
+                        # publishing is bypass — a 404 here must not
+                        # escape the wait loop (the terminal
+                        # bookkeeping above already completed and the
+                        # slot must be released).
+                        _safe_publish(
+                            run_id=run_id, issue=number,
+                            source_repo=source_repo, role=ROLE_REVIEW,
+                            action=lambda: ProgressPublisher(
+                                number, source_repo, run_id,
+                                run_command=run_command,
+                            ).milestone(
+                                f"blocked: the independent review of "
+                                f"PR {pr_url} failed: {detail}"
+                            ),
+                        )
+                        # The blocked scene carries the actual role and
+                        # the completed review rounds (review round 2,
+                        # PR #42): the failure happened during the
+                        # independent review, and the trusted
+                        # review-round comments bound the round count
+                        # (GitHub is the only state store).
+                        _safe_publish(
+                            run_id=run_id, issue=number,
+                            source_repo=source_repo, role=ROLE_REVIEW,
+                            action=lambda: _finish_blocked_progress(
+                                number, run_id, source_repo, worktree,
+                                branch, pr_url,
+                                f"the independent review of PR {pr_url} "
+                                f"failed: {detail}; this is an external "
+                                "precondition the AI cannot safely "
+                                "judge or fix, so it cannot be "
+                                "recovered automatically (the Issue "
+                                "stays ai-blocked until a human "
+                                "decides)",
+                                "fix the precondition above (see the "
+                                "reason) and relabel the Issue "
+                                "ai-fix-needed to resume this same PR",
+                                title=title,
+                                role=ROLE_REVIEW,
+                                review_round=review_rounds_so_far(
+                                    issue_comments(number, repo=source_repo),
+                                ),
+                                priority=priority,
+                            ),
+                        )
+                    return
+                # Issue #50: a RECOVERABLE failure (Pi execution
+                # failure, model wait, runner exception,
+                # missing/malformed verdict, missing worktree,
+                # unpushed local commit) keeps the Issue in the
+                # automatic fix loop: `ai-fix-needed` (the next timer
+                # resumes the same run, branch, worktree and PR — never
+                # ai-blocked, never a replacement PR). The failure
+                # comment carries the full scene and is written to the
+                # Issue AND the PR.
                 edit_issue(
-                    number, repo=source_repo, add=BLOCKED_LABEL,
+                    number, repo=source_repo, add=FIX_NEEDED_LABEL,
                     remove=PR_OPENED_LABEL,
                 )
-                # A review failure while the Issue is in `ai-fix-needed`
-                # (awaiting the next review session) leaves that label
-                # behind: remove it too, so the terminal state is
-                # `ai-blocked` alone (Issue #82 routes both opened-PR
-                # states into the same review).
-                if FIX_NEEDED_LABEL in issue_labels(number, source_repo):
-                    edit_issue(
-                        number, repo=source_repo, remove=FIX_NEEDED_LABEL,
-                    )
                 body = (
-                    f"Muyan Pilot failed: the independent review of "
-                    f"PR {pr_url} failed: {exc}"
+                    f"Muyan Pilot needs a fix: the independent review of "
+                    f"PR {pr_url} failed: {detail}; the Issue stays "
+                    "ai-fix-needed and the next tick resumes the same "
+                    "run, branch, worktree and PR"
+                )
+                # The full scene (run_id, branch, worktree, session,
+                # phase, last activity) is always appended: a
+                # recoverable failure always happens after the scene
+                # was recovered and the worktree derived (a failure
+                # before the derivation is unrecoverable and never
+                # reaches this branch), so worktree, branch and run_id
+                # are set here. The session fields are '-' when no
+                # session file exists yet (the Pi never started or the
+                # dir is gone); a snapshot read failure is logged and
+                # reported as "no session yet" (best-effort
+                # observability, never a second failure).
+                snapshot = None
+                try:
+                    snapshot = activity_snapshot(
+                        worktree / ".pi-session",
+                    )
+                except Exception:
+                    LOGGER.exception(
+                        "issue=%s activity scene failed", number,
+                    )
+                if snapshot is None:
+                    snapshot = {
+                        "session_id": None, "session_file": None,
+                        "phase": "starting",
+                        "last_activity": None, "action": None,
+                        "result": None,
+                    }
+                body += "\n" + format_run_scene(
+                    snapshot,
+                    run_id=run_id or "-",
+                    issue=issue_context(source_repo, number),
+                    role=ROLE_REVIEW, branch=branch,
+                    worktree=str(worktree),
                 )
                 if marker:
                     body = f"{marker}\n{body}"
                 comment_issue(number, repo=source_repo, body=body)
+                comment_pr(_pr_number(pr_url), body=body)
                 if run_id:
-                    # Issue #79: the blocked-scene progress publishing
-                    # is bypass — a 404 here must not escape the wait
-                    # loop (the terminal bookkeeping above already
+                    # Issue #79: the fix-needed-scene progress
+                    # publishing is bypass — a 404 here must not escape
+                    # the wait loop (the label transition above already
                     # completed and the slot must be released).
                     _safe_publish(
                         run_id=run_id, issue=number,
@@ -3924,28 +4318,19 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                             number, source_repo, run_id,
                             run_command=run_command,
                         ).milestone(
-                            f"blocked: the independent review of "
-                            f"PR {pr_url} failed: {exc}"
+                            f"fix needed: the independent review of "
+                            f"PR {pr_url} failed: {sanitize(detail)}"
                         ),
                     )
-                    # The blocked scene carries the actual role and the
-                    # completed review rounds (review round 2, PR #42):
-                    # the failure happened during the independent
-                    # review, and the trusted review-round comments
-                    # bound the round count (GitHub is the only state
-                    # store).
                     _safe_publish(
                         run_id=run_id, issue=number,
                         source_repo=source_repo, role=ROLE_REVIEW,
-                        action=lambda: _finish_blocked_progress(
+                        action=lambda: _finish_fix_needed_progress(
                             number, run_id, source_repo, worktree,
                             branch, pr_url,
                             f"the independent review of PR {pr_url} "
-                            f"failed: {exc}",
-                            "fix the review failure above and resume "
-                            "the delivery of this same PR",
+                            f"failed: {detail}",
                             title=title,
-                            role=ROLE_REVIEW,
                             review_round=review_rounds_so_far(
                                 issue_comments(number, repo=source_repo),
                             ),

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -202,8 +202,8 @@ delivery whose head does not contain the latest remote base.
 
 | State | What happened | What to do |
 |---|---|---|
-| `ai-blocked` | The Runner failed fast (command error, unrecoverable scene, review exhausted) | Read the Issue comment (scene + reason) and the journal. Fix the environment or the task, then either relabel the same PR path as `ai-fix-needed` (same run continues) or remove the labels and re-dispatch as a fresh `ai-ready` (new run). It is never auto-recovered. |
-| `ai-fix-needed` | The PR head is not mergeable yet (review finding or base conflict) | Nothing — the next tick starts the next review session on the same PR, which absorbs the latest base in-session. |
+| `ai-blocked` | Only an external precondition the AI cannot safely judge or fix (Issue #50: unrecoverable scene, base-branch config change, review rounds exhausted, PR closed without merge) — the comment states WHY automatic recovery is impossible | Read the Issue comment (scene + reason) and the journal. Fix the environment or the task, then either relabel the same PR path as `ai-fix-needed` (same run continues) or remove the labels and re-dispatch as a fresh `ai-ready` (new run). It is never auto-recovered. |
+| `ai-fix-needed` | The PR head is not mergeable yet (review finding, base conflict) or an AI-recoverable failure of the run/PR (Issue #50: Pi execution failure, verification failure, unpushed local commit, missing worktree) | Nothing — the next tick resumes the same run_id, branch, worktree and PR and starts the next review session, which absorbs the latest base in-session. |
 | Leftover `ai-in-progress` after a kill | The Runner was SIGKILLed mid-task | The next tick's resume scan picks it up (only when no other Runner is alive): same run id, same worktree, same progress comment — no new run. |
 
 The run artifacts (plan, test log, session JSONL) stay in the task

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -21,10 +21,11 @@ flowchart LR
   progress -->|PR verified: base fresh, run marker, Fixes #N| opened["ai-pr-opened"]
   opened -->|independent review session, fixes in-session| verdict{REVIEW_VERDICT}
   verdict -->|clean verdict + merge gate| merged["ai-merged (terminal)"]
-  verdict -->|finding / base conflict / rounds exhausted| blocked["ai-blocked (terminal, human decides)"]
-  opened -->|finding / base conflict| fixneeded["ai-fix-needed"]
-  fixneeded -->|next tick: next review session on the SAME PR| opened
-  progress -->|fail fast| blocked
+  verdict -->|rounds exhausted (human decision)| blocked["ai-blocked (terminal, human decides)"]
+  opened -->|finding / base conflict / recoverable failure (Issue #50)| fixneeded["ai-fix-needed"]
+  fixneeded -->|next tick: next review session on the SAME run, branch, worktree, PR| opened
+  fixneeded -->|unrecoverable precondition (Issue #50)| blocked
+  progress -->|fail fast (no PR yet)| blocked
 ```
 
 ```text
@@ -38,20 +39,35 @@ ai-ready                a task is dispatched (muyan-pilot add, or a human
                         base/head SHAs and FIXES findings in-session
                         (code, full test suite, 100% coverage, push only
                         the task branch), then emits a REVIEW_VERDICT
-  -> ai-fix-needed      a finding could not be fixed in-session, or the PR
-                        is behind the latest base / has a merge conflict:
-                        the NEXT tick starts the next review session on
-                        the same run, same branch, same PR
+  -> ai-fix-needed      a finding could not be fixed in-session, the PR is
+                        behind the latest base / has a merge conflict, or
+                        an AI-recoverable failure of the existing run/PR
+                        (Issue #50: a Pi execution failure, a verification
+                        failure, an unpushed local commit, a missing
+                        worktree): the failure comment is written to the
+                        Issue AND the PR with the full scene (run_id, PR,
+                        branch, worktree, session, phase, last activity,
+                        concrete error), and the NEXT tick starts the next
+                        review session on the same run_id, branch,
+                        worktree and PR
   -> merge              clean verdict + merge gate (head contains the
                         latest base, PR mergeable, remote head unchanged)
   -> ai-merged          success terminal state; the PR body's Fixes #N
                         closes the Issue natively
 ```
 
-Failure at any point fails fast: the Issue is marked `ai-blocked` with the
-concrete scene (command, return code, stdout/stderr, branch, worktree,
-session file), and the automatic loop never touches it again — a human
-decides the next step.
+A failure of an existing run/PR is classified (Issue #50): an
+AI-recoverable failure (a Pi execution failure, a verification failure, an
+unpushed local commit, a missing worktree, a finding that could not be
+fixed) keeps the Issue in the automatic fix loop — `ai-fix-needed` with
+the failure comment on the Issue AND the PR carrying the full scene — and
+the next tick resumes the same run, branch, worktree and PR (no
+replacement PR, no re-claim). Only an external precondition the AI cannot
+safely judge or fix (an unrecoverable scene, a base-branch config change,
+an exhausted review round budget, a PR closed without merge) fails fast:
+the Issue is marked `ai-blocked` with the explicit reason why automatic
+recovery is impossible, and the automatic loop never touches it again — a
+human decides the next step.
 
 Rules of the chain:
 
@@ -63,8 +79,9 @@ Rules of the chain:
   review session). `ai-ready` is claimed as new work; `ai-blocked` is
   never auto-recovered.
 - The review/fix loop is bounded (5 rounds). Exhausting rounds with
-  findings, or a review that cannot be verified, marks the Issue
-  `ai-blocked`; the PR, branch and worktree stay intact.
+  findings marks the Issue `ai-blocked` (the bounded loop is a human
+  decision); a recoverable failure (Issue #50) keeps it `ai-fix-needed`.
+  Either way the PR, branch and worktree stay intact.
 - Base advances are absorbed by a plain `git merge` of the latest
   `origin/<base>` on the task branch (conflicts resolved manually),
   followed by a full test rerun. No force push, no auto conflict
@@ -88,9 +105,9 @@ commits — initialize them per repository (see
 | `ai-ready` | Explicitly dispatched to the Pilot; may be claimed |
 | `ai-in-progress` | Claimed and running (a leftover after a kill is resumed by the next tick) |
 | `ai-pr-opened` | PR created and verified; awaiting the independent review |
-| `ai-fix-needed` | The PR head is not mergeable yet; the next tick runs the next review session on the same PR |
+| `ai-fix-needed` | The PR head is not mergeable yet, or an AI-recoverable failure of the run/PR (Issue #50); the next tick resumes the same run, branch, worktree and PR |
 | `ai-merged` | Success terminal state; the Runner merged the PR and confirmed the merge commit on the protected branch |
-| `ai-blocked` | The Runner failed fast; a human must decide the next step |
+| `ai-blocked` | Only an external precondition the AI cannot safely judge or fix (Issue #50); the blocked comment states why automatic recovery is impossible; a human must decide the next step |
 
 ## Run marker and run_id
 

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -164,8 +164,8 @@ HEAD` 验证，拒绝 head 不包含最新远端 base 的交付。
 
 | 状态 | 发生了什么 | 怎么办 |
 |---|---|---|
-| `ai-blocked` | Runner fail fast（命令错误、现场无法恢复、审查超轮） | 读 Issue 评论（现场 + 原因）和 journal。修环境或修任务，然后把同一 PR 路径重新标为 `ai-fix-needed`（同一 run 继续），或移除标签重新派发为全新 `ai-ready`（新 run）。它从不自动恢复。 |
-| `ai-fix-needed` | PR head 尚不可合并（review finding 或 base 冲突） | 什么都不用做——下一 tick 在同一 PR 上启动下一个审查会话，会话内吸收最新 base。 |
+| `ai-blocked` | 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50：现场无法恢复、base 分支变更、审查超轮、PR 未合并被关闭）——comment 写明为什么不能自动恢复 | 读 Issue 评论（现场 + 原因）和 journal。修环境或修任务，然后把同一 PR 路径重新标为 `ai-fix-needed`（同一 run 继续），或移除标签重新派发为全新 `ai-ready`（新 run）。它从不自动恢复。 |
+| `ai-fix-needed` | PR head 尚不可合并（review finding、base 冲突），或已有 run/PR 的可恢复失败（Issue #50：Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失） | 什么都不用做——下一 tick 在同一 run_id、branch、worktree、PR 上启动下一个审查会话，会话内吸收最新 base。 |
 | 被杀后残留的 `ai-in-progress` | Runner 在任务中途被 SIGKILL | 下一 tick 的重启扫描接回（仅当没有其他 Runner 活着时）：同一 run id、同一 worktree、同一条进度评论——不新建 run。 |
 
 run 产物（plan、test log、session JSONL）留在任务 worktree 作为本地

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -21,10 +21,11 @@ flowchart LR
   progress -->|PR 验收：base 新鲜、run marker、Fixes #N| opened["ai-pr-opened"]
   opened -->|独立审查会话（会话内修复）| verdict{"REVIEW_VERDICT"}
   verdict -->|clean verdict + merge 门禁| merged["ai-merged（终态）"]
-  verdict -->|finding / base 冲突 / 超轮| blocked["ai-blocked（终态，人工决策）"]
-  opened -->|finding / base 冲突| fixneeded["ai-fix-needed"]
-  fixneeded -->|下一 tick：同一 PR 的下一个审查会话| opened
-  progress -->|fail fast| blocked
+  verdict -->|超轮（人工决策）| blocked["ai-blocked（终态，人工决策）"]
+  opened -->|finding / base 冲突 / 可恢复失败（Issue #50）| fixneeded["ai-fix-needed"]
+  fixneeded -->|下一 tick：同一 run、branch、worktree、PR 的下一个审查会话| opened
+  fixneeded -->|不可恢复前置条件（Issue #50）| blocked
+  progress -->|fail fast（PR 尚未存在）| blocked
 ```
 
 ```text
@@ -37,16 +38,26 @@ ai-ready                任务被派发（muyan-pilot add，或人工加标签�
                         在会话内修复 findings（代码、完整测试、100%
                         覆盖率、只 push task branch），然后输出
                         REVIEW_VERDICT
-  -> ai-fix-needed      会话内未能修复 finding，或 PR 落后最新 base /
-                        有 merge conflict：下一个 tick 在同一 run、
-                        同一 branch、同一 PR 上启动下一个审查会话
+  -> ai-fix-needed      会话内未能修复 finding，PR 落后最新 base / 有
+                        merge conflict，或已有 run/PR 的**可恢复失败**
+                        （Issue #50：Pi 执行失败、验证失败、未推送本地
+                        commit、worktree 缺失）：失败 comment 写入 Issue
+                        和 PR，带完整现场（run_id、PR、branch、worktree、
+                        session、phase、last activity、具体错误）；下一
+                        个 tick 在同一 run_id、branch、worktree、PR 上
+                        启动下一个审查会话
   -> merge              clean verdict + merge 门禁（head 包含最新 base、
                         PR mergeable、远端 head 未变）
   -> ai-merged          成功终态；PR body 的 Fixes #N 原生关闭 Issue
 ```
 
-任何一点失败都 fail fast：Issue 被标记 `ai-blocked` 并留下具体现场
-（命令、返回码、stdout/stderr、branch、worktree、session 文件），自动
+已有 run/PR 的失败被分类（Issue #50）：**可恢复失败**（Pi 执行失败、
+验证失败、未推送本地 commit、worktree 缺失、会话内未能修复的 finding）
+留在自动修复循环——Issue 标记 `ai-fix-needed`，失败 comment 写入 Issue
+和 PR（带完整现场），下一个 tick 在同一 run、branch、worktree、PR 上
+继续（不重新创建 PR、不重复领取）。只有 **AI 无法安全判断或修复的外部
+前置条件**（无可恢复现场、base 分支变更、审查超轮、PR 未合并被关闭）
+才 fail fast：Issue 被标记 `ai-blocked` 并写明为什么不能自动恢复，自动
 循环从此不再碰它——人工决定下一步。
 
 链路规则：
@@ -56,8 +67,9 @@ ai-ready                任务被派发（muyan-pilot add，或人工加标签�
 - 只有两个 opened-PR 状态会被自动拾取：`ai-pr-opened`（等待 review）
   和 `ai-fix-needed`（等待下一个审查会话）。`ai-ready` 作为新工作被
   领取；`ai-blocked` 从不自动恢复。
-- review/fix 循环有界（5 轮）。超轮仍有 findings，或 review 无法验证，
-  Issue 标记 `ai-blocked`；PR、branch 和 worktree 原样保留。
+- review/fix 循环有界（5 轮）。超轮仍有 findings 时 Issue 标记
+  `ai-blocked`（超轮是人工决策）；可恢复失败（Issue #50）保持
+  `ai-fix-needed`。无论哪种，PR、branch 和 worktree 原样保留。
 - base 前进由 task branch 上对最新 `origin/<base>` 的普通 `git merge`
   吸收（冲突手工解决），然后重跑完整测试。不 force push、不自动解决
   冲突、不 push 保护分支。
@@ -78,9 +90,9 @@ GitHub 标签是外部状态机。它们不是 commit 创建的——每个仓�
 | `ai-ready` | 明确派发给 Pilot；可以被领取 |
 | `ai-in-progress` | 已领取、正在执行（被杀后的残留由下一 tick 接回） |
 | `ai-pr-opened` | PR 已创建并验收；等待独立审查 |
-| `ai-fix-needed` | PR head 尚不可合并；下一 tick 在同一 PR 上运行下一个审查会话 |
+| `ai-fix-needed` | PR head 尚不可合并，或已有 run/PR 的可恢复失败（Issue #50）；下一 tick 在同一 run、branch、worktree、PR 上继续 |
 | `ai-merged` | 成功终态；Runner 已合并 PR 并确认 merge commit 落在保护分支 |
-| `ai-blocked` | Runner fail fast；人工必须决定下一步 |
+| `ai-blocked` | 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50）；blocked comment 写明为什么不能自动恢复；人工必须决定下一步 |
 
 ## Run marker 与 run_id
 

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -85,6 +85,13 @@ another session: fix them here, in this same session.
   fails fast — never retry the bare fetch or bypass the lock), plain
   `git merge origin/{{BASE_BRANCH}}`, resolve conflicts manually, rerun the
   full test suite with coverage, and push the task branch.
+- If the local HEAD is ahead of the frozen PR head (`{{HEAD_SHA}}`) — an
+  unpushed local commit, e.g. a fix committed by a previous review session
+  that was killed before `git push` (the #158 `d13b0c56` scene): push the
+  task branch (plain `git push origin {{HEAD_REF}}`, never a force push) so
+  the reviewed head is on the remote before you emit the verdict — never
+  discard the local commit and never create a replacement PR (Issue #50:
+  the same run, branch, worktree and PR continue).
 - After fixing, re-check the diff against R1–R9 and the Issue's acceptance
   items before emitting the verdict.
 - If you cannot make the PR mergeable (the fix is not verifiable, or the

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7179,6 +7179,10 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
     assert "Muyan Pilot needs a fix:" in body
     assert f"<!-- muyan-pilot:run=a1b2c3d4 -->" in body
     assert "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in body
+    # The full scene carries the ACTUAL branch (derived before the
+    # worktree check, Issue #50) — never a `branch=None` placeholder.
+    assert "branch=muyan-pilot/owner-repo-issue-39-a1b2c3d4" in body
+    assert "branch=None" not in body
     assert "delivery_review_failed" in caplog.text
     # The failure comment is written to the Issue AND the PR
     # (Issue #50).

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2655,8 +2655,19 @@ def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
         )
 
 
-def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
+def test_verify_pr_rejects_diverged_remote_pr_head(monkeypatch, tmp_path,
+                                                   caplog):
+    """Issue #50: a remote PR head that is NOT an ancestor of the local
+    HEAD (the branch diverged) is still a failure: a plain push would
+    be rejected and a force push is forbidden, so the resume must not
+    continue on this branch."""
     def fake_run(command, **kwargs):
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            if command[3] == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef":
+                raise subprocess.CalledProcessError(
+                    1, command, stderr="not an ancestor",
+                )
+            return ""
         if command[:2] == ["gh", "pr"]:
             return fake_verify_pr_payload(
                 headRefOid="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
@@ -2664,13 +2675,47 @@ def test_verify_pr_rejects_stale_remote_pr_head(monkeypatch, tmp_path):
         return fake_verify_run(command, **kwargs)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    with pytest.raises(
-        RuntimeError, match="PR head deadbeef.* is not local HEAD 01234567",
+    with caplog.at_level("ERROR"), pytest.raises(
+        RuntimeError,
+        match="PR head deadbeef.* is not local HEAD 01234567.*diverged",
     ):
         runner.verify_pr(
             tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
             FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
         )
+    assert "pr_head_diverged" in caplog.text
+
+
+def test_verify_pr_passes_through_when_local_head_ahead_of_pr_head(
+        monkeypatch, tmp_path, caplog,
+):
+    """Issue #50 (the #158 `d13b0c56` scene): the local HEAD is AHEAD of
+    the remote PR head (a commit made by a killed session that was
+    never pushed). The verification logs the exact heads and PASSES
+    THROUGH — the unpushed commit is preserved and the next review
+    session pushes the task branch on the same PR (it never fails here,
+    never force pushes and never creates a replacement PR)."""
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            # The PR head IS an ancestor of the local HEAD (local is
+            # ahead) — the #158 scene.
+            return ""
+        if command[:2] == ["gh", "pr"]:
+            return fake_verify_pr_payload(
+                headRefOid="ed72915ed72915ed72915ed72915ed72915ed7291",
+            )
+        return fake_verify_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        url = runner.verify_pr(
+            tmp_path, f"muyan-pilot/issue-4-{FAKE_RUN_ID}", "main",
+            FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
+        )
+    assert url == FAKE_PR_URL
+    assert "local_head_ahead_of_pr_head" in caplog.text
+    assert "ed72915ed72915ed72915ed72915ed72915ed7291" in caplog.text
+    assert FAKE_HEAD_SHA in caplog.text
 
 
 def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, caplog):
@@ -7028,17 +7073,20 @@ def test_wait_for_delivery_blocks_when_scene_base_differs_from_config(
     assert "next step:" in blocked
 
 
-def test_wait_for_delivery_blocks_when_resume_worktree_missing(
+def test_wait_for_delivery_worktree_missing_stays_fix_needed(
         monkeypatch, caplog, tmp_path,
 ):
-    """Issue #90: the resume derives the worktree from the repo, Issue
-    and run id (never from a comment). When that directory does not
-    exist the delivery must fail fast BEFORE any git/Pi mutation: no
-    review is started, no command is spawned against the missing
-    scene, and the Issue is marked ai-blocked ALONE with the PR and
-    branch preserved — the same terminal semantics as a malformed
-    scene (the pre-#82 `resume_delivery` fail-fast, restored)."""
+    """Issue #90 + #50: the resume derives the worktree from the repo,
+    Issue and run id (never from a comment). When that directory does
+    not exist the delivery must fail fast BEFORE any git/Pi mutation:
+    no review is started, no command is spawned against the missing
+    scene — but the failure is RECOVERABLE (the branch still exists on
+    the remote and the worktree can be recreated on the next resume):
+    the Issue is marked ai-fix-needed (never ai-blocked) with the PR
+    and branch preserved (the pre-#82 `resume_delivery` fail-fast,
+    restored)."""
     api_calls: list = []
+    pr_comments: list = []
     existing = {
         "id": 77,
         "body": (
@@ -7048,9 +7096,13 @@ def test_wait_for_delivery_blocks_when_resume_worktree_missing(
     }
 
     def fake_run(command, **kwargs):
-        # The fake rejects anything that is not a pr/issue view or the
-        # progress API: a missing worktree must not spawn git/gh.
+        # The fake rejects anything that is not a pr/issue view, the
+        # PR failure comment or the progress API: a missing worktree
+        # must not spawn git/gh.
         if command[:2] == ["gh", "pr"]:
+            if command[2] == "comment":
+                pr_comments.append(command[-1])
+                return ""
             return json.dumps({"state": "OPEN"})
         if command[:2] == ["gh", "api"]:
             api_calls.append(command)
@@ -7112,35 +7164,43 @@ def test_wait_for_delivery_blocks_when_resume_worktree_missing(
     )
     # No review was started and nothing was merged.
     assert reviews == []
-    # The Issue is marked ai-blocked (removing ai-pr-opened) ...
+    # The Issue is marked ai-fix-needed (removing ai-pr-opened) —
+    # never ai-blocked (Issue #50) ...
     assert edits[0][1] == {
         "repo": "owner/repo",
-        "add": "ai-blocked",
+        "add": "ai-fix-needed",
         "remove": "ai-pr-opened",
     }
-    # ... and it is the ALONE terminal state (no other label edit).
+    # ... and it is the only label edit.
     assert len(edits) == 1
     # The failure comment names the missing worktree and carries the
     # run marker.
     body = comments[0][1]["body"]
-    assert "Muyan Pilot failed:" in body
+    assert "Muyan Pilot needs a fix:" in body
     assert f"<!-- muyan-pilot:run=a1b2c3d4 -->" in body
     assert "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in body
     assert "delivery_review_failed" in caplog.text
-    # The terminal failure also posts the blocked milestone (Issue #18)
-    # AND the tracked progress comment becomes the blocked scene.
+    # The failure comment is written to the Issue AND the PR
+    # (Issue #50).
+    assert pr_comments == [body]
+    # The recoverable failure posts the fix-needed milestone (Issue
+    # #18) AND the tracked progress comment becomes the fix-needed
+    # scene.
     posted_bodies = [
         command[command.index("--field") + 1][len("body="):]
         for command in api_calls
         if "--method" in command and "POST" in command
     ]
-    assert any("Muyan Pilot: blocked" in body for body in posted_bodies)
+    assert any("Muyan Pilot: fix needed" in body for body in posted_bodies)
     assert any(
         "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in body
         for body in posted_bodies
     )
+    assert not any(
+        "Muyan Pilot: blocked" in body for body in posted_bodies
+    )
     # No second progress comment: the tracked one (id 77) is PATCHed
-    # into the blocked scene in place.
+    # into the fix-needed scene in place.
     patches = [
         command for command in api_calls
         if command[:2] == ["gh", "api"]
@@ -7148,19 +7208,20 @@ def test_wait_for_delivery_blocks_when_resume_worktree_missing(
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"
-    blocked = patches[-1][patches[-1].index("--field") + 1][len("body="):]
-    assert "Muyan Pilot blocked" in blocked
-    assert "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in blocked
-    assert "next step:" in blocked
+    fix_needed = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot fix needed" in fix_needed
+    assert "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in fix_needed
+    assert "next step:" in fix_needed
 
 
-def test_wait_for_delivery_blocks_when_resume_worktree_missing_while_fix_needed(
+def test_wait_for_delivery_worktree_missing_while_fix_needed_keeps_label(
         monkeypatch, tmp_path,
 ):
-    """Issue #90 + #82: a missing resume worktree while the Issue is
-    `ai-fix-needed` (awaiting the next review session) must leave the
-    terminal state `ai-blocked` ALONE — the leftover `ai-fix-needed`
-    label is removed too — and no review is started."""
+    """Issue #90 + #82 + #50: a missing resume worktree while the
+    Issue is `ai-fix-needed` (awaiting the next review session) keeps
+    the `ai-fix-needed` label (the opened-PR state label is removed,
+    the fix-needed label is the one the next tick scans for) and no
+    review is started."""
     api_calls: list = []
     existing = {
         "id": 77,
@@ -7172,6 +7233,8 @@ def test_wait_for_delivery_blocks_when_resume_worktree_missing_while_fix_needed(
 
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "pr"]:
+            if command[2] == "comment":
+                return ""
             return json.dumps({"state": "OPEN"})
         if command[:2] == ["gh", "api"]:
             api_calls.append(command)
@@ -7223,21 +7286,17 @@ def test_wait_for_delivery_blocks_when_resume_worktree_missing_while_fix_needed(
     )
     # No review was started.
     assert reviews == []
-    # The terminal state is ai-blocked ALONE: the opened-PR state
-    # labels are removed (ai-pr-opened on the first edit, the leftover
-    # ai-fix-needed on the second).
+    # The single transition: ai-pr-opened removed, ai-fix-needed added
+    # (the label the Issue already carries is re-added idempotently —
+    # the next tick's scan needs it; Issue #50: never ai-blocked).
     assert edits[0][1] == {
         "repo": "owner/repo",
-        "add": "ai-blocked",
+        "add": "ai-fix-needed",
         "remove": "ai-pr-opened",
     }
-    assert edits[1][1] == {
-        "repo": "owner/repo",
-        "remove": "ai-fix-needed",
-    }
-    assert len(edits) == 2
+    assert len(edits) == 1
     body = comments[0][1]["body"]
-    assert "Muyan Pilot failed:" in body
+    assert "Muyan Pilot needs a fix:" in body
     assert "muyan-pilot-owner-repo-issue-39-a1b2c3d4" in body
 
 

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -1,0 +1,937 @@
+"""Issue #50: keep AI-recoverable failures in the automatic fix loop.
+
+Recoverable failures of an existing run/PR (Pi execution failure, model
+wait, runner exception, missing/malformed verdict, missing worktree,
+unpushed local commit, ...) must NOT leave the automatic queue: the
+Issue is labeled `ai-fix-needed` (not `ai-blocked`) with a failure
+comment carrying the full scene (run_id, PR, branch, worktree, session,
+phase, last activity, concrete error), and the next timer resumes the
+same run, branch, worktree and PR. `ai-blocked` is reserved for
+external preconditions the AI cannot safely judge or fix; every blocked
+comment states the explicit reason why automatic recovery is impossible.
+"""
+import json
+import subprocess
+
+import pytest
+
+import bootstrap_runner as runner
+
+PR_URL = "https://github.com/owner/repo/pull/46"
+RUN_ID = "a1b2c3d4"
+MARKER = f"<!-- muyan-pilot:run={RUN_ID} -->"
+WORKTREE = "/srv/repo/.worktrees/muyan-pilot-owner-repo-issue-39-a1b2c3d4"
+BRANCH = "muyan-pilot/owner-repo-issue-39-a1b2c3d4"
+
+
+@pytest.fixture(autouse=True)
+def _reset_run_id(monkeypatch):
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+
+
+def _scene_comments():
+    """The trusted opened-PR scene comment (the recovery source)."""
+    return [
+        {
+            "body": (
+                f"{MARKER}\n"
+                f"Muyan Pilot opened PR: {PR_URL} (base_branch=main "
+                f"base_sha=abc123def456 run_id={RUN_ID})"
+            ),
+            "authorAssociation": "OWNER",
+        },
+    ]
+
+
+def make_wait_failure_fake(monkeypatch, *, labels=("ai-pr-opened",),
+                           progress_comments=None, scene=None):
+    """Shared `run_command` fake for the `wait_for_delivery` failure
+    tests: one OPEN PR poll, the progress API (GET/POST/PATCH), the
+    label read, the comment-history read (scene + review rounds).
+    `review_and_merge_if_clean` is monkeypatched separately by the
+    caller. Returns the captured api calls."""
+    if progress_comments is None:
+        progress_comments = [
+            {
+                "id": 77,
+                "body": f"{MARKER}\n\n**Muyan Pilot progress**\n\nawaiting",
+            },
+        ]
+    if scene is None:
+        scene = _scene_comments()
+    api_calls = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps({"state": "OPEN"})
+        if command[:2] == ["gh", "api"]:
+            api_calls.append(command)
+            if "--method" not in command:
+                return json.dumps(progress_comments)
+            method = command[command.index("--method") + 1]
+            if method == "POST":
+                body = command[command.index("--field") + 1]
+                return json.dumps({"id": 78, "body": body[len("body="):],
+                                   "url": "https://x/78"})
+            return ""
+        if command[-1] == "comments":
+            return json.dumps({"comments": scene})
+        return json.dumps({"labels": [{"name": name} for name in labels]})
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    return api_calls
+
+
+def _issue():
+    return {"number": 39, "title": "task", "body": ""}
+
+
+def _config(tmp_path):
+    return {"repo_dir": tmp_path, "base_branch": "main"}
+
+
+# ---------------------------------------------------------------- classification
+
+
+def test_is_unrecoverable_failure_true_only_for_explicit_error():
+    assert runner.is_unrecoverable_failure(
+        runner.UnrecoverableDeliveryError("human decision needed"),
+    )
+
+
+@pytest.mark.parametrize("exc", [
+    RuntimeError(
+        "Pi is stuck in model_wait with a frozen session for 10m: the "
+        "upstream (llama/proxy) is dead; Pi was killed (Issue #75)"
+    ),
+    RuntimeError(
+        "Pi session stayed idle for 15m after idle recovery "
+        "(TERM/KILL of pre-idle descendants); Pi was killed (Issue #94)"
+    ),
+    subprocess.CalledProcessError(1, ["pi", "--print"]),
+    subprocess.TimeoutExpired(["pi", "--print"], 600),
+    ValueError("no REVIEW_VERDICT line in review output"),
+    RuntimeError("worktree missing: /srv/repo/.worktrees/x"),
+    RuntimeError(
+        "PR head 18c78a2 is not local HEAD 18c78a2b; the verified "
+        "commit was not pushed, push the reviewed commit and retry"
+    ),
+])
+def test_is_unrecoverable_failure_false_for_recoverable_failures(exc):
+    # Issue #50: every failure the AI can still diagnose, fix and
+    # verify on the same run/PR stays in the automatic fix loop.
+    assert not runner.is_unrecoverable_failure(exc)
+
+
+# ------------------------------------------------- wait_for_delivery: recoverable
+
+
+@pytest.mark.parametrize("exc", [
+    # Pi execution failure (upstream dead / idle recovery / pi exit).
+    RuntimeError(
+        "Pi is stuck in model_wait with a frozen session for 10m: the "
+        "upstream (llama/proxy) is dead; Pi was killed (Issue #75)"
+    ),
+    subprocess.CalledProcessError(1, ["pi", "--print"]),
+    # Missing/malformed verdict.
+    ValueError("no REVIEW_VERDICT line in review output"),
+    # Missing worktree.
+    RuntimeError(f"worktree missing: {WORKTREE}"),
+])
+def test_wait_for_delivery_recoverable_review_failure_stays_fix_needed(
+        monkeypatch, caplog, tmp_path, exc,
+):
+    """Issue #50: a recoverable review failure (Pi execution failure,
+    model wait, runner exception, malformed verdict, missing worktree)
+    keeps the Issue in the automatic fix loop: `ai-fix-needed` (NOT
+    `ai-blocked`), a failure comment with the full scene on Issue AND
+    PR, the progress comment finished with the fix-needed scene, and
+    the wait returns so the next timer resumes the same run, branch,
+    worktree and PR."""
+    # The worktree exists (created at claim time) so the review runs.
+    (tmp_path / ".worktrees"
+     / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}").mkdir(parents=True)
+    api_calls = make_wait_failure_fake(monkeypatch)
+    edits = []
+    issue_comments = []
+    pr_comments = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_pr",
+        lambda *args, **kwargs: pr_comments.append((args, kwargs)),
+    )
+    reviews = []
+
+    def failing_review(*args, **kwargs):
+        reviews.append((args, kwargs))
+        raise exc
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    caplog.set_level("INFO")
+    # The wait returns (the slot is released by the caller); the next
+    # timer picks the ai-fix-needed Issue up on the same run/PR.
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+
+    # One review attempt, then the fix-needed transition.
+    assert len(reviews) == 1
+    # The Issue is marked ai-fix-needed (removing ai-pr-opened) — and
+    # never ai-blocked.
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-fix-needed",
+                 "remove": "ai-pr-opened"}),
+    ]
+    # The failure comment carries the run marker, the PR, the concrete
+    # error and the full scene (run_id, branch, worktree, session,
+    # phase, last activity).
+    assert len(issue_comments) == 1
+    body = issue_comments[0][1]["body"]
+    assert "Muyan Pilot needs a fix:" in body
+    assert MARKER in body
+    assert PR_URL in body
+    assert str(exc).split(" (Issue")[0] in body
+    assert f"branch={BRANCH}" in body
+    expected_worktree = (
+        tmp_path / ".worktrees"
+        / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}"
+    )
+    assert f"worktree={expected_worktree}" in body
+    assert "session=" in body
+    assert "phase=" in body
+    assert "last_activity=" in body
+    # The SAME failure comment is written to the PR (Issue #50: the
+    # failure comment must be written to Issue/PR).
+    assert len(pr_comments) == 1
+    assert pr_comments[0][1]["body"] == body
+    # The tracked progress comment is finished with the fix-needed
+    # scene (not the blocked scene) ...
+    patches = [
+        command for command in api_calls
+        if command[:2] == ["gh", "api"]
+        and command[2] == "repos/owner/repo/issues/comments/77"
+        and "PATCH" in command
+    ]
+    assert patches, "the tracked progress comment was not updated"
+    finished = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot fix needed" in finished
+    assert "next step:" in finished
+    assert "ai-blocked" not in finished
+    # ... and the fix-needed milestone is posted (mobile notification).
+    posted = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in api_calls
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: fix needed" in body for body in posted)
+    # The failure is logged with the run-scene marker.
+    assert "delivery_review_failed" in caplog.text
+
+
+def test_wait_for_delivery_recoverable_failure_while_fix_needed_keeps_label(
+        monkeypatch, tmp_path,
+):
+    """Issue #50 + #82: a recoverable failure while the Issue is ALREADY
+    `ai-fix-needed` (awaiting the next review session) keeps the
+    `ai-fix-needed` label (the opened-PR state label is removed, the
+    fix-needed label is the one the next tick scans for)."""
+    (tmp_path / ".worktrees"
+     / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}").mkdir(parents=True)
+    make_wait_failure_fake(
+        monkeypatch, labels=("ai-fix-needed",), progress_comments=[],
+    )
+    edits = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+
+    def failing_review(*args, **kwargs):
+        raise RuntimeError("pi_exit_1: the review Pi failed")
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+    # The single transition: ai-pr-opened removed, ai-fix-needed added
+    # (the label the Issue already carries is re-added idempotently —
+    # the next tick's scan needs it, and a leftover fix-needed label
+    # must never be removed on a recoverable failure).
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-fix-needed",
+                 "remove": "ai-pr-opened"}),
+    ]
+
+
+def _write_session(worktree_dir, session_id="sess-1"):
+    """Write one minimal session JSONL (the snapshot's session id)."""
+    session_dir = worktree_dir / ".pi-session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "sess.jsonl").write_text(
+        json.dumps({"type": "session", "id": session_id}) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_wait_for_delivery_recoverable_failure_with_session_file_includes_session_scene(
+        monkeypatch, tmp_path,
+):
+    """Issue #50: when the worktree carries a session file, the
+    failure comment's scene shows the ACTUAL session (not the '-'
+    placeholder): the full debug entry a human needs to continue."""
+    worktree = (
+        tmp_path / ".worktrees"
+        / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}"
+    )
+    worktree.mkdir(parents=True)
+    _write_session(worktree)
+    make_wait_failure_fake(monkeypatch)
+    issue_comments = []
+    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+
+    def failing_review(*args, **kwargs):
+        raise RuntimeError("pi_exit_3: the review Pi failed")
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+    body = issue_comments[0][1]["body"]
+    assert "session=sess-1" in body
+    assert f"session_file={worktree / '.pi-session' / 'sess.jsonl'}" in body
+
+
+def test_wait_for_delivery_recoverable_failure_scene_snapshot_failure_is_logged(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50: a failing session-file read is best-effort
+    observability: it is logged, the failure comment still carries the
+    scene (with the '-' session placeholder), and the wait still
+    completes the fix-needed transition."""
+    worktree = (
+        tmp_path / ".worktrees"
+        / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}"
+    )
+    worktree.mkdir(parents=True)
+    make_wait_failure_fake(monkeypatch)
+    issue_comments = []
+    edits = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+
+    def failing_review(*args, **kwargs):
+        raise RuntimeError("pi_exit_3: the review Pi failed")
+
+    def failing_snapshot(*args, **kwargs):
+        raise OSError("session file unreadable")
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    monkeypatch.setattr(runner, "activity_snapshot", failing_snapshot)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    caplog.set_level("INFO")
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+    assert "activity scene failed" in caplog.text
+    body = issue_comments[0][1]["body"]
+    assert "Muyan Pilot needs a fix:" in body
+    assert "session=-" in body
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-fix-needed",
+                 "remove": "ai-pr-opened"}),
+    ]
+
+
+# ------------------------------------------- wait_for_delivery: unrecoverable
+
+
+def test_wait_for_delivery_recoverable_failure_without_bound_run_id(
+        monkeypatch, tmp_path,
+):
+    """Issue #50: a RECOVERABLE review failure with no bound run id
+    (the defensive branch — the production caller always binds the
+    scene's run id first) still keeps the Issue in the automatic fix
+    loop: the failure comment simply carries no run marker, the scene
+    shows `run=-`, and the milestone / progress scene are skipped (no
+    run id to bind them to)."""
+    (tmp_path / ".worktrees"
+     / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}").mkdir(parents=True)
+    api_calls = make_wait_failure_fake(monkeypatch)
+    issue_comments = []
+    edits = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+
+    def failing_review(*args, **kwargs):
+        raise RuntimeError("pi_exit_3: the review Pi failed")
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    # The autouse fixture resets the run id to None; do not re-bind it.
+    assert runner.current_run_id() is None
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-fix-needed",
+                 "remove": "ai-pr-opened"}),
+    ]
+    body = issue_comments[0][1]["body"]
+    assert "Muyan Pilot needs a fix:" in body
+    assert "<!-- muyan-pilot:run=" not in body
+    assert "run=-" in body
+    # No run id: no milestone, no progress scene at all.
+    assert api_calls == []
+
+
+def test_wait_for_delivery_unrecoverable_failure_marks_blocked_with_reason(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50: an explicit UnrecoverableDeliveryError (an external
+    precondition the AI cannot safely judge or fix) is the ONLY
+    opened-PR failure that leaves the automatic loop: `ai-blocked`
+    ALONE, and the failure comment states the explicit reason why
+    automatic recovery is impossible."""
+    (tmp_path / ".worktrees"
+     / f"muyan-pilot-owner-repo-issue-39-{RUN_ID}").mkdir(parents=True)
+    api_calls = make_wait_failure_fake(monkeypatch)
+    edits = []
+    issue_comments = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+    reason = (
+        "the review/fix loop is bounded (5 rounds) and exhausted "
+        "without a clean verdict; the remaining findings need a human "
+        "decision, so the AI cannot safely continue this PR"
+    )
+
+    def failing_review(*args, **kwargs):
+        raise runner.UnrecoverableDeliveryError(reason)
+
+    monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    caplog.set_level("INFO")
+    runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
+
+    # The terminal state is ai-blocked ALONE ...
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-blocked",
+                 "remove": "ai-pr-opened"}),
+    ]
+    # ... with a failure comment that carries the run marker, the PR
+    # and the EXPLICIT reason why automatic recovery is impossible.
+    body = issue_comments[0][1]["body"]
+    assert "Muyan Pilot failed:" in body
+    assert MARKER in body
+    assert PR_URL in body
+    assert reason in body
+    assert "cannot be recovered automatically" in body
+    # The blocked scene (not the fix-needed scene) finishes the
+    # progress comment.
+    posted = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in api_calls
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: blocked" in body for body in posted)
+    assert not any("Muyan Pilot: fix needed" in body for body in posted)
+    patches = [
+        command for command in api_calls
+        if command[:2] == ["gh", "api"]
+        and command[2] == "repos/owner/repo/issues/comments/77"
+        and "PATCH" in command
+    ]
+    finished = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot blocked" in finished
+    assert reason in finished
+
+
+def test_wait_for_delivery_base_branch_mismatch_marks_blocked_with_reason(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50 + #91: a resume scene frozen on another base branch
+    than the configured one is an external precondition (a config
+    change): the runner must not silently switch bases, so the Issue
+    is marked ai-blocked with the explicit reason — never
+    ai-fix-needed (auto-retrying would keep failing on the same
+    mismatch)."""
+    api_calls = make_wait_failure_fake(
+        monkeypatch,
+        scene=[
+            {
+                "body": (
+                    f"{MARKER}\n"
+                    f"Muyan Pilot opened PR: {PR_URL} (base_branch=develop "
+                    f"base_sha=abc123def456 run_id={RUN_ID})"
+                ),
+                "authorAssociation": "OWNER",
+            },
+        ],
+    )
+    edits = []
+    issue_comments = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: issue_comments.append((args, kwargs)),
+    )
+    monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
+    reviews = []
+    monkeypatch.setattr(
+        runner, "review_and_merge_if_clean",
+        lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
+    )
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    caplog.set_level("INFO")
+    runner.wait_for_delivery(
+        PR_URL, _issue(),
+        {"repo_dir": tmp_path, "base_branch": "main"}, "owner/repo",
+    )
+    # No review was started (the mismatch is terminal before it).
+    assert reviews == []
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-blocked",
+                 "remove": "ai-pr-opened"}),
+    ]
+    body = issue_comments[0][1]["body"]
+    assert "Muyan Pilot failed:" in body
+    assert "base_branch=develop" in body
+    assert "base_branch=main" in body
+    # The blocked comment states why automatic recovery is impossible.
+    assert "cannot be recovered automatically" in body
+    assert "delivery_review_failed" in caplog.text
+
+
+# --------------------------------------------------------- verify_resumed_pr
+
+
+def test_verify_resumed_pr_diverged_pr_head_stays_fix_needed(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50: a resume verification failure from `verify_pr` (here
+    the diverged-head failure — the plain #158 unpushed-commit scene
+    passes through `verify_pr` and is continued by the next review
+    session, which pushes the task branch on the same PR) is a
+    RECOVERABLE failure: the branch, worktree and PR scene are
+    preserved and the Issue is marked `ai-fix-needed` (never
+    `ai-blocked`), so the next tick re-derives the same run, branch,
+    worktree and PR."""
+    from tests.test_resume_pr import (
+        FAKE_PR_URL, FAKE_RUN_ID, make_resume_config, make_resume_issue,
+        make_resume_scene, make_resume_failure_fake,
+        expected_resume_worktree,
+    )
+
+    captured, _ = make_resume_failure_fake(monkeypatch)
+
+    def fake_verify_pr(*args, **kwargs):
+        raise RuntimeError(
+            "PR head ed72915 is not local HEAD 18c78a2 and is not an "
+            "ancestor of it (the branch diverged); a plain push would "
+            "be rejected and a force push is forbidden, so the resume "
+            "must not continue on this branch"
+        )
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    expected_resume_worktree(tmp_path).mkdir(parents=True)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    caplog.set_level("INFO")
+    with pytest.raises(
+        RuntimeError, match="the branch diverged",
+    ):
+        runner.verify_resumed_pr(
+            make_resume_scene(), make_resume_issue(),
+            make_resume_config(tmp_path), "owner/repo",
+        )
+    # The Issue is marked ai-fix-needed (removing ai-pr-opened) — and
+    # never ai-blocked: the branch, worktree and PR are preserved.
+    assert captured["edits"] == [
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
+                "remove": "ai-pr-opened"}),
+    ]
+    # The failure comment carries the run marker, the PR, the branch,
+    # the worktree and the concrete error ...
+    assert len(captured["comments"]) == 1
+    body = captured["comments"][0][1]["body"]
+    assert "Muyan Pilot needs a fix:" in body
+    assert f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->" in body
+    assert FAKE_PR_URL in body
+    assert "muyan-pilot/owner-repo-issue-9-a1b2c3d4" in body
+    assert str(expected_resume_worktree(tmp_path)) in body
+    assert "the branch diverged" in body
+    # ... and the fix-needed milestone (not the blocked one).
+    posted = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in captured["api"]
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: fix needed" in body for body in posted)
+    assert not any("Muyan Pilot: blocked" in body for body in posted)
+    assert "resume_pr_verification_failed" in caplog.text
+
+
+def test_verify_resumed_pr_local_ahead_of_pr_head_continues_to_review(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50 (the #158 `d13b0c56` scene): the local HEAD is ahead
+    of the remote PR head (an unpushed commit from a killed session).
+    The resume verification must NOT fail: the real `verify_pr` logs
+    the exact heads and returns the verified PR URL, so the delivery
+    wait starts the next review session — which pushes the task branch
+    on the same PR before its verdict (prompt_review.md). No label
+    change, no ai-blocked, no replacement PR."""
+    from tests.test_resume_pr import (
+        FAKE_RUN_ID, make_resume_config, make_resume_issue,
+        make_resume_scene, expected_resume_worktree,
+    )
+
+    worktree = expected_resume_worktree(tmp_path)
+    worktree.mkdir(parents=True)
+    branch = f"muyan-pilot/owner-repo-issue-9-{FAKE_RUN_ID}"
+    local_head = "18c78a2" * 5 + "18c78a2"
+    pr_head = "ed72915" * 5 + "ed72915"
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return branch
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            # The PR head IS an ancestor of the local HEAD (local is
+            # ahead) — the #158 scene.
+            return ""
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return local_head
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/owner/repo/pull/9",
+                "baseRefName": "main",
+                "headRefName": branch,
+                "headRefOid": pr_head,
+                "headRepository": {"name": "repo"},
+                "headRepositoryOwner": {"login": "owner"},
+                "body": (
+                    f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n\n"
+                    "Fixes #9\n\nPlan"
+                ),
+            }])
+        raise AssertionError(f"unexpected command: {command}")
+
+    # The fake rejects anything else (the repo's fake-coverage
+    # convention): the resume verification must not run any other
+    # command (no fetch — `require_latest_base=False` — no push).
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    caplog.set_level("INFO")
+    url = runner.verify_resumed_pr(
+        make_resume_scene(), make_resume_issue(),
+        make_resume_config(tmp_path), "owner/repo",
+    )
+    assert url == "https://github.com/owner/repo/pull/9"
+    # The journal carries the commit/push phase: the exact local head
+    # and remote PR head.
+    assert "local_head_ahead_of_pr_head" in caplog.text
+    assert f"pr_head={pr_head}" in caplog.text
+    assert f"local_head={local_head}" in caplog.text
+
+
+def test_verify_resumed_pr_unrecoverable_failure_marks_blocked_with_reason(
+        monkeypatch, tmp_path,
+):
+    """Issue #50: an explicit UnrecoverableDeliveryError from the resume
+    verification (an external precondition the AI cannot safely judge
+    or fix) is terminal: `ai-blocked` ALONE with the explicit reason
+    why automatic recovery is impossible."""
+    from tests.test_resume_pr import (
+        make_resume_config, make_resume_issue, make_resume_scene,
+        make_resume_failure_fake, expected_resume_worktree, FAKE_RUN_ID,
+    )
+
+    captured, _ = make_resume_failure_fake(monkeypatch)
+
+    def fake_verify_pr(*args, **kwargs):
+        raise runner.UnrecoverableDeliveryError(
+            "the PR head repo is a fork the runner is not authorized "
+            "to merge; a human must re-target the PR"
+        )
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    expected_resume_worktree(tmp_path).mkdir(parents=True)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    with pytest.raises(
+        runner.UnrecoverableDeliveryError, match="not authorized",
+    ):
+        runner.verify_resumed_pr(
+            make_resume_scene(), make_resume_issue(),
+            make_resume_config(tmp_path), "owner/repo",
+        )
+    assert captured["edits"] == [
+        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+                "remove": "ai-pr-opened"}),
+    ]
+    body = captured["comments"][0][1]["body"]
+    assert "Muyan Pilot failed:" in body
+    assert "not authorized" in body
+    assert "cannot be recovered automatically" in body
+    posted = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in captured["api"]
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: blocked" in body for body in posted)
+    assert not any("Muyan Pilot: fix needed" in body for body in posted)
+
+
+def test_verify_resumed_pr_recoverable_failure_with_session_file_includes_session_scene(
+        monkeypatch, tmp_path,
+):
+    """Issue #50: when the worktree carries a session file, the resume
+    failure comment's scene shows the ACTUAL session (not the '-'
+    placeholder)."""
+    from tests.test_resume_pr import (
+        make_resume_config, make_resume_issue, make_resume_scene,
+        make_resume_failure_fake, expected_resume_worktree, FAKE_RUN_ID,
+    )
+
+    captured, _ = make_resume_failure_fake(monkeypatch)
+    worktree = expected_resume_worktree(tmp_path)
+    worktree.mkdir(parents=True)
+    _write_session(worktree)
+
+    def fake_verify_pr(*args, **kwargs):
+        raise RuntimeError("the verified commit was not pushed")
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    with pytest.raises(RuntimeError, match="not pushed"):
+        runner.verify_resumed_pr(
+            make_resume_scene(), make_resume_issue(),
+            make_resume_config(tmp_path), "owner/repo",
+        )
+    body = captured["comments"][0][1]["body"]
+    assert "session=sess-1" in body
+    assert f"session_file={worktree / '.pi-session' / 'sess.jsonl'}" in body
+
+
+def test_verify_resumed_pr_recoverable_failure_scene_snapshot_failure_is_logged(
+        monkeypatch, caplog, tmp_path,
+):
+    """Issue #50: a failing session-file read during the resume
+    failure reporting is best-effort observability: it is logged, the
+    failure comment still carries the scene (with the '-' session
+    placeholder), and the original error is still re-raised."""
+    from tests.test_resume_pr import (
+        make_resume_config, make_resume_issue, make_resume_scene,
+        make_resume_failure_fake, expected_resume_worktree, FAKE_RUN_ID,
+    )
+
+    captured, _ = make_resume_failure_fake(monkeypatch)
+    expected_resume_worktree(tmp_path).mkdir(parents=True)
+
+    def fake_verify_pr(*args, **kwargs):
+        raise RuntimeError("the verified commit was not pushed")
+
+    def failing_snapshot(*args, **kwargs):
+        raise OSError("session file unreadable")
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    monkeypatch.setattr(runner, "activity_snapshot", failing_snapshot)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    caplog.set_level("INFO")
+    with pytest.raises(RuntimeError, match="not pushed"):
+        runner.verify_resumed_pr(
+            make_resume_scene(), make_resume_issue(),
+            make_resume_config(tmp_path), "owner/repo",
+        )
+    assert "activity scene failed" in caplog.text
+    body = captured["comments"][0][1]["body"]
+    assert "Muyan Pilot needs a fix:" in body
+    assert "session=-" in body
+
+
+def test_verify_resumed_pr_unrecoverable_failure_removes_leftover_fix_needed_label(
+        monkeypatch, tmp_path,
+):
+    """Issue #50 + #82: an UNRECOVERABLE resume failure while the
+    Issue is in `ai-fix-needed` (awaiting the next review session)
+    leaves the terminal state `ai-blocked` ALONE — the leftover
+    `ai-fix-needed` label is removed too."""
+    from tests.test_resume_pr import (
+        make_resume_config, make_resume_issue, make_resume_scene,
+        make_resume_failure_fake, expected_resume_worktree, FAKE_RUN_ID,
+    )
+
+    captured, _ = make_resume_failure_fake(
+        monkeypatch, labels=["ai-fix-needed"],
+    )
+
+    def fake_verify_pr(*args, **kwargs):
+        raise runner.UnrecoverableDeliveryError("human decision needed")
+
+    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    expected_resume_worktree(tmp_path).mkdir(parents=True)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    with pytest.raises(
+        runner.UnrecoverableDeliveryError, match="human decision",
+    ):
+        runner.verify_resumed_pr(
+            make_resume_scene(), make_resume_issue(),
+            make_resume_config(tmp_path), "owner/repo",
+        )
+    assert captured["edits"] == [
+        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+                "remove": "ai-pr-opened"}),
+        ((9,), {"repo": "owner/repo", "remove": "ai-fix-needed"}),
+    ]
+
+
+def test_finish_fix_needed_progress_without_run_id_is_noop(monkeypatch):
+    """Issue #50: the fix-needed progress scene is bound to the run id
+    (the hidden marker); without one it is a no-op (no gh traffic)."""
+    api_calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda *args, **kwargs: api_calls.append(args) or "",
+    )
+    assert runner._finish_fix_needed_progress(
+        39, None, "owner/repo", None, None, PR_URL, "the failure",
+        "task",
+    ) is None
+    assert api_calls == []
+
+
+# ------------------------------------------------------------- block_scene_failure
+
+
+def test_block_scene_failure_states_why_not_auto_recoverable(
+        monkeypatch, caplog,
+):
+    """Issue #50: a scene that cannot be recovered (no trusted
+    `Muyan Pilot opened PR:` comment) is an external precondition the
+    AI cannot fix by itself (the runner cannot derive run_id/branch/
+    worktree/PR without it and cannot start a review session): the
+    Issue is marked ai-blocked and the comment states the EXPLICIT
+    reason why automatic recovery is impossible plus the human
+    next step."""
+    issue = {"number": 39, "title": "task", "body": ""}
+    comments = [
+        {"body": "public comment", "authorAssociation": "NONE"},
+    ]
+    edits = []
+    posted = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda *args, **kwargs: posted.append(kwargs["body"]),
+    )
+    with pytest.raises(ValueError, match="no trusted"):
+        runner.block_scene_failure(
+            issue, ValueError("no trusted opened PR scene comment"),
+            "owner/repo", comments,
+        )
+    assert edits == [
+        ((39,), {"repo": "owner/repo", "add": "ai-blocked",
+                 "remove": "ai-fix-needed"}),
+    ]
+    assert len(posted) == 1
+    body = posted[0]
+    assert "Muyan Pilot failed:" in body
+    assert "cannot be recovered automatically" in body
+    # The reason names what is missing (the trusted scene) and what a
+    # human must do (restore the scene or relabel).
+    assert "Muyan Pilot opened PR" in body
+    assert "ai-fix-needed" in body
+    assert "resume_scene_failed" in caplog.text or \
+        "resume scene is malformed" in caplog.text
+
+
+# ------------------------------------------------------------------ review rounds
+
+
+def test_review_rounds_exhausted_raises_unrecoverable(monkeypatch, tmp_path):
+    """Issue #50: the bounded review/fix loop (5 rounds) exhausted
+    without a clean verdict is a human decision, not a recoverable
+    failure: `review_and_merge_if_clean` raises
+    UnrecoverableDeliveryError (the caller marks the Issue ai-blocked
+    with the reason)."""
+    from tests.test_resume_pr import FAKE_RUN_ID
+
+    monkeypatch.setattr(
+        runner, "issue_comments",
+        lambda number, repo: [
+            {
+                "body": (
+                    f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->\n"
+                    f"Muyan Pilot review round {i} for PR #46: findings"
+                ),
+                "authorAssociation": "OWNER",
+            }
+            for i in range(1, 6)
+        ],
+    )
+    monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: {
+        "number": 46, "url": PR_URL, "base_ref": "main",
+        "base_oid": "abc", "head_ref": "b", "head_oid": "def",
+    })
+    config = {
+        "run_id": FAKE_RUN_ID, "base_branch": "main",
+        "repo_dir": tmp_path,
+    }
+    with pytest.raises(
+        runner.UnrecoverableDeliveryError, match="exhausted",
+    ):
+        runner.review_and_merge_if_clean(
+            tmp_path, "branch", "main", config, "owner/repo", 39,
+            title="task", priority="normal",
+        )
+
+
+# -------------------------------------------------------------------- prompt
+
+
+def test_prompt_review_covers_unpushed_local_commit():
+    """Issue #50 (the #158 `d13b0c56` scene): the review prompt must
+    tell the reviewer to push an unpushed local commit (local HEAD
+    ahead of the frozen PR head) on the same task branch before
+    emitting the verdict — never discard it, never create a
+    replacement PR."""
+    from pathlib import Path
+    text = (Path(__file__).resolve().parent.parent
+            / "prompt_review.md").read_text(encoding="utf-8").lower()
+    assert "local head" in text
+    assert "ahead of the frozen" in text
+    assert "push" in text

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -149,12 +149,21 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
     ) == "https://github.com/owner/repo/pull/3"
 
 
-def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
-    # Commit A is pushed (the PR points at it); commit B is local only.
+def test_verify_pr_passes_through_when_local_head_ahead_of_pr_head(
+        clone, monkeypatch, caplog,
+):
+    """Issue #50 (the #158 `d13b0c56` scene, real git): commit A is
+    pushed (the PR points at it), commit B is local only (a killed
+    session never pushed it). The verification must NOT fail — it logs
+    the exact heads (local ahead of the PR head) and returns the PR URL
+    so the next review session can push the task branch on the same
+    PR (no replacement PR, no discarded commit, no force push)."""
     git(clone, "checkout", "-b", "muyan-pilot/owner-repo-issue-3-a1b2c3d4")
     commit_file(clone, "delivery-a.txt", "commit A")
     pushed_head = git(clone, "rev-parse", "HEAD")
     commit_file(clone, "delivery-b.txt", "commit B")
+    local_head = git(clone, "rev-parse", "HEAD")
+    assert local_head != pushed_head
     install_fake_gh(
         monkeypatch,
         json.dumps([{
@@ -167,11 +176,15 @@ def test_verify_pr_rejects_pr_head_newer_than_local_head(clone, monkeypatch):
             ),
         }]),
     )
-    with pytest.raises(RuntimeError, match="is not local HEAD"):
-        runner.verify_pr(
+    with caplog.at_level("INFO"):
+        url = runner.verify_pr(
             clone, "muyan-pilot/owner-repo-issue-3-a1b2c3d4", "main",
             "a1b2c3d4", issue=3, repo_dir=clone,
         )
+    assert url == "https://github.com/owner/repo/pull/3"
+    assert "local_head_ahead_of_pr_head" in caplog.text
+    assert f"pr_head={pushed_head}" in caplog.text
+    assert f"local_head={local_head}" in caplog.text
 
 
 def test_git_helper_fails_fast_on_nonzero_exit(clone):

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -251,6 +251,12 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     for comment_id, body in zip(comment_ids, comments)
                 ])
             if command[1] == "pr":
+                if command[2] == "comment":
+                    # Issue #50: the failure comment is written to the
+                    # PR too (the same body as the Issue comment).
+                    comment_ids.append(len(comments) + 1)
+                    comments.append(command[-1])
+                    return ""
                 if command[2] == "view":
                     cwd = kwargs.get("cwd")
                     if cwd is None:
@@ -731,13 +737,17 @@ def test_e2e_public_comment_scene_is_never_resumed(
     assert not any("merge" in " ".join(e) for e in edits)
 
 
-def test_e2e_review_failure_keeps_pr_and_marks_blocked(
+def test_e2e_review_failure_keeps_pr_and_stays_fix_needed(
     clone, tmp_path, monkeypatch, caplog,
 ):
-    """Issue #82: a review session that cannot finish (the fix is not
-    verifiable) fails fast: the Issue is marked ``ai-blocked`` and the
+    """Issue #82 + #50: a review session that cannot finish (the Pi
+    fails, the fix is not verifiable) is a RECOVERABLE failure: the
+    Issue is marked ``ai-fix-needed`` (never ``ai-blocked``) and the
     PR, branch and worktree are preserved (never deleted, never
-    force-pushed, never re-claimed)."""
+    force-pushed, never re-claimed); the failure comment (Issue AND
+    PR) carries the run marker, the concrete error and the full
+    scene, and the next timer resumes the same run, branch, worktree
+    and PR."""
     comments: list[str] = []
     edits: list[list[str]] = []
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
@@ -751,33 +761,37 @@ def test_e2e_review_failure_keeps_pr_and_marks_blocked(
     branch = f"muyan-pilot/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
     worktree = worktree_for(clone, run_id)
 
-    # The review session cannot finish (e.g. the in-session fix is not
-    # verifiable): the delivery wait marks the Issue ai-blocked.
+    # The review session cannot finish (the Pi fails): the delivery
+    # wait keeps the Issue in the automatic fix loop (ai-fix-needed).
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_REVIEW_FAILING)
     runner.set_run_id(run_id)
     runner.wait_for_delivery(
         pr_url, issue(), config, REPO, poll_interval=0.01,
     )
 
-    # The Issue is marked ai-blocked (leaving the opened-PR state)...
+    # The Issue is marked ai-fix-needed (leaving the opened-PR state)
+    # — never ai-blocked (Issue #50) ...
     assert [
         "gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
-        "--add-label", "ai-blocked", "--remove-label", "ai-pr-opened",
+        "--add-label", "ai-fix-needed", "--remove-label", "ai-pr-opened",
     ] in edits
+    assert not any("ai-blocked" in edit for edit in edits)
     # ...the PR, branch and worktree are all preserved (never deleted,
     # never force-pushed).
     assert worktree.is_dir()
     assert git(worktree, "branch", "--show-current") == branch
-    # The failure report and the blocked milestone are the last two
-    # comments (the progress comment is PATCHed in place, never
-    # re-posted).
+    # The failure report is written to the Issue AND the PR (the last
+    # two issue comments: the failure, then the fix-needed milestone;
+    # the progress comment is PATCHed in place, never re-posted).
     failure = comments[-2]
-    assert "Muyan Pilot failed:" in failure
+    assert "Muyan Pilot needs a fix:" in failure
     assert "returned non-zero exit status 3" in failure
     assert f"<!-- muyan-pilot:run={run_id} -->" in failure
-    blocked = comments[-1]
-    assert "Muyan Pilot: blocked" in blocked
-    assert f"<!-- muyan-pilot:run={run_id} -->" in blocked
+    assert f"branch={branch}" in failure
+    assert f"worktree={worktree}" in failure
+    fix_needed = comments[-1]
+    assert "Muyan Pilot: fix needed" in fix_needed
+    assert f"<!-- muyan-pilot:run={run_id} -->" in fix_needed
 
 
 def test_e2e_pr_closed_while_fix_needed_removes_leftover_label(

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -962,23 +962,26 @@ def make_resume_failure_fake(monkeypatch, *, progress_comments=None,
     """Shared `run_command` fake of the resume verification failure
     tests (Issue #89).
 
-    Answers exactly the blocked-scene reporting: the progress API
+    Answers exactly the failure-scene reporting: the progress API
     (GET comment list / POST create / PATCH update), the Issue label
-    read (the leftover `ai-fix-needed` check) and the comment-history
-    read (the completed review rounds — no round comments exist yet).
-    Anything else is rejected. `progress_comments` is the GET payload
-    (an existing tracked progress comment makes the blocked scene
-    PATCH it in place; empty makes it POST a new one) and `labels`
-    the label read. Captures the gh api calls and the label edits /
-    failure comments; monkeypatches `edit_issue` / `comment_issue`
+    read (the leftover `ai-fix-needed` check), the comment-history
+    read (the completed review rounds — no round comments exist yet)
+    and the PR failure comment (Issue #50: the failure comment is
+    written to the Issue AND the PR). Anything else is rejected.
+    `progress_comments` is the GET payload (an existing tracked
+    progress comment makes the blocked/fix-needed scene PATCH it in
+    place; empty makes it POST a new one) and `labels` the label
+    read. Captures the gh api calls and the label edits / failure
+    comments; monkeypatches `edit_issue` / `comment_issue`
     accordingly. Returns `(captured, fake_run)` where `captured` is
-    `{"api": [...], "edits": [...], "comments": [...]}`.
+    `{"api": [...], "edits": [...], "comments": [...],
+    "pr_comments": [...]}`.
     """
     if progress_comments is None:
         progress_comments = []
     if labels is None:
         labels = ["ai-pr-opened"]
-    captured = {"api": [], "edits": [], "comments": []}
+    captured = {"api": [], "edits": [], "comments": [], "pr_comments": []}
 
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
@@ -990,6 +993,10 @@ def make_resume_failure_fake(monkeypatch, *, progress_comments=None,
                 body = command[command.index("--field") + 1]
                 return json.dumps({"id": 78, "body": body[len("body="):],
                                    "url": "https://x/78"})
+            return ""
+        if command[:3] == ["gh", "pr", "comment"]:
+            # Issue #50: the failure comment is written to the PR too.
+            captured["pr_comments"].append(command[command.index("--body") + 1])
             return ""
         if command[-1] == "labels":
             return json.dumps({
@@ -1071,15 +1078,17 @@ def test_resume_failure_fake_answers_blocked_scene_and_rejects_other(
     assert captured["comments"] == []
 
 
-def test_verify_resumed_pr_blocks_issue_when_pr_url_mismatch(
+def test_verify_resumed_pr_pr_url_mismatch_stays_fix_needed(
     monkeypatch, tmp_path, caplog,
 ):
-    """Issue #89 acceptance: the comment URL does not match the open PR
-    of the task branch -> fail fast, the Issue is marked `ai-blocked`
-    ALONE (the opened-PR state label is removed), a run-marked failure
-    comment names the reason, and the error is re-raised so the tick
-    stops — no review Pi is started, the wrong PR is never merged.
-    (The pre-#82 `pr_url_mismatch` resume test, restored.)"""
+    """Issue #89 + #50: the comment URL does not match the open PR of
+    the task branch -> fail fast, but the failure is RECOVERABLE: the
+    Issue is marked `ai-fix-needed` (never `ai-blocked`) with a
+    run-marked failure comment that names the reason, and the error is
+    re-raised so the tick stops — no review Pi is started, the wrong
+    PR is never merged; the next tick resumes the same run, branch,
+    worktree and PR. (The pre-#82 `pr_url_mismatch` resume test,
+    restored.)"""
     existing = {
         "id": 77,
         "body": (
@@ -1115,26 +1124,31 @@ def test_verify_resumed_pr_blocks_issue_when_pr_url_mismatch(
         )
     # No review Pi was started and nothing was merged.
     assert reviews == []
-    # The Issue is marked ai-blocked ALONE (ai-pr-opened removed) ...
+    # The Issue is marked ai-fix-needed (ai-pr-opened removed) — never
+    # ai-blocked (Issue #50: the next tick resumes the same PR) ...
     assert captured["edits"] == [
-        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
                 "remove": "ai-pr-opened"}),
     ]
     # ... with a run-marked failure comment that names the reason ...
     assert len(captured["comments"]) == 1
     body = captured["comments"][0][1]["body"]
-    assert "Muyan Pilot failed:" in body
+    assert "Muyan Pilot needs a fix:" in body
     assert run_marker_body() in body
     assert "not the recovered original PR" in body
-    # ... and the blocked milestone.
+    # ... written to the Issue AND the PR (Issue #50) ...
+    assert len(captured["pr_comments"]) == 1
+    assert captured["pr_comments"][0] == body
+    # ... and the fix-needed milestone.
     posted = [
         command[command.index("--field") + 1][len("body="):]
         for command in captured["api"]
         if "--method" in command and "POST" in command
     ]
-    assert any("Muyan Pilot: blocked" in body for body in posted)
+    assert any("Muyan Pilot: fix needed" in body for body in posted)
     assert any("not the recovered original PR" in body for body in posted)
-    # The tracked progress comment becomes the blocked scene in place.
+    # The tracked progress comment becomes the fix-needed scene in
+    # place.
     patches = [
         command for command in captured["api"]
         if command[:2] == ["gh", "api"]
@@ -1142,17 +1156,18 @@ def test_verify_resumed_pr_blocks_issue_when_pr_url_mismatch(
         and "PATCH" in command
     ]
     assert patches, "the tracked progress comment was not updated"
-    blocked = patches[-1][patches[-1].index("--field") + 1][len("body="):]
-    assert "Muyan Pilot blocked" in blocked
-    assert "next step:" in blocked
+    fix_needed = patches[-1][patches[-1].index("--field") + 1][len("body="):]
+    assert "Muyan Pilot fix needed" in fix_needed
+    assert "next step:" in fix_needed
     assert "resume_pr_verification_failed" in caplog.text
 
 
-def test_verify_resumed_pr_blocks_issue_when_pr_repo_mismatch(
+def test_verify_resumed_pr_pr_repo_mismatch_stays_fix_needed(
     monkeypatch, tmp_path, caplog,
 ):
-    """Issue #89 acceptance: the PR head repo is not the configured
-    source repo -> the same terminal fail-fast (the pre-#82
+    """Issue #89 + #50: the PR head repo is not the configured source
+    repo -> the same fail-fast, but RECOVERABLE: `ai-fix-needed` (the
+    next tick resumes the same PR), never `ai-blocked` (the pre-#82
     `pr_repo_mismatch` resume test, restored)."""
     captured, _ = make_resume_failure_fake(monkeypatch)
 
@@ -1172,23 +1187,25 @@ def test_verify_resumed_pr_blocks_issue_when_pr_repo_mismatch(
             make_resume_config(tmp_path), "owner/repo",
         )
     assert captured["edits"] == [
-        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
                 "remove": "ai-pr-opened"}),
     ]
     body = captured["comments"][0][1]["body"]
-    assert "Muyan Pilot failed:" in body
+    assert "Muyan Pilot needs a fix:" in body
     assert run_marker_body() in body
     assert "fork/repo" in body
+    assert len(captured["pr_comments"]) == 1
     assert "resume_pr_verification_failed" in caplog.text
 
 
-def test_verify_resumed_pr_removes_leftover_fix_needed_label(
+def test_verify_resumed_pr_recoverable_failure_keeps_fix_needed_label(
     monkeypatch, tmp_path,
 ):
-    """A resume that fails while the Issue awaits the next review
-    session (`ai-fix-needed`) leaves that label behind: the terminal
-    state is `ai-blocked` alone (Issue #82 routes both opened-PR
-    states into the same resume)."""
+    """Issue #50: a RECOVERABLE resume failure while the Issue awaits
+    the next review session (`ai-fix-needed`) keeps the `ai-fix-needed`
+    label (the opened-PR state label is removed, the fix-needed label
+    is the one the next tick scans for — Issue #82 routes both
+    opened-PR states into the same resume)."""
     captured, _ = make_resume_failure_fake(
         monkeypatch, labels=["ai-fix-needed"],
     )
@@ -1204,21 +1221,25 @@ def test_verify_resumed_pr_removes_leftover_fix_needed_label(
             make_resume_scene(), make_resume_issue(),
             make_resume_config(tmp_path), "owner/repo",
         )
-    # The opened-PR state transition AND the leftover-label removal.
+    # The single transition: ai-pr-opened removed, ai-fix-needed added
+    # (the label the Issue already carries is re-added idempotently —
+    # the next tick's scan needs it).
     assert captured["edits"] == [
-        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
                 "remove": "ai-pr-opened"}),
-        ((9,), {"repo": "owner/repo", "remove": "ai-fix-needed"}),
     ]
 
 
 def test_verify_resumed_pr_fails_fast_when_scene_base_differs(
     monkeypatch, tmp_path, caplog,
 ):
-    """Issue #91 (pre-verify): the scene freezes the base the PR was
-    opened against; when the configured base differs, the resume fails
-    fast BEFORE any git/gh command (no verify_pr, no fetch) and the
-    Issue is marked ai-blocked with both base values named."""
+    """Issue #91 + #50 (pre-verify): the scene freezes the base the PR
+    was opened against; when the configured base differs, the resume
+    fails fast BEFORE any git/gh command (no verify_pr, no fetch) and
+    the Issue is marked ai-blocked with both base values named — a
+    base-branch change is a human decision (an explicit
+    UnrecoverableDeliveryError), never ai-fix-needed (auto-retrying
+    would keep failing on the same mismatch)."""
     commands: list = []
     captured, fake_run = make_resume_failure_fake(monkeypatch)
 
@@ -1236,17 +1257,21 @@ def test_verify_resumed_pr_fails_fast_when_scene_base_differs(
     caplog.set_level("INFO")
     scene = make_resume_scene()
     scene["base_branch"] = "develop"
-    with pytest.raises(ValueError, match="differs from configured"):
+    with pytest.raises(
+        runner.UnrecoverableDeliveryError, match="differs from configured",
+    ):
         runner.verify_resumed_pr(
             scene, make_resume_issue(),
             make_resume_config(tmp_path), "owner/repo",
         )
     # No git command ran before the terminal transition (the only gh
     # traffic is the blocked-scene reporting: the progress API, the
-    # label read and the comment-history read of the review rounds).
+    # label read, the comment-history read of the review rounds and
+    # the PR failure comment of Issue #50).
     assert all(command[0] != "git" for command in commands)
     assert all(
         command[:2] == ["gh", "api"]
+        or command[:3] == ["gh", "pr", "comment"]
         or command[-1] in ("comments", "labels")
         for command in commands
     )
@@ -1259,6 +1284,9 @@ def test_verify_resumed_pr_fails_fast_when_scene_base_differs(
     assert run_marker_body() in body
     assert "base_branch=develop" in body
     assert "base_branch=main" in body
+    # Issue #50: the blocked comment states why automatic recovery is
+    # impossible.
+    assert "cannot be recovered automatically" in body
     assert "resume_pr_verification_failed" in caplog.text
     # The fake proves the contract when called directly: verify_pr
     # must never run on a base mismatch.
@@ -1268,14 +1296,16 @@ def test_verify_resumed_pr_fails_fast_when_scene_base_differs(
         fake_verify_pr()
 
 
-def test_verify_resumed_pr_fails_fast_when_worktree_missing(
+def test_verify_resumed_pr_worktree_missing_stays_fix_needed(
     monkeypatch, tmp_path, caplog,
 ):
-    """Issue #90 (pre-verify): the worktree is derived from the
+    """Issue #90 + #50 (pre-verify): the worktree is derived from the
     configured repo_dir, source repo, Issue number and run id (never
-    read from a comment); a missing directory means the scene cannot
-    be resumed: fail fast BEFORE any git/gh command and mark the Issue
-    ai-blocked with the PR and branch preserved."""
+    read from a comment); a missing directory is a RECOVERABLE failure
+    (the branch still exists on the remote and the worktree can be
+    recreated on the next resume): fail fast BEFORE any git/gh command
+    and mark the Issue ai-fix-needed (never ai-blocked) with the PR
+    and branch preserved."""
     commands: list = []
     captured, fake_run = make_resume_failure_fake(monkeypatch)
 
@@ -1298,25 +1328,36 @@ def test_verify_resumed_pr_fails_fast_when_worktree_missing(
             make_resume_config(tmp_path), "owner/repo",
         )
     # No git command ran against the missing worktree (the only gh
-    # traffic is the blocked-scene reporting).
+    # traffic is the fix-needed-scene reporting).
     assert all(command[0] != "git" for command in commands)
     assert all(
         command[:2] == ["gh", "api"]
+        or command[:3] == ["gh", "pr", "comment"]
         or command[-1] in ("comments", "labels")
         for command in commands
     )
     assert captured["edits"] == [
-        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
                 "remove": "ai-pr-opened"}),
     ]
     body = captured["comments"][0][1]["body"]
-    assert "Muyan Pilot failed:" in body
+    assert "Muyan Pilot needs a fix:" in body
     assert run_marker_body() in body
     assert str(expected_resume_worktree(tmp_path)) in body
     # The PR and branch are preserved in the failure comment (the
-    # pre-#82 resume_delivery fail-fast scene).
+    # pre-#82 resume_delivery fail-fast scene) ... the failure comment
+    # is written to the Issue AND the PR (Issue #50) ...
     assert FAKE_PR_URL in body
     assert FAKE_BRANCH in body
+    assert len(captured["pr_comments"]) == 1
+    # ... and the fix-needed milestone (not the blocked one).
+    posted = [
+        command[command.index("--field") + 1][len("body="):]
+        for command in captured["api"]
+        if "--method" in command and "POST" in command
+    ]
+    assert any("Muyan Pilot: fix needed" in body for body in posted)
+    assert not any("Muyan Pilot: blocked" in body for body in posted)
     assert "resume_pr_verification_failed" in caplog.text
     # The fake proves the contract when called directly: verify_pr
     # must never run on a missing worktree.
@@ -1355,13 +1396,13 @@ def test_verify_resumed_pr_reraises_when_failure_reporting_fails(
     assert "failure reporting failed" in caplog.text
 
 
-def test_verify_resumed_pr_without_bound_run_id_still_blocks(
+def test_verify_resumed_pr_without_bound_run_id_still_fix_needed(
     monkeypatch, tmp_path, caplog,
 ):
-    """A resume verification failure with no bound run id (the caller
-    must bind the scene's run id first; this is the defensive branch)
-    still marks the Issue ai-blocked: the failure comment and the
-    blocked scene simply carry no run marker, and the milestone /
+    """Issue #50: a RECOVERABLE resume verification failure with no
+    bound run id (the caller must bind the scene's run id first; this
+    is the defensive branch) still marks the Issue ai-fix-needed: the
+    failure comment simply carries no run marker, and the milestone /
     progress scene are skipped (no run id to bind them to)."""
     captured, _ = make_resume_failure_fake(monkeypatch)
 
@@ -1379,16 +1420,17 @@ def test_verify_resumed_pr_without_bound_run_id_still_blocks(
             make_resume_config(tmp_path), "owner/repo",
         )
     assert captured["edits"] == [
-        ((9,), {"repo": "owner/repo", "add": "ai-blocked",
+        ((9,), {"repo": "owner/repo", "add": "ai-fix-needed",
                 "remove": "ai-pr-opened"}),
     ]
     body = captured["comments"][0][1]["body"]
-    assert "Muyan Pilot failed:" in body
-    # No run id: no marker, no milestone, no blocked progress scene —
-    # the only gh traffic is the label read of the leftover-label
-    # check (no progress API at all).
+    assert "Muyan Pilot needs a fix:" in body
+    # No run id: no marker, no milestone, no fix-needed progress scene
+    # — the only gh traffic is the label read of the leftover-label
+    # check and the PR failure comment (no progress API at all).
     assert run_marker_body() not in body
     assert captured["api"] == []
+    assert len(captured["pr_comments"]) == 1
     assert "resume_pr_verification_failed" in caplog.text
 
 


### PR DESCRIPTION
Fixes #50

<!-- muyan-pilot:run=26aa544a -->

run_id=26aa544a

## What

AI-recoverable failures of an existing run/PR now stay in the automatic
fix loop (`ai-fix-needed`) instead of terminating as `ai-blocked`; the
next timer resumes the SAME run_id, branch, worktree and PR. `ai-blocked`
is reserved for external preconditions the AI cannot safely judge or
fix, and every blocked comment states WHY automatic recovery is
impossible.

## Changes

- `UnrecoverableDeliveryError` + `is_unrecoverable_failure`: only an
  explicit external precondition (unrecoverable scene, base-branch
  config change, exhausted review rounds, PR closed without merge) is
  terminal — `ai-blocked` ALONE with the explicit reason. Every other
  failure of the existing run/PR (Pi execution failure, verification
  failure, unpushed local commit, missing worktree, missing/malformed
  verdict) is recoverable → `ai-fix-needed`.
- `wait_for_delivery` / `verify_resumed_pr` failure handlers: recoverable
  failure → `ai-fix-needed` (the opened-PR state label is removed) with
  the failure comment on the Issue AND the PR carrying the full scene
  (run_id, PR, branch, worktree, session, phase, last activity, concrete
  error); the tracked progress comment is finished with the fix-needed
  scene (`_finish_fix_needed_progress`). No replacement PR, no re-claim.
- `verify_pr` (the #158 `d13b0c56` scene): a local HEAD AHEAD of the
  remote PR head (a commit made by a killed session that was never
  pushed) is logged (`local_head_ahead_of_pr_head` with the exact local
  head, remote PR head and branch) and passed through — the unpushed
  commit is preserved and the next review session pushes the task branch
  on the same PR before its verdict; a diverged head still fails (a
  plain push would be rejected, a force push is forbidden).
- `review_and_merge_if_clean`: exhausted rounds raise
  `UnrecoverableDeliveryError` (the bounded loop is a human decision).
- `block_scene_failure`: the blocked comment states the explicit reason
  (no trusted `Muyan Pilot opened PR:` scene → the runner cannot derive
  run_id/branch/worktree/PR and cannot start a review session).
- `prompt_review.md`: the reviewer pushes an unpushed local commit
  (local HEAD ahead of the frozen PR head) on the same task branch
  before emitting the verdict — never discard it, never create a
  replacement PR.
- Docs: README label table + state machine, `docs/workflow.mdx` (+zh),
  `docs/operations.mdx` (+zh), `AGENTS.md` — `ai-blocked` is only for
  external preconditions the AI cannot safely judge or fix.

## Verification

- `timeout 900 /usr/bin/python3 -m pytest tests/ -q` → 1175 passed
  (on the merged head; the base advanced to 7ea3049 while working and
  was merged in before this PR).
- `timeout 900 /usr/bin/python3 -m coverage run --branch -m pytest
  tests/ -q` + `coverage report` → 100% line and branch coverage.
- New: `tests/test_fix_needed_loop.py` (classification, wait/verify
  failure paths, #158 pass-through unit + real-git smoke, prompt
  contract); updated `tests/test_resume_pr.py`,
  `tests/test_resume_e2e.py`, `tests/test_bootstrap_runner.py`,
  `tests/test_git_base_smoke.py`.
- The four "current scene" pairs from the Issue body (#34/PR#38,
  #39/PR#46, #40/PR#44, #18/PR#42) are already MERGED/CLOSED on the
  remote — the live restore is done by history; #11/#15 stay
  `ai-blocked` (no recoverable PR scene), untouched.