### PR TITLE
将 exporter 部署为持久 user systemd 服务

### DIFF
--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -55,18 +55,18 @@ systemd 启动及 exporter 意外退出后都会恢复。它独立于 `install-u
 unit drift 机制，绝不改变 Runner 的业务流程。
 
 ```bash
-install -Dm644 systemd/muyan-pilot-exporter.service \
+timeout 30s install -Dm644 systemd/muyan-pilot-exporter.service \
   ~/.config/systemd/user/muyan-pilot-exporter.service
-systemctl --user daemon-reload
-systemctl --user enable --now muyan-pilot-exporter.service
-systemctl --user status muyan-pilot-exporter.service --no-pager
+timeout 30s systemctl --user daemon-reload
+timeout 30s systemctl --user enable --now muyan-pilot-exporter.service
+timeout 30s systemctl --user status muyan-pilot-exporter.service --no-pager
 ```
 
 部署前可验证 unit 和它引用的真实文件：
 
 ```bash
-systemd-analyze --user verify systemd/muyan-pilot-exporter.service
-/usr/bin/test -f \
+timeout 30s systemd-analyze --user verify systemd/muyan-pilot-exporter.service
+timeout 15s /usr/bin/test -f \
   ~/Documents/muyan/muyan-pilot/monitoring/prometheus/muyan-pilot-exporter.py
 ```
 
@@ -90,30 +90,36 @@ service 实例，默认 `1,2`）、`--cache-ttl`（journal 重读间隔秒数，
 然后 `sudo systemctl reload prometheus`。验证 `muyan-pilot` target 为 UP：
 
 ```bash
-curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
+timeout 15s curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
   /usr/bin/python3 -c 'import json,sys; targets=json.load(sys.stdin)["data"]["activeTargets"]; target=next(t for t in targets if t["labels"].get("job")=="muyan-pilot"); assert target["health"]=="up" and not target["lastError"], target; print(target["scrapeUrl"], target["health"])'
 ```
 
 连续 10 分钟抓取验证（每 30 秒采样一次；任何非 UP 或 scrape error 都失败）：
 
 ```bash
-for _ in $(seq 1 20); do
-  curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
-    /usr/bin/python3 -c 'import json,sys; targets=json.load(sys.stdin)["data"]["activeTargets"]; target=next(t for t in targets if t["labels"].get("job")=="muyan-pilot"); assert target["health"]=="up" and not target["lastError"], target'
-  sleep 30
-done
+timeout 630s /usr/bin/python3 -c '
+import json
+import time
+from urllib.request import urlopen
+for _ in range(20):
+    with urlopen("http://127.0.0.1:9090/api/v1/targets?state=active", timeout=15) as response:
+        targets = json.load(response)["data"]["activeTargets"]
+    target = next(t for t in targets if t["labels"].get("job") == "muyan-pilot")
+    assert target["health"] == "up" and not target["lastError"], target
+    time.sleep(30)
+'
 ```
 
 重启恢复验证（先记录 PID，模拟 exporter 异常退出，再确认 systemd 给出新 PID，
 HTTP 和 Prometheus 均恢复）：
 
 ```bash
