### PR TITLE
自动创建可追踪的 Release 修复 Issue

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -28,6 +28,10 @@ base_branch = "main"
 # pre-#139 behavior: every `ai-ready` Issue is claimable. It is never
 # guessed — an empty or non-string value fails the start fast.
 # active_milestone = "v0.2.0"
+# Disabled by default. When true, a failed release test command with captured
+# output creates (or deduplicates) an ai-ready + bug repair Issue. The Release
+# itself remains ai-blocked and must be explicitly re-run after review/merge.
+# auto_repair_issues = true
 # Maximum concurrent Pilot tasks on this machine. Must be a positive integer;
 # missing means 1. The local AI/GPU can only serve one stable task, so keep
 # the default. A slot (flock on <repo_dir>/.muyan-pilot/slots/slot-N) is

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Release task 是 `ai-ready` + `ai-release` 双标签的 Issue（Issue #98）—�
 7. 发布 GitHub Release（幂等），notes 带完整验证证据（scope/门禁/测试/run marker）；
 8. 成功：`ai-merged`（终态）+ 关闭 Issue + 成功评论（release URL、tag、commit、证据）；任何失败：单独 `ai-blocked`（release 是人工决策点，不自动重试）+ 失败评论（run marker + 具体原因）+ fail fast。
 
+可选的 `auto_repair_issues = true` 只覆盖有捕获输出的 Release 测试命令失败：Runner 按 source Issue、run_id、commit、命令和输出生成稳定签名，在 Issue body 搜索该签名后创建或复用一个 `ai-ready` + `bug` 修复 Issue。新 Issue 包含可复现命令和原始输出，照常走 PR/review/merge；Release 仍保持 `ai-blocked`，不会自动重试或发布，必须在修复合并后显式重跑 gate。没有具体测试输出、其他歧义/外部失败或创建修复 Issue 失败时，Runner 记录该失败并保留原始 Release 失败。
+
 三类任务的边界：Epic（`ai-epic`）只协调、从不被领取；普通任务（`ai-ready`）走 `run_pi` → PR → review → merge；Release task（`ai-ready` + `ai-release`）走 Runner 的 release 状态机，不产生 PR。
 
 ## 自动可观测（正常运行不需要执行任何命令）

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -192,6 +192,10 @@ RELEASE_SECTION = "## Release"
 # that does not terminate within the deadline is a broken path, never
 # ignorable noise.
 RELEASE_TEST_TIMEOUT_SECONDS = 1800
+# Repair-Issue GitHub operations are a convenience path, but they still run
+# during terminal failure handling. Bound them so an unavailable API cannot
+# hold the Runner indefinitely (Issue #95).
+REPAIR_ISSUE_TIMEOUT_SECONDS = 30
 
 # Only comments posted by a repo maintainer are trusted to carry the
 # recovery scene: a public comment (authorAssociation=NONE) must never
@@ -1509,6 +1513,7 @@ def create_repair_issue(*, repo: str, source_issue: int, run_id: str,
     )
     marker = f"muyan-pilot-repair-signature={signature}"
     raw = run_command([
+        "timeout", str(REPAIR_ISSUE_TIMEOUT_SECONDS),
         "gh", "issue", "list", "--repo", repo, "--state", "all",
         "--search", f'in:body "{marker}"', "--json", "number,url", "--limit", "1",
     ])
