### PR TITLE
Docs: getting-started covers the model provider and the full chain

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,8 +1,11 @@
 # Getting started
 
-This page takes you from a fresh clone to a first verified tick. Every
-command works at any clone path — nothing here depends on a specific
-machine layout.
+This page takes you from a fresh clone to a fully verified delivery:
+prerequisites, the model provider, the one-time setup, and a minimal
+smoke that proves the whole loop — a GitHub Issue picked up,
+implemented, tested, opened as a PR, independently reviewed, and
+merged. Every command works at any clone path — nothing here depends on
+a specific machine layout.
 
 ## Prerequisites
 
@@ -20,7 +23,7 @@ verifies the login).
 | Git | Worktrees, branches, base freshness | `git --version` |
 | GitHub CLI (`gh`) | Issues, labels, PRs, merge | `gh auth status` |
 | systemd (user session) | The timer that triggers one tick every 5 minutes | `systemctl --user status` |
-| A working OpenAI-compatible model endpoint | Pi's model provider — a local llama.cpp server or any OpenAI-compatible API | one real `pi --print` call (below) |
+| A working model provider | A model Pi can actually use — either a provider configured in Pi itself, or a `pi_providers` file pointing at an OpenAI-compatible endpoint (a local `llama.cpp` server or any compatible API) | one real `pi --print` call (below); step 4 shows both paths |
 
 Install `uv` with the official installer (verified against the [uv
 docs](https://docs.astral.sh/uv/getting-started/installation/)):
@@ -127,6 +130,10 @@ directory):
 | `max_concurrency` | no | `1` | Concurrent Pilot tasks on this machine (positive integer; a local model/GPU usually serves one stable task) |
 | `skills` | no | `[]` | Optional Pi skill paths (absolute, `~`, or relative to the config file) |
 | `context_files` | no | `[]` | Optional Markdown context files injected into the prompt as paths |
+| `pi_providers` | no | unset | Path to a JSON file in Pi's `models.json` shape that adds or overrides providers in Pi's catalog for every run (Issue #157). Unset = Pi uses its own agent dir unchanged (step 4) |
+| `pi_provider` | no | unset | The provider id selected for every run (Issue #119) — passed to Pi as `--provider`; must be defined when a `pi_providers` file is set |
+| `pi_model` | no | unset | The model id within the selected provider — passed to Pi as `--model`; must exist in the provider's `models` list |
+| `pi_thinking` | no | unset | Thinking level passed to Pi as `--thinking` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) |
 
 Minimal example:
 
@@ -146,7 +153,136 @@ skills = []
 context_files = []
 ```
 
-## 4. Run the one-time setup
+## 4. Configure the model provider
+
+The Runner never starts or manages the model process — it launches Pi,
+and Pi needs a provider it can actually use. There are two paths, and
+you need only one:
+
+### Path A: Pi's own providers (no Muyan Pilot config)
+
+Leave `pi_providers` unset and the Runner launches Pi exactly as you
+would run it by hand — Pi uses its own agent directory and the
+providers you configured there. Verify the provider is ready with Pi's
+own check before dispatching work:
+
+```bash
+pi auth check --provider <provider-id>
+pi --print "reply with the single word: ok"
+```
+
+### Path B: a `pi_providers` file (Muyan Pilot manages the selection)
+
+Point `pi_providers` at a JSON file in Pi's own `models.json` shape.
+At every run the Runner materializes a per-run agent dir
+(`<worktree>/.muyan-pilot/pi-agent/`, gitignored) whose `models.json`
+merges your user providers with the file's providers (the file wins on
+an id collision) — your existing providers keep working, the file adds
+or overrides — and selects the configured provider/model for the run.
+
+An OpenAI-compatible remote endpoint (the key stays out of the file —
+it references an environment variable):
+
+```json
+{
+  "providers": {
+    "groq": {
+      "baseUrl": "https://api.groq.com/openai/v1",
+      "api": "openai-completions",
+      "apiKey": "$GROQ_API_KEY",
+      "models": [
+        {
+          "id": "qwen/qwen3.8-27b",
+          "name": "Qwen 3.8 27B",
+          "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    }
+  }
+}
+```
+
+A local `llama.cpp` server (OpenAI-compatible routes at `/v1`, default
+`127.0.0.1:8080`; `--alias` sets the model name the API reports, so the
+`id` below must match it):
+
+```bash
+./llama-server -m /path/to/model.gguf --alias Qwen3.8-27B
+```
+
+```json
+{
+  "providers": {
+    "local": {
+      "baseUrl": "http://127.0.0.1:8080/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "models": [
+        {
+          "id": "Qwen3.8-27B",
+          "name": "Qwen 3.8 27B (local)",
+          "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    }
+  }
+}
+```
+
+Then select the provider and model in `muyan-pilot.toml` (the Runner
+passes them to Pi as `--provider groq --model qwen/qwen3.8-27b`, and
+`--thinking <level>` when `pi_thinking` is set):
+
+```toml
+pi_providers = ".muyan-pilot/pi-providers.json"
+pi_provider = "groq"
+pi_model = "qwen/qwen3.8-27b"
+```
+
+#### Keeping the API key out of the repo and the docs
+
+The file references the key as an environment variable
+(`"$GROQ_API_KEY"`); the actual value lives in the gitignored state
+dir, in an env file the systemd unit loads at service start:
+
+```bash
+mkdir -p .muyan-pilot
+cat > .muyan-pilot/env <<'EOF'
+GROQ_API_KEY=<your key value>
+EOF
+chmod 600 .muyan-pilot/env
+```
+
+The committed unit template already carries
+`EnvironmentFile=-%h/Documents/muyan/muyan-pilot/.muyan-pilot/env`
+(Issue #172) — if your clone lives elsewhere, point the **installed**
+unit's `EnvironmentFile` at **your** `.muyan-pilot/env` like the
+`WorkingDirectory` Note in step 8. A keyless local server needs no env
+file at all (the literal `"local"` placeholder above satisfies the
+shape check).
+
+#### What the Runner validates (fail fast, before any slot or claim)
+
+- the file exists and is valid JSON with a non-empty `providers`
+  object;
+- every provider that lists models has a non-empty `baseUrl` and an
+  `api` (provider- or model-level);
+- the selected `pi_provider` and `pi_model` are defined in the file;
+- the selected provider's `apiKey` env-var reference resolves to a
+  non-empty value — a missing or empty variable fails the start with
+  the variable **name** only (never a key value).
+
+#### The provider boundary
+
+The documented and tested path is an **OpenAI-compatible** endpoint
+(`api: "openai-completions"`) — a local `llama.cpp` server or any
+compatible API. The file is passed to Pi verbatim, so other Pi catalog
+entries keep working through Pi's own agent dir; Muyan Pilot does not
+test or guarantee per-provider integrations beyond that boundary.
+
+## 5. Run the one-time setup
 
 The setup entry does the whole initialization in one command: it
 verifies the prerequisites you installed (git, gh, python3, uv, the
@@ -170,10 +306,10 @@ dirty checkout or a missing systemd user bus stops it with the concrete
 reason). See [One-time setup](/setup) for the full output contract,
 success and failure examples.
 
-## 5. Run one tick manually
+## 6. Run one tick manually
 
 The manual command is for first verification and troubleshooting only —
-normal operation is scheduled by the timer (step 7):
+normal operation is scheduled by the timer (step 8):
 
 ```bash
 python3 bootstrap_runner.py --config muyan-pilot.toml
@@ -186,7 +322,7 @@ only Issues of that Milestone are claimable — Issue #139), then it
 exits. With an empty ready queue it exits cleanly without claiming
 anything.
 
-## 6. Smoke walkthrough (from zero)
+## 7. Smoke walkthrough (from zero)
 
 The smallest end-to-end proof that your setup works. Run it in the clone
 directory from step 1; every command is relative to that directory.
@@ -216,13 +352,58 @@ muyan-pilot session --follow --config muyan-pilot.toml
 gh issue list --repo OWNER/PILOT-REPO --label ai-pr-opened
 ```
 
-You are done when: the Issue moves `ai-ready → ai-in-progress →
-ai-pr-opened → ai-merged`, a PR exists with `Fixes #<issue>` in its body,
-and the journal shows `run_end ... result=pr_opened`. If any step fails,
-the Issue is marked `ai-blocked` with the scene — see
-[Operations](/operations) for recovery.
+### Verify the full chain
 
-## 7. Verify the timers
+The delivery does not end at the PR — the same run (same run id,
+branch, worktree and PR) continues through an independent review and
+the merge on later ticks (manually or via the timer). Each stage has a
+concrete, checkable success criterion:
+
+| Stage | Success criterion | Where to check |
+|---|---|---|
+| Picked up | The Issue label moves `ai-ready → ai-in-progress`; the task worktree and branch exist (both carry the run id) | `gh issue view <n> --json labels`; journal `run_start run=<run_id> ...` |
+| Implemented and tested | Pi runs the TDD loop in the worktree; the single progress comment on the Issue reports the tests milestone | `muyan-pilot session --follow`; the progress comment on the Issue |
+| PR opened | Journal `run_end ... result=pr_opened pr=<url> commit=<sha>`; the Issue label is `ai-pr-opened`; the PR body contains `Fixes #<n>` and the run marker | `gh pr view <n> --json url,body` |
+| Reviewed | The next tick resumes the same run; journal `review pr=<n> round=1 verdict=pass blockers=0 majors=0` | the journal; the PR |
+| Merged | Journal `merged pr=<n> head=<sha>`; the PR is `MERGED` with a merge commit; the Issue label is `ai-merged` and the Issue carries the `Muyan Pilot merged PR: ...` comment | `gh pr view <n> --json state,mergedAt,mergeCommit`; `gh issue view <n> --json state,labels` |
+
+```bash
+# The two read-only checks for the terminal state:
+gh pr view <n> --json state,mergedAt,mergeCommit
+gh issue view <n> --json state,labels
+```
+
+You are done when the Issue has moved `ai-ready → ai-in-progress →
+ai-pr-opened → ai-merged`, the PR is merged with `Fixes #<n>` in its
+body (GitHub closes the Issue natively on merge), and the journal shows
+`run_end ... result=pr_opened`, `review ... verdict=pass` and
+`merged pr=...`. If any step fails, the Issue is marked `ai-blocked`
+**alone** with the scene (run id, branch, worktree, session, phase,
+last activity, the concrete error) and the journal shows
+`run_failed ... reason=...` — see [Operations](/operations) for
+recovery.
+
+## Troubleshooting
+
+Real failure scenes, where to find the evidence, and the fix. Every one
+of them fails fast — nothing is retried silently.
+
+| Symptom | Evidence | Fix |
+|---|---|---|
+| The start fails before any slot or claim | Journal `API key for provider ... references missing environment variable GROQ_API_KEY` (the variable **name** only) | Put the key value into your `.muyan-pilot/env` (step 4) and make sure the installed unit's `EnvironmentFile` points at it; for a manual tick, export the variable in the shell instead |
+| The start fails on the provider file | Journal `pi_providers file ... is not valid JSON` / `is missing baseUrl` / `pi_provider ... is not defined` | Fix the JSON (step 4 contract: `providers` object, `baseUrl`, `api`, `models[].id`) and re-run `muyan-pilot setup` |
+| Pi starts but the model never answers | The session JSONL stalls in `model_wait`; after the dead-silence window the journal shows `run_failed ... reason=upstream_dead_stale_...` | The upstream (model server/proxy) is down or its connection dropped — check the endpoint with one real `pi --print` call, restart it, and re-dispatch (the Issue is `ai-blocked` with the scene) |
+| The PR is opened but never merges | The Issue label is `ai-fix-needed`; the review findings are on the Issue and the PR | The review found Blocker/Major findings it could not fix in-session — the next review session retries the SAME PR (bounded to 5 rounds); read the findings on the Issue and the PR |
+| The review loop exhausts its rounds | Journal `review_rounds_exhausted issue=<n> rounds=5`; the Issue is `ai-blocked` **alone** | The bounded loop is a human decision — read the findings, fix or close the PR manually; see [Operations](/operations) |
+| The PR is behind the latest base | The Issue is `ai-fix-needed` with a review comment that the PR is behind the latest base or has a merge conflict | Automatic: the next review session merges the latest `origin/<base>` into the branch in-session, resolves conflicts, re-runs the full suite |
+| The service does not start after a restart | `systemctl --user status muyan-pilot@1.service`; journal `unit_drift` / `cli_install_failed` / `transport_check_failed` lines | Follow the structured line: re-run `muyan-pilot install-units` (unit drift), the exact reinstall command it prints (stale editable install), or fix the SSH transport (see [Operations](/operations)) |
+| `muyan-pilot doctor` reports `cli_source: DRIFT` | The structured `cli_source_drift` line with the exact reinstall command | Run the printed `uv tool install --force --reinstall --editable ...` command (or `muyan-pilot setup`) |
+
+For the label lifecycle, the journal fields and the recovery rules see
+[Operations](/operations); for the review/merge contract see
+[Workflow](/workflow).
+
+## 8. Verify the timers
 
 The setup step already installed the unit templates and enabled the two
 timer instances (`muyan-pilot@1.timer` and `muyan-pilot@2.timer`, each

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -1,7 +1,9 @@
 # 快速开始
 
-这一页带你从全新 clone 走到第一个验证过的 tick。这里的所有命令在任何
-clone 路径下都能工作——不依赖任何特定机器布局。
+这一页带你从全新 clone 走到一次完整验证过的交付：前提、模型
+provider、一次性 setup，以及一个最小 smoke——证明完整闭环：GitHub
+Issue 被领取、实现、测试、开 PR、独立审查、合并。这里的所有命令在
+任何 clone 路径下都能工作——不依赖任何特定机器布局。
 
 ## 前提
 
@@ -18,7 +20,7 @@ clone 路径下都能工作——不依赖任何特定机器布局。
 | Git | worktree、分支、base 新鲜度 | `git --version` |
 | GitHub CLI（`gh`） | Issue、标签、PR、merge | `gh auth status` |
 | systemd（user session） | 每 5 分钟触发一个 tick 的 timer | `systemctl --user status` |
-| 可用的 OpenAI-compatible 模型 endpoint | Pi 的模型 provider——本地 llama.cpp server 或任意 OpenAI-compatible API | 一次真实 `pi --print` 调用（见下） |
+| 可用的模型 provider | Pi 能真正使用的模型——Pi 自身配置的 provider，或指向 OpenAI-compatible endpoint（本地 `llama.cpp` server 或任意兼容 API）的 `pi_providers` 文件 | 一次真实 `pi --print` 调用（见下）；第 4 步给出两条路径 |
 
 用官方安装器安装 `uv`（已对照
 [uv 官方文档](https://docs.astral.sh/uv/getting-started/installation/)）：
@@ -109,6 +111,10 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 | `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数（正整数；本地模型/GPU 通常只稳定服务一个任务） |
 | `skills` | 否 | `[]` | 可选 Pi skill 路径（绝对、`~`，或相对配置文件） |
 | `context_files` | 否 | `[]` | 可选 Markdown 上下文文件，以路径形式注入 prompt |
+| `pi_providers` | 否 | 未设置 | 指向 Pi `models.json` 形状 JSON 文件的路径，为每个 run 向 Pi 目录添加或覆盖 provider（Issue #157）。未设置 = Pi 原样使用自己的 agent 目录（第 4 步） |
+| `pi_provider` | 否 | 未设置 | 每个 run 选用的 provider id（Issue #119）——以 `--provider` 传给 Pi；设置 `pi_providers` 文件时必须已在其中定义 |
+| `pi_model` | 否 | 未设置 | 选中 provider 内的 model id——以 `--model` 传给 Pi；必须存在于该 provider 的 `models` 列表 |
+| `pi_thinking` | 否 | 未设置 | 以 `--thinking` 传给 Pi 的思考级别（`off`、`minimal`、`low`、`medium`、`high`、`xhigh`、`max`） |
 
 最小示例：
 
@@ -128,7 +134,129 @@ skills = []
 context_files = []
 ```
 
-## 4. 运行一次性 setup
+## 4. 配置模型 provider
+
+Runner 从不启动或管理模型进程——它启动 Pi，而 Pi 需要一个能真正
+使用的 provider。有两条路径，只需要其中一条：
+
+### 路径 A：Pi 自己的 provider（不配置 Muyan Pilot）
+
+`pi_providers` 不设，Runner 就和你手工运行 Pi 完全一样地启动它——
+Pi 用自己的 agent 目录和你在那里配置的 provider。派活之前先用 Pi
+自己的检查确认 provider 就绪：
+
+```bash
+pi auth check --provider <provider-id>
+pi --print "reply with the single word: ok"
+```
+
+### 路径 B：`pi_providers` 文件（由 Muyan Pilot 管理选择）
+
+把 `pi_providers` 指向一个 Pi 自己的 `models.json` 形状的 JSON 文件。
+每个 run 开始时 Runner 会物化一个 per-run agent 目录
+（`<worktree>/.muyan-pilot/pi-agent/`，gitignored），其 `models.json`
+把你的用户 provider 与文件的 provider 合并（id 冲突时文件胜）——你
+已有的 provider 继续可用，文件只做添加或覆盖——并为该 run 选中配置
+的 provider/model。
+
+一个 OpenAI-compatible 远程 endpoint（key 不进文件——引用环境变量）：
+
+```json
+{
+  "providers": {
+    "groq": {
+      "baseUrl": "https://api.groq.com/openai/v1",
+      "api": "openai-completions",
+      "apiKey": "$GROQ_API_KEY",
+      "models": [
+        {
+          "id": "qwen/qwen3.8-27b",
+          "name": "Qwen 3.8 27B",
+          "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    }
+  }
+}
+```
+
+一个本地 `llama.cpp` server（OpenAI-compatible 路由在 `/v1`，默认
+`127.0.0.1:8080`；`--alias` 设置 API 报告的模型名，所以下面 `id`
+必须与它一致）：
+
+```bash
+./llama-server -m /path/to/model.gguf --alias Qwen3.8-27B
+```
+
+```json
+{
+  "providers": {
+    "local": {
+      "baseUrl": "http://127.0.0.1:8080/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "models": [
+        {
+          "id": "Qwen3.8-27B",
+          "name": "Qwen 3.8 27B (local)",
+          "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    }
+  }
+}
+```
+
+然后在 `muyan-pilot.toml` 里选择 provider 和 model（Runner 会以
+`--provider groq --model qwen/qwen3.8-27b` 传给 Pi；设置
+`pi_thinking` 时再传 `--thinking <level>`）：
+
+```toml
+pi_providers = ".muyan-pilot/pi-providers.json"
+pi_provider = "groq"
+pi_model = "qwen/qwen3.8-27b"
+```
+
+#### 让 API key 不进仓库、不进文档
+
+文件里 key 以环境变量引用（`"$GROQ_API_KEY"`）；真实值放在
+gitignored 状态目录的 env 文件里，由 systemd unit 在 service 启动时
+加载：
+
+```bash
+mkdir -p .muyan-pilot
+cat > .muyan-pilot/env <<'EOF'
+GROQ_API_KEY=<your key value>
+EOF
+chmod 600 .muyan-pilot/env
+```
+
+提交的 unit 模板已带
+`EnvironmentFile=-%h/Documents/muyan/muyan-pilot/.muyan-pilot/env`
+（Issue #172）——如果你的 clone 在别处，像第 8 步的
+`WorkingDirectory` Note 一样，把**已安装** unit 的 `EnvironmentFile`
+指向**你的** `.muyan-pilot/env`。无 key 的本地 server 完全不需要 env
+文件（上面的 `"local"` 字面量占位即可通过形状检查）。
+
+#### Runner 校验什么（fail fast，在任何 slot/claim 之前）
+
+- 文件存在且是合法 JSON，`providers` 对象非空；
+- 每个列出 models 的 provider 都有非空 `baseUrl` 和 `api`（provider
+  级或 model 级）；
+- 选中的 `pi_provider` 和 `pi_model` 在文件里有定义；
+- 选中 provider 的 `apiKey` 环境变量引用能解析出非空值——变量缺失
+  或为空会让启动失败，错误里只报变量**名**（绝不报 key 值）。
+
+#### provider 边界
+
+文档化且经过测试的路径是 **OpenAI-compatible** endpoint
+（`api: "openai-completions"`）——本地 `llama.cpp` server 或任意
+兼容 API。文件原样传给 Pi，所以 Pi 目录里的其他 catalog 条目继续
+可用；Muyan Pilot 不测试、也不保证该边界之外的逐 provider 集成。
+
+## 5. 运行一次性 setup
 
 setup 入口用一条命令完成全部初始化：校验你安装好的前提（git、gh、
 python3、uv、systemd user session——缺失会 fail fast 并给出可执行的
@@ -146,9 +274,9 @@ muyan-pilot setup --config muyan-pilot.toml
 错误、权限不足、checkout 不干净或缺 systemd user bus 都会带具体原因
 停下）。完整输出契约、成功和失败示例见[一次性 setup](/zh/setup)。
 
-## 5. 手工运行一个 tick
+## 6. 手工运行一个 tick
 
-手工命令只用于首次验证和排查——正常运行由 timer 调度（第 7 步）：
+手工命令只用于首次验证和排查——正常运行由 timer 调度（第 8 步）：
 
 ```bash
 python3 bootstrap_runner.py --config muyan-pilot.toml
@@ -160,7 +288,7 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 Milestone 的 Issue——Issue #139），然后退出。ready 队列为空时干净
 退出，不领取任何东西。
 
-## 6. Smoke walkthrough（从零）
+## 7. Smoke walkthrough（从零）
 
 验证环境可用的最小端到端证明。在第 1 步的 clone 目录里运行；每条命令
 都相对该目录。
@@ -189,12 +317,53 @@ muyan-pilot session --follow --config muyan-pilot.toml
 gh issue list --repo OWNER/PILOT-REPO --label ai-pr-opened
 ```
 
-完成标志：Issue 走完 `ai-ready → ai-in-progress → ai-pr-opened →
-ai-merged`，存在一个 body 带 `Fixes #<issue>` 的 PR，journal 显示
-`run_end ... result=pr_opened`。任何一步失败，Issue 会被标记
-`ai-blocked` 并留下现场——恢复方法见[运维](/zh/operations)。
+### 验证完整链路
 
-## 7. 验证 timers
+交付不止于 PR——同一个 run（同一 run id、分支、worktree、PR）在后续
+tick（手工或 timer）里继续走独立审查和 merge。每个阶段都有具体、可
+检查的成功标准：
+
+| 阶段 | 成功标准 | 在哪里检查 |
+|---|---|---|
+| 被领取 | Issue 标签 `ai-ready → ai-in-progress`；任务 worktree 和分支存在（都带 run id） | `gh issue view <n> --json labels`；journal `run_start run=<run_id> ...` |
+| 实现并测试 | Pi 在 worktree 里跑 TDD 循环；Issue 上唯一的 progress comment 报告 tests milestone | `muyan-pilot session --follow`；Issue 上的 progress comment |
+| PR 打开 | journal `run_end ... result=pr_opened pr=<url> commit=<sha>`；Issue 标签 `ai-pr-opened`；PR body 含 `Fixes #<n>` 和 run marker | `gh pr view <n> --json url,body` |
+| 独立审查 | 下一个 tick 恢复同一个 run；journal `review pr=<n> round=1 verdict=pass blockers=0 majors=0` | journal；PR |
+| 合并 | journal `merged pr=<n> head=<sha>`；PR 为 `MERGED` 且有 merge commit；Issue 标签 `ai-merged`，Issue 上有 `Muyan Pilot merged PR: ...` 评论 | `gh pr view <n> --json state,mergedAt,mergeCommit`；`gh issue view <n> --json state,labels` |
+
+```bash
+# 终态的两个只读检查：
+gh pr view <n> --json state,mergedAt,mergeCommit
+gh issue view <n> --json state,labels
+```
+
+完成标志：Issue 走完 `ai-ready → ai-in-progress → ai-pr-opened →
+ai-merged`，PR 已合并且 body 带 `Fixes #<n>`（GitHub 在 merge 时原生
+关闭 Issue），journal 显示 `run_end ... result=pr_opened`、
+`review ... verdict=pass` 和 `merged pr=...`。任何一步失败，Issue 会
+被**单独**标记 `ai-blocked` 并留下现场（run id、分支、worktree、
+session、phase、last activity、具体错误），journal 显示
+`run_failed ... reason=...`——恢复方法见[运维](/zh/operations)。
+
+## 故障排查
+
+真实失败现场、证据在哪里、怎么修。它们全部 fail fast——没有静默重试。
+
+| 症状 | 证据 | 修复 |
+|---|---|---|
+| 启动在任何 slot/claim 前失败 | journal `API key for provider ... references missing environment variable GROQ_API_KEY`（只报变量**名**） | 把 key 值放进你的 `.muyan-pilot/env`（第 4 步），并确认已安装 unit 的 `EnvironmentFile` 指向它；手工 tick 则在 shell 里 export 该变量 |
+| 启动在 provider 文件上失败 | journal `pi_providers file ... is not valid JSON` / `is missing baseUrl` / `pi_provider ... is not defined` | 修 JSON（第 4 步契约：`providers` 对象、`baseUrl`、`api`、`models[].id`），重跑 `muyan-pilot setup` |
+| Pi 起来了但模型一直不响应 | session JSONL 停在 `model_wait`；死寂窗口后 journal 出现 `run_failed ... reason=upstream_dead_stale_...` | 上游（模型 server/proxy）挂了或连接断了——用一次真实 `pi --print` 调用检查 endpoint，重启后重新派活（Issue 带现场 `ai-blocked`） |
+| PR 打开了但一直不 merge | Issue 标签 `ai-fix-needed`；审查 findings 在 Issue 和 PR 上 | 审查发现会话内修不掉的 Blocker/Major findings——下一个审查 session 重试**同一个** PR（上限 5 轮）；读 Issue 和 PR 上的 findings |
+| 审查循环耗尽轮数 | journal `review_rounds_exhausted issue=<n> rounds=5`；Issue **单独** `ai-blocked` | 有界循环是人工决策——读 findings，手工修 PR 或关闭；见[运维](/zh/operations) |
+| PR 落后于最新 base | Issue `ai-fix-needed`，review 评论说 PR 落后于最新 base 或有 merge 冲突 | 自动：下一个审查 session 在会话内把最新 `origin/<base>` merge 进分支、解冲突、重跑全量测试 |
+| 重启后 service 起不来 | `systemctl --user status muyan-pilot@1.service`；journal `unit_drift` / `cli_install_failed` / `transport_check_failed` 行 | 按结构化行处理：重跑 `muyan-pilot install-units`（unit 漂移）、它打印的精确重装命令（editable 安装过期）、或修 SSH transport（见[运维](/zh/operations)） |
+| `muyan-pilot doctor` 报告 `cli_source: DRIFT` | 结构化 `cli_source_drift` 行带精确重装命令 | 跑它打印的 `uv tool install --force --reinstall --editable ...` 命令（或 `muyan-pilot setup`） |
+
+标签生命周期、journal 字段和恢复规则见[运维](/zh/operations)；
+review/merge 契约见[工作流](/zh/workflow)。
+
+## 8. 验证 timers
 
 setup 已经安装 unit 模板并 enable 了两个 timer 实例
 （`muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`，各自触发自己的

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -65,6 +65,12 @@ KNOWN_CONFIG_FIELDS = frozenset({
     "max_concurrency",
     "skills",
     "context_files",
+    # Issue #119/#157: the optional Pi model selection keys (load_config
+    # plus the committed example, commented out).
+    "pi_provider",
+    "pi_model",
+    "pi_thinking",
+    "pi_providers",
 })
 
 CONFIG_FIELD_PATTERN = re.compile(r"^\s*([a-z][a-z_]+)\s*=", re.MULTILINE)
@@ -190,6 +196,67 @@ def test_chinese_getting_started_documents_prerequisites_and_smoke():
         "journalctl --user -u muyan-pilot@1.service -u "
         "muyan-pilot@2.service" in text
     ), "smoke must show the real journal command (both service instances)"
+
+
+def test_chinese_getting_started_documents_the_model_provider_configuration():
+    """Issue #179: the Chinese getting-started article carries the same
+    model provider facts as the English page — the optional
+    `pi_providers` file in Pi's `models.json` shape, the
+    OpenAI-compatible boundary (local llama.cpp or any compatible
+    API), the env-var API key reference, the gitignored env file the
+    systemd unit loads, and the explicit boundary that no
+    per-provider integration is claimed as complete."""
+    text = zh_page_text("getting-started")
+    for field in ("pi_providers", "pi_provider", "pi_model", "pi_thinking"):
+        assert field in text, f"Chinese getting-started must document {field}"
+    assert "models.json" in text, (
+        "the provider file must be named in Pi's models.json shape"
+    )
+    assert "baseUrl" in text and "apiKey" in text, (
+        "the provider file contract must name baseUrl and apiKey"
+    )
+    assert "$GROQ_API_KEY" in text, (
+        "the OpenAI-compatible example must reference the key as an env var"
+    )
+    assert ".muyan-pilot/env" in text, (
+        "the key value must live in the gitignored env file"
+    )
+    assert "EnvironmentFile" in text, (
+        "the systemd unit's EnvironmentFile must be named"
+    )
+    assert "127.0.0.1:8080/v1" in text, (
+        "the local example must use the real llama.cpp OpenAI-compatible URL"
+    )
+    assert "--alias" in text, ("the model id must be tied to the llama.cpp --alias")
+    assert "OpenAI-compatible" in text, (
+        "the documented provider boundary must be named"
+    )
+    assert "guarantee" in text.lower() or "tested" in text.lower() or "保证" in text, (
+        "the article must state what is and is not tested/guaranteed"
+    )
+    assert "fail" in text.lower() or "失败" in text, (
+        "the provider validation must be described as fail-fast"
+    )
+
+
+def test_chinese_getting_started_documents_the_full_chain_and_troubleshooting():
+    """Issue #179: the Chinese smoke walkthrough verifies the FULL chain
+    — picked up, implemented, tested, PR opened, independently
+    reviewed, merged — with the same concrete success criteria as the
+    English page (the real journal lines and the real `gh` checks), and
+    the article carries a troubleshooting section."""
+    text = zh_page_text("getting-started")
+    assert "ai-pr-opened" in text, "the chain must reach ai-pr-opened"
+    assert "ai-merged" in text, "the chain must reach ai-merged"
+    assert "result=pr_opened" in text, ("the PR stage must cite the real run_end journal line")
+    assert "verdict=pass" in text, ("the review stage must cite the real review journal line")
+    assert "merged pr=" in text, ("the merge stage must cite the real merged journal line")
+    assert "Fixes #" in text, "the PR body contract must be part of the success criteria"
+    assert "gh pr view" in text, ("the terminal state must be checked with the real gh command")
+    assert "mergedAt" in text, ("the gh PR check must use the real mergedAt field")
+    assert "ai-blocked" in text, ("the failure outcome must be named")
+    assert "run_failed" in text, ("the failure must cite the real journal line")
+    assert "故障排查" in text, ("the article must carry a troubleshooting section")
 
 
 def test_chinese_config_field_table_matches_the_implementation():

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -70,6 +70,12 @@ KNOWN_CONFIG_FIELDS = frozenset({
     "max_concurrency",
     "skills",
     "context_files",
+    # Issue #119/#157: the optional Pi model selection keys (load_config
+    # plus the committed example, commented out).
+    "pi_provider",
+    "pi_model",
+    "pi_thinking",
+    "pi_providers",
 })
 
 CONFIG_FIELD_PATTERN = re.compile(
@@ -276,6 +282,78 @@ def test_docs_config_field_table_matches_the_implementation():
     assert not missing, (
         f"docs field table misses fields of the committed example: {sorted(missing)}"
     )
+
+
+def test_docs_getting_started_documents_the_model_provider_configuration():
+    """Issue #179: the getting-started article must take a new user
+    through the model provider configuration with the real v0.2.0
+    contract: the optional `pi_providers` file in Pi's `models.json`
+    shape, the OpenAI-compatible boundary (local llama.cpp or any
+    compatible API), the env-var API key reference (never a literal
+    key in the docs), the gitignored env file the systemd unit loads,
+    the fail-fast validation, and the explicit boundary that no
+    per-provider integration is claimed as complete."""
+    text = page_text("getting-started")
+    # The selection keys are documented as real config fields.
+    for field in ("pi_providers", "pi_provider", "pi_model", "pi_thinking"):
+        assert field in text, f"getting-started must document {field}"
+    # The provider file uses Pi's models.json shape.
+    assert "models.json" in text, ("the provider file must be named in Pi's models.json shape")
+    assert "baseUrl" in text and "apiKey" in text, (
+        "the provider file contract must name baseUrl and apiKey"
+    )
+    # The key is an env-var reference, never a literal in the docs.
+    assert "$GROQ_API_KEY" in text, (
+        "the OpenAI-compatible example must reference the key as an env var"
+    )
+    assert ".muyan-pilot/env" in text, (
+        "the key value must live in the gitignored env file"
+    )
+    assert "EnvironmentFile" in text, (
+        "the systemd unit's EnvironmentFile must be named"
+    )
+    # The local llama.cpp boundary with the real server facts.
+    assert "llama.cpp" in text.lower() or "llama.cpp" in text, (
+        "the local provider path must name llama.cpp"
+    )
+    assert "127.0.0.1:8080/v1" in text, (
+        "the local example must use the real llama.cpp OpenAI-compatible URL"
+    )
+    assert "--alias" in text, ("the model id must be tied to the llama.cpp --alias")
+    # The honest boundary: no per-provider integration is claimed.
+    assert "OpenAI-compatible" in text, (
+        "the documented provider boundary must be named"
+    )
+    assert "guarantee" in text.lower() or "tested" in text.lower(), (
+        "the article must state what is and is not tested/guaranteed"
+    )
+    # The fail-fast validation is documented (missing key env var).
+    assert "fail" in text.lower(), (
+        "the provider validation must be described as fail-fast"
+    )
+
+
+def test_docs_getting_started_documents_the_full_chain_and_troubleshooting():
+    """Issue #179: the smoke walkthrough must verify the FULL chain —
+    picked up, implemented, tested, PR opened, independently reviewed,
+    merged — with concrete success criteria per stage (the real journal
+    lines and the real `gh` checks), and the article must carry a
+    troubleshooting section with the real failure scenes."""
+    text = page_text("getting-started")
+    # The chain stages with their real evidence.
+    assert "ai-pr-opened" in text, "the chain must reach ai-pr-opened"
+    assert "ai-merged" in text, "the chain must reach ai-merged"
+    assert "result=pr_opened" in text, ("the PR stage must cite the real run_end journal line")
+    assert "verdict=pass" in text, ("the review stage must cite the real review journal line")
+    assert "merged pr=" in text, ("the merge stage must cite the real merged journal line")
+    assert "Fixes #" in text, "the PR body contract must be part of the success criteria"
+    assert "gh pr view" in text, ("the terminal state must be checked with the real gh command")
+    assert "mergedAt" in text, ("the gh PR check must use the real mergedAt field")
+    # The failure scene.
+    assert "ai-blocked" in text, ("the failure outcome must be named")
+    assert "run_failed" in text, ("the failure must cite the real journal line")
+    # The troubleshooting section.
+    assert "Troubleshooting" in text, ("the article must carry a troubleshooting section")
 
 
 def test_docs_document_the_full_issue_to_merge_workflow():


### PR DESCRIPTION
Fixes #179

<!-- muyan-pilot:run=23b0e3b0 -->

run_id=23b0e3b0

## What this PR does

The v0.2.0 getting-started article (EN `docs/getting-started.mdx` + ZH
`docs/zh/getting-started.mdx`) now takes a new user from a clean
environment through a **fully verified delivery** — Issue picked up,
implemented, tested, PR opened, independently reviewed, merged:

1. **New step 4 — configure the model provider.** Two supported paths:
   - Path A: Pi's own providers (no Muyan Pilot config), verified with
     `pi auth check --provider <id>` + one real `pi --print` call.
   - Path B: a `pi_providers` file in Pi's own `models.json` shape —
     the Runner materializes a per-run agent dir (merged models.json,
     file wins on id collision) and passes `--provider`/`--model`
     (`--thinking` when set). Documented examples: an OpenAI-compatible
     remote endpoint (key as `$GROQ_API_KEY` env-var reference) and a
     local `llama.cpp` server (`/v1` at `127.0.0.1:8080`, `--alias`
     tied to the model id, keyless `"local"` placeholder).
   - API key handling: the value lives in the gitignored
     `.muyan-pilot/env` file the systemd unit loads via
     `EnvironmentFile` (Issue #172) — never in the repo, never in the
     docs, never logged (only the variable name appears in errors).
   - The fail-fast validation contract (before any slot or claim) and
     the explicit **provider boundary**: the documented and tested path
     is OpenAI-compatible (`api: "openai-completions"`); no per-provider
     integration beyond that is claimed as complete.
2. **Config field table**: the four real `load_config` selection keys
   (`pi_providers`, `pi_provider`, `pi_model`, `pi_thinking`) are
   documented with their defaults and Pi flag mapping.
3. **Full-chain verification**: the smoke walkthrough now ends with a
   per-stage success-criterion table (picked up / implemented and
   tested / PR opened / reviewed / merged) naming the exact journal
   lines (`run_start`, `run_end ... result=pr_opened`,
   `review ... verdict=pass`, `merged pr=...`) and the two read-only
   `gh` checks for the terminal state (`gh pr view --json
   state,mergedAt,mergeCommit`, `gh issue view --json state,labels`).
4. **Troubleshooting section**: eight real failure scenes (missing key
   env var, invalid provider file, dead upstream, unfixed review
   findings, exhausted review rounds, PR behind base, unit/CLI drift,
   transport) with the evidence location and the fix — all fail-fast,
   nothing retried silently.

## Verification

- TDD: the 4 new docs tests fail on the base docs (red) and pass after
  the article change (green).
- Every quoted command, journal line, error message, label and provider
  contract was verified against the code (`bootstrap_runner.py`,
  `muyan_pilot.py`, `pi_activity.py`, the systemd unit template) or the
  real CLIs (`gh pr view --help`, `pi --help`) — Issue #73 hard rule.
- Full suite: `1247 passed`, **100% line and branch coverage**
  (TOTAL 15741 statements / 2214 branches, 0 missing).

## Changed files

- `docs/getting-started.mdx`
- `docs/zh/getting-started.mdx`
- `tests/test_docs_site.py` (KNOWN_CONFIG_FIELDS + 2 new contract tests)
- `tests/test_docs_i18n.py` (KNOWN_CONFIG_FIELDS + 2 new contract tests)