### PR TITLE
Add the ai-release Release task type with a Runner-side release state machine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,12 +428,61 @@ acceptance criteria.
 - The Epic's completion is judged from GitHub evidence — sub-Issues
   done, their PRs merged, the release tag/artifacts on the remote, no
   leftover `ai-in-progress` — and the Epic is closed by a human or a
-  release task (a regular `ai-ready` Issue that reconciles that
-  evidence, typically with a final `Fixes #<epic>`). The Runner never
-  marks an Epic complete or closes it: while any completion condition
-  is unmet the Epic stays open. No database, queue or resident service
-  tracks the Epic — GitHub Issues/labels, native `blockedBy`, PRs and
-  the remote tag are the only state.
+  release task (an `ai-ready`+`ai-release` Issue, see Release tasks
+  below). The Runner never marks an Epic complete or closes it: while
+  any completion condition is unmet the Epic stays open. No database,
+  queue or resident service tracks the Epic — GitHub Issues/labels,
+  native `blockedBy`, PRs and the remote tag are the only state.
+
+## Release tasks (ai-release)
+
+- A Release task is an `ai-ready` Issue additionally marked with the
+  plain `ai-release` label (Issue #98). It is NOT a development task
+  and NEVER enters the `run_pi` path: the ready scan picks it up like
+  any task, but `process_issue` routes it to the Runner's deterministic
+  release state machine — no Pi session, no PR. The three task types
+  stay distinct: an Epic (`ai-epic`) is coordination only and never
+  claimed; a normal task (`ai-ready`) delivers through `run_pi` → PR
+  → review → merge; a Release task (`ai-ready`+`ai-release`) delivers
+  through the release state machine.
+- The state machine is idempotent and resumable (a restart resumes the
+  same run id/worktree, the same resume rule as normal tasks) and runs
+  these steps in order:
+  1. Strictly parse the `## Release` declaration from the Issue body:
+     `version`, `base_branch`, `test_command`, `scope` (a list of
+     `#N` items). Missing, duplicated or unknown fields fail fast.
+  2. Freeze the base — the release commit is exactly
+     `origin/<base_branch>` (fetched under the base-sync lock).
+  3. Enforce the pre-release gates: no leftover open
+     `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed` Issues (the
+     release Issue itself excluded), CI green on the release commit
+     (no check runs passes with explicit evidence), and no open PRs
+     targeting the base branch. A gate that cannot be checked because
+     of a real `gh` failure is a failed gate.
+  4. Verify the scope item by item: `gh pr view` must report `MERGED`,
+     otherwise `gh issue view` must report `CLOSED`. Checkbox parsing
+     is forbidden — every scope item is checked against the live API.
+  5. Run the declared `test_command` in a clean worktree at the
+     release commit (`timeout`-wrapped, Issue #95).
+  6. Tag: when the remote tag is absent, create an annotated tag at
+     the release commit and push it with a plain push (never
+     `--force`). When it exists it must point EXACTLY at the release
+     commit — a mismatch fails fast. An existing tag is never moved,
+     overwritten or force-pushed.
+  7. Publish the GitHub Release (idempotent) whose notes carry the
+     full verification evidence: version, tag, release commit,
+     per-item scope evidence, gate evidence, test evidence and the run
+     marker.
+  8. Success: `ai-merged` (terminal) and the release Issue is closed,
+     with the success comment (release URL, tag, commit, evidence).
+     Any failure: `ai-blocked` ALONE (a release is a human decision
+     point — no automatic retry), the failure comment carries the run
+     marker and the concrete reason, and the exception propagates so
+     the tick fails fast.
+- The `ai-release` label is a type marker, NOT a delivery state: it is
+  not part of the delivery-state machine, not an exclusion of the
+  ready scan, and the Runner never adds or removes it — only the
+  human does (at dispatch time, together with `ai-ready`).
 
 ## Review, in-session fix and merge (same PR)
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ gh label create p0 --repo xqliu/muyan-pilot --force --color "fbca04" \
 # ai-epic 是 Epic 协调 label（不是交付状态，见「Epic Issue（ai-epic）」）
 gh label create ai-epic --repo xqliu/muyan-pilot --force --color "bfdadc" \
   --description "Epic coordination issue; not directly executable by Runner"
+# ai-release 是 Release task 标记（不是交付状态，见「Release task（ai-release）」）
+gh label create ai-release --repo xqliu/muyan-pilot --force --color "5319e7" \
+  --description "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
 gh label list --repo xqliu/muyan-pilot
 ```
 
@@ -213,6 +216,7 @@ gh label list --repo xqliu/muyan-pilot
 | `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | **只用于 AI 无法安全判断或修复的外部前置条件**（Issue #50）：无可恢复的 opened-PR 现场（缺少/不可信 `Muyan Pilot opened PR` 评论）、base 分支变更、审查超轮、PR 未合并被关闭；进入时 comment 必须写明为什么不能自动恢复。已有 run/PR 的可恢复失败**不**进入此状态（转 `ai-fix-needed`，见上） | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
 | `p0` | 紧急优先级（**不是交付状态**）：只改变领取顺序，不改变 Issue 粒度、交付状态或终态语义 | 人工加 label（生产链路出现高优先级故障时） | 人工移除；Runner 从不增删该 label |
 | `ai-epic` | Epic 协调 Issue（发布清单/多任务聚合，**不是可执行任务、不是交付状态**）：只负责聚合与发布门禁 | 人工加 label（创建 Epic 时） | 人工移除（Epic 完成并关闭时）；Runner 从不增删该 label，也从不领取带它的 Issue |
+| `ai-release` | Release task 标记（**不是交付状态**）：带它的 `ai-ready` Issue 由 Runner 的确定性 release 状态机处理（tag + GitHub Release），**从不进 `run_pi` 开发路径**（Issue #98） | 人工加 label（派发 release task 时，与 `ai-ready` 同时） | 成功发布后 Runner 加 `ai-merged`（终态）并关闭 Issue；任何失败单独转 `ai-blocked`（不自动重试，人工决策点）；Runner 从不增删该 label 本身 |
 
 ## 任务依赖（blockedBy）
 
@@ -250,7 +254,22 @@ Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引�
 - **职责边界**：Epic 只负责聚合和发布门禁；实际开发项必须拆成独立的 `ai-ready` 子 Issue，每个子 Issue 一个 runtime outcome、一个 PR、一次独立审查、一次合并。子 Issue 之间的前置条件用 GitHub 原生 `blockedBy` 表达（见「任务依赖（blockedBy）」），Runner 不解析正文复选框或 `Depends on` 行；
 - **Runner 行为（Issue #93）**：普通领取扫描（P0/bug/普通三次扫描）**从不领取**带 `ai-epic` 的 Issue——不加 `ai-in-progress`、不改任何标签、不建 worktree、不启动 `run_pi`、不占执行 slot，记录结构化日志 `epic_not_claimed issue=N repo=...` 后继续检查下一个 ready Issue（Epic 检查先于 blockedBy 检查：「它是 Epic」才是被记录的原因）；重启恢复扫描同样排除 `ai-epic`——遗留 `ai-in-progress` 的 Epic（#80 场景）绝不会被恢复进 run；
 - **完成条件**：子 Issue 已完成、相关 PR 已合并、发布 tag/交付物已存在于远端、没有遗留 `ai-in-progress`。这些条件由 GitHub Issue/label、原生 `blockedBy`、PR 和远端 tag 证据确定；
-- **关闭门禁**：任一完成条件未满足时，Epic 不得被标记完成或自动关闭。Epic 由人工或 release task（一个普通 `ai-ready` Issue，职责是对账上述证据，通常伴随最后一个 `Fixes #<epic>` commit/PR）关闭——Runner 从不标记 Epic 完成，也从不自动关闭 Epic。
+- **关闭门禁**：任一完成条件未满足时，Epic 不得被标记完成或自动关闭。Epic 由人工或 release task（带 `ai-release` 标签的 `ai-ready` Issue，由 Runner 的 release 状态机执行，见「Release task（ai-release）」）关闭——Runner 的 release 状态机只关闭 release task 自己，从不标记 Epic 完成，也从不自动关闭 Epic。
+
+## Release task（ai-release）
+
+Release task 是 `ai-ready` + `ai-release` 双标签的 Issue（Issue #98）——**不是**开发任务：Runner 通过普通 ready 扫描领取，但 `process_issue` 把它路由到确定性的 release 状态机而不是 `run_pi`（没有 Pi 会话、没有 PR）。状态机幂等且可恢复（重启后恢复同一 run id/worktree），步骤：
+
+1. 严格解析 Issue 正文的 `## Release` 声明（`version`、`base_branch`、`test_command`、`scope`；缺失/重复/未知字段 fail fast）；
+2. 冻结 base——release commit 就是 `origin/<base_branch>`（base-sync 锁下 fetch）；
+3. 发布前门禁：无遗留 `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`（release Issue 自身除外）、release commit 的 CI 全绿（无 check run 时以证据放行）、base 分支无 open PR；
+4. 逐项验证 scope：`gh pr view` 必须 `MERGED`，否则 `gh issue view` 必须 `CLOSED`（绝不解析复选框）；
+5. 在 release commit 的干净 worktree 里跑声明的 `test_command`（`timeout` 包裹）；
+6. tag：远端 tag 不存在时在 release commit 上创建 annotated tag 并**普通 push**（绝不 `--force`）；已存在时必须精确指向 release commit（指向别处 fail fast——已存在的 tag 绝不移动/覆盖）；
+7. 发布 GitHub Release（幂等），notes 带完整验证证据（scope/门禁/测试/run marker）；
+8. 成功：`ai-merged`（终态）+ 关闭 Issue + 成功评论（release URL、tag、commit、证据）；任何失败：单独 `ai-blocked`（release 是人工决策点，不自动重试）+ 失败评论（run marker + 具体原因）+ fail fast。
+
+三类任务的边界：Epic（`ai-epic`）只协调、从不被领取；普通任务（`ai-ready`）走 `run_pi` → PR → review → merge；Release task（`ai-ready` + `ai-release`）走 Runner 的 release 状态机，不产生 PR。
 
 ## 自动可观测（正常运行不需要执行任何命令）
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -129,6 +129,7 @@ PI_IDLE_RECOVERY_CYCLES = 3
 # has at most two Pi sessions (implement, then review).
 ROLE_IMPLEMENT = "implement"
 ROLE_REVIEW = "review"
+ROLE_RELEASE = "release"
 
 # Run correlation (Issue #41): one task attempt generates one run_id and
 # every journal line of the attempt starts with `[run_id]`, so a single
@@ -171,6 +172,26 @@ P0_LABEL = "p0"
 # tag on the remote, no leftover `ai-in-progress`) and closed by a
 # human or a release task — never by the claim path.
 EPIC_LABEL = "ai-epic"
+# Release task marker (Issue #98): the plain `ai-release` label marks a
+# Release task — a first-class task type that the Runner picks up from
+# the ready scan and executes with its own deterministic release state
+# machine (scope verification, pre-release gates, tag, GitHub Release).
+# It is NOT a delivery state and NEVER enters the normal `run_pi`
+# development path: `process_issue` routes it to `process_release`
+# instead. On success the Issue gets `ai-merged` (terminal) and is
+# closed; on failure it gets `ai-blocked` ALONE (the `ai-ready` residue
+# is excluded by every ready scan, so no tick re-claims it).
+RELEASE_LABEL = "ai-release"
+# The machine-readable section a release Issue body must carry (Issue
+# #98): `- version:`, `- base_branch:`, `- test_command:` and
+# `- scope:` with `  - #N` items. Parsed strictly — a missing or
+# malformed declaration fails fast, never guessed.
+RELEASE_SECTION = "## Release"
+# The declared `test_command` runs in a clean worktree at the release
+# commit wrapped in `timeout <seconds> bash -c ...` (Issue #95): a test
+# that does not terminate within the deadline is a broken path, never
+# ignorable noise.
+RELEASE_TEST_TIMEOUT_SECONDS = 1800
 
 # Only comments posted by a repo maintainer are trusted to carry the
 # recovery scene: a public comment (authorAssociation=NONE) must never
@@ -1009,6 +1030,692 @@ def is_epic(issue: dict) -> bool:
         if isinstance(label, dict) and label.get("name") == EPIC_LABEL:
             return True
     return False
+
+
+def is_release(issue: dict) -> bool:
+    """Return True when one issue carries the `ai-release` label (#98).
+
+    A pure function of the issue's `labels` (the scans fetch `labels`,
+    so no extra gh call), the same style as `is_epic` and
+    `issue_priority`. A missing or malformed `labels` field fails open
+    to "not a release task": the scan always requests `labels`, so a
+    shape change only loses the release routing for one run — it must
+    never deadlock the queue.
+    """
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") == RELEASE_LABEL:
+            return True
+    return False
+
+
+def parse_release_declaration(body: str) -> dict:
+    """Strictly parse the `## Release` section of a release Issue body.
+
+    The declaration is the machine-readable contract of a Release task
+    (Issue #98) — the only state a release run reads from the Issue
+    body (checkboxes are never parsed):
+
+    ```markdown
+    ## Release
+
+    - version: v0.3.0
+    - base_branch: main
+    - test_command: <shell command>
+    - scope:
+      - #123
+      - #124
+    ```
+
+    `version` is the exact tag name (no spaces), `base_branch` the
+    branch the release commit is frozen from, `test_command` the
+    shell command that must pass in a clean worktree at the release
+    commit, and `scope` the Issue/PR numbers verified one by one.
+    Every deviation fails fast with the concrete field: missing
+    section, missing or duplicated field, unknown key, empty value,
+    empty scope or a malformed scope item. No guessing.
+    """
+    if not isinstance(body, str):
+        raise ValueError("release declaration body must be a string")
+    lines = body.splitlines()
+    try:
+        start = next(
+            i for i, line in enumerate(lines)
+            if line.strip() == RELEASE_SECTION
+        )
+    except StopIteration:
+        raise ValueError(
+            f"release Issue body is missing the `{RELEASE_SECTION}` "
+            "section with version, base_branch, test_command and scope"
+        ) from None
+    section: list[str] = []
+    for line in lines[start + 1:]:
+        if line.lstrip().startswith("## "):
+            break
+        section.append(line)
+    fields: dict[str, str] = {}
+    scope: list[int] = []
+    scope_open = False
+    for line in section:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            content = stripped[2:].strip()
+            if scope_open and re.fullmatch(r"#\d+", content):
+                number = int(content[1:])
+                if number < 1:
+                    raise ValueError(
+                        f"release declaration scope item {content!r} "
+                        "must be a positive Issue or PR number"
+                    )
+                scope.append(number)
+                continue
+            if scope_open and ":" not in content:
+                raise ValueError(
+                    f"release declaration scope item {content!r} is "
+                    "malformed (expected `  - #N`)"
+                )
+            # A `- key: value` line closes the scope list (and a
+            # duplicated or unknown key is caught below).
+            scope_open = False
+            key, sep, value = content.partition(":")
+            if not sep:
+                raise ValueError(
+                    f"release declaration field {key.strip()!r} is "
+                    "malformed (expected `- key: value`)"
+                )
+            key = key.strip()
+            value = value.strip()
+            if key in fields:
+                raise ValueError(
+                    f"release declaration field {key!r} is duplicated"
+                )
+            if key == "scope":
+                if value:
+                    raise ValueError(
+                        "release declaration `scope` must be a list of "
+                        "`  - #N` items, not an inline value"
+                    )
+                scope_open = True
+                fields["scope"] = ""
+            elif key in ("version", "base_branch", "test_command"):
+                fields[key] = value
+            else:
+                raise ValueError(
+                    f"release declaration has the unknown field {key!r} "
+                    "(expected version, base_branch, test_command or scope)"
+                )
+        elif scope_open:
+            raise ValueError(
+                f"release declaration scope item {stripped!r} is "
+                "malformed (expected `  - #N`)"
+            )
+        else:
+            raise ValueError(
+                f"release declaration line {stripped!r} is not a "
+                "`- key: value` field or a scope item"
+            )
+    for key in ("version", "base_branch", "test_command"):
+        if key not in fields:
+            raise ValueError(
+                f"release declaration is missing the `{key}` field"
+            )
+        if not fields[key]:
+            raise ValueError(
+                f"release declaration field `{key}` is empty"
+            )
+    if "scope" not in fields:
+        raise ValueError(
+            "release declaration is missing the `scope` field"
+        )
+    if not scope:
+        raise ValueError(
+            "release declaration `scope` must list at least one "
+            "`  - #N` Issue or PR number"
+        )
+    for key in ("version", "base_branch"):
+        if any(ch.isspace() for ch in fields[key]):
+            raise ValueError(
+                f"release declaration field `{key}` must not contain "
+                "spaces"
+            )
+    return {
+        "version": fields["version"],
+        "base_branch": fields["base_branch"],
+        "test_command": fields["test_command"],
+        "scope": scope,
+    }
+
+
+def verify_release_scope(repo: str, scope: list[int]) -> list[str]:
+    """Verify every release scope item ONE BY ONE (Issue #98).
+
+    The scope is verified against GitHub, never by parsing Issue-body
+    checkboxes: each number is probed as a PR first (`gh pr view` —
+    which exits 1 with the real "Could not resolve to a PullRequest"
+    error when the number is an Issue, verified against the live CLI)
+    and, failing that, as an Issue (`gh issue view`). A PR must be
+    `MERGED` (its merge commit is the evidence); an Issue must be
+    `CLOSED`. An item that is neither, a PR that is not merged or an
+    Issue that is not closed fails fast with the concrete number and
+    state. A real `gh` failure (auth, rate limit) is re-raised, never
+    misread as "not a PR".
+    """
+    evidence: list[str] = []
+    for number in scope:
+        try:
+            raw = run_command([
+                "gh", "pr", "view", str(number), "--repo", repo,
+                "--json", "number,state,mergeCommit",
+            ])
+        except subprocess.CalledProcessError as exc:
+            if "Could not resolve to a PullRequest" not in (exc.stderr or ""):
+                raise
+            raw = None
+        if raw is not None:
+            pr = json.loads(raw)
+            state = pr.get("state")
+            if state != "MERGED":
+                raise RuntimeError(
+                    f"release scope PR #{number} is not merged "
+                    f"(state={state})"
+                )
+            merge_commit = (pr.get("mergeCommit") or {}).get("oid")
+            if not merge_commit:
+                raise RuntimeError(
+                    f"release scope PR #{number} is merged but has no "
+                    "merge commit evidence"
+                )
+            evidence.append(
+                f"PR #{number} merged (mergeCommit={merge_commit})"
+            )
+            continue
+        try:
+            raw = run_command([
+                "gh", "issue", "view", str(number), "--repo", repo,
+                "--json", "number,state",
+            ])
+        except subprocess.CalledProcessError as exc:
+            if "Could not resolve to an Issue" not in (exc.stderr or ""):
+                raise
+            raise RuntimeError(
+                f"release scope item #{number} is neither a PR nor an "
+                "Issue"
+            ) from exc
+        issue = json.loads(raw)
+        state = issue.get("state")
+        if state != "CLOSED":
+            raise RuntimeError(
+                f"release scope Issue #{number} is not closed "
+                f"(state={state})"
+            )
+        evidence.append(f"Issue #{number} closed")
+    return evidence
+
+
+def check_release_gates(repo: str, base_branch: str, release_commit: str,
+                        release_number: int) -> list[str]:
+    """Enforce the pre-release gates (Issue #98) and return their evidence.
+
+    Three gates, each checked against GitHub (never against local
+    state), each failure raising with the concrete offender:
+
+    1. No open Issue still carries `ai-in-progress`, `ai-pr-opened`
+       or `ai-fix-needed` — the release Issue itself is excluded (it
+       carries `ai-in-progress` while the release runs).
+    2. CI on the release commit is green: every check run reported by
+       the GitHub API for the commit is `completed` with a
+       `success`/`neutral`/`skipped` conclusion (a pending, failing,
+       cancelled or error check fails the gate; no check runs at all
+       is recorded as such, not invented).
+    3. No open PR targets the base branch — an open PR against the
+       release base would make the released commit non-final.
+
+    A real `gh` failure (auth, rate limit, API error) propagates
+    unchanged — a gate that cannot be checked is a failed gate.
+    """
+    evidence: list[str] = []
+    for label in (IN_PROGRESS_LABEL, PR_OPENED_LABEL, FIX_NEEDED_LABEL):
+        raw = run_command([
+            "gh", "issue", "list", "--repo", repo, "--label", label,
+            "--state", "open", "--json", "number", "--limit", "50",
+        ])
+        for item in json.loads(raw):
+            number = int(item["number"])
+            if number == release_number:
+                continue
+            raise RuntimeError(
+                f"release gate: Issue #{number} still carries "
+                f"{label} — finish or block that delivery before "
+                "releasing"
+            )
+    evidence.append(
+        "no open Issue carries "
+        f"{IN_PROGRESS_LABEL} / {PR_OPENED_LABEL} / {FIX_NEEDED_LABEL}"
+    )
+    raw = run_command([
+        "gh", "api", f"repos/{repo}/commits/{release_commit}/check-runs",
+        "--jq", ".check_runs",
+    ])
+    check_runs = json.loads(raw)
+    for check in check_runs:
+        name = check.get("name")
+        status = check.get("status")
+        conclusion = check.get("conclusion")
+        if status != "completed" or conclusion not in (
+            "success", "neutral", "skipped",
+        ):
+            raise RuntimeError(
+                f"release gate: CI check '{name}' is {status}/{conclusion} "
+                f"on the release commit {release_commit}"
+            )
+    if check_runs:
+        evidence.append(
+            f"CI on the release commit: {len(check_runs)} check(s) all "
+            "success/neutral/skipped"
+        )
+    else:
+        evidence.append(
+            f"CI on the release commit: no check runs on "
+            f"{release_commit} (nothing to gate)"
+        )
+    raw = run_command([
+        "gh", "pr", "list", "--repo", repo,
+        "--search", f"is:pr is:open base:{base_branch}",
+        "--json", "number,headRefName", "--limit", "50",
+    ])
+    for pr in json.loads(raw):
+        raise RuntimeError(
+            f"release gate: PR #{pr.get('number')} "
+            f"(head {pr.get('headRefName')}) is still open against "
+            f"{base_branch}"
+        )
+    evidence.append(f"no open PR targets {base_branch}")
+    return evidence
+
+
+def run_release_tests(worktree: Path, test_command: str,
+                      timeout_seconds: int) -> None:
+    """Run the declared release test command in the release worktree.
+
+    The command is a shell string (it may chain steps with `&&`), so
+    it runs through `bash -c` wrapped in `timeout <seconds>` (Issue
+    #95): a test that does not terminate within the deadline is a
+    broken path and fails fast with `timeout`'s exit 124 — never
+    ignorable noise, never a second unbounded attempt.
+    """
+    run_command(
+        ["timeout", str(timeout_seconds), "bash", "-c", test_command],
+        cwd=worktree,
+    )
+
+
+def release_tag_commit(repo_dir: Path, tag: str) -> str | None:
+    """Return the commit the tag points to on the remote, or None.
+
+    (Issue #98) The tag is fetched under the base-sync lock — a task
+    worktree shares the checkout's common dir, so an unlocked
+    concurrent fetch would race on `refs/tags/<tag>` exactly like the
+    shared remote-tracking ref of Issue #171. When the remote has no
+    such tag the fetch exits 128 (verified against the real CLI) and
+    None is returned; after a successful fetch the tag is resolved to
+    the commit it points to locally (annotated tags are peeled with
+    `^{commit}`). Any other fetch failure fails fast.
+    """
+    fd = acquire_base_sync_lock(repo_dir, 300.0)
+    try:
+        try:
+            run_command(
+                ["git", "fetch", "origin",
+                 f"refs/tags/{tag}:refs/tags/{tag}"],
+                cwd=repo_dir,
+            )
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode != 128:
+                raise
+            return None
+        return run_command(
+            ["git", "rev-parse", "-q", "--verify",
+             f"refs/tags/{tag}^{{commit}}"],
+            cwd=repo_dir,
+        )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def publish_release(*, repo: str, tag: str, version: str,
+                    release_commit: str, scope_evidence: list[str],
+                    gate_evidence: list[str], test_evidence: str,
+                    run_id: str, issue_number: int) -> str:
+    """Create the GitHub Release for the tag — idempotently (Issue #98).
+
+    When a Release for the tag already exists (a restart after a
+    successful `gh release create`) its URL is reused, never a second
+    Release is created. Otherwise the Release is created from the
+    EXISTING tag (the tag was created and pushed by the caller first —
+    `gh release create` never creates or moves the tag itself) with
+    notes carrying the full verification evidence: version, tag,
+    release commit, the per-item scope evidence, the gate evidence, the
+    test evidence and the run marker (the same stable machine-readable
+    marker every run comment carries).
+    """
+    try:
+        raw = run_command([
+            "gh", "release", "view", tag, "--repo", repo,
+            "--json", "tagName,url",
+        ])
+        return json.loads(raw)["url"]
+    except subprocess.CalledProcessError as exc:
+        if "not found" not in (exc.stderr or ""):
+            raise
+    notes = "\n".join([
+        f"# {version}",
+        "",
+        f"- tag: `{tag}`",
+        f"- release commit: `{release_commit}`",
+        f"- release task: Issue #{issue_number}",
+        "",
+        "## Scope (verified item by item)",
+        "",
+        *(f"- {item}" for item in scope_evidence),
+        "",
+        "## Pre-release gates",
+        "",
+        *(f"- {item}" for item in gate_evidence),
+        "",
+        "## Tests",
+        "",
+        f"- {test_evidence}",
+        "",
+        f"<!-- muyan-pilot:run={run_id} -->",
+        f"run_id={run_id}",
+    ])
+    run_command([
+        "gh", "release", "create", tag, "--repo", repo,
+        "--title", version, "--notes", notes,
+    ])
+    raw = run_command([
+        "gh", "release", "view", tag, "--repo", repo,
+        "--json", "tagName,url",
+    ])
+    return json.loads(raw)["url"]
+
+
+def release_success_comment_body(run_id: str, run_info: str,
+                                 release_url: str, tag: str,
+                                 release_commit: str,
+                                 scope_evidence: list[str],
+                                 gate_evidence: list[str],
+                                 test_evidence: str) -> str:
+    """The terminal success comment: the full verification evidence.
+
+    (Issue #98) The comment is the auditable record of the release:
+    run marker, release URL, version/tag/release commit, the
+    per-item scope evidence, the gate evidence and the test evidence.
+    """
+    return "\n".join([
+        run_marker(run_id),
+        f"Muyan Pilot released: {release_url}",
+        run_info,
+        f"tag={tag} release_commit={release_commit}",
+        "",
+        "## Scope (verified item by item)",
+        "",
+        *(f"- {item}" for item in scope_evidence),
+        "",
+        "## Pre-release gates",
+        "",
+        *(f"- {item}" for item in gate_evidence),
+        "",
+        "## Tests",
+        "",
+        f"- {test_evidence}",
+        "",
+        f"run_id={run_id}",
+    ])
+
+
+def release_failure_comment_body(run_id: str, run_info: str,
+                                 error: str) -> str:
+    """The terminal failure comment: the blocked scene (Issue #98).
+
+    A release failure is terminal (`ai-blocked` ALONE, no automatic
+    retry): the comment carries the run marker and the concrete
+    reason, so the recoverable scene is on GitHub, not only in the
+    journal.
+    """
+    return "\n".join([
+        run_marker(run_id),
+        "Muyan Pilot release failed (ai-blocked)",
+        run_info,
+        "",
+        f"failure: {error}",
+        "",
+        f"run_id={run_id}",
+    ])
+
+
+def process_release(issue: dict, config: dict, source_repo: str) -> str:
+    """Run the deterministic release state machine for one release Issue.
+
+    (Issue #98) A release task NEVER enters the normal `run_pi`
+    development path: the Runner executes the state machine itself,
+    step by step, each step idempotent so a restart resumes the same
+    run (same run id, same worktree) from the top:
+
+    1. Claim (`ai-in-progress`; a restart reuses the existing run id
+       from the worktree — the same resume rule as normal tasks).
+    2. Strictly parse the `## Release` declaration from the Issue
+       body (version, base_branch, test_command, scope).
+    3. Freeze the base — the release commit is exactly
+       `origin/<base_branch>` (fetched under the base-sync lock).
+    4. Enforce the pre-release gates (`check_release_gates`).
+    5. Verify the scope item by item (`verify_release_scope`).
+    6. Run the declared test command in a clean worktree at the
+       release commit (`timeout`-wrapped, Issue #95).
+    7. Tag: the remote tag must not exist or must point EXACTLY at
+       the release commit (a mismatch fails — an existing tag is
+       never moved); otherwise create an annotated tag at the release
+       commit and push it with a plain push (never `--force`).
+    8. Publish the GitHub Release (idempotent) with the full
+       verification evidence.
+    9. Success: `ai-merged` (terminal, the Issue is closed, the
+       success comment carries the evidence).
+    10. Any failure: `ai-blocked` ALONE (no automatic retry — a
+        release is a human decision point), the failure comment
+        carries the run marker and the concrete reason, and the
+        exception propagates so the tick fails fast.
+    """
+    number = int(issue["number"])
+    title = issue["title"]
+    run_id = new_run_id()
+    set_run_id(run_id)
+    if has_in_progress_label(number, source_repo):
+        existing_run_id = latest_run_id(
+            config["repo_dir"], source_repo, number,
+        )
+        if existing_run_id is not None:
+            run_id = existing_run_id
+            set_run_id(run_id)
+            LOGGER.info(
+                "issue=%s release_resuming_run run_id=%s", number, run_id,
+            )
+    priority = issue_priority(issue)
+    started = time.monotonic()
+    # Bound before the try: the failure comment needs it even when the
+    # declaration parse fails on the very first step.
+    run_info = f"run_id={run_id} priority={priority}"
+    publisher = ProgressPublisher(
+        number, source_repo, run_id, run_command=run_command,
+    )
+    branch = task_branch(source_repo, number, run_id)
+    worktree = worktree_path(
+        config["repo_dir"], source_repo, number, run_id,
+    )
+
+    def progress() -> dict:
+        return _progress_state(
+            issue=number, title=title, run_id=run_id, role=ROLE_RELEASE,
+            branch=branch, worktree=worktree, started=started,
+            pr_url=None, review_round=0, priority=priority,
+            activity={},
+        )
+
+    try:
+        declaration = parse_release_declaration(issue["body"])
+        base_branch = declaration["base_branch"]
+        run_info = (
+            f"base_branch={base_branch} run_id={run_id} "
+            f"priority={priority}"
+        )
+        LOGGER.info(
+            "issue=%s release_task %s", number, run_info,
+        )
+        edit_issue(number, repo=source_repo, add=IN_PROGRESS_LABEL)
+        set_active_run(
+            number, title, branch, str(worktree),
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.ensure(progress_body(progress())),
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.milestone(
+                f"**Muyan Pilot release started**: {run_info}",
+            ),
+        )
+        release_commit = freeze_base(config["repo_dir"], base_branch)
+        run_info = (
+            f"base_branch={base_branch} base_sha={release_commit} "
+            f"run_id={run_id} priority={priority}"
+        )
+        gate_evidence = check_release_gates(
+            source_repo, base_branch, release_commit, number,
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.milestone(
+                f"**Muyan Pilot release gates passed**: "
+                f"{'; '.join(gate_evidence)}",
+            ),
+        )
+        scope_evidence = verify_release_scope(source_repo, declaration["scope"])
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.milestone(
+                f"**Muyan Pilot release scope verified**: "
+                f"{'; '.join(scope_evidence)}",
+            ),
+        )
+        worktree = create_worktree(
+            config["repo_dir"], source_repo, number, run_id, release_commit,
+        )
+        run_release_tests(
+            worktree, declaration["test_command"],
+            RELEASE_TEST_TIMEOUT_SECONDS,
+        )
+        test_evidence = (
+            f"declared test command passed in a clean worktree at "
+            f"{release_commit} (timeout {RELEASE_TEST_TIMEOUT_SECONDS}s)"
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.milestone(
+                f"**Muyan Pilot release tests passed**: {test_evidence}",
+            ),
+        )
+        tag = declaration["version"]
+        existing_tag_commit = release_tag_commit(config["repo_dir"], tag)
+        if existing_tag_commit is not None:
+            if existing_tag_commit != release_commit:
+                raise RuntimeError(
+                    f"release tag {tag} already exists on the remote "
+                    f"and points at {existing_tag_commit}, not the "
+                    f"release commit {release_commit} — an existing "
+                    "tag is never moved or overwritten"
+                )
+            LOGGER.info(
+                "issue=%s release_tag_exists tag=%s commit=%s",
+                number, tag, existing_tag_commit,
+            )
+        else:
+            run_command(
+                ["git", "tag", "-a", tag, "-m", f"Release {tag}",
+                 release_commit],
+                cwd=config["repo_dir"],
+            )
+            run_command(
+                ["git", "push", "origin", f"refs/tags/{tag}"],
+                cwd=config["repo_dir"],
+            )
+            LOGGER.info(
+                "issue=%s release_tag_pushed tag=%s commit=%s",
+                number, tag, release_commit,
+            )
+        release_url = publish_release(
+            repo=source_repo, tag=tag, version=tag,
+            release_commit=release_commit,
+            scope_evidence=scope_evidence, gate_evidence=gate_evidence,
+            test_evidence=test_evidence, run_id=run_id, issue_number=number,
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.milestone(
+                f"**Muyan Pilot released**: {release_url}",
+            ),
+        )
+        edit_issue(
+            number, repo=source_repo, add=MERGED_LABEL,
+            remove=IN_PROGRESS_LABEL,
+        )
+        run_command(
+            ["gh", "issue", "close", str(number), "--repo", source_repo],
+        )
+        comment_issue(
+            number, repo=source_repo,
+            body=release_success_comment_body(
+                run_id, run_info, release_url, tag, release_commit,
+                scope_evidence, gate_evidence, test_evidence,
+            ),
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.finish(progress_body(progress())),
+        )
+        LOGGER.info(
+            "issue=%s run_end release_success tag=%s url=%s "
+            "elapsed=%.1fs", number, tag, release_url,
+            time.monotonic() - started,
+        )
+        return release_url
+    except Exception as exc:
+        LOGGER.exception("issue=%s release_failed", number)
+        edit_issue(
+            number, repo=source_repo, add=BLOCKED_LABEL,
+            remove=IN_PROGRESS_LABEL,
+        )
+        comment_issue(
+            number, repo=source_repo,
+            body=release_failure_comment_body(run_id, run_info, str(exc)),
+        )
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_RELEASE,
+            action=lambda: publisher.finish(progress_body(progress())),
+        )
+        raise
 
 
 def pick_issue(repo: str, active_milestone: str | None = None) -> dict | None:
