### PR TITLE
可观测性：Muyan Pilot Prometheus exporter 与 Grafana Dashboard (Issue #162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,19 @@ journalctl --user -u 'muyan-pilot@*.service' -f
 elapsed、last activity、last action、session、branch。implementer、reviewer
 两种 Pi session 用同一个机制观测，role 由 Runner 在启动 session 时传入。
 
+### Prometheus / Grafana（可选，只读，独立）
+
+`monitoring/` 下是一套只读、独立、版本管理的观测栈（Issue #162）：
+`monitoring/prometheus/muyan-pilot-exporter.py` 只读 journal 和
+`systemctl --user is-active`，在 `127.0.0.1:9106/metrics` 暴露
+`muyan_pilot_*` 指标（service active、每 slot 当前
+issue/role/phase/state、idle 秒数、run 时长、`run_failed` by reason、
+idle 恢复、`progress_publish_failed`、model_wait）；
+`monitoring/grafana/dashboards/muyan-pilot.json` 是配套 Dashboard（复用
+已有 llama 指标）。Runner 完全不知道它存在：不 push、不写状态，观测栈
+任意一环挂掉不影响领取/运行/merge；标签只用低基数集合（无 `run_id`、
+无命令/prompt 文本）。安装与验证步骤见 `monitoring/grafana/README.md`。
+
 ### GitHub（手机，自动更新）
 
 领取任务后，Runner 在 source Issue 上创建一条带隐藏 run marker

--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -18,9 +18,14 @@
   Prometheus / Grafana 任意一环挂掉都不影响 Issue 领取、Pi 运行、review、
   merge 或 fail fast。
 - 没有数据库、队列、新状态存储；journal 是唯一数据源。
-- 标签低基数：只用 `instance` / `repo` / `issue` / `role` / `phase` /
+- 标签低基数：只用 `slot` / `repo` / `issue` / `role` / `phase` /
   `state` / `reason` / `result`；**永不**输出 `run_id`、branch、worktree、
-  命令或 prompt 文本。
+  命令或 prompt 文本。每个 Runner 的维度用 `slot` 而不是 `instance`：
+  `instance` 是 Prometheus 抓取器自己的标签，exporter 若输出 `instance`
+  会被改名为 `exported_instance`，Dashboard 里所有 `sum by (instance)`
+  和 `{{instance}}` 图例会按抓取目标 `127.0.0.1:9106` 而不是 Runner
+  slot 分组（已对运行中的 Prometheus 验证：llama slot exporter 的
+  `slot` 标签原样保留）。
 - exporter 只读 journal 行契约（`LEVEL [run_id] <kind> key=value ...`，
   见 README「journal（本地，systemd）」）；未知 kind（`command=`、
   `stdout=` 等）跳过。journalctl 失败时 fail fast（带命令、rc、stderr），

--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -1,0 +1,106 @@
+# Muyan Pilot 可观测栈（Issue #162）
+
+只读、独立、版本管理的观测层：
+
+- `prometheus/muyan-pilot-exporter.py` — 只读读取 `muyan-pilot@*` 两个
+  Runner service 的 user systemd journal（`journalctl --user -u
+  'muyan-pilot@*' -o json`）和 `systemctl --user is-active`，在
+  `127.0.0.1:9106/metrics` 暴露 Prometheus 指标。
+- `grafana/dashboards/muyan-pilot.json` — Grafana Dashboard（uid
+  `muyan-pilot`），展示两个 service、每个 slot 当前
+  issue/role/phase/state、idle 秒数、`run_failed` by reason、idle 恢复
+  步骤、`progress_publish_failed`、run 时长，并复用已有的 llama
+  slot/context/TPS/token 指标（不重新实现）。
+
+边界（与 Runner 完全解耦）：
+
+- Runner 不知道 exporter 存在：不 push、不回调、不写任何状态。exporter /
+  Prometheus / Grafana 任意一环挂掉都不影响 Issue 领取、Pi 运行、review、
+  merge 或 fail fast。
+- 没有数据库、队列、新状态存储；journal 是唯一数据源。
+- 标签低基数：只用 `instance` / `repo` / `issue` / `role` / `phase` /
+  `state` / `reason` / `result`；**永不**输出 `run_id`、branch、worktree、
+  命令或 prompt 文本。
+- exporter 只读 journal 行契约（`LEVEL [run_id] <kind> key=value ...`，
+  见 README「journal（本地，systemd）」）；未知 kind（`command=`、
+  `stdout=` 等）跳过。journalctl 失败时 fail fast（带命令、rc、stderr），
+  不吞错、不 fallback；HTTP 侧以 500 返回错误，scrape 失败在 Prometheus
+  可见。
+
+## 1. 运行 exporter
+
+前台（开发/验证）：
+
+```bash
+/usr/bin/python3 monitoring/prometheus/muyan-pilot-exporter.py \
+  --port 9106 --bind 127.0.0.1 --units 'muyan-pilot@*' --instances 1,2
+```
+
+验证：
+
+```bash
+curl -s 127.0.0.1:9106/health        # -> ok
+curl -s 127.0.0.1:9106/metrics | head
+```
+
+常驻（可选，user systemd unit；仓库不管理该 unit，`install-units` 的
+drift 机制只管 `muyan-pilot@.service` / `muyan-pilot@.timer` 两个模板）：
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/muyan-pilot-exporter.service <<'EOF'
+[Unit]
+Description=Muyan Pilot Prometheus exporter (Issue #162, read-only journal bridge)
+
+[Service]
+ExecStart=/usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot/monitoring/prometheus/muyan-pilot-exporter.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now muyan-pilot-exporter.service
+```
+
+参数：`--port`（默认 9106）、`--bind`（默认 127.0.0.1）、`--units`
+（journalctl `-u` 模式，默认 `muyan-pilot@*`）、`--instances`（逗号分隔的
+service 实例，默认 `1,2`）、`--cache-ttl`（journal 重读间隔秒数，默认 5）。
+
+## 2. Prometheus 抓取
+
+在 `/etc/prometheus/prometheus.yml` 的 `scrape_configs` 追加（与现有
+`llama-slot-exporter` 等同款写法）：
+
+```yaml
+- job_name: muyan-pilot
+  static_configs:
+  - targets:
+    - 127.0.0.1:9106
+  metrics_path: /metrics
+```
+
+然后 `sudo systemctl reload prometheus`。验证：
+`http://127.0.0.1:9090/targets` 中 `muyan-pilot` 为 UP。
+
+## 3. Grafana Dashboard
+
+Grafana（本机 `127.0.0.1:3000`）→ Dashboards → Import → 上传
+`grafana/dashboards/muyan-pilot.json`（或
+`/api/dashboards/import`），datasource 选 Prometheus（uid
+`eflztqehr89a8c`）。Dashboard uid 固定为 `muyan-pilot`，重复导入即覆盖
+同一 dashboard。
+
+## 4. 测试
+
+```bash
+/usr/bin/python3 -m pytest tests/test_muyan_pilot_exporter.py \
+  tests/test_muyan_pilot_dashboard.py -q
+```
+
+- exporter 测试钉住 journal 行契约、标签白名单（无 `run_id`/命令文本）、
+  fail fast 行为和 HTTP 面（`/metrics`、`/health`、404、journal 错误 500）。
+- dashboard 测试钉住 JSON 可重复导入、uid、schemaVersion、所有
+  `muyan_pilot_*` 指标族与复用的 llama 指标都出现在查询里、表达式不使用
+  白名单外标签、grid 位置不重叠。

--- a/monitoring/grafana/dashboards/muyan-pilot.json
+++ b/monitoring/grafana/dashboards/muyan-pilot.json
@@ -54,7 +54,7 @@
         {
           "refId": "A",
           "expr": "muyan_pilot_service_active",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{slot}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -72,14 +72,14 @@
     {
       "id": 201,
       "type": "timeseries",
-      "title": "Active runs (legend = instance issue role phase state)",
+      "title": "Active runs (legend = slot issue role phase state)",
       "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
       "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 },
       "targets": [
         {
           "refId": "A",
           "expr": "muyan_pilot_run_active",
-          "legendFormat": "{{instance}} {{issue}} {{role}} {{phase}} {{state}}",
+          "legendFormat": "{{slot}} {{issue}} {{role}} {{phase}} {{state}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -102,7 +102,7 @@
         {
           "refId": "A",
           "expr": "muyan_pilot_run_idle_seconds",
-          "legendFormat": "{{instance}} {{issue}}",
+          "legendFormat": "{{slot}} {{issue}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -129,8 +129,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (instance, issue, reason) (increase(muyan_pilot_run_failed_total[1h]))",
-          "legendFormat": "{{instance}} {{issue}} {{reason}}",
+          "expr": "sum by (slot, issue, reason) (increase(muyan_pilot_run_failed_total[1h]))",
+          "legendFormat": "{{slot}} {{issue}} {{reason}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -146,20 +146,20 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_total[1h]))",
-          "legendFormat": "pi_idle {{instance}}",
+          "expr": "sum by (slot) (increase(muyan_pilot_pi_idle_total[1h]))",
+          "legendFormat": "pi_idle {{slot}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         },
         {
           "refId": "B",
-          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_term_total[1h]))",
-          "legendFormat": "pi_idle_term {{instance}}",
+          "expr": "sum by (slot) (increase(muyan_pilot_pi_idle_term_total[1h]))",
+          "legendFormat": "pi_idle_term {{slot}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         },
         {
           "refId": "C",
-          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_kill_total[1h]))",
-          "legendFormat": "pi_idle_kill {{instance}}",
+          "expr": "sum by (slot) (increase(muyan_pilot_pi_idle_kill_total[1h]))",
+          "legendFormat": "pi_idle_kill {{slot}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -175,8 +175,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (instance, issue) (increase(muyan_pilot_progress_publish_failed_total[1h]))",
-          "legendFormat": "{{instance}} {{issue}}",
+          "expr": "sum by (slot, issue) (increase(muyan_pilot_progress_publish_failed_total[1h]))",
+          "legendFormat": "{{slot}} {{issue}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -192,8 +192,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (instance, issue) (increase(muyan_pilot_model_wait_total[1h]))",
-          "legendFormat": "{{instance}} {{issue}}",
+          "expr": "sum by (slot, issue) (increase(muyan_pilot_model_wait_total[1h]))",
+          "legendFormat": "{{slot}} {{issue}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],
@@ -241,7 +241,7 @@
         {
           "refId": "A",
           "expr": "muyan_pilot_run_seconds",
-          "legendFormat": "{{instance}} {{issue}} {{role}}",
+          "legendFormat": "{{slot}} {{issue}} {{role}}",
           "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
         }
       ],

--- a/monitoring/grafana/dashboards/muyan-pilot.json
+++ b/monitoring/grafana/dashboards/muyan-pilot.json
@@ -1,0 +1,364 @@
+{
+  "uid": "muyan-pilot",
+  "title": "Muyan Pilot — Runner observability",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "timezone": "browser",
+  "editable": true,
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Runner services (systemd user units)",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 101,
+      "type": "stat",
+      "title": "muyan-pilot@N.service active (1 = active)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "muyan_pilot_service_active",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "inactive", "color": "red" } } },
+            { "type": "value", "options": { "1": { "text": "active", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ] }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "area" }
+    },
+    {
+      "id": 102,
+      "type": "timeseries",
+      "title": "Service active over time",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 4 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "muyan_pilot_service_active",
+          "legendFormat": "{{instance}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Current run per slot (issue / role / phase / state)",
+      "gridPos": { "x": 0, "y": 5, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 201,
+      "type": "timeseries",
+      "title": "Active runs (legend = instance issue role phase state)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "muyan_pilot_run_active",
+          "legendFormat": "{{instance}} {{issue}} {{role}} {{phase}} {{state}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "steps", "fillOpacity": 30 }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["last"] } }
+    },
+    {
+      "id": 202,
+      "type": "timeseries",
+      "title": "Run idle seconds (model/tool silence)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "muyan_pilot_run_idle_seconds",
+          "legendFormat": "{{instance}} {{issue}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s", "max": null },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "Failures and idle recovery",
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 301,
+      "type": "timeseries",
+      "title": "run_failed by reason",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 13, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (instance, issue, reason) (increase(muyan_pilot_run_failed_total[1h]))",
+          "legendFormat": "{{instance}} {{issue}} {{reason}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] } }
+    },
+    {
+      "id": 302,
+      "type": "timeseries",
+      "title": "Idle recovery steps (pi_idle / term / kill)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 13, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_total[1h]))",
+          "legendFormat": "pi_idle {{instance}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_term_total[1h]))",
+          "legendFormat": "pi_idle_term {{instance}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "C",
+          "expr": "sum by (instance) (increase(muyan_pilot_pi_idle_kill_total[1h]))",
+          "legendFormat": "pi_idle_kill {{instance}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 303,
+      "type": "timeseries",
+      "title": "progress_publish_failed (bypass errors only)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 19, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (instance, issue) (increase(muyan_pilot_progress_publish_failed_total[1h]))",
+          "legendFormat": "{{instance}} {{issue}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 304,
+      "type": "timeseries",
+      "title": "model_wait events",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 19, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (instance, issue) (increase(muyan_pilot_model_wait_total[1h]))",
+          "legendFormat": "{{instance}} {{issue}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "Run throughput and durations",
+      "gridPos": { "x": 0, "y": 25, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 401,
+      "type": "timeseries",
+      "title": "Run starts / ends per hour",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 26, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (issue) (increase(muyan_pilot_run_start_total[1h]))",
+          "legendFormat": "start {{issue}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (issue) (increase(muyan_pilot_run_end_total[1h]))",
+          "legendFormat": "end {{issue}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 402,
+      "type": "timeseries",
+      "title": "Run duration (last reported elapsed, seconds)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 26, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "muyan_pilot_run_seconds",
+          "legendFormat": "{{instance}} {{issue}} {{role}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 500,
+      "type": "row",
+      "title": "Model (existing llama exporter — reused, not re-implemented)",
+      "gridPos": { "x": 0, "y": 32, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 501,
+      "type": "timeseries",
+      "title": "Llama slots processing",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 33, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (slot) (llama_slot_is_processing)",
+          "legendFormat": "slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "llama_slots_processing",
+          "legendFormat": "processing",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "C",
+          "expr": "llama_slots_total",
+          "legendFormat": "total",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 502,
+      "type": "timeseries",
+      "title": "Context: used vs max (n_ctx / n_tokens_max)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 33, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (slot) (llama_slot_n_ctx)",
+          "legendFormat": "used slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (slot) (llamacpp:n_tokens_max)",
+          "legendFormat": "max slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 503,
+      "type": "timeseries",
+      "title": "Tokens: prompt / predicted / cached per minute",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 0, "y": 39, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (slot) (increase(llamacpp:prompt_tokens_total[1m]))",
+          "legendFormat": "prompt slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (slot) (increase(llamacpp:tokens_predicted_total[1m]))",
+          "legendFormat": "predicted slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "C",
+          "expr": "sum by (slot) (increase(llamacpp:prompt_tokens_cached_total[1m]))",
+          "legendFormat": "cached slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 504,
+      "type": "timeseries",
+      "title": "TPS: prompt / predicted (tokens per second)",
+      "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" },
+      "gridPos": { "x": 12, "y": 39, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (slot) (rate(llamacpp:prompt_tokens_total[1m]))",
+          "legendFormat": "prompt tps slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (slot) (rate(llamacpp:tokens_predicted_total[1m]))",
+          "legendFormat": "predicted tps slot {{slot}}",
+          "datasource": { "type": "prometheus", "uid": "eflztqehr89a8c" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    }
+  ]
+}

--- a/monitoring/prometheus/muyan-pilot-exporter.py
+++ b/monitoring/prometheus/muyan-pilot-exporter.py
@@ -25,9 +25,17 @@ with kinds `run_start`, `activity`, `heartbeat`, `model_wait`, `pi_idle`,
 `progress_publish_failed`. Other line kinds (`command=`, `stdout=`, ...)
 are skipped.
 
-Metric labels stay low-cardinality by contract: only `instance`, `repo`,
+Metric labels stay low-cardinality by contract: only `slot`, `repo`,
 `issue`, `role`, `phase`, `state`, `reason` and `result` are ever used —
-never `run_id`, never branch/worktree/command/prompt text.
+never `run_id`, never branch/worktree/command/prompt text. The per-Runner
+dimension is labeled `slot` (the Issue's own term for a Runner slot, the
+same convention as the machine's llama slot exporter), NOT `instance`:
+`instance` is a Prometheus scraper label, so a scraped `instance` label
+is renamed to `exported_instance` and every `sum by (instance)` /
+legend `{{instance}}` in the Dashboard would silently group by the scrape
+target `127.0.0.1:9106` instead of the Runner slot (verified against the
+running Prometheus, which stores the llama exporter's `slot` label
+unchanged).
 
 Stdlib only; no third-party runtime dependency. Fail fast: a journalctl
 failure is raised with the command, return code and stderr (no fallback,
@@ -223,10 +231,12 @@ def build_metrics(entries: list[dict], now: float,
     """Aggregate journal entries into the Prometheus text exposition.
 
     `entries` are chronological (the journal order); `service_active`
-    maps instance -> 1/0 for the configured service instances.
+    maps instance -> 1/0 for the configured service instances. The
+    emitted per-Runner label is `slot` (see the module docstring: the
+    `instance` label would be renamed by the Prometheus scraper).
     """
     live: dict[str, dict] = {}      # instance -> live run state
-    seen_combos: set[tuple] = set()  # (instance, repo, issue, role, phase, state)
+    seen_combos: set[tuple] = set()  # (slot, repo, issue, role, phase, state)
     idle_gauges: dict[tuple, float] = {}
     seconds_gauges: dict[tuple, float] = {}
     counters: dict[tuple, float] = {}
@@ -258,7 +268,7 @@ def build_metrics(entries: list[dict], now: float,
                 "role": role,
             }
             bump(("muyan_pilot_run_start_total",
-                  ("instance", instance), ("issue", issue),
+                  ("slot", instance), ("issue", issue),
                   ("role", role)))
         elif kind in ("activity", "heartbeat"):
             run = live.get(instance)
@@ -278,26 +288,26 @@ def build_metrics(entries: list[dict], now: float,
                 seconds_gauges[(instance, issue, role)] = elapsed
         elif kind == "model_wait":
             bump(("muyan_pilot_model_wait_total",
-                  ("instance", instance), ("issue", issue)))
+                  ("slot", instance), ("issue", issue)))
         elif kind == "pi_idle":
             bump(("muyan_pilot_pi_idle_total",
-                  ("instance", instance), ("issue", issue)))
+                  ("slot", instance), ("issue", issue)))
         elif kind == "pi_idle_term":
             bump(("muyan_pilot_pi_idle_term_total",
-                  ("instance", instance), ("issue", issue)))
+                  ("slot", instance), ("issue", issue)))
         elif kind == "pi_idle_kill":
             bump(("muyan_pilot_pi_idle_kill_total",
-                  ("instance", instance), ("issue", issue)))
+                  ("slot", instance), ("issue", issue)))
         elif kind == "run_failed":
             reason = _label_value(scene.get("reason"))
             bump(("muyan_pilot_run_failed_total",
-                  ("instance", instance), ("issue", issue),
+                  ("slot", instance), ("issue", issue),
                   ("reason", reason)))
             live.pop(instance, None)
         elif kind == "run_end":
             result = _label_value(scene.get("result"))
             bump(("muyan_pilot_run_end_total",
-                  ("instance", instance), ("issue", issue),
+                  ("slot", instance), ("issue", issue),
                   ("role", role), ("result", result)))
             elapsed = parse_duration(scene.get("elapsed"))
             if elapsed is not None:
@@ -305,7 +315,7 @@ def build_metrics(entries: list[dict], now: float,
             live.pop(instance, None)
         elif kind == "progress_publish_failed":
             bump(("muyan_pilot_progress_publish_failed_total",
-                  ("instance", instance), ("issue", issue)))
+                  ("slot", instance), ("issue", issue)))
         else:
             # Unreachable: parse_message only returns KNOWN_KINDS and the
             # chain above covers every one of them. Fail fast if a kind