@@ -1539,6 +1544,7 @@ def create_repair_issue(*, repo: str, source_issue: int, run_id: str,
         "保持 `ai-blocked`，必须在修复合并后显式重新运行 Release gate。",
     ])
     return run_command([
+        "timeout", str(REPAIR_ISSUE_TIMEOUT_SECONDS),
         "gh", "issue", "create", "--repo", repo,
         "--title", f"修复 Release #{source_issue} 测试门禁失败",
         "--body", body, "--label", "ai-ready", "--label", "bug",
@@ -1546,8 +1552,16 @@ def create_repair_issue(*, repo: str, source_issue: int, run_id: str,
 
 
 def release_test_evidence(exc: subprocess.CalledProcessError) -> str | None:
-    """Extract concrete output from a failed release test command only."""
-    evidence = (exc.stderr or exc.stdout or "").strip()
+    """Extract every concrete output stream from a failed release test."""
+    streams = [
+        ("stdout", exc.stdout),
+        ("stderr", exc.stderr),
+    ]
+    evidence = "\n\n".join(
+        f"[{name}]\n{output.strip()}"
+        for name, output in streams
+        if output and output.strip()
+    )
     return evidence or None
 
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -400,6 +400,12 @@ def load_config(path: Path) -> dict:
         not isinstance(active_milestone, str) or not active_milestone
     ):
         raise ValueError("active_milestone must be a non-empty string")
+    # Repair-Issue creation (Issue #202) is deliberately opt-in. A
+    # release remains blocked either way; this merely dispatches a normal
+    # ai-ready bug Issue when a release test command reports evidence.
+    auto_repair_issues = data.get("auto_repair_issues", False)
+    if not isinstance(auto_repair_issues, bool):
+        raise ValueError("auto_repair_issues must be a boolean")
     # Concurrency cap (Issue #39): the local machine can only serve a
     # limited number of concurrent tasks, so the default is 1. Any other
     # value must be a positive integer; fail fast on anything else.
@@ -445,6 +451,7 @@ def load_config(path: Path) -> dict:
         ],
         "base_branch": base_branch,
         "active_milestone": active_milestone,
+        "auto_repair_issues": auto_repair_issues,
         "max_concurrency": max_concurrency,
         "slot_dir": slot_dir_for(repo_dir),
         "pi_provider": pi_provider,
@@ -1481,6 +1488,69 @@ def run_release_tests(worktree: Path, test_command: str,
     )
 
 
+def repair_signature(source_issue: int, run_id: str, release_commit: str,
+                     command: str, evidence: str) -> str:
+    """Return the stable identity for one evidenced release-test failure."""
+    scene = "\0".join((str(source_issue), run_id, release_commit, command, evidence))
+    return hashlib.sha256(scene.encode("utf-8")).hexdigest()[:16]
+
+
+def create_repair_issue(*, repo: str, source_issue: int, run_id: str,
+                        release_commit: str, command: str,
+                        evidence: str) -> str:
+    """Create or find one normal repair Issue for a release test failure.
+
+    GitHub Issue search's documented ``in:body`` qualifier searches the
+    stable signature written into every generated body. This makes the
+    deduplication external, auditable, and safe across process restarts.
+    """
+    signature = repair_signature(
+        source_issue, run_id, release_commit, command, evidence,
+    )
+    marker = f"muyan-pilot-repair-signature={signature}"
+    raw = run_command([
+        "gh", "issue", "list", "--repo", repo, "--state", "all",
+        "--search", f'in:body "{marker}"', "--json", "number,url", "--limit", "1",
+    ])
+    existing = parse_issue_array(raw)
+    if existing:
+        return existing[0]["url"]
+    body = "\n".join([
+        "## 自动生成的 Release 测试修复",
+        "",
+        f"- source Issue: #{source_issue}",
+        f"- run_id={run_id}",
+        f"- commit: `{release_commit}`",
+        f"- {marker}",
+        "",
+        "## Reproduce",
+        "",
+        "```bash",
+        command,
+        "```",
+        "",
+        "## Captured evidence",
+        "",
+        "```text",
+        evidence,
+        "```",
+        "",
+        "该 Issue 由正常 `ai-ready` → PR → review → merge 流程处理；原 Release "
+        "保持 `ai-blocked`，必须在修复合并后显式重新运行 Release gate。",
+    ])
+    return run_command([
+        "gh", "issue", "create", "--repo", repo,
+        "--title", f"修复 Release #{source_issue} 测试门禁失败",
+        "--body", body, "--label", "ai-ready", "--label", "bug",
+    ])
+
+
+def release_test_evidence(exc: subprocess.CalledProcessError) -> str | None:
+    """Extract concrete output from a failed release test command only."""
+    evidence = (exc.stderr or exc.stdout or "").strip()
+    return evidence or None
+
+
 def release_tag_commit(repo_dir: Path, tag: str) -> str | None:
     """Return the commit the tag points to on the remote, or None.
 
@@ -1703,6 +1773,9 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             activity={},
         )
 
+    release_commit: str | None = None
+    release_test_error: subprocess.CalledProcessError | None = None
+    declaration: dict | None = None
     try:
         declaration = parse_release_declaration(issue["body"])
         base_branch = declaration["base_branch"]
@@ -1761,10 +1834,14 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, release_commit,
         )
-        run_release_tests(
-            worktree, declaration["test_command"],
-            RELEASE_TEST_TIMEOUT_SECONDS,
-        )
+        try:
+            run_release_tests(
+                worktree, declaration["test_command"],
+                RELEASE_TEST_TIMEOUT_SECONDS,
+            )
+        except subprocess.CalledProcessError as exc:
+            release_test_error = exc
+            raise
         test_evidence = (
             f"declared test command and 100% coverage gate passed in a "
             f"clean worktree at {release_commit} "
@@ -1845,6 +1922,30 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         return release_url
     except Exception as exc:
         LOGGER.exception("issue=%s release_failed", number)
+        evidence = (
+            release_test_evidence(release_test_error)
+            if release_test_error is not None else None
+        )
+        if config.get("auto_repair_issues") and evidence is not None:
+            try:
+                repair_url = create_repair_issue(
+                    repo=source_repo, source_issue=number, run_id=run_id,
+                    release_commit=release_commit or "unknown",
+                    command=declaration["test_command"] if declaration else "unknown",
+                    evidence=evidence,
+                )
+                LOGGER.info(
+                    "repair_issue source_issue=%s run_id=%s url=%s",
+                    number, run_id, repair_url,
+                )
+            except Exception:
+                # A repair Issue is an auditable convenience only: failure to
+                # create it must be visible but cannot replace the original
+                # release-test failure or unblock/publish the release.
+                LOGGER.exception(
+                    "repair_issue_failed source_issue=%s run_id=%s",
+                    number, run_id,
+                )
         edit_issue(
             number, repo=source_repo, add=BLOCKED_LABEL,
             remove=IN_PROGRESS_LABEL,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -10286,7 +10286,7 @@ def test_create_repair_issue_deduplicates_a_matching_failure_signature(monkeypat
 
     def fake_run(command, **kwargs):
         calls.append(command)
-        if command[:3] == ["gh", "issue", "list"]:
+        if command[:5] == ["timeout", "30", "gh", "issue", "list"]:
             return json.dumps([{"number": 77, "url": "https://github.com/o/r/issues/77"}])
         raise AssertionError(f"unexpected command: {command}")
 
@@ -10296,6 +10296,7 @@ def test_create_repair_issue_deduplicates_a_matching_failure_signature(monkeypat
         release_commit="abc123", command="pytest -q", evidence="1 failed",
     )
     assert url == "https://github.com/o/r/issues/77"
+    assert calls[0][:5] == ["timeout", "30", "gh", "issue", "list"]
     search = calls[0][calls[0].index("--search") + 1]
     assert "muyan-pilot-repair-signature=" in search
     assert "--label" not in calls[0]
@@ -10308,9 +10309,9 @@ def test_create_repair_issue_creates_a_reproducible_ready_bug(monkeypatch):
 
     def fake_run(command, **kwargs):
         calls.append(command)
-        if command[:3] == ["gh", "issue", "list"]:
+        if command[:5] == ["timeout", "30", "gh", "issue", "list"]:
             return "[]"
-        if command[:3] == ["gh", "issue", "create"]:
+        if command[:5] == ["timeout", "30", "gh", "issue", "create"]:
             return "https://github.com/o/r/issues/77"
         raise AssertionError(f"unexpected command: {command}")
 
@@ -10321,7 +10322,7 @@ def test_create_repair_issue_creates_a_reproducible_ready_bug(monkeypatch):
     )
     assert url == "https://github.com/o/r/issues/77"
     create = calls[1]
-    assert create[:3] == ["gh", "issue", "create"]
+    assert create[:5] == ["timeout", "30", "gh", "issue", "create"]
     assert create.count("--label") == 2
     assert "ai-ready" in create and "bug" in create
     body = create[create.index("--body") + 1]
@@ -10371,6 +10372,17 @@ def test_process_release_fails_on_malformed_declaration(monkeypatch):
     assert "## Release" in comment_kwargs["body"]
 
 
+def test_release_test_evidence_keeps_stdout_and_stderr():
+    error = subprocess.CalledProcessError(
+        1, ["timeout"], output="tests/test_x.py::test_y FAILED\n",
+        stderr="coverage gate failed\n",
+    )
+    assert runner.release_test_evidence(error) == (
+        "[stdout]\ntests/test_x.py::test_y FAILED\n\n"
+        "[stderr]\ncoverage gate failed"
+    )
+
+
 def test_process_release_test_failure_creates_repair_and_keeps_release_blocked(monkeypatch):
     state = make_release_process_env(monkeypatch)
 
@@ -10398,7 +10410,7 @@ def test_process_release_test_failure_creates_repair_and_keeps_release_blocked(m
         "repo": "o/r", "source_issue": 99, "run_id": "a1b2c3d4",
         "release_commit": "abc123",
         "command": RELEASE_DECLARATION_BODY.split("- test_command: ")[1].split("\n")[0],
-        "evidence": "tests/test_x.py::test_y FAILED",
+        "evidence": "[stderr]\ntests/test_x.py::test_y FAILED",
     }]
     assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
                                         "remove": "ai-in-progress"})

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -70,6 +70,23 @@ def test_load_config_defaults_base_branch_to_main(tmp_path):
     assert config["base_branch"] == "main"
 
 
+def test_load_config_repair_issue_creation_is_opt_in(tmp_path):
+    config_path = tmp_path / "muyan-pilot.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    assert runner.load_config(config_path)["auto_repair_issues"] is False
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nauto_repair_issues = true\n',
+        encoding="utf-8",
+    )
+    assert runner.load_config(config_path)["auto_repair_issues"] is True
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nauto_repair_issues = "yes"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="auto_repair_issues must be a boolean"):
+        runner.load_config(config_path)
+
+
 def test_load_config_reads_explicit_base_branch(tmp_path):
     config_path = tmp_path / "muyan-pilot.toml"
     config_path.write_text(
@@ -10264,6 +10281,59 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert state["run_ids"][0] == "a1b2c3d4"
 
 
+def test_create_repair_issue_deduplicates_a_matching_failure_signature(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([{"number": 77, "url": "https://github.com/o/r/issues/77"}])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    url = runner.create_repair_issue(
+        repo="o/r", source_issue=99, run_id="a1b2c3d4",
+        release_commit="abc123", command="pytest -q", evidence="1 failed",
+    )
+    assert url == "https://github.com/o/r/issues/77"
+    search = calls[0][calls[0].index("--search") + 1]
+    assert "muyan-pilot-repair-signature=" in search
+    assert "--label" not in calls[0]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_create_repair_issue_creates_a_reproducible_ready_bug(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["gh", "issue", "list"]:
+            return "[]"
+        if command[:3] == ["gh", "issue", "create"]:
+            return "https://github.com/o/r/issues/77"
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    url = runner.create_repair_issue(
+        repo="o/r", source_issue=99, run_id="a1b2c3d4",
+        release_commit="abc123", command="pytest -q", evidence="1 failed",
+    )
+    assert url == "https://github.com/o/r/issues/77"
+    create = calls[1]
+    assert create[:3] == ["gh", "issue", "create"]
+    assert create.count("--label") == 2
+    assert "ai-ready" in create and "bug" in create
+    body = create[create.index("--body") + 1]
+    assert "source Issue: #99" in body
+    assert "run_id=a1b2c3d4" in body
+    assert "commit: `abc123`" in body
+    assert "pytest -q" in body and "1 failed" in body
+    assert "muyan-pilot-repair-signature=" in body
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
 def test_process_release_reuses_the_run_id_on_resume(monkeypatch):
     state = make_release_process_env(
         monkeypatch, in_progress=True, existing_run_id="deadbeef",
@@ -10299,6 +10369,83 @@ def test_process_release_fails_on_malformed_declaration(monkeypatch):
     (comment_number, comment_kwargs), = state["comments"]
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in comment_kwargs["body"]
     assert "## Release" in comment_kwargs["body"]
+
+
+def test_process_release_test_failure_creates_repair_and_keeps_release_blocked(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+
+    def test_failure(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, ["timeout", "1800", "bash", "-c", "pytest -q"],
+            stderr="tests/test_x.py::test_y FAILED",
+        )
+
+    repairs = []
+    monkeypatch.setattr(runner, "run_release_tests", test_failure)
+    monkeypatch.setattr(
+        runner, "create_repair_issue",
+        lambda **kwargs: repairs.append(kwargs) or "https://github.com/o/r/issues/77",
+    )
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main",
+                    "auto_repair_issues": True}, "o/r",
+        )
+    assert repairs == [{
+        "repo": "o/r", "source_issue": 99, "run_id": "a1b2c3d4",
+        "release_commit": "abc123",
+        "command": RELEASE_DECLARATION_BODY.split("- test_command: ")[1].split("\n")[0],
+        "evidence": "tests/test_x.py::test_y FAILED",
+    }]
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                        "remove": "ai-in-progress"})
+    assert not any(k.get("add") == "ai-merged" for _, k in state["edits"])
+
+
+def test_process_release_test_failure_stays_blocked_when_repair_opt_in_is_disabled(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    monkeypatch.setattr(
+        runner, "run_release_tests",
+        lambda *args: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, ["timeout"], stderr="1 failed"),
+        ),
+    )
+    monkeypatch.setattr(
+        runner, "create_repair_issue",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("must remain opt-in")),
+    )
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                        "remove": "ai-in-progress"})
+
+
+def test_process_release_repair_creation_failure_is_observable_and_preserves_test_failure(monkeypatch, caplog):
+    make_release_process_env(monkeypatch)
+    monkeypatch.setattr(runner, "LOGGER", logging.getLogger("repair-test"))
+    original = subprocess.CalledProcessError(1, ["timeout"], stderr="1 failed")
+    monkeypatch.setattr(runner, "run_release_tests",
+                        lambda *args: (_ for _ in ()).throw(original))
+    monkeypatch.setattr(runner, "create_repair_issue",
+                        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("GitHub unavailable")))
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with caplog.at_level("ERROR"), pytest.raises(subprocess.CalledProcessError) as excinfo:
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main",
+                    "auto_repair_issues": True}, "o/r",
+        )
+    assert excinfo.value is original
+    assert "repair_issue_failed source_issue=99 run_id=a1b2c3d4" in caplog.text
 
 
 def test_process_release_fails_on_tag_mismatch_without_moving_it(monkeypatch):


### PR DESCRIPTION
Fixes #202

## 变更
- 增加默认关闭的 `auto_repair_issues` 开关。
- 对有捕获输出的 Release 测试失败，按稳定签名创建或复用带 `ai-ready` 与 `bug` 的修复 Issue。
- 原 Release 保持 `ai-blocked`，修复合并后仍需显式重跑发布门禁；创建失败记录日志且保留原始失败。

## 验证
- `timeout 600 /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q`
- `timeout 120 /usr/bin/python3 -m coverage report --show-missing --fail-under=100`
- 1323 passed，line/branch coverage 100%。

<!-- muyan-pilot:run=53173dc1 -->
run_id=53173dc1