@@ -3881,6 +4588,12 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     # or non-string title fails fast here (KeyError / ValueError in
     # `progress.issue_field`) — it is never fabricated.
     title = issue["title"]
+    # Release task (Issue #98): a first-class task type that NEVER
+    # enters the normal `run_pi` development path. The Runner executes
+    # its own deterministic release state machine instead (scope
+    # verification, gates, tests, tag, GitHub Release).
+    if is_release(issue):
+        return process_release(issue, config, source_repo)
     base_branch = config["base_branch"]
     # The run id is generated once per attempt and bound BEFORE any
     # other step is logged, so every journal line of the attempt

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1190,7 +1190,8 @@ def parse_release_declaration(body: str) -> dict:
     }
 
 
-def verify_release_scope(repo: str, scope: list[int]) -> list[str]:
+def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
+                         release_commit: str) -> list[str]:
     """Verify every release scope item ONE BY ONE (Issue #98).
 
     The scope is verified against GitHub, never by parsing Issue-body
@@ -1198,10 +1199,13 @@ def verify_release_scope(repo: str, scope: list[int]) -> list[str]:
     which exits 1 with the real "Could not resolve to a PullRequest"
     error when the number is an Issue, verified against the live CLI)
     and, failing that, as an Issue (`gh issue view`). A PR must be
-    `MERGED` (its merge commit is the evidence); an Issue must be
-    `CLOSED`. An item that is neither, a PR that is not merged or an
-    Issue that is not closed fails fast with the concrete number and
-    state. A real `gh` failure (auth, rate limit) is re-raised, never
+    `MERGED` and its merge commit must be an ancestor of the frozen
+    release commit; an Issue must be `CLOSED`. This ancestor check proves
+    the scoped PR is actually contained in the tag, rather than merely
+    having been merged into some other branch. An item that is neither, a
+    PR that is not merged/in the release base, or an Issue that is not
+    closed fails fast with the concrete number and state. A real `gh` or
+    git failure (auth, rate limit, missing object) is re-raised, never
     misread as "not a PR".
     """
     evidence: list[str] = []