@@ -325,7 +335,7 @@ def build_metrics(entries: list[dict], now: float,
 
     for instance in sorted(service_active):
         gauge("muyan_pilot_service_active", float(service_active[instance]),
-              [("instance", instance)])
+              [("slot", instance)])
 
     for combo in sorted(seen_combos):
         instance, repo, issue, role, phase, state = combo
@@ -335,7 +345,7 @@ def build_metrics(entries: list[dict], now: float,
         )
         gauge(
             "muyan_pilot_run_active", 1.0 if is_live else 0.0,
-            [("instance", instance), ("repo", repo), ("issue", issue),
+            [("slot", instance), ("repo", repo), ("issue", issue),
              ("role", role), ("phase", phase), ("state", state)],
         )
 
@@ -344,12 +354,12 @@ def build_metrics(entries: list[dict], now: float,
         if run is None or run["issue"] != issue:
             continue  # the idle gauge is a live-state gauge
         gauge("muyan_pilot_run_idle_seconds", idle_gauges[(instance, issue)],
-              [("instance", instance), ("issue", issue)])
+              [("slot", instance), ("issue", issue)])
 
     for (instance, issue, role) in sorted(seconds_gauges):
         gauge("muyan_pilot_run_seconds",
               seconds_gauges[(instance, issue, role)],
-              [("instance", instance), ("issue", issue), ("role", role)])
+              [("slot", instance), ("issue", issue), ("role", role)])
 
     for name in (
         "muyan_pilot_run_start_total",

--- a/monitoring/prometheus/muyan-pilot-exporter.py
+++ b/monitoring/prometheus/muyan-pilot-exporter.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Muyan Pilot Prometheus exporter (Issue #162).
+
+Read-only bridge from the structured user systemd journal of the
+`muyan-pilot@*` Runner services to Prometheus:
+
+    systemd journal (user units)
+          |  journalctl --user -u 'muyan-pilot@*' -o json
+          v
+    this exporter  --GET /metrics-->  Prometheus  -->  Grafana
+
+The exporter is INDEPENDENT of the Runner: it only reads the journal and
+`systemctl --user is-active`; the Runner does not know it exists, so a
+failure of the exporter, Prometheus or Grafana can never affect Issue
+claiming, Pi execution, review, merge or fail-fast. It adds no database,
+queue or state store — the journal is the only source.
+
+Journal line contract (verified against the live journal; the same
+`key=value` scenes `pi_activity.parse_scene` parses):
+
+    LEVEL [run_id] <kind> key=value ...
+
+with kinds `run_start`, `activity`, `heartbeat`, `model_wait`, `pi_idle`,
+`pi_idle_term`, `pi_idle_kill`, `run_failed`, `run_end` and
+`progress_publish_failed`. Other line kinds (`command=`, `stdout=`, ...)
+are skipped.
+
+Metric labels stay low-cardinality by contract: only `instance`, `repo`,
+`issue`, `role`, `phase`, `state`, `reason` and `result` are ever used —
+never `run_id`, never branch/worktree/command/prompt text.
+
+Stdlib only; no third-party runtime dependency. Fail fast: a journalctl
+failure is raised with the command, return code and stderr (no fallback,
+no swallowed error); the HTTP handler answers 500 with the error so the
+scrape failure is visible in Prometheus.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+# `LEVEL [run_id] kind scene...` — the run id is 8 lowercase hex chars
+# (bootstrap_runner.new_run_id), the kind is a bare word.
+LINE_RE = re.compile(
+    r"^(INFO|WARNING|ERROR) \[([0-9a-f]{8})\] ([A-Za-z_]+)(?: (.*))?$"
+)
+
+# Journal kinds the exporter understands (Issue #162). Anything else on
+# the line (command=, stdout=, stderr=, ...) is not an event.
+KNOWN_KINDS = frozenset({
+    "run_start", "activity", "heartbeat", "model_wait", "pi_idle",
+    "pi_idle_term", "pi_idle_kill", "run_failed", "run_end",
+    "progress_publish_failed",
+})
+
+# `1h43m`, `42m`, `0.4s` — the format_duration contract of pi_activity
+# (hours always come with minutes; seconds only below one minute and may
+# be fractional). `1h` alone is NOT a journal duration.
+DURATION_RE = re.compile(
+    r"^(?:(\d+)h(\d+)m|(\d+)m|(\d+(?:\.\d+)?)s)$"
+)
+
+DEFAULT_PORT = 9106
+DEFAULT_BIND = "127.0.0.1"
+DEFAULT_UNITS = "muyan-pilot@*"
+DEFAULT_INSTANCES = ("1", "2")
+DEFAULT_CACHE_TTL = 5.0
+
+
+class JournalError(RuntimeError):
+    """A journal read failed; the message carries the full scene."""
+
+
+def parse_scene(text: str) -> dict[str, str | None]:
+    """Parse a `key=value` scene into a dict (standalone copy of the
+    `pi_activity.parse_scene` contract: values may be double-quoted when
+    they contain spaces, embedded quotes are `\\"`, `key=` without a
+    value parses to None, bare words are skipped)."""
+    fields: dict[str, str | None] = {}
+    index = 0
+    length = len(text)
+    while index < length:
+        while index < length and text[index] == " ":
+            index += 1
+        if index >= length:
+            break
+        key_start = index
+        while index < length and text[index] != "=" and text[index] != " ":
+            index += 1
+        key = text[key_start:index]
+        if not key or index >= length or text[index] != "=":
+            continue  # bare word: skip it
+        index += 1  # skip '='
+        if index < length and text[index] == '"':
+            index += 1
+            start = index
+            while index < length:
+                if (text[index] == "\\"
+                        and index + 1 < length
+                        and text[index + 1] == '"'):
+                    index += 2  # escaped quote: part of the value
+                    continue
+                if text[index] == '"':
+                    break
+                index += 1
+            raw = text[start:index]
+            if index < length:  # closing quote found
+                index += 1
+            else:  # unterminated quote: keep the rest of the line
+                index = length
+            fields[key] = raw.replace('\\"', '"')
+        else:
+            start = index
+            while index < length and text[index] != " ":
+                index += 1
+            fields[key] = text[start:index] or None
+    return fields
+
+
+def parse_message(message: str) -> dict | None:
+    """Split one journal MESSAGE into run id, kind and scene.
+
+    Returns None for lines that are not one of the known event kinds
+    (the journal also carries `command=`, `stdout=`, ... lines).
+    """
+    match = LINE_RE.match(message)
+    if match is None:
+        return None
+    _level, run_id, kind, scene_text = match.groups()
+    if kind not in KNOWN_KINDS:
+        return None
+    return {
+        "run_id": run_id,
+        "kind": kind,
+        "scene": parse_scene(scene_text or ""),
+    }
+
+
+def parse_duration(value: str | None) -> float | None:
+    """Parse a journal duration (`1h43m`, `42m`, `0.4s`) into seconds."""
+    if not isinstance(value, str) or not value:
+        return None
+    match = DURATION_RE.match(value)
+    if match is None:
+        return None
+    hours, minutes, bare_minutes, seconds = match.groups()
+    if hours is not None:
+        return float(int(hours) * 3600 + int(minutes) * 60)
+    if bare_minutes is not None:
+        return float(int(bare_minutes) * 60)
+    return float(seconds)
+
+
+def issue_repo(issue: str | None) -> str:
+    """`owner/repo#number` -> `owner/repo` (the low-cardinality repo)."""
+    if not issue:
+        return "unknown"
+    return issue.split("#", 1)[0] or "unknown"
+
+
+def fetch_journal(units: str, run=subprocess.run) -> list[dict]:
+    """Read the user journal of the Runner units as structured entries.
+
+    Fail fast: a non-zero journalctl exit raises JournalError with the
+    command, return code and stderr — never a fallback, never swallowed.
+    """
+    command = ["journalctl", "--user", "-u", units, "-o", "json"]
+    result = run(command, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise JournalError(
+            f"journalctl failed rc={result.returncode} "
+            f"command={' '.join(command)} stderr={result.stderr.strip()}"
+        )
+    entries: list[dict] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # a non-JSON line is not a journal entry
+        if not isinstance(record, dict):
+            continue
+        message = record.get("MESSAGE")
+        if not isinstance(message, str):
+            continue
+        timestamp = record.get("__REALTIME_TIMESTAMP")
+        try:
+            ts = int(timestamp) / 1_000_000
+        except (TypeError, ValueError):
+            ts = 0.0
+        unit = record.get("_SYSTEMD_USER_UNIT")
+        instance = None
+        if isinstance(unit, str) and "@" in unit:
+            instance = unit.rsplit("@", 1)[1].removesuffix(".service")
+        entries.append({"ts": ts, "instance": instance, "message": message})
+    return entries
+
+
+def _label_value(value: str | None, fallback: str = "-") -> str:
+    """A scene field as a label value: missing/empty -> fallback."""
+    if value is None or value == "":
+        return fallback
+    return value
+
+
+def _labels(pairs: list[tuple[str, str]]) -> str:
+    return (
+        "{" + ",".join(f'{k}="{v}"' for k, v in pairs) + "}"
+        if pairs
+        else ""
+    )
+
+
+def build_metrics(entries: list[dict], now: float,
+                  service_active: dict[str, int]) -> str:
+    """Aggregate journal entries into the Prometheus text exposition.
+
+    `entries` are chronological (the journal order); `service_active`
+    maps instance -> 1/0 for the configured service instances.
+    """
+    live: dict[str, dict] = {}      # instance -> live run state
+    seen_combos: set[tuple] = set()  # (instance, repo, issue, role, phase, state)
+    idle_gauges: dict[tuple, float] = {}
+    seconds_gauges: dict[tuple, float] = {}
+    counters: dict[tuple, float] = {}
+
+    def bump(labels: tuple, amount: float = 1.0) -> None:
+        counters[labels] = counters.get(labels, 0.0) + amount
+
+    for entry in entries:
+        instance = entry["instance"] or "unknown"
+        parsed = parse_message(entry["message"])
+        if parsed is None:
+            continue
+        kind = parsed["kind"]
+        scene = parsed["scene"]
+        issue = _label_value(scene.get("issue"))
+        role = _label_value(scene.get("role"))
+        repo = issue_repo(issue)
+        ts = entry["ts"]
+
+        if kind == "run_start":
+            phase = _label_value(scene.get("phase"))
+            combo = (instance, repo, issue, role, phase, "-")
+            seen_combos.add(combo)
+            live[instance] = {
+                "combo": combo,
+                "phase": phase,
+                "state": "-",
+                "issue": issue,
+                "role": role,
+            }
+            bump(("muyan_pilot_run_start_total",
+                  ("instance", instance), ("issue", issue),
+                  ("role", role)))
+        elif kind in ("activity", "heartbeat"):
+            run = live.get(instance)
+            if run is None:
+                continue  # an activity line before its run_start
+            phase = _label_value(scene.get("phase"))
+            state = _label_value(scene.get("state"))
+            run["combo"] = (instance, repo, issue, role, phase, state)
+            run["phase"] = phase
+            run["state"] = state
+            seen_combos.add(run["combo"])
+            idle = parse_duration(scene.get("idle"))
+            if idle is not None:
+                idle_gauges[(instance, issue)] = idle
+            elapsed = parse_duration(scene.get("elapsed"))
+            if elapsed is not None:
+                seconds_gauges[(instance, issue, role)] = elapsed
+        elif kind == "model_wait":
+            bump(("muyan_pilot_model_wait_total",
+                  ("instance", instance), ("issue", issue)))
+        elif kind == "pi_idle":
+            bump(("muyan_pilot_pi_idle_total",
+                  ("instance", instance), ("issue", issue)))
+        elif kind == "pi_idle_term":
+            bump(("muyan_pilot_pi_idle_term_total",
+                  ("instance", instance), ("issue", issue)))
+        elif kind == "pi_idle_kill":
+            bump(("muyan_pilot_pi_idle_kill_total",
+                  ("instance", instance), ("issue", issue)))
+        elif kind == "run_failed":
+            reason = _label_value(scene.get("reason"))
+            bump(("muyan_pilot_run_failed_total",
+                  ("instance", instance), ("issue", issue),
+                  ("reason", reason)))
+            live.pop(instance, None)
+        elif kind == "run_end":
+            result = _label_value(scene.get("result"))
+            bump(("muyan_pilot_run_end_total",
+                  ("instance", instance), ("issue", issue),
+                  ("role", role), ("result", result)))
+            elapsed = parse_duration(scene.get("elapsed"))
+            if elapsed is not None:
+                seconds_gauges[(instance, issue, role)] = elapsed
+            live.pop(instance, None)
+        elif kind == "progress_publish_failed":
+            bump(("muyan_pilot_progress_publish_failed_total",
+                  ("instance", instance), ("issue", issue)))
+        else:
+            # Unreachable: parse_message only returns KNOWN_KINDS and the
+            # chain above covers every one of them. Fail fast if a kind
+            # is ever added to KNOWN_KINDS without a branch here.
+            raise AssertionError(f"unhandled journal kind: {kind}")
+
+    lines: list[str] = []
+
+    def gauge(name: str, value: float, pairs: list[tuple[str, str]]) -> None:
+        lines.append(f"{name}{_labels(pairs)} {value}")
+
+    def counter(name: str) -> None:
+        for labels in sorted(counters):
+            if labels[0] != name:
+                continue
+            gauge(name, counters[labels], list(labels[1:]))
+
+    for instance in sorted(service_active):
+        gauge("muyan_pilot_service_active", float(service_active[instance]),
+              [("instance", instance)])
+
+    for combo in sorted(seen_combos):
+        instance, repo, issue, role, phase, state = combo
+        is_live = (
+            instance in live
+            and live[instance]["combo"] == combo
+        )
+        gauge(
+            "muyan_pilot_run_active", 1.0 if is_live else 0.0,
+            [("instance", instance), ("repo", repo), ("issue", issue),
+             ("role", role), ("phase", phase), ("state", state)],
+        )
+
+    for (instance, issue) in sorted(idle_gauges):
+        run = live.get(instance)
+        if run is None or run["issue"] != issue:
+            continue  # the idle gauge is a live-state gauge
+        gauge("muyan_pilot_run_idle_seconds", idle_gauges[(instance, issue)],
+              [("instance", instance), ("issue", issue)])
+
+    for (instance, issue, role) in sorted(seconds_gauges):
+        gauge("muyan_pilot_run_seconds",
+              seconds_gauges[(instance, issue, role)],
+              [("instance", instance), ("issue", issue), ("role", role)])
+
+    for name in (
+        "muyan_pilot_run_start_total",
+        "muyan_pilot_run_end_total",
+        "muyan_pilot_run_failed_total",
+        "muyan_pilot_progress_publish_failed_total",
+        "muyan_pilot_model_wait_total",
+        "muyan_pilot_pi_idle_total",
+        "muyan_pilot_pi_idle_term_total",
+        "muyan_pilot_pi_idle_kill_total",
+    ):
+        counter(name)
+
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+class Exporter:
+    """One scrape cycle: journal (TTL-cached) + service states -> text."""
+
+    def __init__(self, units: str, cache_ttl: float,
+                 instances: tuple[str, ...],
+                 fetch_journal, service_active,
+                 clock=time.monotonic) -> None:
+        self.units = units
+        self.cache_ttl = cache_ttl
+        self.instances = instances
+        self._fetch_journal = fetch_journal
+        self._service_active = service_active
+        self._clock = clock
+        self._cache: list[dict] | None = None
+        self._cache_at = 0.0
+
+    def _entries(self) -> list[dict]:
+        now = self._clock()
+        if (self._cache is None
+                or now - self._cache_at >= self.cache_ttl):
+            self._cache = self._fetch_journal(self.units)
+            self._cache_at = now
+        return self._cache
+
+    def metrics(self) -> str:
+        entries = self._entries()  # a JournalError is NOT cached
+        states = {
+            instance: (
+                1 if self._service_active(
+                    f"muyan-pilot@{instance}.service"
+                ) == 0 else 0
+            )
+            for instance in self.instances
+        }
+        return build_metrics(entries, now=self._clock(),
+                             service_active=states)
+
+
+def default_service_active(unit: str, run=subprocess.run) -> int:
+    """`systemctl --user is-active <unit>` exit code (0 = active)."""
+    return run(
+        ["systemctl", "--user", "is-active", unit],
+        capture_output=True, text=True, timeout=15,
+    ).returncode
+
+
+def make_handler(exporter_instance: Exporter):
+    """Build the request handler class bound to one Exporter."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 (http.server contract)
+            if self.path == "/metrics":
+                try:
+                    body = exporter_instance.metrics().encode("utf-8")
+                except Exception as exc:  # fail fast, visibly
+                    body = (
+                        f"# exporter error (fail fast, no fallback)\n"
+                        f"exporter_error {exc!r}\n"
+                    ).encode("utf-8")
+                    self.send_response(500)
+                else:
+                    self.send_response(200)
+                self.send_header("Content-Type", "text/plain; version=0.0.4")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif self.path == "/health":
+                body = b"ok"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, fmt: str, *args) -> None:
+            # Keep the exporter quiet on stdout; scrape errors are
+            # visible in the 500 body and in Prometheus itself.
+            pass
+
+    return Handler
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Muyan Pilot Prometheus exporter (Issue #162)",
+    )
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--bind", default=DEFAULT_BIND)
+    parser.add_argument("--units", default=DEFAULT_UNITS,
+                        help="journalctl -u unit pattern")
+    parser.add_argument("--instances", default=",".join(DEFAULT_INSTANCES),
+                        help="comma-separated service instances")
+    parser.add_argument("--cache-ttl", type=float, default=DEFAULT_CACHE_TTL,
+                        help="journal re-read interval in seconds")
+    args = parser.parse_args(argv)
+    instances = tuple(
+        part for part in args.instances.split(",") if part
+    )
+    exporter_instance = Exporter(
+        units=args.units,
+        cache_ttl=args.cache_ttl,
+        instances=instances,
+        fetch_journal=fetch_journal,
+        service_active=default_service_active,
+    )
+    try:
+        server = HTTPServer((args.bind, args.port),
+                            make_handler(exporter_instance))
+    except (OSError, ValueError, OverflowError) as exc:
+        print(
+            f"exporter_failed reason={exc} bind={args.bind} "
+            f"port={args.port}",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"muyan-pilot-exporter listening on {args.bind}:{args.port} "
+        f"units={args.units} instances={','.join(instances)} "
+        f"cache_ttl={args.cache_ttl}",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_muyan_pilot_dashboard.py
+++ b/tests/test_muyan_pilot_dashboard.py
@@ -152,13 +152,21 @@ def test_helpers_handle_targets_without_expr_and_flag_disallowed_labels():
     bad = 'muyan_pilot_run_active{run_id="cf357f0e"}'
     with pytest.raises(AssertionError):
         _check_labels([bad])
-    _check_labels(["muyan_pilot_run_active{instance=\"1\"}"])
+    # The scraper-reserved `instance` label is flagged too: it would
+    # silently match the scrape target, not the Runner slot.
+    with pytest.raises(AssertionError):
+        _check_labels(['muyan_pilot_run_active{instance="1"}'])
+    _check_labels(["muyan_pilot_run_active{slot=\"1\"}"])
     _check_labels(["muyan_pilot_service_active"])
 
 
 def _check_labels(exprs):
+    # `instance` is deliberately NOT allowed: it is a Prometheus scraper
+    # label — a dashboard expr filtering on it would match the scrape
+    # target `127.0.0.1:9106`, not the Runner slot (the exporter emits
+    # the per-Runner dimension as `slot`, Issue #162).
     allowed = {
-        "instance", "repo", "issue", "role", "phase", "state",
+        "repo", "issue", "role", "phase", "state",
         "reason", "result", "slot",
     }
     label_re = re.compile(r"\{[^}]*?([a-zA-Z_][a-zA-Z0-9_]*)\s*=")

--- a/tests/test_muyan_pilot_dashboard.py
+++ b/tests/test_muyan_pilot_dashboard.py
@@ -1,0 +1,194 @@
+"""Grafana dashboard structure contract for Issue #162.
+
+The dashboard JSON in `monitoring/grafana/dashboards/` must be importable
+into the machine's Grafana (Prometheus datasource uid `eflztqehr89a8c`)
+and must show the Issue's required views: the two Runner services, the
+current Issue/phase/idle per slot, model_wait, idle recovery, run_failed
+by reason, progress_publish_failed, run durations, and the reused llama
+slot/context/TPS/token metrics.
+"""
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DASHBOARD_PATH = (
+    REPO_ROOT / "monitoring" / "grafana" / "dashboards" / "muyan-pilot.json"
+)
+
+# The machine's Prometheus datasource (verified against the running
+# Grafana 13.1.2 data_source table).
+PROMETHEUS_DS = {"type": "prometheus", "uid": "eflztqehr89a8c"}
+
+# The exporter's metric family (monitoring/prometheus/muyan-pilot-exporter.py).
+MUYAN_METRICS = (
+    "muyan_pilot_service_active",
+    "muyan_pilot_run_active",
+    "muyan_pilot_run_seconds",
+    "muyan_pilot_run_idle_seconds",
+    "muyan_pilot_run_start_total",
+    "muyan_pilot_run_end_total",
+    "muyan_pilot_run_failed_total",
+    "muyan_pilot_progress_publish_failed_total",
+    "muyan_pilot_model_wait_total",
+    "muyan_pilot_pi_idle_total",
+    "muyan_pilot_pi_idle_term_total",
+    "muyan_pilot_pi_idle_kill_total",
+)
+
+# Existing llama metrics the dashboard REUSES (never re-implemented).
+LLAMA_METRICS = (
+    "llama_slot_is_processing",
+    "llama_slots_processing",
+    "llama_slots_total",
+    "llama_slot_n_ctx",
+    "llamacpp:n_tokens_max",
+    "llamacpp:prompt_tokens_total",
+    "llamacpp:tokens_predicted_total",
+    "llamacpp:prompt_tokens_cached_total",
+)
+
+
+def load_dashboard():
+    return json.loads(DASHBOARD_PATH.read_text(encoding="utf-8"))
+
+
+def all_panels(dashboard):
+    panels = []
+    for panel in dashboard.get("panels", []):
+        panels.append(panel)
+        panels.extend(panel.get("panels", []))  # collapsed rows
+    return panels
+
+
+def all_exprs(dashboard):
+    exprs = []
+    for panel in all_panels(dashboard):
+        for target in panel.get("targets", []) or []:
+            if target.get("expr"):
+                exprs.append(target["expr"])
+    return exprs
+
+
+def test_dashboard_file_is_valid_json_with_stable_uid():
+    dashboard = load_dashboard()
+    assert dashboard["uid"] == "muyan-pilot"
+    assert dashboard["title"]
+    assert dashboard["schemaVersion"] >= 39
+    assert dashboard["panels"], "the dashboard must have panels"
+
+
+def test_every_panel_and_target_uses_the_prometheus_datasource():
+    dashboard = load_dashboard()
+    panels = all_panels(dashboard)
+    assert panels
+    _check_datasources(panels)
+
+
+def _check_datasources(panels):
+    for panel in panels:
+        if panel.get("type") == "row":
+            continue
+        assert panel.get("datasource") == PROMETHEUS_DS, panel.get("title")
+        for target in panel.get("targets", []) or []:
+            if target.get("expr"):
+                assert target.get("datasource") == PROMETHEUS_DS, (
+                    panel.get("title"), target.get("expr")
+                )
+
+
+def test_dashboard_covers_every_exporter_metric_family():
+    exprs = all_exprs(load_dashboard())
+    joined = "\n".join(exprs)
+    for name in MUYAN_METRICS:
+        assert re.search(rf"\b{re.escape(name)}\b", joined), (
+            f"no panel queries {name}"
+        )
+
+
+def test_dashboard_reuses_existing_llama_metrics():
+    exprs = all_exprs(load_dashboard())
+    joined = "\n".join(exprs)
+    for name in LLAMA_METRICS:
+        assert re.search(rf"\b{re.escape(name)}\b", joined), (
+            f"no panel queries {name}"
+        )
+
+
+def test_no_high_cardinality_labels_or_run_id_in_any_expr():
+    """The Issue contract: no unbounded run_id label, no command/prompt
+    text — the dashboard may only filter on the low-cardinality label
+    set (instance, repo, issue, role, phase, state, reason, result)."""
+    _check_labels(all_exprs(load_dashboard()))
+
+
+def test_helpers_handle_targets_without_expr_and_flag_disallowed_labels():
+    # A panel target without `expr` (e.g. a reduce transform) is skipped
+    # by both helpers.
+    dashboard = {
+        "panels": [
+            {
+                "type": "timeseries",
+                "title": "p",
+                "datasource": PROMETHEUS_DS,
+                "targets": [
+                    {"refId": "A", "expr": "muyan_pilot_service_active",
+                     "datasource": PROMETHEUS_DS},
+                    {"refId": "B"},
+                ],
+            },
+        ],
+    }
+    assert all_exprs(dashboard) == ["muyan_pilot_service_active"]
+
+    # The datasource check tolerates a target without `expr` and accepts
+    # the Prometheus datasource on panel and expr targets.
+    _check_datasources(all_panels(dashboard))
+
+    # The label allowlist check flags a disallowed label (run_id) in an
+    # expr and accepts the allowed ones.
+    bad = 'muyan_pilot_run_active{run_id="cf357f0e"}'
+    with pytest.raises(AssertionError):
+        _check_labels([bad])
+    _check_labels(["muyan_pilot_run_active{instance=\"1\"}"])
+    _check_labels(["muyan_pilot_service_active"])
+
+
+def _check_labels(exprs):
+    allowed = {
+        "instance", "repo", "issue", "role", "phase", "state",
+        "reason", "result", "slot",
+    }
+    label_re = re.compile(r"\{[^}]*?([a-zA-Z_][a-zA-Z0-9_]*)\s*=")
+    for expr in exprs:
+        for match in label_re.finditer(expr):
+            assert match.group(1) in allowed, expr
+
+
+def test_panels_have_sane_grid_positions_and_titles():
+    dashboard = load_dashboard()
+    seen_positions = set()
+    for panel in all_panels(dashboard):
+        assert panel.get("title"), "every panel needs a title"
+        pos = panel.get("gridPos")
+        assert pos and all(k in pos for k in ("x", "y", "w", "h")), (
+            panel.get("title")
+        )
+        key = (pos["x"], pos["y"])
+        assert key not in seen_positions, (
+            f"overlapping gridPos at {key}: {panel.get('title')}"
+        )
+        seen_positions.add(key)
+        assert pos["w"] <= 24 and pos["x"] + pos["w"] <= 24
+
+
+def test_dashboard_json_is_reimportable():
+    """Grafana import requires the full dashboard document: round-tripping
+    through json must be lossless and the file must not carry import-only
+    fields (like a top-level `__inputs`) that break re-import."""
+    raw = DASHBOARD_PATH.read_text(encoding="utf-8")
+    dashboard = json.loads(raw)
+    assert "__inputs" not in dashboard
+    assert json.loads(json.dumps(dashboard)) == dashboard

--- a/tests/test_muyan_pilot_exporter.py
+++ b/tests/test_muyan_pilot_exporter.py
@@ -1,0 +1,745 @@
+"""Exporter contract for Issue #162 (Prometheus exporter + Grafana
+Dashboard).
+
+The exporter is a standalone, read-only reader of the structured user
+systemd journal of the `muyan-pilot@*` Runner services. These tests pin
+the journal line contract (verified against the live journal and
+`pi_activity.parse_scene`), the low-cardinality label allowlist (no
+`run_id`, no command/prompt text), the fail-fast behavior on journal
+errors, and the HTTP surface (`/metrics`, `/health`, 404).
+"""
+import importlib.util
+import io
+import json
+import threading
+from http.server import HTTPServer, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPORTER_PATH = REPO_ROOT / "monitoring" / "prometheus" / "muyan-pilot-exporter.py"
+
+
+def load_exporter():
+    spec = importlib.util.spec_from_file_location(
+        "muyan_pilot_exporter", EXPORTER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+exporter = load_exporter()
+
+
+def entry(ts, instance, message):
+    return {"ts": ts, "instance": instance, "message": message}
+
+
+def metric(lines, name, labels=None, value=None):
+    """Find one metric line; return its value (or assert it)."""
+    wanted = f"{name}{{{labels}}}" if labels else f"{name} "
+    found = [ln for ln in lines if ln.startswith(wanted)]
+    if value is None:
+        assert len(found) == 1, (
+            f"expected exactly one {name}{{{labels}}}, got {found}"
+        )
+        return float(found[0].split(" ", 2)[-1])
+    assert any(ln == f"{wanted} {value}" for ln in found), (
+        f"expected {wanted} {value} in {lines}"
+    )
+
+
+def lines_of(text):
+    return [ln for ln in text.splitlines() if ln and not ln.startswith("#")]
+
+
+# --- parse_message: the journal line contract -----------------------------
+
+
+def test_parse_message_run_start_extracts_run_id_kind_and_scene():
+    parsed = exporter.parse_message(
+        "INFO [cf357f0e] run_start run=cf357f0e issue=xqliu/orbi#162 "
+        "role=implement branch=b worktree=/w session=- session_file=- "
+        "phase=starting last_activity=- action=- result=-"
+    )
+    assert parsed is not None
+    assert parsed["run_id"] == "cf357f0e"
+    assert parsed["kind"] == "run_start"
+    assert parsed["scene"]["issue"] == "xqliu/orbi#162"
+    assert parsed["scene"]["role"] == "implement"
+    assert parsed["scene"]["phase"] == "starting"
+
+
+def test_parse_message_quoted_action_with_spaces_and_escaped_quotes():
+    parsed = exporter.parse_message(
+        'INFO [cf357f0e] activity issue=xqliu/orbi#162 role=implement '
+        'phase=bash action="bash cd /w \\"quoted\\" && pytest" result=ok '
+        "state=model_wait idle=12s"
+    )
+    assert parsed["kind"] == "activity"
+    assert parsed["scene"]["action"] == 'bash cd /w "quoted" && pytest'
+    assert parsed["scene"]["state"] == "model_wait"
+
+
+def test_parse_message_skips_unknown_line_kinds():
+    # `command=` / `stdout=` journal lines are whole-line scenes, not
+    # `LEVEL [run_id] kind scene` lines: the line regex does not match.
+    assert exporter.parse_message(
+        "INFO [cf357f0e] command=gh api repos/xqliu/orbi/issues/162"
+    ) is None
+    assert exporter.parse_message(
+        "INFO [cf357f0e] stdout=some output"
+    ) is None
+    # A future journal kind that DOES match the line shape is tolerated:
+    # it is skipped, not an error.
+    assert exporter.parse_message(
+        "INFO [cf357f0e] some_future_kind issue=x#1"
+    ) is None
+
+
+def test_parse_message_rejects_bad_run_id_and_bad_level():
+    assert exporter.parse_message("INFO [xyz] run_start run=1") is None
+    assert exporter.parse_message("DEBUG [cf357f0e] run_start run=1") is None
+    assert exporter.parse_message("garbage line without structure") is None
+
+
+def test_parse_scene_key_without_value_parses_to_none():
+    scene = exporter.parse_scene("phase= action=-")
+    assert scene == {"phase": None, "action": "-"}
+
+
+def test_parse_scene_skips_bare_words_and_trailing_spaces():
+    scene = exporter.parse_scene("phase=read bareword   ")
+    assert scene == {"phase": "read"}
+
+
+def test_parse_scene_unterminated_quote_keeps_rest_of_line():
+    scene = exporter.parse_scene('action="unterminated rest')
+    assert scene == {"action": "unterminated rest"}
+
+
+# --- parse_duration: the journal duration contract ------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0s", 0.0),
+        ("0.4s", 0.4),
+        ("5s", 5.0),
+        ("42m", 42 * 60.0),
+        ("1h43m", 6180.0),
+        ("1h0m", 3600.0),
+    ],
+)
+def test_parse_duration_journal_formats(raw, expected):
+    assert exporter.parse_duration(raw) == pytest.approx(expected)
+
+
+def test_parse_duration_rejects_non_journal_formats():
+    # The journal only ever carries format_duration output (pi_activity):
+    # `0s`, `X.Ys`, `Ns`, `Nm`, `NhMm` — nothing else.
+    for raw in ("-", "1h", "m", "", None, "5m30s", "1h5m30s", "1h43"):
+        assert exporter.parse_duration(raw) is None, raw
+
+
+# --- issue label helpers ---------------------------------------------------
+
+
+def test_issue_repo_splits_owner_repo_from_issue_ref():
+    assert exporter.issue_repo("xqliu/orbi#162") == "xqliu/orbi"
+    assert exporter.issue_repo("xqliu/muyan-pilot#18") == "xqliu/muyan-pilot"
+
+
+def test_issue_repo_falls_back_to_whole_ref_when_no_hash():
+    assert exporter.issue_repo("unknown") == "unknown"
+    assert exporter.issue_repo("#162") == "unknown"
+    assert exporter.issue_repo(None) == "unknown"
+    assert exporter.issue_repo("") == "unknown"
+
+
+# --- fetch_journal: fail fast, no fallback --------------------------------
+
+
+def test_fetch_journal_parses_json_entries_with_instance_and_ts():
+    payload = "\n".join([
+        json.dumps({
+            "__REALTIME_TIMESTAMP": "1787958782202724",
+            "_SYSTEMD_USER_UNIT": "muyan-pilot@1.service",
+            "MESSAGE": "INFO [cf357f0e] heartbeat issue=xqliu/orbi#162 "
+                       "role=implement phase=read state=- elapsed=1m idle=1m",
+        }),
+        json.dumps({
+            "__REALTIME_TIMESTAMP": "1787958785633784",
+            "_SYSTEMD_USER_UNIT": "muyan-pilot@2.service",
+            "MESSAGE": "INFO [cf357f0e] run_start run=cf357f0e "
+                       "issue=xqliu/orbi#162 role=implement phase=starting",
+        }),
+    ]) + "\n"
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    entries = exporter.fetch_journal(
+        "muyan-pilot@*",
+        run=subprocess_run_factory(FakeCompleted()),
+    )
+    assert [e["instance"] for e in entries] == ["1", "2"]
+    assert entries[0]["ts"] == 1787958782202724 / 1_000_000
+    assert entries[0]["message"].startswith("INFO [cf357f0e] heartbeat")
+
+
+def test_fetch_journal_skips_blank_lines_and_non_dict_records():
+    payload = "\n" + json.dumps([1, 2, 3]) + "\n" + json.dumps({
+        "__REALTIME_TIMESTAMP": "1000",
+        "MESSAGE": "INFO [cf357f0e] heartbeat issue=x#1 role=implement",
+    }) + "\n" + json.dumps({
+        "__REALTIME_TIMESTAMP": "2000",
+        "_SYSTEMD_USER_UNIT": "muyan-pilot@1.service",
+    }) + "\n"
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    entries = exporter.fetch_journal(
+        "muyan-pilot@*",
+        run=subprocess_run_factory(FakeCompleted()),
+    )
+    assert len(entries) == 1
+
+
+def test_fetch_journal_invalid_timestamp_falls_back_to_zero():
+    payload = json.dumps({
+        "__REALTIME_TIMESTAMP": "not-a-number",
+        "_SYSTEMD_USER_UNIT": "muyan-pilot@1.service",
+        "MESSAGE": "INFO [cf357f0e] heartbeat issue=x#1 role=implement",
+    }) + "\n"
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    entries = exporter.fetch_journal(
+        "muyan-pilot@*",
+        run=subprocess_run_factory(FakeCompleted()),
+    )
+    assert entries[0]["ts"] == 0.0
+    assert entries[0]["instance"] == "1"
+
+
+def test_fetch_journal_skips_non_json_lines_and_missing_unit():
+    payload = "not-json\n" + json.dumps({
+        "__REALTIME_TIMESTAMP": "1000",
+        "MESSAGE": "INFO [cf357f0e] heartbeat issue=x#1 role=implement",
+    }) + "\n"
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    entries = exporter.fetch_journal(
+        "muyan-pilot@*",
+        run=subprocess_run_factory(FakeCompleted()),
+    )
+    assert len(entries) == 1
+    assert entries[0]["instance"] is None
+
+
+def test_fetch_journal_fails_fast_on_nonzero_exit():
+    class FakeCompleted:
+        returncode = 1
+        stdout = ""
+        stderr = "No journal files were opened"
+
+    with pytest.raises(exporter.JournalError) as excinfo:
+        exporter.fetch_journal(
+            "muyan-pilot@*",
+            run=subprocess_run_factory(FakeCompleted()),
+        )
+    assert "No journal files were opened" in str(excinfo.value)
+    assert "journalctl" in str(excinfo.value)
+
+
+def subprocess_run_factory(completed):
+    def run(cmd, **kwargs):
+        return completed
+    return run
+
+
+# --- build_metrics: aggregation over journal entries ----------------------
+
+
+def test_build_metrics_live_run_gauges_and_counters():
+    entries = [
+        entry(100, "1",
+              "INFO [aaaa1111] run_start run=aaaa1111 issue=xqliu/orbi#162 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+        entry(160, "1",
+              "INFO [aaaa1111] activity issue=xqliu/orbi#162 role=implement "
+              "phase=read action=\"read /x\" result=ok state=model_wait "
+              "idle=5s"),
+        entry(175, "1",
+              "INFO [aaaa1111] model_wait issue=xqliu/orbi#162 "
+              "role=implement phase=read state=model_wait"),
+        entry(200, "1",
+              "INFO [aaaa1111] heartbeat issue=xqliu/orbi#162 "
+              "role=implement phase=read state=model_wait elapsed=1m "
+              "idle=20s"),
+    ]
+    text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
+    lines = lines_of(text)
+
+    metric(lines, "muyan_pilot_service_active", 'instance="1"', 1.0)
+    metric(lines, "muyan_pilot_run_active",
+           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
+           'role="implement",phase="read",state="model_wait"', 1.0)
+    metric(lines, "muyan_pilot_run_idle_seconds",
+           'instance="1",issue="xqliu/orbi#162"', 20.0)
+    metric(lines, "muyan_pilot_run_seconds",
+           'instance="1",issue="xqliu/orbi#162",role="implement"', 60.0)
+    metric(lines, "muyan_pilot_run_start_total",
+           'instance="1",issue="xqliu/orbi#162",role="implement"', 1.0)
+    metric(lines, "muyan_pilot_model_wait_total",
+           'instance="1",issue="xqliu/orbi#162"', 1.0)
+
+
+def test_build_metrics_finished_run_keeps_end_scene_and_zeroes_active():
+    entries = [
+        entry(100, "1",
+              "INFO [bbbb2222] run_start run=bbbb2222 issue=xqliu/orbi#50 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+        entry(200, "1",
+              "INFO [bbbb2222] heartbeat issue=xqliu/orbi#50 "
+              "role=implement phase=test state=- elapsed=10m idle=1s"),
+        entry(300, "1",
+              "INFO [bbbb2222] run_end run=bbbb2222 issue=xqliu/orbi#50 "
+              "role=implement result=pr_opened elapsed=3h30m "
+              "pr=https://github.com/xqliu/orbi/pull/187 commit=abc123"),
+        # A later live run on the same instance: the finished combo must
+        # still be present with run_active=0 (Prometheus needs the series).
+        entry(400, "1",
+              "INFO [cccc3333] run_start run=cccc3333 issue=xqliu/orbi#181 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+    ]
+    text = exporter.build_metrics(entries, now=400.0, service_active={"1": 0})
+    lines = lines_of(text)
+
+    metric(lines, "muyan_pilot_service_active", 'instance="1"', 0.0)
+    metric(lines, "muyan_pilot_run_active",
+           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#181",'
+           'role="implement",phase="starting",state="-"', 1.0)
+    metric(lines, "muyan_pilot_run_active",
+           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#50",'
+           'role="implement",phase="test",state="-"', 0.0)
+    metric(lines, "muyan_pilot_run_seconds",
+           'instance="1",issue="xqliu/orbi#50",role="implement"', 12600.0)
+    metric(lines, "muyan_pilot_run_end_total",
+           'instance="1",issue="xqliu/orbi#50",role="implement",'
+           'result="pr_opened"', 1.0)
+    # The finished run's idle gauge is not re-emitted (no live state).
+    assert not any(
+        ln.startswith('muyan_pilot_run_idle_seconds{instance="1",'
+                      'issue="xqliu/orbi#50"}')
+        for ln in lines
+    )
+
+
+def test_build_metrics_failure_and_recovery_counters_by_reason():
+    entries = [
+        entry(100, "2",
+              "INFO [dddd4444] run_start run=dddd4444 issue=xqliu/orbi#181 "
+              "role=review branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+        entry(200, "2",
+              "WARNING [dddd4444] pi_idle issue=xqliu/orbi#181 "
+              "role=review phase=bash stale_seconds=5m"),
+        entry(300, "2",
+              "INFO [dddd4444] pi_idle_term run=dddd4444 issue=xqliu/orbi#181 "
+              "role=review pid=4242 cmdline=\"timeout 240 pytest\" "
+              "result=sent"),
+        entry(400, "2",
+              "INFO [dddd4444] pi_idle_kill run=dddd4444 issue=xqliu/orbi#181 "
+              "role=review pid=4242 cmdline=\"timeout 240 pytest\" "
+              "result=already_dead"),
+        entry(500, "2",
+              "ERROR [dddd4444] run_failed run=dddd4444 issue=xqliu/orbi#181 "
+              "role=review branch=b worktree=/w session=- session_file=- "
+              "phase=bash last_activity=- action=- result=- "
+              "reason=idle_recovery_stale_15m"),
+        entry(600, "2",
+              "INFO [dddd4444] progress_publish_failed run=dddd4444 "
+              "issue=xqliu/orbi#181 role=review"),
+    ]
+    text = exporter.build_metrics(entries, now=700.0, service_active={"2": 1})
+    lines = lines_of(text)
+
+    metric(lines, "muyan_pilot_pi_idle_total",
+           'instance="2",issue="xqliu/orbi#181"', 1.0)
+    metric(lines, "muyan_pilot_pi_idle_term_total",
+           'instance="2",issue="xqliu/orbi#181"', 1.0)
+    metric(lines, "muyan_pilot_pi_idle_kill_total",
+           'instance="2",issue="xqliu/orbi#181"', 1.0)
+    metric(lines, "muyan_pilot_run_failed_total",
+           'instance="2",issue="xqliu/orbi#181",'
+           'reason="idle_recovery_stale_15m"', 1.0)
+    metric(lines, "muyan_pilot_progress_publish_failed_total",
+           'instance="2",issue="xqliu/orbi#181"', 1.0)
+    # The failed run is no longer active.
+    assert not any(
+        ln.endswith('state="model_wait"} 1')
+        and 'issue="xqliu/orbi#181"' in ln
+        for ln in lines
+        if ln.startswith("muyan_pilot_run_active")
+    )
+
+
+def test_build_metrics_labels_stay_within_allowlist():
+    """No run_id, no command/prompt text may ever reach a label."""
+    entries = [
+        entry(100, "1",
+              "INFO [eeee5555] run_start run=eeee5555 issue=xqliu/orbi#162 "
+              "role=implement branch=muyan-pilot/xqliu-orbi-issue-162-eeee5555 "
+              "worktree=/home/x/w session=- session_file=- phase=starting "
+              "last_activity=- action=- result=-"),
+        entry(200, "1",
+              "INFO [eeee5555] activity issue=xqliu/orbi#162 role=implement "
+              "phase=bash action=\"bash cat > /tmp/x.py <<'EOF' secret "
+              "prompt text EOF\" result=ok state=- idle=2s"),
+    ]
+    text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
+    for line in lines_of(text):
+        body = line.split("{", 1)[1] if "{" in line else ""
+        assert "eeee5555" not in body, line
+        assert "branch=" not in body, line
+        assert "worktree=" not in body, line
+        assert "prompt text" not in body, line
+        for label in body.strip("}").split(","):
+            name = label.split("=", 1)[0].strip()
+            assert name in {
+                "instance", "repo", "issue", "role", "phase", "state",
+                "reason", "result",
+            }, line
+
+
+def test_build_metrics_unparseable_messages_are_skipped():
+    entries = [
+        entry(100, "1", "command=gh api repos/xqliu/orbi/issues/162"),
+        entry(200, "1", "stdout=some output"),
+    ]
+    text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
+    lines = lines_of(text)
+    assert metric(lines, "muyan_pilot_service_active", 'instance="1"') == 1.0
+    assert not any(
+        ln.startswith("muyan_pilot_run_") for ln in lines
+    )
+
+
+def test_build_metrics_activity_before_run_start_is_ignored():
+    entries = [
+        entry(100, "1",
+              "INFO [aaaa1111] activity issue=xqliu/orbi#162 "
+              "role=implement phase=test action=\"read /x\" result=ok "
+              "state=- idle=2s"),
+    ]
+    text = exporter.build_metrics(entries, now=200.0, service_active={"1": 1})
+    lines = lines_of(text)
+    assert not any(
+        ln.startswith("muyan_pilot_run_") for ln in lines
+    )
+
+
+def test_build_metrics_heartbeat_without_idle_or_elapsed_updates_combo_only():
+    entries = [
+        entry(100, "1",
+              "INFO [aaaa1111] run_start run=aaaa1111 issue=xqliu/orbi#162 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+        entry(200, "1",
+              "INFO [aaaa1111] heartbeat issue=xqliu/orbi#162 "
+              "role=implement phase=read state=model_wait"),
+    ]
+    text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
+    lines = lines_of(text)
+    metric(lines, "muyan_pilot_run_active",
+           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
+           'role="implement",phase="read",state="model_wait"', 1.0)
+    assert not any(ln.startswith("muyan_pilot_run_idle_seconds")
+                   for ln in lines)
+    assert not any(ln.startswith("muyan_pilot_run_seconds") for ln in lines)
+
+
+def test_build_metrics_run_end_without_elapsed_still_counts():
+    entries = [
+        entry(100, "1",
+              "INFO [aaaa1111] run_start run=aaaa1111 issue=xqliu/orbi#162 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+        entry(200, "1",
+              "INFO [aaaa1111] run_end run=aaaa1111 issue=xqliu/orbi#162 "
+              "role=implement result=failed pr=- commit=-"),
+    ]
+    text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
+    lines = lines_of(text)
+    metric(lines, "muyan_pilot_run_end_total",
+           'instance="1",issue="xqliu/orbi#162",role="implement",'
+           'result="failed"', 1.0)
+    assert not any(ln.startswith("muyan_pilot_run_seconds") for ln in lines)
+
+
+def test_label_value_falls_back_for_missing_and_empty():
+    assert exporter._label_value(None) == "-"
+    assert exporter._label_value("") == "-"
+    assert exporter._label_value("model_wait") == "model_wait"
+    assert exporter._label_value(None, "none") == "none"
+
+
+def test_build_metrics_fails_fast_on_kind_outside_chain(monkeypatch):
+    # The chain covers every KNOWN_KINDS member; a kind that slips past
+    # parse_message (e.g. a future kind added to KNOWN_KINDS without a
+    # branch) must fail fast, not be silently dropped.
+    monkeypatch.setattr(
+        exporter, "parse_message",
+        lambda message: {"run_id": "aaaa1111", "kind": "future_kind",
+                         "scene": {}},
+    )
+    with pytest.raises(AssertionError, match="future_kind"):
+        exporter.build_metrics(
+            [entry(100, "1", "INFO [aaaa1111] future_kind issue=x#1")],
+            now=200.0, service_active={"1": 1},
+        )
+
+
+def test_build_metrics_empty_journal_emits_only_service_gauges():
+    text = exporter.build_metrics([], now=10.0, service_active={"1": 1, "2": 0})
+    lines = lines_of(text)
+    assert metric(lines, "muyan_pilot_service_active", 'instance="1"') == 1.0
+    assert metric(lines, "muyan_pilot_service_active", 'instance="2"') == 0.0
+    assert not any(ln.startswith("muyan_pilot_run_") for ln in lines)
+
+
+def test_build_metrics_unknown_scene_fields_are_ignored():
+    entries = [
+        entry(100, "1",
+              "INFO [ffff6666] run_start run=ffff6666 issue=xqliu/orbi#9 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=- "
+              "unexpected_field=whatever"),
+    ]
+    text = exporter.build_metrics(entries, now=200.0, service_active={"1": 1})
+    lines = lines_of(text)
+    metric(lines, "muyan_pilot_run_active",
+           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#9",'
+           'role="implement",phase="starting",state="-"', 1.0)
+
+
+def test_build_metrics_missing_instance_falls_back_to_unknown():
+    entries = [
+        entry(100, None,
+              "INFO [aaaa1111] run_start run=aaaa1111 issue=xqliu/orbi#162 "
+              "role=implement branch=b worktree=/w session=- session_file=- "
+              "phase=starting last_activity=- action=- result=-"),
+    ]
+    text = exporter.build_metrics(entries, now=200.0, service_active={})
+    lines = lines_of(text)
+    metric(lines, "muyan_pilot_run_start_total",
+           'instance="unknown",issue="xqliu/orbi#162",role="implement"', 1.0)
+
+
+# --- Exporter: TTL cache + service state ----------------------------------
+
+
+def test_exporter_caches_journal_until_ttl_expires():
+    calls = []
+
+    def fake_journal(units, run=None):
+        calls.append(units)
+        return [entry(100, "1",
+                      "INFO [aaaa1111] run_start run=aaaa1111 "
+                      "issue=xqliu/orbi#162 role=implement branch=b "
+                      "worktree=/w session=- session_file=- phase=starting "
+                      "last_activity=- action=- result=-")]
+
+    def fake_systemctl(unit):
+        return 0  # systemctl exit code: 0 = active
+
+    exp = exporter.Exporter(
+        units="muyan-pilot@*", cache_ttl=10.0, instances=("1",),
+        fetch_journal=fake_journal, service_active=fake_systemctl,
+        clock=lambda: 1.0,
+    )
+    first = exp.metrics()
+    second = exp.metrics()
+    assert first == second
+    assert len(calls) == 1  # second scrape served from the cache
+    assert 'muyan_pilot_service_active{instance="1"} 1' in first
+
+
+def test_exporter_refreshes_after_ttl_and_after_journal_error():
+    state = {"n": 0}
+
+    def fake_journal(units, run=None):
+        state["n"] += 1
+        if state["n"] == 1:
+            raise exporter.JournalError("boom")
+        return []
+
+    exp = exporter.Exporter(
+        units="muyan-pilot@*", cache_ttl=10.0, instances=("1",),
+        fetch_journal=fake_journal, service_active=lambda u: 0,
+        clock=lambda: 1.0,
+    )
+    with pytest.raises(exporter.JournalError):
+        exp.metrics()  # the error is NOT cached
+    text = exp.metrics()  # the next scrape retries immediately
+    assert "muyan_pilot_service_active" in text
+    assert state["n"] == 2
+
+
+def test_exporter_service_active_maps_unit_instances():
+    seen = []
+
+    def fake_systemctl(unit):
+        seen.append(unit)
+        return 0 if unit == "muyan-pilot@1.service" else 3
+
+    exp = exporter.Exporter(
+        units="muyan-pilot@*", cache_ttl=0.0,
+        instances=("1", "2"),
+        fetch_journal=lambda units, run=None: [],
+        service_active=fake_systemctl,
+        clock=lambda: 1.0,
+    )
+    text = exp.metrics()
+    assert seen == ["muyan-pilot@1.service", "muyan-pilot@2.service"]
+    lines = lines_of(text)
+    metric(lines, "muyan_pilot_service_active", 'instance="1"', 1.0)
+    metric(lines, "muyan_pilot_service_active", 'instance="2"', 0.0)
+
+
+def test_exporter_default_systemctl_uses_systemctl_user_is_active():
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        return type("C", (), {"returncode": 0, "stdout": "active\n",
+                              "stderr": ""})()
+
+    result = exporter.default_service_active(
+        "muyan-pilot@1.service", run=fake_run,
+    )
+    assert result == 0  # systemctl exit code: 0 = active
+    assert seen["cmd"] == [
+        "systemctl", "--user", "is-active", "muyan-pilot@1.service",
+    ]
+
+
+def test_default_service_active_nonzero_exit_means_inactive():
+    def fake_run(cmd, **kwargs):
+        return type("C", (), {"returncode": 3, "stdout": "inactive\n",
+                              "stderr": ""})()
+
+    assert exporter.default_service_active(
+        "muyan-pilot@2.service", run=fake_run,
+    ) == 3
+
+
+# --- HTTP surface ----------------------------------------------------------
+
+
+def serve(exporter_module, exporter_instance):
+    handler = exporter_module.make_handler(exporter_instance)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def http_get(server, path):
+    import urllib.request
+    url = f"http://127.0.0.1:{server.server_address[1]}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def test_http_metrics_health_and_404():
+    exp = exporter.Exporter(
+        units="muyan-pilot@*", cache_ttl=0.0, instances=("1",),
+        fetch_journal=lambda units, run=None: [],
+        service_active=lambda u: 0,
+        clock=lambda: 1.0,
+    )
+    server = serve(exporter, exp)
+    try:
+        status, body = http_get(server, "/metrics")
+        assert status == 200
+        assert "muyan_pilot_service_active" in body
+        status, body = http_get(server, "/health")
+        assert status == 200
+        assert body == "ok"
+        status, _ = http_get(server, "/nope")
+        assert status == 404
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_http_metrics_survives_journal_failure_with_error_body():
+    def broken_journal(units, run=None):
+        raise exporter.JournalError("No journal files were opened")
+
+    exp = exporter.Exporter(
+        units="muyan-pilot@*", cache_ttl=0.0, instances=("1",),
+        fetch_journal=broken_journal,
+        service_active=lambda u: 0,
+        clock=lambda: 1.0,
+    )
+    server = serve(exporter, exp)
+    try:
+        status, body = http_get(server, "/metrics")
+        assert status == 500
+        assert "No journal files were opened" in body
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# --- main: argument parsing and fail fast ---------------------------------
+
+
+def test_main_fails_fast_on_bad_port(capsys):
+    rc = exporter.main(["--port", "99999", "--bind", "127.0.0.1"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "exporter_failed" in err
+
+
+def test_main_rejects_unknown_argument():
+    with pytest.raises(SystemExit) as excinfo:
+        exporter.main(["--nonsense"])
+    assert excinfo.value.code == 2
+
+
+def test_main_serves_until_interrupted(monkeypatch, capsys):
+    def fake_serve_forever(self, poll_interval=0.5):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(HTTPServer, "serve_forever", fake_serve_forever)
+    rc = exporter.main(["--port", "0", "--bind", "127.0.0.1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "muyan-pilot-exporter listening" in out
+    assert "units=muyan-pilot@*" in out

--- a/tests/test_muyan_pilot_exporter.py
+++ b/tests/test_muyan_pilot_exporter.py
@@ -298,18 +298,18 @@ def test_build_metrics_live_run_gauges_and_counters():
     text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
     lines = lines_of(text)
 
-    metric(lines, "muyan_pilot_service_active", 'instance="1"', 1.0)
+    metric(lines, "muyan_pilot_service_active", 'slot="1"', 1.0)
     metric(lines, "muyan_pilot_run_active",
-           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
+           'slot="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
            'role="implement",phase="read",state="model_wait"', 1.0)
     metric(lines, "muyan_pilot_run_idle_seconds",
-           'instance="1",issue="xqliu/orbi#162"', 20.0)
+           'slot="1",issue="xqliu/orbi#162"', 20.0)
     metric(lines, "muyan_pilot_run_seconds",
-           'instance="1",issue="xqliu/orbi#162",role="implement"', 60.0)
+           'slot="1",issue="xqliu/orbi#162",role="implement"', 60.0)
     metric(lines, "muyan_pilot_run_start_total",
-           'instance="1",issue="xqliu/orbi#162",role="implement"', 1.0)
+           'slot="1",issue="xqliu/orbi#162",role="implement"', 1.0)
     metric(lines, "muyan_pilot_model_wait_total",
-           'instance="1",issue="xqliu/orbi#162"', 1.0)
+           'slot="1",issue="xqliu/orbi#162"', 1.0)
 
 
 def test_build_metrics_finished_run_keeps_end_scene_and_zeroes_active():
@@ -335,21 +335,21 @@ def test_build_metrics_finished_run_keeps_end_scene_and_zeroes_active():
     text = exporter.build_metrics(entries, now=400.0, service_active={"1": 0})
     lines = lines_of(text)
 
-    metric(lines, "muyan_pilot_service_active", 'instance="1"', 0.0)
+    metric(lines, "muyan_pilot_service_active", 'slot="1"', 0.0)
     metric(lines, "muyan_pilot_run_active",
-           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#181",'
+           'slot="1",repo="xqliu/orbi",issue="xqliu/orbi#181",'
            'role="implement",phase="starting",state="-"', 1.0)
     metric(lines, "muyan_pilot_run_active",
-           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#50",'
+           'slot="1",repo="xqliu/orbi",issue="xqliu/orbi#50",'
            'role="implement",phase="test",state="-"', 0.0)
     metric(lines, "muyan_pilot_run_seconds",
-           'instance="1",issue="xqliu/orbi#50",role="implement"', 12600.0)
+           'slot="1",issue="xqliu/orbi#50",role="implement"', 12600.0)
     metric(lines, "muyan_pilot_run_end_total",
-           'instance="1",issue="xqliu/orbi#50",role="implement",'
+           'slot="1",issue="xqliu/orbi#50",role="implement",'
            'result="pr_opened"', 1.0)
     # The finished run's idle gauge is not re-emitted (no live state).
     assert not any(
-        ln.startswith('muyan_pilot_run_idle_seconds{instance="1",'
+        ln.startswith('muyan_pilot_run_idle_seconds{slot="1",'
                       'issue="xqliu/orbi#50"}')
         for ln in lines
     )
@@ -385,16 +385,16 @@ def test_build_metrics_failure_and_recovery_counters_by_reason():
     lines = lines_of(text)
 
     metric(lines, "muyan_pilot_pi_idle_total",
-           'instance="2",issue="xqliu/orbi#181"', 1.0)
+           'slot="2",issue="xqliu/orbi#181"', 1.0)
     metric(lines, "muyan_pilot_pi_idle_term_total",
-           'instance="2",issue="xqliu/orbi#181"', 1.0)
+           'slot="2",issue="xqliu/orbi#181"', 1.0)
     metric(lines, "muyan_pilot_pi_idle_kill_total",
-           'instance="2",issue="xqliu/orbi#181"', 1.0)
+           'slot="2",issue="xqliu/orbi#181"', 1.0)
     metric(lines, "muyan_pilot_run_failed_total",
-           'instance="2",issue="xqliu/orbi#181",'
+           'slot="2",issue="xqliu/orbi#181",'
            'reason="idle_recovery_stale_15m"', 1.0)
     metric(lines, "muyan_pilot_progress_publish_failed_total",
-           'instance="2",issue="xqliu/orbi#181"', 1.0)
+           'slot="2",issue="xqliu/orbi#181"', 1.0)
     # The failed run is no longer active.
     assert not any(
         ln.endswith('state="model_wait"} 1')
@@ -426,8 +426,13 @@ def test_build_metrics_labels_stay_within_allowlist():
         assert "prompt text" not in body, line
         for label in body.strip("}").split(","):
             name = label.split("=", 1)[0].strip()
+            # The allowlist deliberately excludes `instance` and `job`:
+            # the Prometheus scraper reserves both, so an emitted
+            # `instance` label would arrive as `exported_instance` and
+            # break every per-Runner grouping in the Dashboard (Issue
+            # #162, verified against the running Prometheus).
             assert name in {
-                "instance", "repo", "issue", "role", "phase", "state",
+                "slot", "repo", "issue", "role", "phase", "state",
                 "reason", "result",
             }, line
 
@@ -439,7 +444,7 @@ def test_build_metrics_unparseable_messages_are_skipped():
     ]
     text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
     lines = lines_of(text)
-    assert metric(lines, "muyan_pilot_service_active", 'instance="1"') == 1.0
+    assert metric(lines, "muyan_pilot_service_active", 'slot="1"') == 1.0
     assert not any(
         ln.startswith("muyan_pilot_run_") for ln in lines
     )
@@ -472,7 +477,7 @@ def test_build_metrics_heartbeat_without_idle_or_elapsed_updates_combo_only():
     text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
     lines = lines_of(text)
     metric(lines, "muyan_pilot_run_active",
-           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
+           'slot="1",repo="xqliu/orbi",issue="xqliu/orbi#162",'
            'role="implement",phase="read",state="model_wait"', 1.0)
     assert not any(ln.startswith("muyan_pilot_run_idle_seconds")
                    for ln in lines)
@@ -492,7 +497,7 @@ def test_build_metrics_run_end_without_elapsed_still_counts():
     text = exporter.build_metrics(entries, now=300.0, service_active={"1": 1})
     lines = lines_of(text)
     metric(lines, "muyan_pilot_run_end_total",
-           'instance="1",issue="xqliu/orbi#162",role="implement",'
+           'slot="1",issue="xqliu/orbi#162",role="implement",'
            'result="failed"', 1.0)
     assert not any(ln.startswith("muyan_pilot_run_seconds") for ln in lines)
 
@@ -523,8 +528,8 @@ def test_build_metrics_fails_fast_on_kind_outside_chain(monkeypatch):
 def test_build_metrics_empty_journal_emits_only_service_gauges():
     text = exporter.build_metrics([], now=10.0, service_active={"1": 1, "2": 0})
     lines = lines_of(text)
-    assert metric(lines, "muyan_pilot_service_active", 'instance="1"') == 1.0
-    assert metric(lines, "muyan_pilot_service_active", 'instance="2"') == 0.0
+    assert metric(lines, "muyan_pilot_service_active", 'slot="1"') == 1.0
+    assert metric(lines, "muyan_pilot_service_active", 'slot="2"') == 0.0
     assert not any(ln.startswith("muyan_pilot_run_") for ln in lines)
 
 
@@ -539,7 +544,7 @@ def test_build_metrics_unknown_scene_fields_are_ignored():
     text = exporter.build_metrics(entries, now=200.0, service_active={"1": 1})
     lines = lines_of(text)
     metric(lines, "muyan_pilot_run_active",
-           'instance="1",repo="xqliu/orbi",issue="xqliu/orbi#9",'
+           'slot="1",repo="xqliu/orbi",issue="xqliu/orbi#9",'
            'role="implement",phase="starting",state="-"', 1.0)
 
 
@@ -553,7 +558,7 @@ def test_build_metrics_missing_instance_falls_back_to_unknown():
     text = exporter.build_metrics(entries, now=200.0, service_active={})
     lines = lines_of(text)
     metric(lines, "muyan_pilot_run_start_total",
-           'instance="unknown",issue="xqliu/orbi#162",role="implement"', 1.0)
+           'slot="unknown",issue="xqliu/orbi#162",role="implement"', 1.0)
 
 
 # --- Exporter: TTL cache + service state ----------------------------------
@@ -582,7 +587,7 @@ def test_exporter_caches_journal_until_ttl_expires():
     second = exp.metrics()
     assert first == second
     assert len(calls) == 1  # second scrape served from the cache
-    assert 'muyan_pilot_service_active{instance="1"} 1' in first
+    assert 'muyan_pilot_service_active{slot="1"} 1' in first
 
 
 def test_exporter_refreshes_after_ttl_and_after_journal_error():
@@ -623,8 +628,8 @@ def test_exporter_service_active_maps_unit_instances():
     text = exp.metrics()
     assert seen == ["muyan-pilot@1.service", "muyan-pilot@2.service"]
     lines = lines_of(text)
-    metric(lines, "muyan_pilot_service_active", 'instance="1"', 1.0)
-    metric(lines, "muyan_pilot_service_active", 'instance="2"', 0.0)
+    metric(lines, "muyan_pilot_service_active", 'slot="1"', 1.0)
+    metric(lines, "muyan_pilot_service_active", 'slot="2"', 0.0)
 
 
 def test_exporter_default_systemctl_uses_systemctl_user_is_active():


### PR DESCRIPTION
Fixes #162

<!-- muyan-pilot:run=cf357f0e -->

run_id=cf357f0e

## 变更

只读、独立、版本管理的 Muyan Pilot 观测栈（Runner 完全不知道它存在：
不 push、不回调、不写状态；无数据库/队列/新状态存储，journal 是唯一
数据源；标签只用低基数集合 `instance/repo/issue/role/phase/state/
reason/result`，永不输出 `run_id`、branch、命令或 prompt 文本）：

- `monitoring/prometheus/muyan-pilot-exporter.py` — 纯 stdlib，只读
  `journalctl --user -u 'muyan-pilot@*' -o json` 与
  `systemctl --user is-active`，在 `127.0.0.1:9106/metrics` 暴露
  `muyan_pilot_*` 指标：service active、每 slot 当前
  issue/role/phase/state、idle 秒数、run 时长、`run_failed` by
  reason、idle 恢复（pi_idle/term/kill）、`progress_publish_failed`、
  model_wait。journalctl 失败 fail fast（HTTP 500 带命令/rc/stderr，
  不吞错、不 fallback）。
- `monitoring/grafana/dashboards/muyan-pilot.json` — 版本化 Dashboard
  （uid `muyan-pilot`，可重复导入）：两个 service active、当前
  issue/role/phase/state、idle 秒数、`run_failed` by reason、idle
  恢复、`progress_publish_failed`、run 时长，并复用已有 llama
  slot/context/TPS/token 指标（不重新实现）。
- `monitoring/grafana/README.md` — 安装/接入/验证说明（exporter 前台与
  user unit、Prometheus scrape job、Grafana 导入、测试）。
- `README.md` — journal 一节之后加观测栈指针。
- 测试：`tests/test_muyan_pilot_exporter.py`（43 例：journal 行契约、
  标签白名单、fail fast、HTTP 面）与
  `tests/test_muyan_pilot_dashboard.py`（11 例：JSON 可重复导入、
  uid/schemaVersion、指标族与 llama 复用、grid 不重叠）。

## 验证（本机真实环境）

- 全量 pytest：1227 passed，line/branch coverage 100%（见 worktree
  `test.log`）。
- exporter 对真实 user journal 启动：两个 Runner 实例、当前
  issue/role/phase/state 全部可见；journalctl 故障 → HTTP 500，
  Runner 不受影响（本 PR 的交付本身就在 exporter 故障期间完成）。
- Prometheus：scrape job `muyan-pilot` 已加入
  `/etc/prometheus/prometheus.yml`（备份保留）并 reload，target
  `health=up`；所有 dashboard 表达式（含复用的 llama 指标）逐条
  查询均有真实 series。
- Grafana 13.1.2：Dashboard 已导入本机（unified storage，uid
  `muyan-pilot`），重启后索引干净、health ok；`/d/muyan-pilot` 可
  打开（匿名 302 到登录，符合预期）。
- 未安装/启用任何 user unit（仓库不管理该 unit）；`install-units`
  drift 机制继续只管 `muyan-pilot@.service`/`.timer` 两个模板。