### PR TITLE
Log the active Issue context when the Runner is stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,11 @@ Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`boo
 - `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed），整个 idle 恢复状态同时复位；
 - `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|upstream_dead_stale_...s|idle_recovery_stale_...s`——进程异常退出、超时、上游已死（Issue #75）或连续 3 个 idle 窗口（`PI_IDLE_RECOVERY_CYCLES=3`）仍无新活动（Issue #94，Runner 杀掉 Pi 会话本身）时先记录完整现场再抛出错误；
 - `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
+- `run_stopping issue=N title="..." signal=SIGTERM phase=... branch=... worktree=... session=...`——systemd 停止 service（SIGTERM）时若 run 正在进行，先记录完整停止现场（复用现有 run_id 前缀和 activity 快照的 phase/session，不引入新 id），再对活着的 Pi 子进程发 SIGTERM 并等待其退出，绝不留下孤儿 Pi；
+- `run_stopped issue=N result=interrupted`——Pi 子进程退出后记录停止结果；
+- `run_stopped result=idle`——在领取 Issue 之前被停止时只记录 idle 结果，不虚构任何 Issue 字段。
+
+停止顺序（Issue #48）：`run_stopping` → Pi 子进程退出 → `run_stopped` → 进程以 128+信号值（SIGTERM 为 143）退出。systemd 的 generic `Stopped` 行之后，journal 里始终能查到是哪个 Issue 在跑、跑到哪个 phase、branch/worktree/session 是什么。systemd unit 的 `Description` 保持静态，不做动态描述。
 
 上游已死检测（Issue #75，Issue #169 起基于证据）：`model_wait` 期间 session JSONL 冻结超过 `PI_MODEL_WAIT_DEAD_SECONDS`（默认 600 秒）**且** Pi 进程没有活的上游连接（fd 表里的 `socket:[...]` 在 `/proc/net/tcp`/`tcp6` 中没有处于 ESTABLISHED/SYN_SENT/SYN_RECV 状态且带远端地址的 socket；CLOSE_WAIT 等已断开状态不算）才判定上游（llama/proxy）已死——HTTP 超时或连接断开后 Pi 停在 epoll_wait 永不退出：Runner 杀掉 Pi 进程，记录 `run_failed ... reason=upstream_dead_stale_...s` 后 fail fast（Issue 标记 `ai-blocked`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍可 resume 或领取下一个 `ai-fix-needed`）。session 冻结本身不是证据：本地慢模型生成几分钟时连接仍然活着（heartbeat 显示 `state=model_wait_slow`），Runner 不杀（#158 回归）；事件持续到达时同样永不触发（慢模型不是死上游）。它也不是业务任务 timeout。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -33,6 +33,7 @@ import re
 import select
 import signal
 import subprocess
+import threading
 import time
 import tomllib
 import uuid
@@ -245,6 +246,109 @@ def current_run_id() -> str | None:
 def run_marker(run_id: str) -> str:
     """Return the stable machine-readable run marker for GitHub text."""
     return f"<!-- muyan-pilot:run={validate_run_id(run_id)} -->"
+
+# Stop scene (Issue #48): when systemd (or any caller) stops the Runner
+# with SIGTERM, the journal must show which Issue context was active
+# BEFORE systemd's generic "Stopped" line, and the live Pi child must be
+# shut down (no orphan Pi). The context is bound while a delivery is in
+# flight (after the claim, or after a resumed scene is bound) and cleared
+# when the delivery ends. It carries no new id: the run id is the
+# existing `_CURRENT_RUN_ID`, and the phase/session come from the
+# existing activity snapshot of the worktree's `.pi-session`.
+_ACTIVE_RUN: dict | None = None
+
+
+def set_active_run(issue: int, title: str, branch: str, worktree: str) -> None:
+    """Bind the in-flight delivery scene for the stop handler (Issue #48)."""
+    global _ACTIVE_RUN
+    _ACTIVE_RUN = {
+        "issue": int(issue),
+        "title": title,
+        "branch": branch,
+        "worktree": worktree,
+        "pi": None,
+    }
+
+
+def set_active_pi(process: subprocess.Popen | None) -> None:
+    """Track the live Pi child of the in-flight delivery (Issue #48).
+
+    `stream_pi` calls it after the child is spawned (and again with None
+    after the child is reaped), so the stop handler signals exactly the
+    child that is alive — never an already-exited process. Without a
+    bound run (unit tests call `stream_pi` directly) it is a no-op.
+    """
+    if _ACTIVE_RUN is not None:
+        _ACTIVE_RUN["pi"] = process
+
+
+def clear_active_run() -> None:
+    """No delivery in flight anymore (Issue #48)."""
+    global _ACTIVE_RUN
+    _ACTIVE_RUN = None
+
+
+def _stop_delivery(signum: int) -> None:
+    """Log the stop scene, shut down the live Pi child, exit (Issue #48).
+
+    Runs from the SIGTERM handler. With no run in flight the stop is
+    idle: one `run_stopped result=idle` line, no invented Issue fields.
+    With a run in flight the `run_stopping` line carries the full scene
+    (issue, title, signal, phase, branch, worktree, session —
+    phase/session from the existing activity snapshot, `-` when absent)
+    BEFORE the stop, the live Pi child is TERMed and waited for, then
+    the `run_stopped issue=N result=interrupted` line. The process then
+    exits with 128+signum (143 for SIGTERM) — the same value systemd
+    records for a signal-caused stop.
+    """
+    run = _ACTIVE_RUN
+    if run is None:
+        LOGGER.info("run_stopped result=idle")
+    else:
+        phase = "-"
+        session = "-"
+        try:
+            snapshot = activity_snapshot(Path(run["worktree"]) / ".pi-session")
+            if snapshot is not None:
+                phase = snapshot["phase"] or "-"
+                session = snapshot["session_id"] or "-"
+        except Exception:
+            LOGGER.exception("stop scene activity snapshot failed")
+        LOGGER.info(
+            "run_stopping issue=%s title=%s signal=%s phase=%s "
+            "branch=%s worktree=%s session=%s",
+            run["issue"], quote_value(run["title"]),
+            signal.Signals(signum).name, quote_value(phase),
+            quote_value(run["branch"]), quote_value(run["worktree"]),
+            quote_value(session),
+        )
+        child = run["pi"]
+        if child is not None and child.poll() is None:
+            child.terminate()
+            child.wait()
+        LOGGER.info(
+            "run_stopped issue=%s result=interrupted", run["issue"],
+        )
+    _die_from_signal(signum)
+
+
+def _die_from_signal(signum: int) -> None:
+    """Exit the process from the ORIGINAL signal (Issue #48).
+
+    `os._exit` never returns in production; the two lines after it
+    exist so a handler crash can never swallow the stop: restore the
+    default disposition and re-raise the ORIGINAL signal at ourselves,
+    so the process dies from the signal itself (systemd sees a
+    signal-caused stop, exit 128+signum).
+    """
+    os._exit(128 + signum)
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+def _handle_stop(signum: int, frame: object) -> None:
+    """SIGTERM handler: log the active Issue context, then exit (Issue #48)."""
+    _stop_delivery(signum)
 
 
 def _config_path(value: str, base: Path) -> Path:
@@ -1598,6 +1702,10 @@ def stream_pi(
         command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
         env=None if pi_env is None else {**os.environ, **pi_env},
     )
+    # Track the live Pi child for the stop handler (Issue #48): a
+    # SIGTERM during this window must shut the child down, never
+    # orphan it. Cleared again once the child is reaped (finally).
+    set_active_pi(process)
     LOGGER.info(
         "run_start %s",
         format_run_scene(
@@ -1991,6 +2099,9 @@ def stream_pi(
             if process.poll() is not None:
                 break
     finally:
+        # The child is reaped (or dead): the stop handler must never
+        # signal an already-exited process (Issue #48).
+        set_active_pi(None)
         _drain_stream(process.stdout, stdout_chunks)
         _drain_stream(process.stderr, stderr_chunks)
     stdout = _decode_chunks(stdout_chunks)
@@ -3790,6 +3901,15 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         "issue=%s %s", number, run_info,
     )
     edit_issue(number, repo=source_repo, add=IN_PROGRESS_LABEL)
+    # The Issue is in flight from the claim label on: bind the stop
+    # scene (Issue #48) so a SIGTERM during this tick logs the active
+    # Issue context, not only systemd's generic "Stopped" line. The
+    # branch and worktree path are the same derived values the
+    # worktree creation below uses (bound before the worktree exists).
+    set_active_run(
+        number, title, branch,
+        str(worktree_path(config["repo_dir"], source_repo, number, run_id)),
+    )
     publisher = ProgressPublisher(
         number, source_repo, run_id, run_command=run_command,
     )
@@ -4557,6 +4677,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format=log_format())
+    # Stop scene (Issue #48): install the SIGTERM handler BEFORE any
+    # other step so every phase of the tick (pre-claim, claim,
+    # implement, delivery wait) stops with the active Issue context
+    # logged and the live Pi child shut down — never an orphan Pi and
+    # never only systemd's generic "Stopped" line. Python only allows
+    # signal handlers in the main thread (the CLI entry point always
+    # is; in-thread `main()` test calls skip the install).
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGTERM, _handle_stop)
 
     config = load_config(args.config)
     validate_config(config)
@@ -4661,6 +4790,19 @@ def main(argv: list[str] | None = None) -> int:
             # the progress failure of Issue #70, is reviewed the same
             # way).
             set_run_id(scene["run_id"])
+            # The resumed delivery is in flight: bind the stop scene
+            # (Issue #48) with the same derived branch/worktree the
+            # delivery wait uses (never read from a comment).
+            set_active_run(
+                int(issue["number"]), issue["title"],
+                task_branch(
+                    source_repo, int(issue["number"]), scene["run_id"],
+                ),
+                str(worktree_path(
+                    config["repo_dir"], source_repo,
+                    int(issue["number"]), scene["run_id"],
+                )),
+            )
             # Issue #89: verify the open PR BEFORE any git/Pi mutation
             # (head repo, base, run marker, exact URL of the recovered
             # scene — the pre-#82 resume_delivery check, restored):
@@ -4677,6 +4819,9 @@ def main(argv: list[str] | None = None) -> int:
         wait_for_delivery(pr_url, issue, config, source_repo)
     finally:
         slot.release()
+        # The delivery is over (merged, terminally failed, or the tick
+        # found no work): a stop from here on is idle again (Issue #48).
+        clear_active_run()
     return 0
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -8987,3 +8988,416 @@ def test_prepare_pi_agent_dir_is_idempotent_on_resume(
     # The stale settings symlink is replaced by the real per-run file.
     assert not settings.is_symlink()
     assert json.loads(settings.read_text(encoding="utf-8")) == {}
+
+
+# ---------------------------------------------------------------------------
+# Issue #48: log the active Issue context when the Runner is stopped
+# (SIGTERM): `run_stopping` before the stop, `run_stopped` after the Pi
+# child exits, `result=idle` when no Issue was claimed yet.
+# ---------------------------------------------------------------------------
+
+def _write_session_file(worktree: Path, session_id: str = "sess-1") -> None:
+    """A session JSONL with a tool call so the snapshot shows phase=test."""
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(exist_ok=True)
+    records = [
+        {"type": "session", "id": session_id,
+         "timestamp": fresh_timestamp(), "cwd": str(worktree)},
+        {"type": "message", "id": "a1", "timestamp": fresh_timestamp(),
+         "message": {"role": "assistant", "content": [
+             {"type": "toolCall", "id": "t1", "name": "bash",
+              "arguments": {"command": "pytest tests/"}}]}},
+    ]
+    with open(session_dir / f"{session_id}.jsonl", "w",
+              encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+
+
+def test_stop_handler_idle_logs_run_stopped_idle_and_exits(
+    monkeypatch, caplog,
+):
+    # No run in flight (before the claim): the stop logs result=idle
+    # WITHOUT any invented issue fields and exits 143.
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    died = {}
+    monkeypatch.setattr(
+        runner, "_die_from_signal",
+        lambda signum: died.setdefault("signum", signum),
+    )
+    with caplog.at_level("INFO"):
+        runner._handle_stop(signal.SIGTERM, None)
+    assert 128 + died["signum"] == 143
+    lines = [line for line in caplog.text.splitlines()
+             if " run_stopped " in line]
+    assert len(lines) == 1
+    assert "result=idle" in lines[0]
+    assert "issue=" not in lines[0]
+    # No run was in flight: no run_stopping line either.
+    assert "run_stopping" not in caplog.text
+
+
+def test_stop_handler_active_run_logs_stopping_then_stopped_and_exits(
+    monkeypatch, caplog, tmp_path,
+):
+    # Run in flight: run_stopping carries the full scene BEFORE the
+    # stop, the live Pi child is TERMed and waited for, then
+    # run_stopped result=interrupted, then the process exits 143.
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    runner.set_active_run(
+        48, "Log the stop scene", "muyan-pilot/owner-repo-issue-48-a1b2c3d4",
+        str(worktree),
+    )
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+    )
+    runner.set_active_pi(child)
+    died = {}
+    monkeypatch.setattr(
+        runner, "_die_from_signal",
+        lambda signum: died.setdefault("signum", signum),
+    )
+    with caplog.at_level("INFO"):
+        runner._handle_stop(signal.SIGTERM, None)
+    assert 128 + died["signum"] == 143
+    lines = caplog.text.splitlines()
+    stopping = [line for line in lines if " run_stopping " in line]
+    stopped = [line for line in lines if " run_stopped " in line]
+    assert len(stopping) == 1
+    assert len(stopped) == 1
+    # run_stopping comes BEFORE run_stopped (the child exit is in
+    # between).
+    assert lines.index(stopping[0]) < lines.index(stopped[0])
+    line = stopping[0]
+    assert "issue=48" in line
+    assert 'title="Log the stop scene"' in line
+    assert "signal=SIGTERM" in line
+    # No session file yet: the snapshot fields are '-' (never invented).
+    assert "phase=-" in line
+    assert "session=-" in line
+    assert "branch=muyan-pilot/owner-repo-issue-48-a1b2c3d4" in line
+    assert f"worktree={worktree}" in line
+    assert stopped[0].endswith("run_stopped issue=48 result=interrupted")
+    # The live Pi child was shut down: no orphan survives the stop.
+    assert child.wait(timeout=5) == -signal.SIGTERM
+
+
+def test_stop_handler_active_run_uses_activity_snapshot_for_scene(
+    monkeypatch, caplog, tmp_path,
+):
+    # With a session file the run_stopping line carries the phase and
+    # session of the existing activity snapshot (reused, not re-parsed
+    # ad hoc).
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    _write_session_file(worktree, session_id="sess-48")
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    runner.set_active_run(48, "t", "b", str(worktree))
+    died = {}
+    monkeypatch.setattr(
+        runner, "_die_from_signal",
+        lambda signum: died.setdefault("signum", signum),
+    )
+    with caplog.at_level("INFO"):
+        runner._handle_stop(signal.SIGTERM, None)
+    line = [line for line in caplog.text.splitlines()
+            if " run_stopping " in line][0]
+    assert "phase=test" in line
+    assert "session=sess-48" in line
+    assert 128 + died["signum"] == 143
+
+
+def test_stop_handler_active_run_without_live_child_still_stops(
+    monkeypatch, caplog, tmp_path,
+):
+    # Run in flight but no live Pi child (between sessions): both lines
+    # are still logged and the process exits 143.
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    runner.set_active_run(48, "t", "b", str(worktree))
+    died = {}
+    monkeypatch.setattr(
+        runner, "_die_from_signal",
+        lambda signum: died.setdefault("signum", signum),
+    )
+    with caplog.at_level("INFO"):
+        runner._handle_stop(signal.SIGTERM, None)
+    lines = caplog.text.splitlines()
+    assert any(" run_stopping " in line for line in lines)
+    assert any(
+        line.endswith("run_stopped issue=48 result=interrupted")
+        for line in lines
+    )
+    assert 128 + died["signum"] == 143
+
+
+def test_stop_handler_snapshot_failure_still_logs_and_exits(
+    monkeypatch, caplog,
+):
+    # A failing activity snapshot never swallows the stop: the scene
+    # falls back to `-` for phase/session and the stop still exits.
+    monkeypatch.setattr(
+        runner, "_ACTIVE_RUN",
+        {"issue": 48, "title": "t", "branch": "b", "worktree": "/w",
+         "pi": None},
+    )
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    died = {}
+    monkeypatch.setattr(
+        runner, "_die_from_signal",
+        lambda signum: died.setdefault("signum", signum),
+    )
+    def boom(_dir):
+        raise RuntimeError("snapshot exploded")
+    monkeypatch.setattr(runner, "activity_snapshot", boom)
+    with caplog.at_level("INFO"):
+        runner._stop_delivery(signal.SIGTERM)
+    assert died["signum"] == signal.SIGTERM
+    stopping = [
+        line for line in caplog.text.splitlines()
+        if " run_stopping " in line
+    ]
+    assert len(stopping) == 1
+    assert "phase=-" in stopping[0]
+    assert "session=-" in stopping[0]
+    assert "snapshot exploded" in caplog.text
+
+
+def test_stop_handler_reinstalls_default_disposition_and_raises_signal(
+    monkeypatch, caplog,
+):
+    # After the stop work the handler restores SIGTERM's default
+    # disposition and re-raises the signal at itself: the process dies
+    # from the ORIGINAL signal (systemd sees a signal-caused stop, exit
+    # 143) and a handler crash can never swallow the stop.
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(runner.os, "_exit", lambda code: None)
+    raised = {}
+    monkeypatch.setattr(
+        runner.os, "kill",
+        lambda pid, sig: raised.setdefault("args", (pid, sig)),
+    )
+    runner._die_from_signal(signal.SIGTERM)
+    assert signal.getsignal(signal.SIGTERM) is signal.SIG_DFL
+    assert raised["args"] == (os.getpid(), signal.SIGTERM)
+
+
+def test_set_active_run_binds_scene_and_pi_tracking(monkeypatch):
+    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    runner.set_active_run(7, "t", "b", "/w")
+    assert runner._ACTIVE_RUN == {
+        "issue": 7, "title": "t", "branch": "b", "worktree": "/w",
+        "pi": None,
+    }
+    child = object()
+    runner.set_active_pi(child)
+    assert runner._ACTIVE_RUN["pi"] is child
+    runner.set_active_pi(None)
+    assert runner._ACTIVE_RUN["pi"] is None
+    runner.clear_active_run()
+    assert runner._ACTIVE_RUN is None
+    # set_active_pi without a bound run is a no-op (never crashes).
+    runner.set_active_pi(child)
+    assert runner._ACTIVE_RUN is None
+
+
+def test_main_installs_the_stop_handler(monkeypatch, tmp_path):
+    # main() installs the SIGTERM handler right after logging is set up,
+    # so every phase of the tick (pre-claim, claim, implement, delivery
+    # wait) stops with the scene.
+    installed = {}
+    monkeypatch.setattr(
+        signal, "signal",
+        lambda sig, handler: installed.setdefault(sig, handler),
+    )
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n'
+        'workspace_root = ".."\nprompt = "prompt.md"\n'
+        'prompt_review = "prompt_review.md"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "prompt.md").write_text("p", encoding="utf-8")
+    (tmp_path / "prompt_review.md").write_text("p", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.setattr(
+        runner, "pick_next_delivery", lambda *args: None,
+    )
+    monkeypatch.setattr(runner, "acquire_slot", lambda *args: Mock(release=lambda: None))
+    monkeypatch.setattr(runner, "refresh_cli_install", lambda *a, **k: "unchanged")
+    monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "check_transport", lambda *a, **k: {})
+    assert runner.main(["--config", str(config_path)]) == 0
+    assert installed[signal.SIGTERM] is runner._handle_stop
+
+
+# Issue #48 acceptance: a REAL subprocess SIGTERM test — the Runner
+# process is a real child of the test, stopped with a real SIGTERM, and
+# the journal (captured from its stderr) proves the ordering and fields.
+STOP_DRIVER = """
+import logging
+import signal
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, {repo!r})
+import bootstrap_runner as runner
+
+logging.basicConfig(level=logging.INFO, format=runner.log_format())
+# Exactly what main() does (Issue #48): install the stop handler first.
+signal.signal(signal.SIGTERM, runner._handle_stop)
+runner.set_run_id("a1b2c3d4")
+runner.set_active_run(
+    48, "Log the stop scene",
+    "muyan-pilot/owner-repo-issue-48-a1b2c3d4", {worktree!r},
+)
+# The real Pi-like child: a real long-running process (what stream_pi
+# tracks via set_active_pi). It lingers briefly on SIGTERM before
+# exiting (a slow shutdown), so the stop handler's child.wait() has a
+# real wait to do.
+child = subprocess.Popen(
+    [sys.executable, "-c",
+     "import os, signal, time\\n"
+     "signal.signal(signal.SIGTERM, lambda s, f: "
+     "(time.sleep(0.5), os._exit(0)))\\n"
+     "time.sleep(60)\\n"],
+)
+runner.set_active_pi(child)
+print("ready child=" + str(child.pid), flush=True)
+# Sit in the poll loop (like stream_pi) until stopped.
+time.sleep(120)
+"""
+
+
+def test_real_subprocess_sigterm_logs_stop_scene_and_shuts_down_pi(
+    tmp_path,
+):
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    _write_session_file(worktree, session_id="sess-48")
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        STOP_DRIVER.format(
+            repo=str(Path(__file__).resolve().parent.parent),
+            worktree=str(worktree),
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(driver)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    ready = proc.stdout.readline()
+    assert ready.startswith("ready child=")
+    child_pid = int(ready.strip().split("=")[1])
+    # The Pi child is alive before the stop.
+    time.sleep(0.2)
+    assert _pid_alive(child_pid)
+    # The real SIGTERM that systemd would send on stop.
+    proc.send_signal(signal.SIGTERM)
+    stderr = proc.stderr.read()
+    # The process exits with 128+SIGTERM = 143 (the value systemd
+    # records for a signal-caused stop).
+    assert proc.wait(timeout=10) == 143
+    lines = [line for line in stderr.splitlines() if line]
+    stopping = [line for line in lines if " run_stopping " in line]
+    stopped = [line for line in lines if " run_stopped " in line]
+    assert len(stopping) == 1
+    assert len(stopped) == 1
+    # Ordering: run_stopping BEFORE run_stopped (the Pi child exit is
+    # in between), and both BEFORE the process termination (they are in
+    # the captured stderr of the already-exited process).
+    assert lines.index(stopping[0]) < lines.index(stopped[0])
+    # The [run_id] prefix (the existing run correlation, reused); the
+    # journal format is `LEVEL message`.
+    assert stopping[0].startswith("INFO [a1b2c3d4] run_stopping ")
+    assert stopped[0].startswith("INFO [a1b2c3d4] run_stopped ")
+    line = stopping[0]
+    assert "issue=48" in line
+    assert 'title="Log the stop scene"' in line
+    assert "signal=SIGTERM" in line
+    # phase/session from the existing activity snapshot of the
+    # worktree's .pi-session.
+    assert "phase=test" in line
+    assert "session=sess-48" in line
+    assert "branch=muyan-pilot/owner-repo-issue-48-a1b2c3d4" in line
+    assert f"worktree={worktree}" in line
+    assert stopped[0].endswith("run_stopped issue=48 result=interrupted")
+    # No orphan Pi: the stop handler waited for the child to exit
+    # BEFORE the process exited (driver exit implies the child was
+    # reaped), so the child must be gone now.
+    assert not _pid_alive(child_pid)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The pid exists but belongs to another user: alive.
+        return True
+    return True
+
+
+def test_pid_alive_reports_zombie_and_foreign_pid(monkeypatch):
+    # A killed-but-unreaped child is a zombie: os.kill(pid, 0) succeeds
+    # on it, so it still counts as alive (the stop handler's
+    # child.poll() check is what distinguishes a zombie).
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+    )
+    child.kill()
+    time.sleep(0.2)
+    assert _pid_alive(child.pid) is True
+    child.wait(timeout=5)
+    # A pid that no longer exists (reaped).
+    assert _pid_alive(child.pid) is False
+    # A foreign pid (owned by another user) reports alive via
+    # PermissionError — exercise the branch by stubbing os.kill.
+    monkeypatch.setattr(
+        runner.os, "kill",
+        lambda pid, sig: (_ for _ in ()).throw(PermissionError()),
+    )
+    assert _pid_alive(1) is True
+
+
+def test_real_subprocess_sigterm_before_claim_logs_idle(tmp_path):
+    # Stopped before claiming an Issue: run_stopped result=idle, no
+    # invented Issue fields.
+    driver = tmp_path / "driver_idle.py"
+    driver.write_text(
+        "import logging, signal, sys, time\n"
+        f"sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})\n"
+        "import bootstrap_runner as runner\n"
+        "logging.basicConfig(level=logging.INFO, format=runner.log_format())\n"
+        "signal.signal(signal.SIGTERM, runner._handle_stop)\n"
+        "print('ready', flush=True)\n"
+        "time.sleep(120)\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(driver)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    assert proc.stdout.readline().strip() == "ready"
+    proc.send_signal(signal.SIGTERM)
+    stderr = proc.stderr.read()
+    assert proc.wait(timeout=10) == 143
+    lines = [line for line in stderr.splitlines() if line]
+    stopped = [line for line in lines if " run_stopped " in line]
+    assert len(stopped) == 1
+    assert stopped[0] == "INFO run_stopped result=idle"
+    assert "issue=" not in stderr
+    assert "run_stopping" not in stderr


### PR DESCRIPTION
Fixes #48

<!-- muyan-pilot:run=e56325e9 -->
run_id=e56325e9

## What

When systemd (or any caller) stops the Runner with SIGTERM, the journal
now shows which Issue context was active BEFORE the generic `Stopped`
line, and the live Pi child is shut down — no orphan Pi:

```text
[run_id] run_stopping issue=N title="..." signal=SIGTERM phase=... branch=... worktree=... session=...
[run_id] run_stopped issue=N result=interrupted
```

A stop before claiming an Issue logs `run_stopped result=idle` without
any invented Issue fields.

## How (smallest complete change)

- `bootstrap_runner.py`:
  - `_ACTIVE_RUN` context bound at the claim (`process_issue`) and on
    resume (`main`), cleared when the delivery ends; carries
    issue/title/branch/worktree + the live Pi child. No new id: the run
    id is the existing `_CURRENT_RUN_ID`, phase/session come from the
    existing activity snapshot of the worktree's `.pi-session`
    (`-` when absent).
  - `_handle_stop` (SIGTERM) installed in `main()` right after logging —
    covers pre-claim, claim, implement and delivery wait. Logs
    `run_stopping` with the full scene, TERMs the live Pi child (only
    if alive) and waits for it, logs `run_stopped result=interrupted`,
    exits 128+signum (143). Idle stop: one `run_stopped result=idle`
    line.
  - `stream_pi` registers the Pi `Popen` after spawn and clears it after
    the child is reaped, so the handler never signals an already-exited
    child.
- `tests/test_bootstrap_runner.py`: 11 new tests, including the
  acceptance proof — a REAL subprocess SIGTERM test (real Runner
  process, real long-running Pi-like child, real SIGTERM) asserting the
  ordering (`run_stopping` before `run_stopped`, both before the
  process is gone), every field, exit 143, no orphan child, and the
  idle stop.
- `README.md`: journal section documents `run_stopping` /
  `run_stopped`.

The systemd unit description stays static (per the Issue). No timeout,
retry framework, tracing backend or second ID is added.

## Verification

- Full suite: `1239 passed` (baseline 1228 + 11 new tests).
- 100% line and branch coverage: `TOTAL 15603 stmts, 0 miss, 2202
  branches, 0 partial`.
- Details in the worktree's `test.log` (run artifacts, gitignored by
  design).