@@ -1229,6 +1233,19 @@ def verify_release_scope(repo: str, scope: list[int]) -> list[str]:
                     f"release scope PR #{number} is merged but has no "
                     "merge commit evidence"
                 )
+            try:
+                run_command(
+                    ["git", "merge-base", "--is-ancestor", merge_commit,
+                     release_commit],
+                    cwd=repo_dir,
+                )
+            except subprocess.CalledProcessError as exc:
+                if exc.returncode != 1:
+                    raise
+                raise RuntimeError(
+                    f"release scope PR #{number} merge commit {merge_commit} "
+                    f"is not contained in release commit {release_commit}"
+                ) from exc
             evidence.append(
                 f"PR #{number} merged (mergeCommit={merge_commit})"
             )
@@ -1343,12 +1360,20 @@ def run_release_tests(worktree: Path, test_command: str,
 
     The command is a shell string (it may chain steps with `&&`), so
     it runs through `bash -c` wrapped in `timeout <seconds>` (Issue
-    #95): a test that does not terminate within the deadline is a
-    broken path and fails fast with `timeout`'s exit 124 — never
-    ignorable noise, never a second unbounded attempt.
+    #95). Its success is followed by the repository's mandatory 100%
+    line-and-branch coverage gate: a declaration such as `true` or a
+    bare `pytest` must not let a release claim the coverage contract.
+    A test that does not terminate within the deadline fails fast with
+    `timeout`'s exit 124 — never ignorable noise or a second unbounded
+    attempt.
     """
+    coverage_gate = (
+        "/usr/bin/python3 -m coverage report --fail-under=100 "
+        "--show-missing"
+    )
     run_command(
-        ["timeout", str(timeout_seconds), "bash", "-c", test_command],
+        ["timeout", str(timeout_seconds), "bash", "-c",
+         f"{test_command} && {coverage_gate}"],
         cwd=worktree,
     )
 
@@ -1436,7 +1461,7 @@ def publish_release(*, repo: str, tag: str, version: str,
     ])
     run_command([
         "gh", "release", "create", tag, "--repo", repo,
-        "--title", version, "--notes", notes,
+        "--verify-tag", "--title", version, "--notes", notes,
     ])
     raw = run_command([
         "gh", "release", "view", tag, "--repo", repo,
@@ -1607,7 +1632,10 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
                 f"{'; '.join(gate_evidence)}",
             ),
         )
-        scope_evidence = verify_release_scope(source_repo, declaration["scope"])
+        scope_evidence = verify_release_scope(
+            source_repo, declaration["scope"], config["repo_dir"],
+            release_commit,
+        )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_RELEASE,
@@ -1624,8 +1652,9 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             RELEASE_TEST_TIMEOUT_SECONDS,
         )
         test_evidence = (
-            f"declared test command passed in a clean worktree at "
-            f"{release_commit} (timeout {RELEASE_TEST_TIMEOUT_SECONDS}s)"
+            f"declared test command and 100% coverage gate passed in a "
+            f"clean worktree at {release_commit} "
+            f"(timeout {RELEASE_TEST_TIMEOUT_SECONDS}s)"
         )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -14,8 +14,8 @@ same PR — only its head may advance):
 flowchart LR
   epic["Epic (ai-epic) — coordination only, never claimed"]
   epic -.splits into.-> ready
-  release["Release task — a regular ai-ready Issue (release reconciliation)"]
-  release -.delivers through.-> ready
+  release["Release task (ai-ready + ai-release)<br/>— Runner release state machine, never run_pi"]
+  release -.claims like.-> ready
   ready["ai-ready<br/>(pickup order: P0-labeled first, then bug-labeled, then plain)"]
   ready -->|claim: label + worktree + Pi| progress["ai-in-progress"]
   progress -->|PR verified: base fresh, run marker, Fixes #N| opened["ai-pr-opened"]
@@ -160,11 +160,27 @@ DAG, no priority numbers, no separate queues:
   and while any condition is unmet the Epic stays open: it is closed by
   a human or a release task, typically with a final `Fixes #<epic>`
   commit/PR — never by the Runner.
-- **Release task**: a regular `ai-ready` Issue whose job is release
-  reconciliation — checking that the sub-Issues are merged, the version
-  tag exists on the remote, and the release evidence is complete. Like
-  any task it delivers through one PR (or closes the Epic when the
-  evidence is already on the remote).
+- **Release task**: an `ai-ready` Issue additionally marked with the
+  `ai-release` label (Issue #98). It is NOT a development task: the
+  Runner picks it up through the normal ready scan, but `process_issue`
+  routes it to the deterministic release state machine instead of
+  `run_pi` — no Pi session, no PR. The state machine is idempotent and
+  resumable (a restart resumes the same run id/worktree): strictly parse
+  the `## Release` declaration from the Issue body (`version`,
+  `base_branch`, `test_command`, `scope`), freeze the base (the release
+  commit is exactly `origin/<base_branch>`), enforce the pre-release
+  gates (no leftover `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`,
+  CI green on the release commit, no open PRs against the base branch),
+  verify the scope item by item with `gh pr view` / `gh issue view`
+  (never checkbox parsing), run the declared test command in a clean
+  worktree at the release commit, then create the annotated tag at the
+  release commit and push it with a plain push (an existing tag must
+  point exactly at the release commit — it is never moved, overwritten
+  or force-pushed), and finally publish the GitHub Release with the full
+  verification evidence. Success: `ai-merged` (terminal) and the Issue
+  is closed. Any failure: `ai-blocked` ALONE (a release is a human
+  decision point — no automatic retry) with the run marker and the
+  concrete reason on the Issue.
 - **P0 priority**: the plain `p0` GitHub label marks an urgent Issue
   (a production outage). It is NOT a delivery state — it only orders the
   ready pickup, never changes the Issue granularity, any delivery state,

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -14,8 +14,8 @@
 flowchart LR
   epic["Epic（ai-epic）— 只协调，从不被领取"]
   epic -.拆分为.-> ready
-  release["Release task — 普通 ai-ready Issue（release 对账）"]
-  release -.交付于.-> ready
+  release["Release task（ai-ready + ai-release）<br/>— Runner release 状态机，从不进 run_pi"]
+  release -.像普通任务领取.-> ready
   ready["ai-ready<br/>（领取顺序：P0 标签最先，然后 bug 标签，最后普通）"]
   ready -->|领取：加标签 + 建 worktree + 启动 Pi| progress["ai-in-progress"]
   progress -->|PR 验收：base 新鲜、run marker、Fixes #N| opened["ai-pr-opened"]
@@ -139,9 +139,22 @@ PR 验收时校验该关键词，缺失即 fail fast。
   遗留 `ai-in-progress`）确定；任一条件未满足时 Epic 保持 open：由人工
   或 release task 关闭（通常伴随最后一个 `Fixes #<epic>` commit/PR），
   绝不由 Runner 关闭。
-- **Release task**：一个普通 `ai-ready` Issue，职责是 release 对账——
-  检查子 Issue 已合并、版本 tag 在远端存在、release 证据完整。和任何
-  任务一样通过一个 PR 交付（或当证据已在远端时直接关闭 Epic）。
+- **Release task**：带 `ai-release` 标签的 `ai-ready` Issue（Issue
+  #98）。它**不是**开发任务：Runner 通过普通 ready 扫描领取，但
+  `process_issue` 把它路由到确定性的 release 状态机而不是 `run_pi`——
+  没有 Pi 会话、没有 PR。状态机幂等且可恢复（重启后恢复同一
+  run id/worktree）：严格解析 Issue 正文的 `## Release` 声明
+  （`version`、`base_branch`、`test_command`、`scope`），冻结 base
+  （release commit 就是 `origin/<base_branch>`），执行发布前门禁
+  （无遗留 `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`、release
+  commit 的 CI 全绿、base 分支无 open PR），用 `gh pr view` /
+  `gh issue view` 逐项验证 scope（绝不解析复选框），在 release commit
+  的干净 worktree 里跑声明的测试命令，然后在 release commit 上创建
+  annotated tag 并普通 push（已存在的 tag 必须精确指向 release commit——
+  绝不移动、覆盖或 force-push），最后发布带完整验证证据的 GitHub
+  Release。成功：`ai-merged`（终态）并关闭 Issue。任何失败：单独进入
+  `ai-blocked`（release 是人工决策点——不自动重试），Issue 上带 run
+  marker 和具体原因。
 - **P0 优先级**：普通 `p0` GitHub 标签标记紧急 Issue（生产故障）。它
   **不是**交付状态——只决定 ready 领取顺序，从不改变 Issue 粒度、任何
   交付状态或终态语义，Runner 也从不增删它。ready 领取顺序固定：

--- a/labels.toml
+++ b/labels.toml
@@ -49,3 +49,8 @@ description = "Muyan Pilot urgent priority: picked up before bugs and features"
 name = "ai-epic"
 color = "bfdadc"
 description = "Epic coordination issue; not directly executable by Runner"
+
+[[label]]
+name = "ai-release"
+color = "5319e7"
+description = "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -64,6 +64,11 @@ REQUIRED_LABELS = (
     # (`epic_not_claimed`), so the label is platform state the setup
     # entry must guarantee — same as every delivery-state label.
     "ai-epic",
+    # Release task marker (Issue #98): the ready scan picks up
+    # `ai-ready`+`ai-release` Issues and `process_issue` routes them to
+    # the deterministic release state machine (never `run_pi`), so the
+    # label is platform state the setup entry must guarantee.
+    "ai-release",
 )
 COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -9401,3 +9401,972 @@ def test_real_subprocess_sigterm_before_claim_logs_idle(tmp_path):
     assert stopped[0] == "INFO run_stopped result=idle"
     assert "issue=" not in stderr
     assert "run_stopping" not in stderr
+
+
+# --- Release task (Issue #98) ---------------------------------------------
+
+RELEASE_DECLARATION_BODY = """Ship v0.3.0 to the remote.
+
+## Release
+
+- version: v0.3.0
+- base_branch: main
+- test_command: /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q && /usr/bin/python3 -m coverage report --show-missing
+- scope:
+  - #123
+  - #124
+
+## Notes
+
+- this text is outside the release section
+"""
+
+
+def test_parse_release_declaration_returns_all_fields():
+    decl = runner.parse_release_declaration(RELEASE_DECLARATION_BODY)
+    assert decl == {
+        "version": "v0.3.0",
+        "base_branch": "main",
+        "test_command": (
+            "/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q "
+            "&& /usr/bin/python3 -m coverage report --show-missing"
+        ),
+        "scope": [123, 124],
+    }
+
+
+def test_parse_release_declaration_requires_the_release_section():
+    with pytest.raises(ValueError, match="## Release"):
+        runner.parse_release_declaration("no section here\n")
+
+
+def test_parse_release_declaration_requires_version():
+    body = RELEASE_DECLARATION_BODY.replace("- version: v0.3.0\n", "")
+    with pytest.raises(ValueError, match="version"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_requires_base_branch():
+    body = RELEASE_DECLARATION_BODY.replace("- base_branch: main\n", "")
+    with pytest.raises(ValueError, match="base_branch"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_requires_test_command():
+    body = RELEASE_DECLARATION_BODY.replace("- test_command: ", "- test_command2: ")
+    with pytest.raises(ValueError, match="test_command"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_requires_scope():
+    lines = [line for line in RELEASE_DECLARATION_BODY.splitlines()
+             if not line.strip().startswith("- #")]
+    body = "\n".join(line for line in lines if line.strip() != "- scope:") + "\n"
+    with pytest.raises(ValueError, match="scope"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_empty_scope():
+    lines = [line for line in RELEASE_DECLARATION_BODY.splitlines()
+             if not line.strip().startswith("- #")]
+    with pytest.raises(ValueError, match="scope"):
+        runner.parse_release_declaration("\n".join(lines) + "\n")
+
+
+def test_parse_release_declaration_rejects_duplicate_field():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "\n## Notes", "\n- version: v9.9.9\n\n## Notes",
+    )
+    with pytest.raises(ValueError, match="version"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_unknown_key():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "\n## Notes", "\n- channel: stable\n\n## Notes",
+    )
+    with pytest.raises(ValueError, match="channel"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_version_with_space():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0", "- version: v0.3 .0",
+    )
+    with pytest.raises(ValueError, match="version"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_empty_value():
+    body = RELEASE_DECLARATION_BODY.replace("- base_branch: main",
+                                            "- base_branch:")
+    with pytest.raises(ValueError, match="base_branch"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_malformed_scope_item():
+    body = RELEASE_DECLARATION_BODY.replace("  - #123", "  - #abc")
+    with pytest.raises(ValueError, match="scope item"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_scope_item_without_hash():
+    body = RELEASE_DECLARATION_BODY.replace("  - #123", "  - 123")
+    with pytest.raises(ValueError, match="scope item"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_zero_scope_item():
+    body = RELEASE_DECLARATION_BODY.replace("  - #123", "  - #0")
+    with pytest.raises(ValueError, match="scope item"):
+        runner.parse_release_declaration(body)
+
+
+def test_is_release_detects_the_label():
+    issue = {"number": 99, "labels": [
+        {"name": "ai-ready"}, {"name": "ai-release"},
+    ]}
+    assert runner.is_release(issue) is True
+
+
+def test_is_release_false_without_label_or_malformed():
+    assert runner.is_release({"number": 1, "labels": [{"name": "ai-ready"}]}) is False
+    assert runner.is_release({"number": 1}) is False
+    assert runner.is_release({"number": 1, "labels": "ai-release"}) is False
+
+
+def test_process_issue_routes_release_to_process_release(monkeypatch):
+    issue = {"number": 99, "title": "Release v0.3.0", "body": "",
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    calls = []
+    monkeypatch.setattr(runner, "process_release",
+                        lambda i, c, r: calls.append("release") or "rel-url")
+    monkeypatch.setattr(runner, "run_pi", Mock(
+        side_effect=AssertionError("run_pi must not run for a release task")))
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc")
+    result = runner.process_issue(issue, {"base_branch": "main"}, "o/r")
+    assert result == "rel-url"
+    assert calls == ["release"]
+
+
+def test_process_issue_keeps_normal_flow_without_release_label(monkeypatch):
+    issue = {"number": 99, "title": "Normal", "body": "",
+             "labels": [{"name": "ai-ready"}]}
+    monkeypatch.setattr(runner, "is_release", lambda i: False)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
+    monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(runner, "edit_issue", Mock())
+    monkeypatch.setattr(runner, "set_active_run", Mock())
+    monkeypatch.setattr(runner, "create_worktree",
+                        lambda *a: Path("/wt"))
+    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(runner, "ProgressPublisher", Mock())
+    monkeypatch.setattr(runner, "run_pi",
+                        lambda *a, **k: "https://github.com/o/r/pull/1")
+    monkeypatch.setattr(runner, "verify_pr",
+                        lambda *a, **k: "https://github.com/o/r/pull/1")
+    monkeypatch.setattr(runner, "run_command",
+                        lambda c, **k: "abc123")
+    monkeypatch.setattr(runner, "wait_for_delivery", Mock())
+    monkeypatch.setattr(runner, "edit_issue", Mock())
+    monkeypatch.setattr(runner, "LOGGER", Mock())
+    monkeypatch.setattr(runner, "activity_snapshot", lambda p: None)
+    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(runner, "format_end_scene", lambda **k: "end")
+    monkeypatch.setattr(runner, "issue_context", lambda r, n: "#n")
+    monkeypatch.setattr(runner, "format_run_scene", lambda *a, **k: "scene")
+    monkeypatch.setattr(runner, "_finish_blocked_progress", Mock())
+    runner.process_issue(issue, {"base_branch": "main", "repo_dir": Path("/r")}, "o/r")
+
+
+def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):
+    """Answer `gh pr view` / `gh issue view` for scope verification.
+
+    `pr_state_map`: number -> (state, merge_commit_oid) for PRs; a
+    number absent from the map is NOT a PR (gh exits 1 with the real
+    "Could not resolve to a PullRequest" error).
+    `issue_state_map`: number -> state for Issues; a number absent from
+    BOTH maps is neither.
+    """
+    pr_state_map = pr_state_map or {}
+    issue_state_map = issue_state_map or {}
+    calls = []
+
+    def fake_run_command(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["gh", "pr", "view"]:
+            number = int(command[3])
+            if number not in pr_state_map:
+                raise subprocess.CalledProcessError(
+                    1, command,
+                    stderr=(
+                        "GraphQL: Could not resolve to a PullRequest "
+                        f"with the number of {number}. "
+                        "(repository.pullRequest)"
+                    ),
+                )
+            state, oid = pr_state_map[number]
+            return json.dumps({
+                "number": number, "state": state,
+                "mergeCommit": {"oid": oid} if oid else None,
+            })
+        if command[:3] == ["gh", "issue", "view"]:
+            number = int(command[3])
+            if number not in issue_state_map:
+                raise subprocess.CalledProcessError(
+                    1, command,
+                    stderr=(
+                        "GraphQL: Could not resolve to an Issue with "
+                        f"the number of {number}."
+                    ),
+                )
+            return json.dumps({"number": number, "state": issue_state_map[number]})
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    return calls
+
+
+def test_verify_release_scope_evidence_for_pr_and_issue(monkeypatch):
+    make_scope_gh(
+        monkeypatch,
+        pr_state_map={123: ("MERGED", "aaa111")},
+        issue_state_map={124: "CLOSED"},
+    )
+    evidence = runner.verify_release_scope("o/r", [123, 124])
+    assert evidence == [
+        "PR #123 merged (mergeCommit=aaa111)",
+        "Issue #124 closed",
+    ]
+
+
+def test_verify_release_scope_fails_on_unmerged_pr(monkeypatch):
+    make_scope_gh(monkeypatch, pr_state_map={123: ("OPEN", None)})
+    with pytest.raises(RuntimeError, match="PR #123 is not merged"):
+        runner.verify_release_scope("o/r", [123])
+
+
+def test_verify_release_scope_fails_on_unclosed_issue(monkeypatch):
+    make_scope_gh(monkeypatch, issue_state_map={124: "OPEN"})
+    with pytest.raises(RuntimeError, match="Issue #124 is not closed"):
+        runner.verify_release_scope("o/r", [124])
+
+
+def test_verify_release_scope_fails_on_merged_pr_without_merge_commit(
+        monkeypatch):
+    # A MERGED PR without merge-commit evidence is not evidence.
+    make_scope_gh(monkeypatch, pr_state_map={123: ("MERGED", None)})
+    with pytest.raises(RuntimeError, match="no merge commit evidence"):
+        runner.verify_release_scope("o/r", [123])
+
+
+def test_verify_release_scope_fails_on_unknown_item(monkeypatch):
+    make_scope_gh(monkeypatch)
+    with pytest.raises(RuntimeError, match="neither a PR nor an Issue"):
+        runner.verify_release_scope("o/r", [999])
+
+
+def test_verify_release_scope_reraises_real_gh_failure(monkeypatch):
+    calls = []
+
+    def fake_run_command(command, **kwargs):
+        calls.append(command)
+        raise subprocess.CalledProcessError(
+            1, command, stderr="HTTP 403: rate limited",
+        )
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.verify_release_scope("o/r", [123])
+
+
+def make_gate_gh(monkeypatch, *, leftover_labels=None, check_runs=None,
+                 open_prs=None):
+    """Answer the gh calls of `check_release_gates`.
+
+    `leftover_labels`: label -> [issue numbers] still open with it.
+    `check_runs`: list of (name, status, conclusion) for the release
+    commit (None -> the call fails, which must propagate).
+    `open_prs`: list of (number, head_ref) open against the base.
+    """
+    leftover_labels = leftover_labels or {}
+    open_prs = open_prs or []
+    calls = []
+
+    def fake_run_command(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["gh", "issue", "list"]:
+            label = command[command.index("--label") + 1]
+            return json.dumps([{"number": n} for n in leftover_labels.get(label, [])])
+        if command[:2] == ["gh", "api"]:
+            if check_runs is None:
+                raise subprocess.CalledProcessError(
+                    1, command, stderr="HTTP 500: server error",
+                )
+            return json.dumps([
+                {"name": name, "status": status, "conclusion": conclusion}
+                for name, status, conclusion in check_runs
+            ])
+        if command[:3] == ["gh", "pr", "list"]:
+            return json.dumps([
+                {"number": n, "headRefName": head} for n, head in open_prs
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    return calls
+
+
+def test_check_release_gates_pass_clean(monkeypatch):
+    calls = make_gate_gh(
+        monkeypatch,
+        check_runs=[("tests", "completed", "success"),
+                    ("lint", "completed", "skipped")],
+    )
+    evidence = runner.check_release_gates("o/r", "main", "abc123", 99)
+    assert evidence == [
+        "no open Issue carries ai-in-progress / ai-pr-opened / ai-fix-needed",
+        "CI on the release commit: 2 check(s) all success/neutral/skipped",
+        "no open PR targets main",
+    ]
+    # The release Issue itself is excluded from the leftover scan:
+    # every leftover scan fetched the label's open Issues.
+    labels = [c[c.index("--label") + 1] for c in calls
+              if c[:3] == ["gh", "issue", "list"]]
+    assert labels == ["ai-in-progress", "ai-pr-opened", "ai-fix-needed"]
+
+
+def test_check_release_gates_excludes_the_release_issue_itself(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        leftover_labels={"ai-in-progress": [99]},  # the release Issue
+        check_runs=[],
+    )
+    evidence = runner.check_release_gates("o/r", "main", "abc123", 99)
+    assert evidence[0].startswith("no open Issue carries")
+
+
+def test_check_release_gates_fails_on_leftover_in_progress(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        leftover_labels={"ai-in-progress": [7]},
+        check_runs=[],
+    )
+    with pytest.raises(RuntimeError, match="Issue #7 still carries ai-in-progress"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_check_release_gates_fails_on_leftover_fix_needed(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        leftover_labels={"ai-fix-needed": [8]},
+        check_runs=[],
+    )
+    with pytest.raises(RuntimeError, match="Issue #8 still carries ai-fix-needed"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_check_release_gates_fails_on_failing_ci(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        check_runs=[("tests", "completed", "failure")],
+    )
+    with pytest.raises(RuntimeError, match="check 'tests' is completed/failure"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_check_release_gates_fails_on_pending_ci(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        check_runs=[("tests", "in_progress", None)],
+    )
+    with pytest.raises(RuntimeError, match="check 'tests' is in_progress/None"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_check_release_gates_reraises_real_gh_failure(monkeypatch):
+    make_gate_gh(monkeypatch, check_runs=None)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_check_release_gates_fails_on_open_pr_against_base(monkeypatch):
+    make_gate_gh(
+        monkeypatch,
+        check_runs=[],
+        open_prs=[(55, "feature/x")],
+    )
+    with pytest.raises(RuntimeError,
+                       match="PR #55 \\(head feature/x\\) is still open against main"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
+def test_run_release_tests_wraps_the_command_in_timeout_bash(monkeypatch):
+    calls = []
+    monkeypatch.setattr(runner, "run_command",
+                        lambda c, **k: calls.append((c, k)) or "")
+    runner.run_release_tests(Path("/wt"), "pytest -q", 120)
+    (command, kwargs), = calls
+    assert command == ["timeout", "120", "bash", "-c", "pytest -q"]
+    assert kwargs == {"cwd": Path("/wt")}
+
+
+def test_run_release_tests_fails_fast_on_nonzero(monkeypatch):
+    def fail(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command, stderr="1 failed",
+        )
+    monkeypatch.setattr(runner, "run_command", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.run_release_tests(Path("/wt"), "pytest -q", 120)
+
+
+def make_local_remote_pair(tmp_path):
+    """A real local 'origin' bare remote + a working clone with one commit."""
+    remote = tmp_path / "remote.git"
+    work = tmp_path / "work"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "init", "-b", "main", str(work)],
+        check=True, capture_output=True,
+    )
+    for key, value in (
+        ("user.email", "t@t"), ("user.name", "t"),
+        ("commit.gpgsign", "false"), ("tag.gpgsign", "false"),
+    ):
+        subprocess.run(
+            ["git", "-C", str(work), "config", key, value],
+            check=True, capture_output=True,
+        )
+    (work / "f.txt").write_text("hi\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(work), "add", "f.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "commit", "-m", "one"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "remote", "add", "origin", str(remote)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "push", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    head = subprocess.run(
+        ["git", "-C", str(work), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    return work, head
+
+
+def test_release_tag_commit_returns_none_for_missing_remote_tag(tmp_path):
+    work, _ = make_local_remote_pair(tmp_path)
+    assert runner.release_tag_commit(work, "v9.9.9") is None
+
+
+def test_release_tag_commit_returns_the_tagged_commit(tmp_path):
+    work, head = make_local_remote_pair(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(work), "tag", "-a", "v0.1.0", "-m", "rel", head],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(work), "push", "origin", "v0.1.0"],
+        check=True, capture_output=True,
+    )
+    assert runner.release_tag_commit(work, "v0.1.0") == head
+
+
+def test_release_tag_commit_reraises_real_fetch_failure(tmp_path, monkeypatch):
+    work, _ = make_local_remote_pair(tmp_path)
+    def fail(command, **kwargs):
+        raise subprocess.CalledProcessError(1, command, stderr="boom")
+    monkeypatch.setattr(runner, "run_command", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.release_tag_commit(work, "v0.1.0")
+
+
+def make_release_gh(monkeypatch, *, release_exists=False):
+    """Answer `gh release view` / `gh release create`.
+
+    `release_exists=False` starts with "release not found" (the real
+    gh error, verified against the live CLI) and flips to found after
+    a `gh release create` — the same state transition the real remote
+    makes.
+    """
+    calls = []
+    state = {"exists": release_exists}
+
+    def fake_run_command(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["gh", "release", "view"]:
+            if not state["exists"]:
+                raise subprocess.CalledProcessError(
+                    1, command, stderr="release not found",
+                )
+            return json.dumps({
+                "tagName": command[3],
+                "url": "https://github.com/o/r/releases/tag/" + command[3],
+            })
+        if command[:3] == ["gh", "release", "create"]:
+            state["exists"] = True
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    return calls
+
+
+def test_publish_release_creates_when_missing_and_returns_url(monkeypatch):
+    calls = make_release_gh(monkeypatch, release_exists=False)
+    url = runner.publish_release(
+        repo="o/r", tag="v0.3.0", version="v0.3.0",
+        release_commit="abc123",
+        scope_evidence=["PR #123 merged (mergeCommit=aaa111)"],
+        gate_evidence=["no open Issue carries ai-in-progress"],
+        test_evidence="tests passed (exit 0)",
+        run_id="a1b2c3d4", issue_number=99,
+    )
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    creates = [c for c in calls if c[:3] == ["gh", "release", "create"]]
+    assert len(creates) == 1
+    create = creates[0]
+    assert create[:3] == ["gh", "release", "create"]
+    assert create[3] == "v0.3.0"
+    notes = create[create.index("--notes") + 1]
+    assert "v0.3.0" in notes
+    assert "abc123" in notes
+    assert "PR #123 merged (mergeCommit=aaa111)" in notes
+    assert "no open Issue carries ai-in-progress" in notes
+    assert "tests passed (exit 0)" in notes
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in notes
+    assert "run_id=a1b2c3d4" in notes
+    assert "Issue #99" in notes
+
+
+def test_publish_release_reuses_the_existing_release(monkeypatch):
+    calls = make_release_gh(monkeypatch, release_exists=True)
+    url = runner.publish_release(
+        repo="o/r", tag="v0.3.0", version="v0.3.0",
+        release_commit="abc123",
+        scope_evidence=[], gate_evidence=[], test_evidence="ok",
+        run_id="a1b2c3d4", issue_number=99,
+    )
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    assert not [c for c in calls if c[:3] == ["gh", "release", "create"]]
+
+
+def test_publish_release_reraises_real_gh_failure(monkeypatch):
+    def fail(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command, stderr="HTTP 403: rate limited",
+        )
+    monkeypatch.setattr(runner, "run_command", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.publish_release(
+            repo="o/r", tag="v0.3.0", version="v0.3.0",
+            release_commit="abc123",
+            scope_evidence=[], gate_evidence=[], test_evidence="ok",
+            run_id="a1b2c3d4", issue_number=99,
+        )
+
+
+def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
+                             tag_commit=None, release_url="https://github.com/o/r/releases/tag/v0.3.0",
+                             in_progress=False, existing_run_id=None):
+    """Full fake environment for `process_release`.
+
+    Returns a dict of captured state: edit_issue / comment_issue calls,
+    run_command calls, and the monkeypatched pieces.
+    """
+    state = {
+        "edits": [], "comments": [], "commands": [],
+        "run_ids": [], "active_runs": [],
+    }
+
+    def fake_run_command(command, **kwargs):
+        state["commands"].append((command, kwargs))
+        if command[:3] == ["gh", "pr", "view"]:
+            number = int(command[3])
+            if number == 123:
+                return json.dumps({
+                    "number": 123, "state": "MERGED",
+                    "mergeCommit": {"oid": "aaa111"},
+                })
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr=(
+                    "GraphQL: Could not resolve to a PullRequest with "
+                    f"the number of {number}. (repository.pullRequest)"
+                ),
+            )
+        if command[:3] == ["gh", "issue", "view"]:
+            number = int(command[3])
+            if number == 124:
+                return json.dumps({"number": 124, "state": "CLOSED"})
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr=(
+                    "GraphQL: Could not resolve to an Issue with the "
+                    f"number of {number}."
+                ),
+            )
+        if command[:3] == ["gh", "issue", "list"]:
+            return "[]"
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([
+                {"name": "tests", "status": "completed",
+                 "conclusion": "success"},
+            ])
+        if command[:3] == ["gh", "pr", "list"]:
+            return "[]"
+        if command[:2] == ["git", "fetch"]:
+            return ""
+        if command[:2] == ["git", "tag"]:
+            return ""
+        if command[:2] == ["git", "push"]:
+            return ""
+        if command[0] == "timeout":
+            return ""
+        if command[:3] == ["gh", "issue", "close"]:
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(runner, "set_run_id",
+                        lambda rid: state["run_ids"].append(rid))
+    monkeypatch.setattr(runner, "has_in_progress_label",
+                        lambda n, r: in_progress)
+    monkeypatch.setattr(runner, "latest_run_id",
+                        lambda r, s, n: existing_run_id)
+    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(runner, "edit_issue",
+                        lambda n, **k: state["edits"].append((n, k)))
+    monkeypatch.setattr(runner, "comment_issue",
+                        lambda n, **k: state["comments"].append((n, k)))
+    monkeypatch.setattr(runner, "create_worktree",
+                        lambda *a: Path("/wt"))
+    monkeypatch.setattr(runner, "ProgressPublisher", Mock())
+    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(runner, "set_active_run",
+                        lambda *a: state["active_runs"].append(a))
+    monkeypatch.setattr(runner, "LOGGER", Mock())
+    monkeypatch.setattr(runner, "release_tag_commit",
+                        lambda r, t: tag_commit)
+    monkeypatch.setattr(runner, "publish_release", lambda **k: release_url)
+    return state
+
+
+def test_process_release_success_end_to_end(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    url = runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    # Claim first, terminal ai-merged at the end (ai-in-progress removed).
+    assert state["edits"][0] == (99, {"repo": "o/r",
+                                      "add": "ai-in-progress"})
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-merged",
+                                       "remove": "ai-in-progress"})
+    # The tag was created at the release commit and pushed plainly.
+    commands = [c for c, _ in state["commands"]]
+    assert (["git", "tag", "-a", "v0.3.0", "-m", "Release v0.3.0",
+             "abc123"], {"cwd": Path("/r")}) in state["commands"]
+    assert (["git", "push", "origin", "refs/tags/v0.3.0"],
+            {"cwd": Path("/r")}) in state["commands"]
+    assert not any("--force" in c or "-f" == c for c in commands)
+    # The release Issue is closed.
+    assert ["gh", "issue", "close", "99", "--repo", "o/r"] in commands
+    # The declared test command ran timeout-wrapped in the worktree.
+    assert (["timeout", str(runner.RELEASE_TEST_TIMEOUT_SECONDS),
+             "bash", "-c",
+             "/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q "
+             "&& /usr/bin/python3 -m coverage report --show-missing"],
+            {"cwd": Path("/wt")}) in state["commands"]
+    # The success comment carries the run marker and the release URL.
+    (comment_number, comment_kwargs), = state["comments"]
+    assert comment_number == 99
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comment_kwargs["body"]
+    assert "run_id=a1b2c3d4" in comment_kwargs["body"]
+    assert "https://github.com/o/r/releases/tag/v0.3.0" in comment_kwargs["body"]
+    assert "PR #123 merged (mergeCommit=aaa111)" in comment_kwargs["body"]
+    assert "Issue #124 closed" in comment_kwargs["body"]
+    assert state["run_ids"][0] == "a1b2c3d4"
+
+
+def test_process_release_reuses_the_run_id_on_resume(monkeypatch):
+    state = make_release_process_env(
+        monkeypatch, in_progress=True, existing_run_id="deadbeef",
+    )
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"},
+                        {"name": "ai-in-progress"}]}
+    runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    # The fresh id is generated first (the normal-path rule), then the
+    # resumed run id wins — the terminal comment carries the resumed id.
+    assert state["run_ids"] == ["a1b2c3d4", "deadbeef"]
+    (comment_number, comment_kwargs), = state["comments"]
+    assert "<!-- muyan-pilot:run=deadbeef -->" in comment_kwargs["body"]
+
+
+def test_process_release_fails_on_malformed_declaration(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    issue = {"number": 99, "title": "Release v0.3.0", "body": "no section",
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(ValueError, match="## Release"):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    # Terminal failure: ai-blocked ALONE, no ai-merged, no close.
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+    assert not any(k.get("add") == "ai-merged" for _, k in state["edits"])
+    commands = [c for c, _ in state["commands"]]
+    assert not [c for c in commands if c[:3] == ["gh", "issue", "close"]]
+    (comment_number, comment_kwargs), = state["comments"]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comment_kwargs["body"]
+    assert "## Release" in comment_kwargs["body"]
+
+
+def test_process_release_fails_on_tag_mismatch_without_moving_it(monkeypatch):
+    state = make_release_process_env(monkeypatch, tag_commit="other123")
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(RuntimeError, match="never moved"):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    commands = [c for c, _ in state["commands"]]
+    assert not [c for c in commands if c[:2] == ["git", "tag"]]
+    assert not [c for c in commands if c[:2] == ["git", "push"]]
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+    (comment_number, comment_kwargs), = state["comments"]
+    assert "other123" in comment_kwargs["body"]
+    assert "abc123" in comment_kwargs["body"]
+
+
+def test_process_release_reuses_a_matching_existing_tag(monkeypatch):
+    state = make_release_process_env(monkeypatch, tag_commit="abc123")
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    url = runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    commands = [c for c, _ in state["commands"]]
+    assert not [c for c in commands if c[:2] == ["git", "tag"]]
+    assert not [c for c in commands if c[:2] == ["git", "push"]]
+
+
+def test_process_release_fails_on_scope_violation(monkeypatch):
+    # Reuse the env, but make scope item #123 an OPEN PR.
+    state = make_release_process_env(monkeypatch)
+    real = runner.run_command
+    def scope_failing(command, **kwargs):
+        if command[:3] == ["gh", "pr", "view"] and command[3] == "123":
+            return json.dumps({
+                "number": 123, "state": "OPEN", "mergeCommit": None,
+            })
+        return real(command, **kwargs)
+    monkeypatch.setattr(runner, "run_command", scope_failing)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(RuntimeError, match="PR #123 is not merged"):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+
+
+def test_parse_release_declaration_rejects_non_string_body():
+    with pytest.raises(ValueError, match="must be a string"):
+        runner.parse_release_declaration(123)
+
+
+def test_parse_release_declaration_rejects_empty_section():
+    # `## Release` is the very last line: the section holds no fields.
+    with pytest.raises(ValueError, match="version"):
+        runner.parse_release_declaration("Ship it.\n\n## Release\n")
+
+
+def test_parse_release_declaration_rejects_colonless_field_line():
+    # A `- ` line without a colon BEFORE the scope list is a malformed
+    # field line (after the scope list it is a malformed scope item).
+    body = RELEASE_DECLARATION_BODY.replace(
+        "## Release\n", "## Release\n\n- broken\n",
+    )
+    with pytest.raises(ValueError, match=r"field 'broken' is malformed"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_inline_scope_value():
+    body = RELEASE_DECLARATION_BODY.replace("- scope:\n", "- scope: 123\n")
+    with pytest.raises(ValueError, match="not an inline value"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_plain_line_in_scope():
+    body = RELEASE_DECLARATION_BODY.replace("  - #123", "hello")
+    with pytest.raises(ValueError, match=r"scope item 'hello' is malformed"):
+        runner.parse_release_declaration(body)
+
+
+def test_parse_release_declaration_rejects_plain_line_outside_scope():
+    # A plain line while the scope list is NOT open is rejected as a
+    # non-field line (the same line inside the scope list is a
+    # malformed scope item).
+    body = RELEASE_DECLARATION_BODY.replace(
+        "## Release\n", "## Release\n\nhello\n",
+    )
+    with pytest.raises(ValueError, match=r"line 'hello' is not a"):
+        runner.parse_release_declaration(body)
+
+
+def test_verify_release_scope_reraises_real_issue_gh_failure(monkeypatch):
+    def fail(command, **kwargs):
+        if command[:3] == ["gh", "pr", "view"]:
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr="GraphQL: Could not resolve to a PullRequest with "
+                       "the number of 7.",
+            )
+        if command[:3] == ["gh", "issue", "view"]:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="HTTP 403: rate limited",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fail)
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        runner.verify_release_scope("o/r", [7])
+    assert "HTTP 403: rate limited" in str(excinfo.value.stderr)
+    # The fake rejects anything that is not pr/issue view traffic.
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fail(["gh", "release", "list"])
+
+
+def test_process_release_keeps_the_fresh_id_when_no_run_id_is_recoverable(
+        monkeypatch):
+    # ai-in-progress is present but no run id can be recovered: the
+    # fresh id is kept (the resume branch is skipped).
+    state = make_release_process_env(monkeypatch, in_progress=True,
+                                     existing_run_id=None)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"},
+                        {"name": "ai-in-progress"}]}
+    runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert state["run_ids"] == ["a1b2c3d4"]
+    (comment_number, comment_kwargs), = state["comments"]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comment_kwargs["body"]
+
+
+def test_process_release_publishes_the_release_role_progress_body(
+        monkeypatch):
+    # `_safe_publish` really invokes the action here, so the progress
+    # closure renders the body: role=release, run marker, branch.
+    state = make_release_process_env(monkeypatch)
+    publishes = []
+
+    def publish(**kwargs):
+        publishes.append(kwargs)
+        kwargs["action"]()
+
+    monkeypatch.setattr(runner, "_safe_publish", publish)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    url = runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    assert publishes, "no progress publish happened"
+    assert all(kwargs["role"] == "release" for kwargs in publishes)
+    assert all(kwargs["issue"] == 99 for kwargs in publishes)
+    publisher = runner.ProgressPublisher.return_value
+    assert publisher.ensure.call_count == 1
+    body = publisher.ensure.call_args[0][0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in body
+    assert "- role: release" in body
+    assert "- priority: normal" in body
+    assert "- branch: muyan-pilot/o-r-issue-99-a1b2c3d4" in body
+
+
+def test_process_release_fails_on_scope_item_that_is_neither(monkeypatch):
+    # Scope item #125 is neither a PR nor an Issue on the remote: the
+    # item-by-item verification fails fast and the release is blocked.
+    body = RELEASE_DECLARATION_BODY.replace("  - #124", "  - #125")
+    state = make_release_process_env(monkeypatch, body=body)
+    issue = {"number": 99, "title": "Release v0.3.0", "body": body,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(RuntimeError, match="neither a PR nor an Issue"):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                        "remove": "ai-in-progress"})
+
+
+def test_scope_gh_fake_rejects_unexpected_command(monkeypatch):
+    make_scope_gh(monkeypatch)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        runner.run_command(["gh", "release", "list"])
+
+
+def test_gate_gh_fake_rejects_unexpected_command(monkeypatch):
+    make_gate_gh(monkeypatch)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        runner.run_command(["gh", "release", "list"])
+
+
+def test_release_gh_fake_rejects_unexpected_command(monkeypatch):
+    make_release_gh(monkeypatch)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        runner.run_command(["git", "tag", "v0.3.0"])
+
+
+def test_release_process_env_fake_rejects_unexpected_command(monkeypatch):
+    make_release_process_env(monkeypatch)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        runner.run_command(["gh", "label", "list"])
+
+
+def test_release_process_env_fake_answers_the_real_tag_fetch(tmp_path,
+                                                             monkeypatch):
+    # The env fake answers the `git fetch` of the REAL
+    # `release_tag_commit` (the lock is taken for real on tmp_path).
+    real_release_tag_commit = runner.release_tag_commit
+    make_release_process_env(monkeypatch)
+    monkeypatch.setattr(runner, "release_tag_commit",
+                        real_release_tag_commit)
+    env_fake = runner.run_command
+
+    def fake(command, **kwargs):
+        if command[:2] == ["git", "rev-parse"]:
+            return "abc123"
+        return env_fake(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake)
+    assert runner.release_tag_commit(tmp_path, "v0.3.0") == "abc123"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -9624,6 +9624,8 @@ def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):
                     ),
                 )
             return json.dumps({"number": number, "state": issue_state_map[number]})
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            return ""
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
@@ -9636,7 +9638,7 @@ def test_verify_release_scope_evidence_for_pr_and_issue(monkeypatch):
         pr_state_map={123: ("MERGED", "aaa111")},
         issue_state_map={124: "CLOSED"},
     )
-    evidence = runner.verify_release_scope("o/r", [123, 124])
+    evidence = runner.verify_release_scope("o/r", [123, 124], Path("/repo"), "release123")
     assert evidence == [
         "PR #123 merged (mergeCommit=aaa111)",
         "Issue #124 closed",
@@ -9646,13 +9648,45 @@ def test_verify_release_scope_evidence_for_pr_and_issue(monkeypatch):
 def test_verify_release_scope_fails_on_unmerged_pr(monkeypatch):
     make_scope_gh(monkeypatch, pr_state_map={123: ("OPEN", None)})
     with pytest.raises(RuntimeError, match="PR #123 is not merged"):
-        runner.verify_release_scope("o/r", [123])
+        runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
+
+
+def test_verify_release_scope_rejects_merged_pr_outside_release_base(
+        monkeypatch):
+    """A PR merged on another branch is not evidence for this tag."""
+    make_scope_gh(monkeypatch, pr_state_map={123: ("MERGED", "other123")})
+    original = runner.run_command
+
+    def not_an_ancestor(command, **kwargs):
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            raise subprocess.CalledProcessError(1, command)
+        return original(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", not_an_ancestor)
+    with pytest.raises(RuntimeError, match="not contained in release commit"):
+        runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
+
+
+def test_verify_release_scope_reraises_git_ancestry_check_failure(
+        monkeypatch):
+    make_scope_gh(monkeypatch, pr_state_map={123: ("MERGED", "aaa111")})
+    original = runner.run_command
+
+    def git_failure(command, **kwargs):
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            raise subprocess.CalledProcessError(128, command, stderr="bad object")
+        return original(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", git_failure)
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
+    assert excinfo.value.stderr == "bad object"
 
 
 def test_verify_release_scope_fails_on_unclosed_issue(monkeypatch):
     make_scope_gh(monkeypatch, issue_state_map={124: "OPEN"})
     with pytest.raises(RuntimeError, match="Issue #124 is not closed"):
-        runner.verify_release_scope("o/r", [124])
+        runner.verify_release_scope("o/r", [124], Path("/repo"), "release123")
 
 
 def test_verify_release_scope_fails_on_merged_pr_without_merge_commit(
@@ -9660,13 +9694,13 @@ def test_verify_release_scope_fails_on_merged_pr_without_merge_commit(
     # A MERGED PR without merge-commit evidence is not evidence.
     make_scope_gh(monkeypatch, pr_state_map={123: ("MERGED", None)})
     with pytest.raises(RuntimeError, match="no merge commit evidence"):
-        runner.verify_release_scope("o/r", [123])
+        runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
 
 
 def test_verify_release_scope_fails_on_unknown_item(monkeypatch):
     make_scope_gh(monkeypatch)
     with pytest.raises(RuntimeError, match="neither a PR nor an Issue"):
-        runner.verify_release_scope("o/r", [999])
+        runner.verify_release_scope("o/r", [999], Path("/repo"), "release123")
 
 
 def test_verify_release_scope_reraises_real_gh_failure(monkeypatch):
@@ -9679,7 +9713,7 @@ def test_verify_release_scope_reraises_real_gh_failure(monkeypatch):
         )
     monkeypatch.setattr(runner, "run_command", fake_run_command)
     with pytest.raises(subprocess.CalledProcessError):
-        runner.verify_release_scope("o/r", [123])
+        runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
 
 
 def make_gate_gh(monkeypatch, *, leftover_labels=None, check_runs=None,
@@ -9809,7 +9843,11 @@ def test_run_release_tests_wraps_the_command_in_timeout_bash(monkeypatch):
                         lambda c, **k: calls.append((c, k)) or "")
     runner.run_release_tests(Path("/wt"), "pytest -q", 120)
     (command, kwargs), = calls
-    assert command == ["timeout", "120", "bash", "-c", "pytest -q"]
+    assert command == [
+        "timeout", "120", "bash", "-c",
+        "pytest -q && /usr/bin/python3 -m coverage report "
+        "--fail-under=100 --show-missing",
+    ]
     assert kwargs == {"cwd": Path("/wt")}
 
 
@@ -9941,6 +9979,7 @@ def test_publish_release_creates_when_missing_and_returns_url(monkeypatch):
     create = creates[0]
     assert create[:3] == ["gh", "release", "create"]
     assert create[3] == "v0.3.0"
+    assert "--verify-tag" in create
     notes = create[create.index("--notes") + 1]
     assert "v0.3.0" in notes
     assert "abc123" in notes
@@ -10032,6 +10071,8 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             return ""
         if command[:2] == ["git", "tag"]:
             return ""
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            return ""
         if command[:2] == ["git", "push"]:
             return ""
         if command[0] == "timeout":
@@ -10093,7 +10134,9 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert (["timeout", str(runner.RELEASE_TEST_TIMEOUT_SECONDS),
              "bash", "-c",
              "/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q "
-             "&& /usr/bin/python3 -m coverage report --show-missing"],
+             "&& /usr/bin/python3 -m coverage report --show-missing && "
+             "/usr/bin/python3 -m coverage report --fail-under=100 "
+             "--show-missing"],
             {"cwd": Path("/wt")}) in state["commands"]
     # The success comment carries the run marker and the release URL.
     (comment_number, comment_kwargs), = state["comments"]
@@ -10258,7 +10301,7 @@ def test_verify_release_scope_reraises_real_issue_gh_failure(monkeypatch):
 
     monkeypatch.setattr(runner, "run_command", fail)
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
-        runner.verify_release_scope("o/r", [7])
+        runner.verify_release_scope("o/r", [7], Path("/repo"), "release123")
     assert "HTTP 403: rate limited" in str(excinfo.value.stderr)
     # The fake rejects anything that is not pr/issue view traffic.
     with pytest.raises(AssertionError, match="unexpected command"):

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -41,6 +41,7 @@ REQUIRED_ZH_PAGES = (
 KNOWN_LABELS = frozenset({
     "ai-ready",
     "ai-epic",
+    runner.RELEASE_LABEL,
     runner.IN_PROGRESS_LABEL,
     runner.PR_OPENED_LABEL,
     runner.FIX_NEEDED_LABEL,

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -28,6 +28,7 @@ KNOWN_LABELS = frozenset({
     runner.MERGED_LABEL,
     runner.BLOCKED_LABEL,
     runner.EPIC_LABEL,
+    runner.RELEASE_LABEL,
 })
 
 LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -46,6 +46,7 @@ REQUIRED_PAGES = (
 KNOWN_LABELS = frozenset({
     "ai-ready",
     "ai-epic",
+    runner.RELEASE_LABEL,
     runner.IN_PROGRESS_LABEL,
     runner.PR_OPENED_LABEL,
     runner.FIX_NEEDED_LABEL,

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -68,6 +68,10 @@ VALID_DEFS = [
     # Issue #93: the Epic marker is platform state (the claim scan
     # skips `ai-epic`), so it is part of the platform label set.
     {"name": "ai-epic", "color": "bfdadc", "description": "epic"},
+    # Issue #98: the Release task marker is platform state (the ready
+    # scan routes `ai-ready`+`ai-release` to the release state machine),
+    # so it is part of the platform label set.
+    {"name": "ai-release", "color": "5319e7", "description": "release"},
 ]
 
 
@@ -203,12 +207,13 @@ def test_fake_run_factory_rejects_an_unexpected_command():
 # --- labels.toml: the single source of truth -------------------------------
 
 
-def test_load_label_defs_parses_all_eight_platform_labels(tmp_path):
+def test_load_label_defs_parses_all_nine_platform_labels(tmp_path):
     path = write_labels_toml(tmp_path, VALID_DEFS)
     defs = pilot_setup.load_label_defs(path)
     assert [entry["name"] for entry in defs] == [
         "ai-ready", "ai-in-progress", "ai-pr-opened",
         "ai-fix-needed", "ai-merged", "ai-blocked", "p0", "ai-epic",
+        "ai-release",
     ]
     assert defs[0] == {
         "name": "ai-ready", "color": "1d76db", "description": "dispatched",
@@ -266,8 +271,8 @@ def test_load_label_defs_rejects_malformed_toml(tmp_path):
         pilot_setup.load_label_defs(path)
 
 
-def test_committed_labels_toml_covers_the_eight_platform_labels():
-    """The committed labels.toml (repo root) must define exactly the 8
+def test_committed_labels_toml_covers_the_nine_platform_labels():
+    """The committed labels.toml (repo root) must define exactly the 9
     platform labels with valid colors and non-empty descriptions."""
     path = Path(__file__).resolve().parent.parent / "labels.toml"
     defs = pilot_setup.load_label_defs(path)
@@ -454,8 +459,8 @@ def test_align_labels_creates_missing_and_edits_drifted(tmp_path):
         run_command=fake_run,
     )
     assert result["repo"] == "xqliu/muyan-pilot"
-    assert result["aligned"] == 8
-    assert result["total"] == 8
+    assert result["aligned"] == 9
+    assert result["total"] == 9
     # Only the drifted p0 label is written; ai-ready already matches and
     # the business label `bug` is never touched.
     creates = [c for c in calls if c[:3] == ["gh", "label", "create"]]
@@ -477,7 +482,7 @@ def test_align_labels_is_idempotent_when_everything_matches(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 8
+    assert result["aligned"] == 9
     assert [c for c in calls if c[:3] == ["gh", "label", "create"]] == []
 
 
@@ -490,9 +495,9 @@ def test_align_labels_reports_partial_alignment(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 8
-    assert result["total"] == 8
-    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 8
+    assert result["aligned"] == 9
+    assert result["total"] == 9
+    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 9
 
 
 def test_align_labels_fails_fast_on_a_label_write_error(tmp_path):
@@ -1006,7 +1011,7 @@ def test_run_setup_success_reports_all_steps(tmp_path):
             "repo": "xqliu/muyan-pilot",
             "permission": "ADMIN",
             "default_branch": "main",
-            "labels": {"aligned": 8, "total": 8},
+            "labels": {"aligned": 9, "total": 9},
         },
     ]
     assert result["service"]["installed"] is True
@@ -1233,7 +1238,7 @@ def sample_result() -> dict:
                 "repo": "xqliu/muyan-pilot",
                 "permission": "ADMIN",
                 "default_branch": "main",
-                "labels": {"aligned": 8, "total": 8},
+                "labels": {"aligned": 9, "total": 9},
             },
         ],
         "service": {
@@ -1290,7 +1295,7 @@ def test_format_setup_renders_stable_key_value_lines():
     )
     assert (
         "repo=xqliu/muyan-pilot permission=ADMIN "
-        "default_branch=main labels=8/8" in lines
+        "default_branch=main labels=9/9" in lines
     )
     assert (
         "service=installed path=/home/u/.config/systemd/user/"
@@ -1336,14 +1341,14 @@ def test_format_setup_renders_multiple_repos():
             "repo": "xqliu/muyan-ceo",
             "permission": "WRITE",
             "default_branch": "main",
-            "labels": {"aligned": 6, "total": 8},
+            "labels": {"aligned": 6, "total": 9},
         },
     )
     lines = pilot_setup.format_setup(result)
     repo_lines = [line for line in lines if line.startswith("repo=")]
     assert len(repo_lines) == 2
     assert repo_lines[1].startswith("repo=xqliu/muyan-ceo ")