-before=$(systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
+before=$(timeout 15s systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
 kill -TERM "$before"
-sleep 6
-after=$(systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
-test "$before" != "$after"
-curl -fsS http://127.0.0.1:9106/health
+timeout 10s sleep 6
+after=$(timeout 15s systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
+timeout 15s test "$before" != "$after"
+timeout 15s curl -fsS http://127.0.0.1:9106/health
 # 再运行上面的 Prometheus target 验证命令
 ```
 
@@ -129,7 +135,7 @@ Grafana（本机 `127.0.0.1:3000`）→ Dashboards → Import → 上传
 ## 4. 测试
 
 ```bash
-/usr/bin/python3 -m pytest tests/test_muyan_pilot_exporter.py \
+timeout 120s /usr/bin/python3 -m pytest tests/test_muyan_pilot_exporter.py \
   tests/test_muyan_pilot_dashboard.py -q
 ```
 

--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -48,25 +48,26 @@ curl -s 127.0.0.1:9106/health        # -> ok
 curl -s 127.0.0.1:9106/metrics | head
 ```
 
-常驻（可选，user systemd unit；仓库不管理该 unit，`install-units` 的
-drift 机制只管 `muyan-pilot@.service` / `muyan-pilot@.timer` 两个模板）：
+常驻（user systemd service）：仓库中的
+`systemd/muyan-pilot-exporter.service` 是唯一应部署的 unit 模板。它使用
+部署 checkout 的 exporter 路径、`Restart=always` 和 `default.target`，因此用户
+systemd 启动及 exporter 意外退出后都会恢复。它独立于 `install-units` 的 Runner
+unit drift 机制，绝不改变 Runner 的业务流程。
 
 ```bash
-mkdir -p ~/.config/systemd/user
-cat > ~/.config/systemd/user/muyan-pilot-exporter.service <<'EOF'
-[Unit]
-Description=Muyan Pilot Prometheus exporter (Issue #162, read-only journal bridge)
-
-[Service]
-ExecStart=/usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot/monitoring/prometheus/muyan-pilot-exporter.py
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-EOF
+install -Dm644 systemd/muyan-pilot-exporter.service \
+  ~/.config/systemd/user/muyan-pilot-exporter.service
 systemctl --user daemon-reload
 systemctl --user enable --now muyan-pilot-exporter.service
+systemctl --user status muyan-pilot-exporter.service --no-pager
+```
+
+部署前可验证 unit 和它引用的真实文件：
+
+```bash
+systemd-analyze --user verify systemd/muyan-pilot-exporter.service
+/usr/bin/test -f \
+  ~/Documents/muyan/muyan-pilot/monitoring/prometheus/muyan-pilot-exporter.py
 ```
 
 参数：`--port`（默认 9106）、`--bind`（默认 127.0.0.1）、`--units`
@@ -86,8 +87,35 @@ service 实例，默认 `1,2`）、`--cache-ttl`（journal 重读间隔秒数，
   metrics_path: /metrics
 ```
 
-然后 `sudo systemctl reload prometheus`。验证：
-`http://127.0.0.1:9090/targets` 中 `muyan-pilot` 为 UP。
+然后 `sudo systemctl reload prometheus`。验证 `muyan-pilot` target 为 UP：
+
+```bash
+curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
+  /usr/bin/python3 -c 'import json,sys; targets=json.load(sys.stdin)["data"]["activeTargets"]; target=next(t for t in targets if t["labels"].get("job")=="muyan-pilot"); assert target["health"]=="up" and not target["lastError"], target; print(target["scrapeUrl"], target["health"])'
+```
+
+连续 10 分钟抓取验证（每 30 秒采样一次；任何非 UP 或 scrape error 都失败）：
+
+```bash
+for _ in $(seq 1 20); do
+  curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' |
+    /usr/bin/python3 -c 'import json,sys; targets=json.load(sys.stdin)["data"]["activeTargets"]; target=next(t for t in targets if t["labels"].get("job")=="muyan-pilot"); assert target["health"]=="up" and not target["lastError"], target'
+  sleep 30
+done
+```
+
+重启恢复验证（先记录 PID，模拟 exporter 异常退出，再确认 systemd 给出新 PID，
+HTTP 和 Prometheus 均恢复）：
+
+```bash
+before=$(systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
+kill -TERM "$before"
+sleep 6
+after=$(systemctl --user show -p MainPID --value muyan-pilot-exporter.service)
+test "$before" != "$after"
+curl -fsS http://127.0.0.1:9106/health
+# 再运行上面的 Prometheus target 验证命令
+```
 
 ## 3. Grafana Dashboard
 
@@ -95,7 +123,8 @@ Grafana（本机 `127.0.0.1:3000`）→ Dashboards → Import → 上传
 `grafana/dashboards/muyan-pilot.json`（或
 `/api/dashboards/import`），datasource 选 Prometheus（uid
 `eflztqehr89a8c`）。Dashboard uid 固定为 `muyan-pilot`，重复导入即覆盖
-同一 dashboard。
+同一 dashboard。重启前后打开该 Dashboard，确认 “Service active over time” 和
+“Run throughput and durations” 均有数据；将两次截图和时间范围保存在交付证据中。
 
 ## 4. 测试
 

--- a/systemd/muyan-pilot-exporter.service
+++ b/systemd/muyan-pilot-exporter.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Muyan Pilot Prometheus exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Documents/muyan/muyan-pilot
+ExecStart=/usr/bin/python3 %h/Documents/muyan/muyan-pilot/monitoring/prometheus/muyan-pilot-exporter.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/tests/test_muyan_pilot_exporter.py
+++ b/tests/test_muyan_pilot_exporter.py
@@ -11,6 +11,8 @@ errors, and the HTTP surface (`/metrics`, `/health`, 404).
 import importlib.util
 import io
 import json
+import shutil
+import subprocess
 import threading
 from http.server import HTTPServer, ThreadingHTTPServer
 from pathlib import Path
@@ -73,6 +75,20 @@ def test_exporter_unit_runs_the_deployed_exporter_and_restarts():
     assert "RestartSec=5" in unit
     assert "[Install]" in unit
     assert "WantedBy=default.target" in unit
+    assert EXPORTER_PATH.is_file()
+
+
+@pytest.mark.skipif(
+    shutil.which("systemd-analyze") is None,
+    reason="systemd-analyze not available on this machine",
+)
+def test_exporter_unit_passes_systemd_verify():
+    """The versioned unit is accepted by the real systemd parser."""
+    result = subprocess.run(
+        ["systemd-analyze", "--user", "verify", str(EXPORTER_UNIT_PATH)],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 # --- parse_message: the journal line contract -----------------------------

--- a/tests/test_muyan_pilot_exporter.py
+++ b/tests/test_muyan_pilot_exporter.py
@@ -19,6 +19,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 EXPORTER_PATH = REPO_ROOT / "monitoring" / "prometheus" / "muyan-pilot-exporter.py"
+EXPORTER_UNIT_PATH = REPO_ROOT / "systemd" / "muyan-pilot-exporter.service"
 
 
 def load_exporter():
@@ -53,6 +54,25 @@ def metric(lines, name, labels=None, value=None):
 
 def lines_of(text):
     return [ln for ln in text.splitlines() if ln and not ln.startswith("#")]
+
+
+# --- systemd deployment: persistent exporter contract ---------------------
+
+
+def test_exporter_unit_runs_the_deployed_exporter_and_restarts():
+    """The versioned user unit keeps the exporter available after boot/exit."""
+    unit = EXPORTER_UNIT_PATH.read_text(encoding="utf-8")
+    assert "[Service]" in unit
+    assert "WorkingDirectory=%h/Documents/muyan/muyan-pilot" in unit
+    assert (
+        "ExecStart=/usr/bin/python3 "
+        "%h/Documents/muyan/muyan-pilot/monitoring/prometheus/"
+        "muyan-pilot-exporter.py"
+    ) in unit
+    assert "Restart=always" in unit
+    assert "RestartSec=5" in unit
+    assert "[Install]" in unit
+    assert "WantedBy=default.target" in unit
 
 
 # --- parse_message: the journal line contract -----------------------------

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -137,7 +137,8 @@ def test_service_fast_forwards_main_before_runner_starts():
     non-fast-forwardable state makes the preflight command fail: the
     service does not start and the reason lands in the systemd journal
     (fail fast). No new refresh service, worker or dispatcher: only the
-    existing service and timer exist."""
+    existing Runner service and timer exist. The independent exporter
+    service is not a Runner unit."""
     service = parse_unit(SERVICE_FILE)
     section = service["Service"]
     assert "ExecStartPre" in section
@@ -147,11 +148,11 @@ def test_service_fast_forwards_main_before_runner_starts():
     # The preflight runs in the main checkout (the unit's
     # WorkingDirectory), before the Python Runner.
     assert "WorkingDirectory" in section
-    systemd_files = sorted(
+    runner_units = sorted(
         path.name for path in (REPO_ROOT / "systemd").iterdir()
-        if path.is_file()
+        if path.is_file() and path.name.startswith("muyan-pilot@")
     )
-    assert systemd_files == ["muyan-pilot@.service", "muyan-pilot@.timer"]
+    assert runner_units == ["muyan-pilot@.service", "muyan-pilot@.timer"]
 
 
 def test_service_preflight_is_serialized_with_a_short_lived_flock():


### PR DESCRIPTION
Fixes #198

<!-- muyan-pilot:run=4658f431 -->
run_id=4658f431

## 变更

- 新增版本管理的 `muyan-pilot-exporter.service` user systemd unit：指向部署 checkout 的真实 exporter，`Restart=always`、5 秒重启间隔并随 `default.target` 启用。
- 用该模板替换文档中的临时 heredoc，补齐 HTTP、Prometheus 连续 10 分钟抓取与 exporter 异常退出恢复验证步骤。
- 添加 exporter unit 契约测试；保持 Runner unit 集合断言只覆盖 Runner 模板，exporter 不进入 Runner 业务流程。

## 验证

- `1311 passed`，全量 Python line/branch coverage 100%。
- 已部署并验证 `/health=ok`、`/metrics` 返回 `muyan_pilot_*` 指标。
- SIGTERM 后 systemd 将 exporter 从 PID 224612 重启为 2182144；恢复后 Prometheus `muyan-pilot` target 为 UP、无 scrape error。
- 连续 10 分钟 20 次 Prometheus target 采样均为 UP。
- Grafana 已存储 `muyan-pilot` Dashboard（13 个 Muyan Pilot 查询），Prometheus datasource 有 `slot=1/2` 实际序列；Playwright 截图保存在本次 run artifact。Grafana UI 在此环境要求认证，因此截图记录登录边界，未变更认证或 Grafana 配置。
