### PR TITLE
生成分类且可读的 Release notes

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1523,23 +1523,16 @@ def publish_release(*, repo: str, tag: str, version: str,
 
     When a Release for the tag already exists (a restart after a
     successful `gh release create`) its URL is reused, never a second
-    Release is created. Otherwise the Release is created from the
-    EXISTING tag (the tag was created and pushed by the caller first —
-    `gh release create` never creates or moves the tag itself) with
-    notes carrying the full verification evidence: version, tag,
+    Release is created. A legacy existing Release without this changelog
+    is upgraded in place; a Release that already contains it is unchanged.
+    Otherwise the Release is created from the EXISTING tag (the tag was
+    created and pushed by the caller first — `gh release create` never
+    creates or moves the tag itself) with notes carrying the full
+    verification evidence: version, tag,
     release commit, the per-item scope evidence, the gate evidence, the
     test evidence and the run marker (the same stable machine-readable
     marker every run comment carries).
     """
-    try:
-        raw = run_command([
-            "gh", "release", "view", tag, "--repo", repo,
-            "--json", "tagName,url",
-        ])
-        return json.loads(raw)["url"]
-    except subprocess.CalledProcessError as exc:
-        if "not found" not in (exc.stderr or ""):
-            raise
     notes = "\n".join([
         f"# {version}",
         "",
@@ -1564,6 +1557,21 @@ def publish_release(*, repo: str, tag: str, version: str,
         f"<!-- muyan-pilot:run={run_id} -->",
         f"run_id={run_id}",
     ])
+    try:
+        raw = run_command([
+            "gh", "release", "view", tag, "--repo", repo,
+            "--json", "tagName,url,body",
+        ])
+        release = json.loads(raw)
+        if changelog not in release.get("body", ""):
+            run_command([
+                "gh", "release", "edit", tag, "--repo", repo,
+                "--notes", notes,
+            ])
+        return release["url"]
+    except subprocess.CalledProcessError as exc:
+        if "not found" not in (exc.stderr or ""):
+            raise
     run_command([
         "gh", "release", "create", tag, "--repo", repo,
         "--verify-tag", "--title", version, "--notes", notes,

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1273,6 +1273,109 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
     return evidence
 
 
+RELEASE_CHANGELOG_CATEGORIES = (
+    "Features", "Reliability and recovery", "Deployment and operations",
+    "Observability", "Documentation", "Bug fixes",
+)
+
+
+def release_changelog_category(item: dict) -> str:
+    """Classify one live scoped Issue into a stable reader-facing group."""
+    labels = item.get("labels")
+    label_names = {
+        label.get("name", "").lower() for label in labels
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    } if isinstance(labels, list) else set()
+    title = item.get("title")
+    text = title.lower() if isinstance(title, str) else ""
+    if "documentation" in label_names or any(
+        term in text for term in ("documentation", "docs", "readme", "文档")
+    ):
+        return "Documentation"
+    if any(term in text for term in (
+        "deploy", "deployment", "systemd", "install", " cli", "ssh",
+        "service", "timer", "packaging", "setup",
+    )):
+        return "Deployment and operations"
+    if any(term in text for term in (
+        "recovery", "recover", "resume", "timeout", "concurren", "reliab",
+        "stale", "dead", "hang", "lock",
+    )):
+        return "Reliability and recovery"
+    if any(term in text for term in (
+        "observability", "prometheus", "grafana", "dashboard", "metrics",
+        "exporter", "journal", "progress",
+    )):
+        return "Observability"
+    if "bug" in label_names:
+        return "Bug fixes"
+    return "Features"
+
+
+def build_release_changelog(repo: str, scope: list[int]) -> str:
+    """Render deterministic readable notes from live scoped Issue evidence.
+
+    The official ``gh issue view --json`` contract supplies each Issue's
+    title, body, URL, labels, and closing PR references.  A title is the
+    concise change description; when it is absent, the first non-empty body
+    line is usable summary evidence.  Missing or malformed evidence is an
+    unsafe release input and fails before a tag or Release is created.
+    """
+    grouped: dict[str, list[tuple[int, str]]] = {
+        category: [] for category in RELEASE_CHANGELOG_CATEGORIES
+    }
+    for number in scope:
+        raw = run_command([
+            "gh", "issue", "view", str(number), "--repo", repo, "--json",
+            "number,title,body,url,labels,closedByPullRequestsReferences",
+        ])
+        item = json.loads(raw)
+        issue_url = item.get("url")
+        issue_path = f"https://github.com/{repo}/issues/{number}"
+        pull_path = f"https://github.com/{repo}/pull/{number}"
+        if item.get("number") != number or issue_url not in (issue_path, pull_path):
+            raise ValueError(
+                f"release changelog Issue #{number} has malformed Issue evidence"
+            )
+        title = item.get("title")
+        body = item.get("body")
+        summary = title.strip() if isinstance(title, str) else ""
+        if not summary and isinstance(body, str):
+            summary = next((line.strip() for line in body.splitlines()
+                            if line.strip()), "")
+        if not summary or re.fullmatch(r"Issue #\d+ closed", summary, re.I):
+            raise ValueError(
+                f"release changelog Issue #{number} has no usable title/summary evidence"
+            )
+        source_kind = "PR" if issue_url == pull_path else "Issue"
+        links = [f"[{source_kind} #{number}]({issue_url})"]
+        pull_requests = item.get("closedByPullRequestsReferences")
+        if not isinstance(pull_requests, list):
+            raise ValueError(
+                f"release changelog Issue #{number} has malformed PR evidence"
+            )
+        for pull_request in sorted(pull_requests, key=lambda pr: pr.get("number", 0)
+                                   if isinstance(pr, dict) else 0):
+            pr_number = pull_request.get("number") if isinstance(pull_request, dict) else None
+            pr_url = pull_request.get("url") if isinstance(pull_request, dict) else None
+            if (not isinstance(pr_number, int) or pr_number < 1 or
+                    pr_url != f"https://github.com/{repo}/pull/{pr_number}"):
+                raise ValueError(
+                    f"release changelog Issue #{number} has malformed PR evidence"
+                )
+            links.append(f"[PR #{pr_number}]({pr_url})")
+        grouped[release_changelog_category(item)].append(
+            (number, f"- {summary} ({'; '.join(links)})")
+        )
+    sections = ["## Changelog"]
+    for category in RELEASE_CHANGELOG_CATEGORIES:
+        entries = grouped[category]
+        if entries:
+            sections.extend(["", f"### {category}", "",
+                             *(entry for _, entry in sorted(entries))])
+    return "\n".join(sections)
+
+
 def check_release_gates(repo: str, base_branch: str, release_commit: str,
                         release_number: int) -> list[str]:
     """Enforce the pre-release gates (Issue #98) and return their evidence.
@@ -1413,8 +1516,8 @@ def release_tag_commit(repo_dir: Path, tag: str) -> str | None:
 
 
 def publish_release(*, repo: str, tag: str, version: str,
-                    release_commit: str, scope_evidence: list[str],
-                    gate_evidence: list[str], test_evidence: str,
+                    release_commit: str, changelog: str,
+                    scope_evidence: list[str], gate_evidence: list[str], test_evidence: str,
                     run_id: str, issue_number: int) -> str:
     """Create the GitHub Release for the tag — idempotently (Issue #98).
 
@@ -1439,6 +1542,8 @@ def publish_release(*, repo: str, tag: str, version: str,
             raise
     notes = "\n".join([
         f"# {version}",
+        "",
+        changelog,
         "",
         f"- tag: `{tag}`",
         f"- release commit: `{release_commit}`",
@@ -1636,6 +1741,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             source_repo, declaration["scope"], config["repo_dir"],
             release_commit,
         )
+        changelog = build_release_changelog(source_repo, declaration["scope"])
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_RELEASE,
@@ -1693,7 +1799,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             )
         release_url = publish_release(
             repo=source_repo, tag=tag, version=tag,
-            release_commit=release_commit,
+            release_commit=release_commit, changelog=changelog,
             scope_evidence=scope_evidence, gate_evidence=gate_evidence,
             test_evidence=test_evidence, run_id=run_id, issue_number=number,
         )

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -9932,16 +9932,11 @@ def test_release_tag_commit_reraises_real_fetch_failure(tmp_path, monkeypatch):
         runner.release_tag_commit(work, "v0.1.0")
 
 
-def make_release_gh(monkeypatch, *, release_exists=False):
-    """Answer `gh release view` / `gh release create`.
-
-    `release_exists=False` starts with "release not found" (the real
-    gh error, verified against the live CLI) and flips to found after
-    a `gh release create` — the same state transition the real remote
-    makes.
-    """
+def make_release_gh(monkeypatch, *, release_exists=False,
+                    release_body="## Changelog"):
+    """Answer `gh release view` / `gh release create` / `gh release edit`."""
     calls = []
-    state = {"exists": release_exists}
+    state = {"exists": release_exists, "body": release_body}
 
     def fake_run_command(command, **kwargs):
         calls.append(command)
@@ -9953,9 +9948,13 @@ def make_release_gh(monkeypatch, *, release_exists=False):
             return json.dumps({
                 "tagName": command[3],
                 "url": "https://github.com/o/r/releases/tag/" + command[3],
+                "body": state["body"],
             })
         if command[:3] == ["gh", "release", "create"]:
             state["exists"] = True
+            return ""
+        if command[:3] == ["gh", "release", "edit"]:
+            state["body"] = command[command.index("--notes") + 1]
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
@@ -10090,6 +10089,23 @@ def test_publish_release_reuses_the_existing_release(monkeypatch):
     )
     assert url == "https://github.com/o/r/releases/tag/v0.3.0"
     assert not [c for c in calls if c[:3] == ["gh", "release", "create"]]
+    assert not [c for c in calls if c[:3] == ["gh", "release", "edit"]]
+
+
+def test_publish_release_upgrades_existing_notes_without_a_changelog(monkeypatch):
+    calls = make_release_gh(
+        monkeypatch, release_exists=True, release_body="# v0.2.0\n\nIssue #10 closed",
+    )
+    runner.publish_release(
+        repo="o/r", tag="v0.2.0", version="v0.2.0",
+        release_commit="abc123", changelog="## Changelog\n\n### Features\n\n- Useful change",
+        scope_evidence=[], gate_evidence=[], test_evidence="ok",
+        run_id="a1b2c3d4", issue_number=99,
+    )
+    edits = [c for c in calls if c[:3] == ["gh", "release", "edit"]]
+    assert len(edits) == 1
+    assert edits[0][:6] == ["gh", "release", "edit", "v0.2.0", "--repo", "o/r"]
+    assert "## Changelog" in edits[0][edits[0].index("--notes") + 1]
 
 
 def test_publish_release_reraises_real_gh_failure(monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -9963,11 +9963,98 @@ def make_release_gh(monkeypatch, *, release_exists=False):
     return calls
 
 
+def test_build_release_changelog_groups_descriptions_links_and_orders(monkeypatch):
+    source = {
+        30: {
+            "number": 30, "title": "Deploy the exporter as a persistent service",
+            "body": "The service keeps metrics available after restart.",
+            "url": "https://github.com/o/r/issues/30",
+            "labels": [{"name": "bug"}],
+            "closedByPullRequestsReferences": [{
+                "number": 301, "url": "https://github.com/o/r/pull/301",
+            }],
+        },
+        10: {
+            "number": 10, "title": "Add Prometheus metrics dashboard",
+            "body": "Users can inspect delivery metrics.",
+            "url": "https://github.com/o/r/issues/10",
+            "labels": [{"name": "enhancement"}],
+            "closedByPullRequestsReferences": [],
+        },
+        20: {
+            "number": 20, "title": "Explain the full setup workflow",
+            "body": "Documentation covers first use.",
+            "url": "https://github.com/o/r/issues/20",
+            "labels": [{"name": "documentation"}],
+            "closedByPullRequestsReferences": [],
+        },
+    }
+
+    def fake_run_command(command, **kwargs):
+        assert command[:3] == ["gh", "issue", "view"]
+        return json.dumps(source[int(command[3])])
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    changelog = runner.build_release_changelog("o/r", [30, 10, 20])
+    assert changelog == """## Changelog
+
+### Deployment and operations
+
+- Deploy the exporter as a persistent service ([Issue #30](https://github.com/o/r/issues/30); [PR #301](https://github.com/o/r/pull/301))
+
+### Observability
+
+- Add Prometheus metrics dashboard ([Issue #10](https://github.com/o/r/issues/10))
+
+### Documentation
+
+- Explain the full setup workflow ([Issue #20](https://github.com/o/r/issues/20))"""
+
+
+def test_release_changelog_category_covers_reliability_bug_and_features():
+    assert runner.release_changelog_category({
+        "title": "Recover a stalled delivery", "labels": [],
+    }) == "Reliability and recovery"
+    assert runner.release_changelog_category({
+        "title": "Fix an unrelated failure", "labels": [{"name": "bug"}],
+    }) == "Bug fixes"
+    assert runner.release_changelog_category({
+        "title": "Add a provider setting", "labels": "malformed",
+    }) == "Features"
+
+
+def test_build_release_changelog_fails_on_empty_or_malformed_evidence(monkeypatch):
+    bad_items = [
+        {"number": 10, "title": "", "body": "", "url": "https://github.com/o/r/issues/10", "labels": [], "closedByPullRequestsReferences": []},
+        {"number": 10, "title": "Useful title", "body": "detail", "url": "not-a-url", "labels": [], "closedByPullRequestsReferences": []},
+        {"number": 10, "title": "Useful title", "body": "detail", "url": "https://github.com/o/r/issues/10", "labels": [], "closedByPullRequestsReferences": "malformed"},
+        {"number": 10, "title": "Useful title", "body": "detail", "url": "https://github.com/o/r/issues/10", "labels": [], "closedByPullRequestsReferences": [{"number": "bad", "url": "https://github.com/o/r/pull/20"}]},
+    ]
+    for item in bad_items:
+        monkeypatch.setattr(runner, "run_command", lambda *args, item=item, **kwargs: json.dumps(item))
+        with pytest.raises(ValueError, match="release changelog"):
+            runner.build_release_changelog("o/r", [10])
+    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: json.dumps({
+        "number": 10, "title": "", "body": "\nConcrete summary\n",
+        "url": "https://github.com/o/r/issues/10", "labels": [],
+        "closedByPullRequestsReferences": [],
+    }))
+    assert "Concrete summary" in runner.build_release_changelog("o/r", [10])
+    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: json.dumps({
+        "number": 10, "title": "Merge direct release work", "body": "",
+        "url": "https://github.com/o/r/pull/10", "labels": [],
+        "closedByPullRequestsReferences": [],
+    }))
+    assert "[PR #10](https://github.com/o/r/pull/10)" in (
+        runner.build_release_changelog("o/r", [10])
+    )
+
+
 def test_publish_release_creates_when_missing_and_returns_url(monkeypatch):
     calls = make_release_gh(monkeypatch, release_exists=False)
     url = runner.publish_release(
         repo="o/r", tag="v0.3.0", version="v0.3.0",
-        release_commit="abc123",
+        release_commit="abc123", changelog="## Changelog\n\n### Features\n\n- A useful change ([Issue #123](https://github.com/o/r/issues/123))",
         scope_evidence=["PR #123 merged (mergeCommit=aaa111)"],
         gate_evidence=["no open Issue carries ai-in-progress"],
         test_evidence="tests passed (exit 0)",
@@ -9982,6 +10069,8 @@ def test_publish_release_creates_when_missing_and_returns_url(monkeypatch):
     assert "--verify-tag" in create
     notes = create[create.index("--notes") + 1]
     assert "v0.3.0" in notes
+    assert "## Changelog" in notes
+    assert "A useful change" in notes
     assert "abc123" in notes
     assert "PR #123 merged (mergeCommit=aaa111)" in notes
     assert "no open Issue carries ai-in-progress" in notes
@@ -9995,7 +10084,7 @@ def test_publish_release_reuses_the_existing_release(monkeypatch):
     calls = make_release_gh(monkeypatch, release_exists=True)
     url = runner.publish_release(
         repo="o/r", tag="v0.3.0", version="v0.3.0",
-        release_commit="abc123",
+        release_commit="abc123", changelog="## Changelog",
         scope_evidence=[], gate_evidence=[], test_evidence="ok",
         run_id="a1b2c3d4", issue_number=99,
     )
@@ -10012,7 +10101,7 @@ def test_publish_release_reraises_real_gh_failure(monkeypatch):
     with pytest.raises(subprocess.CalledProcessError):
         runner.publish_release(
             repo="o/r", tag="v0.3.0", version="v0.3.0",
-            release_commit="abc123",
+            release_commit="abc123", changelog="## Changelog",
             scope_evidence=[], gate_evidence=[], test_evidence="ok",
             run_id="a1b2c3d4", issue_number=99,
         )
@@ -10049,8 +10138,18 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             )
         if command[:3] == ["gh", "issue", "view"]:
             number = int(command[3])
-            if number == 124:
+            fields = command[command.index("--json") + 1]
+            if fields == "number,state" and number == 124:
                 return json.dumps({"number": 124, "state": "CLOSED"})
+            if fields.startswith("number,title,") and number in (123, 124):
+                return json.dumps({
+                    "number": number,
+                    "title": f"Deliver release scope item {number}",
+                    "body": "Concrete release behavior.",
+                    "url": f"https://github.com/o/r/issues/{number}",
+                    "labels": [],
+                    "closedByPullRequestsReferences": [],
+                })
             raise subprocess.CalledProcessError(
                 1, command,
                 stderr=(


### PR DESCRIPTION
Fixes #204

## 变更
- 从每个发布范围项的实时 Issue/PR 证据生成确定性的分类 changelog。
- 每条记录使用具体标题或摘要，并链接到来源 Issue 与已合并 PR。
- 缺失或格式错误的证据会在创建 tag/Release 前 fail fast；现有 scope、gate、测试、commit 与 run 证据保持不变。

## 验证
- `1315 passed`，Python line/branch coverage 100%。

<!-- muyan-pilot:run=990be3cc -->
run_id=990be3cc