-    assert "labels=6/8" in repo_lines[1]
+    assert "labels=6/9" in repo_lines[1]
 
 
 def test_install_units_step_result_is_json_serializable(tmp_path):


### PR DESCRIPTION
Fixes #98

Adds the `ai-release` Release task type: a first-class task type the
Runner picks from the same ready scan and executes with its own
deterministic release state machine — it never enters the normal
`run_pi` development path.

## What changed

- **`ai-release` label** — added to `labels.toml` and
  `pilot_setup.py` REQUIRED_LABELS (9th label).
- **`process_issue` routing** — an issue carrying `ai-release` is
  routed to `process_release()` before any run id / worktree / Pi step.
- **`parse_release_declaration`** — strict machine-readable `## Release`
  section (`version`, `base_branch`, `test_command`, `scope` with
  `  - #N` items); every deviation fails fast with the concrete field.
- **`verify_release_scope`** — item-by-item verification against
  GitHub (`gh pr view` → MERGED + merge commit; `gh issue view` →
  CLOSED), never by parsing Issue-body checkboxes. Real `gh` failures
  (auth, rate limit) propagate unchanged; only the verified
  "Could not resolve to a PullRequest / Issue" conditions are domain
  outcomes.
- **`check_release_gates`** — no leftover `ai-in-progress` /
  `ai-pr-opened` / `ai-fix-needed` issues, CI check runs passing on the
  release commit, no open PRs against the base.
- **`run_release_tests`** — the declared `test_command` in a clean
  worktree at the release commit, wrapped in `timeout <s> bash -c ...`
  (Issue #95).
- **`release_tag_commit`** — tag fetch under the base-sync lock
  (worktrees share the checkout common dir, Issue #171 semantics);
  missing remote tag → `None`, any other fetch failure fails fast.
  Existing tags are never moved or overwritten; a tag pointing at a
  different commit fails the release.
- **`publish_release`** — idempotent GitHub Release (an existing
  Release for the tag is reused by URL, never duplicated).
- **`process_release`** — the full state machine: run id resume (same
  scene as the normal path), scope → gates → tests → tag → Release →
  success comment + `ai-merged` + close on success; on failure a
  concrete failure comment, `ai-blocked` ALONE, and the exception
  re-raised (fail fast). Progress comment `role: release`, pure bypass
  (Issue #79).
- **Docs** — `AGENTS.md`, `README.md`, `docs/workflow.mdx` and
  `docs/zh/workflow.mdx` document the Epic / normal task / Release task
  boundary and the 8-step state machine.

## Verification

- `timeout 900 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`
  → **1308 passed**
- `timeout 120 /usr/bin/python3 -m coverage report`
  → **TOTAL 100%** (16463 statements, 2362 branches, 0 missing / 0
  partial) — full evidence in `test.log` in the task worktree.
- `gh` behaviors asserted against the live CLI (pr/issue view error
  strings, release view "not found", tag fetch rc=128).
- `prompt.md` / `prompt_review.md` unchanged: release tasks never reach
  Pi, so no prompt text describes a path Pi never traverses.

<!-- muyan-pilot:run=30e76050 -->
run_id=30e76050
