### PR TITLE
按并发配置同步 Runner timer

### DIFF
--- a/.muyan-pilot.example.toml
+++ b/.muyan-pilot.example.toml
@@ -32,8 +32,8 @@ base_branch = "main"
 # output creates (or deduplicates) an ai-ready + bug repair Issue. The Release
 # itself remains ai-blocked and must be explicitly re-run after review/merge.
 # auto_repair_issues = true
-# Maximum concurrent Pilot tasks on this machine. Must be a positive integer;
-# missing means 1. The local AI/GPU can only serve one stable task, so keep
+# Maximum concurrent Pilot tasks and enabled Runner timers on this machine.
+# Must be 1 or 2 (the fixed timer instance set); missing means 1. The local AI/GPU can only serve one stable task, so keep
 # the default. A slot (flock on <repo_dir>/.muyan-pilot/slots/slot-N) is
 # taken before any claim and held for the whole delivery lifecycle
 # (implement -> review -> fix -> merge); the kernel releases it when the

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ python3 bootstrap_runner.py --config muyan-pilot.toml
 
 ```bash
 # 幂等安装用户级 service/timer 模板（仓库模板复制到用户 systemd 目录、
-# daemon-reload、enable 两个 timer 实例），并输出部署 commit/hash：
+# daemon-reload，并按 max_concurrency 启用对应的 timer 实例），并输出部署 commit/hash：
 muyan-pilot install-units --config muyan-pilot.toml
 systemctl --user list-timers 'muyan-pilot@*.timer'
 ```
 
-两个 timer 实例 `muyan-pilot@1.timer` 和 `muyan-pilot@2.timer` 各自触发自己的 service 实例（`muyan-pilot@1.timer` → `muyan-pilot@1.service`，`muyan-pilot@2.timer` → `muyan-pilot@2.service`），所以可以同时运行两个独立的 Runner 实例；容量仍由 Runner 内的 flock slot（`max_concurrency`）决定，而不是实例数（Issue #149）。
+安装按 `max_concurrency` 同步 timer：`1` 只启用 `muyan-pilot@1.timer`，`2` 启用 `muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`。降低并发只停止多余 timer，不触碰正在运行的 service；两个实例各自仍触发自己的 service，slot 仍是最终并发安全边界（Issue #189）。
 
 `install-units` 是幂等的：重复执行只会把仓库模板重新复制到位并 `daemon-reload`，**不会**启动、停止或重启正在运行的 Runner（新配置从下一次 service 启动生效）。手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
 
@@ -78,9 +78,9 @@ Issue #171：两个 Runner（或 Runner 与 Pi 会话）并发 `git fetch` 会�
 
 仓库中的 `systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。Issue #149 起部署启用两个 timer 实例 `muyan-pilot@1.timer` / `muyan-pilot@2.timer`，各自触发自己的 service 实例。
 
-**幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`、`systemctl --user enable --now` 两个 timer 实例，并输出部署 commit（部署 checkout 的 HEAD，即模板来源）和每个 unit 的 sha256。安装**不会**启动、停止或重启 service：当前运行中的 Runner 不被中断，新配置从下一次 service 启动生效。安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` / `systemd/muyan-pilot.timer`）：`systemctl --user disable --now muyan-pilot.timer`（停的是 timer，绝不停/启/重启 service，运行中的 Runner 不受影响）并删除旧文件，旧单实例调度不会再拉起旧 service（模板变更即部署变更，无需人工步骤）；已迁移过的机器上这一步是 no-op。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
+**幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`，并按 `max_concurrency` 启用 `@1` 或 `@1`/`@2` timer；降低并发时以 `disable --now` 停掉多余 **timer**，绝不停止 service。安装**不会**启动、停止或重启正在运行的 Runner：新配置从下一次 timer 调度生效；slot 锁语义不变。安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` / `systemd/muyan-pilot.timer`）：`systemctl --user disable --now muyan-pilot.timer`（停的是 timer，绝不停/启/重启 service，运行中的 Runner 不受影响）并删除旧文件，旧单实例调度不会再拉起旧 service（模板变更即部署变更，无需人工步骤）；已迁移过的机器上这一步是 no-op。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
 
-**启动前漂移检查（含自愈，Issue #142）**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 模板都覆盖）。一致时记录 `unit_drift clean`；发现漂移时用**同一个幂等安装**自愈（复制模板、`daemon-reload`、enable 两个 timer 实例——不启动、停止或重启 service，运行中的 Runner 不受影响），再用**同一个哈希检查**复核：复核通过时每个 unit 记录一行结构化 `unit_drift auto_synced`（before/after sha256、部署 commit），本次启动继续；复核后仍然漂移（或安装步骤本身失败）时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签）：
+**启动前漂移检查（含自愈，Issue #142）**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 模板都覆盖）。一致时记录 `unit_drift clean`；发现漂移时用**同一个幂等安装**自愈（复制模板、`daemon-reload`，按 `max_concurrency` 同步 timer——不启动、停止或重启 service，运行中的 Runner 不受影响），再用**同一个哈希检查**复核：复核通过时每个 unit 记录一行结构化 `unit_drift auto_synced`（before/after sha256、部署 commit），本次启动继续；复核后仍然漂移（或安装步骤本身失败）时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签）：
 
 ```text
 unit_drift auto_synced unit=muyan-pilot@.timer before_sha256=... after_sha256=... commit=<deployed HEAD>
@@ -402,7 +402,7 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 # 编辑 muyan-pilot.toml
 ```
 
-Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在整个 implement → review（会话内修复）→ merge 期间持有并发 slot，PR 合并或终态失败后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。并发上限见下一节 `max_concurrency`：拿不到 slot 的 Runner 记录 `capacity_full` 后正常退出，不领取 Issue。Issue #149 起两个 timer 实例（`muyan-pilot@1.timer` / `muyan-pilot@2.timer`）可能同时触发两个 Runner 实例，它们竞争同一组 flock slot：容量仍是 `max_concurrency`（默认 1 时行为与之前完全一致），实例数不是容量。
+Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在整个 implement → review（会话内修复）→ merge 期间持有并发 slot，PR 合并或终态失败后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。`max_concurrency` 同时决定已启用 timer 的数量（1 或 2）；slot 仍是最终安全边界，拿不到 slot 的 Runner 仍记录 `capacity_full` 后正常退出，不领取 Issue。
 
 ## 并发限制（max_concurrency）
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Issue #171：两个 Runner（或 Runner 与 Pi 会话）并发 `git fetch` 会�
 
 ## 部署一致性（Issue #103）
 
-仓库中的 `systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。Issue #149 起部署启用两个 timer 实例 `muyan-pilot@1.timer` / `muyan-pilot@2.timer`，各自触发自己的 service 实例。
+仓库中的 `systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。两个可用 timer 实例 `muyan-pilot@1.timer` / `muyan-pilot@2.timer` 各自触发自己的 service 实例；安装按 `max_concurrency` 启用前 1 或 2 个实例。
 
 **幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`，并按 `max_concurrency` 启用 `@1` 或 `@1`/`@2` timer；降低并发时以 `disable --now` 停掉多余 **timer**，绝不停止 service。安装**不会**启动、停止或重启正在运行的 Runner：新配置从下一次 timer 调度生效；slot 锁语义不变。安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` / `systemd/muyan-pilot.timer`）：`systemctl --user disable --now muyan-pilot.timer`（停的是 timer，绝不停/启/重启 service，运行中的 Runner 不受影响）并删除旧文件，旧单实例调度不会再拉起旧 service（模板变更即部署变更，无需人工步骤）；已迁移过的机器上这一步是 no-op。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
 
@@ -161,7 +161,7 @@ muyan-pilot session --follow --config muyan-pilot.toml
 `session` 是排查附件（日常仍看 journal / GitHub），不是日常入口：没有 session 文件时 fail fast（退出码非零，说明没有正在跑的 Pi），不猜路径；`--pretty` 把 JSONL 打一行摘要（timestamp / role / tool|text|thinking 截断），默认仍是原始 JSONL。不开 tmux、不新包装脚本、不新增 systemd unit（Issue #74）。
 
 ```bash
-# 幂等安装 systemd unit 模板 + 两个 timer 实例（见「部署一致性」）：
+# 幂等安装 systemd unit 模板 + 按 max_concurrency 同步 timer 实例（见「部署一致性」）：
 # 输出部署 commit 和每个 unit 的 sha256
 muyan-pilot install-units --config muyan-pilot.toml
 
@@ -406,7 +406,7 @@ Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在
 
 ## 并发限制（max_concurrency）
 
-本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是正整数，缺失时默认 1（本地 AI/GPU 只能稳定服务一个任务）；非整数、布尔值、0 或负数启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
+本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是 1 或 2 的整数，缺失时默认 1（固定模板只有两个实例）；非整数、布尔值、0、负数或大于 2 的值启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
 
 - 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与 Pi 活动轮询同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding、base 冲突，或已有 run/PR 的**可恢复失败**——Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）时，**下一个 tick 在同一 run_id、同一 branch、同一 worktree、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
 - 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -74,6 +74,7 @@ from pi_activity import (
 )
 from progress import ProgressPublisher, format_elapsed, progress_body
 from systemd_deploy import (
+    TIMER_INSTANCES,
     UnitDriftError,
     check_unit_drift,
     sync_drifted_units,
@@ -423,9 +424,12 @@ def load_config(path: Path) -> dict:
     if (
         isinstance(max_concurrency, bool)
         or not isinstance(max_concurrency, int)
-        or max_concurrency < 1
+        or not 1 <= max_concurrency <= len(TIMER_INSTANCES)
     ):
-        raise ValueError("max_concurrency must be a positive integer")
+        raise ValueError(
+            "max_concurrency must be a positive integer with a matching "
+            f"Runner timer instance (1..{len(TIMER_INSTANCES)})"
+        )
     # Optional Pi model selection (Issue #119): each key is absent -> None
     # (the Pi flag is not passed, Pi keeps its own default) or a non-empty
     # string passed to Pi verbatim. Anything else fails fast.
@@ -5852,7 +5856,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         check_unit_drift(config["repo_dir"])
     except UnitDriftError:
-        sync_drifted_units(config["repo_dir"], run_command=run_command)
+        sync_drifted_units(
+            config["repo_dir"], max_concurrency=config["max_concurrency"],
+            run_command=run_command,
+        )
     # Git transport preflight (Issue #114): BEFORE any slot or claim
     # the deployment checkout's git transport must be SSH and reachable
     # (the task worktrees share the checkout's single `origin` remote,

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -127,7 +127,7 @@ directory):
 | `prompt_review` | no | `prompt_review.md` | Review prompt template for the independent post-PR review session |
 | `base_branch` | no | `main` | Delivery base branch; every task worktree is created from the frozen `origin/<base_branch>` SHA |
 | `active_milestone` | no | unset | Claim scope for the fresh-claim scans (Issue #139): the active GitHub Milestone title (e.g. `v0.2.0`). Set it to restrict the p0/bug/plain ready scans to that Milestone (the `milestone:"<title>"` qualifier is part of the gh search query — an Issue of another or no Milestone never enters the queue); `ai-ready` stays the execution switch, the pickup order is unchanged, P0 does not cross milestones, and resume states (opened PRs, in-flight restarts) are never gated by it. Unset = every `ai-ready` Issue is claimable (pre-#139 behavior) |
-| `max_concurrency` | no | `1` | Concurrent Pilot tasks on this machine (positive integer; a local model/GPU usually serves one stable task) |
+| `max_concurrency` | no | `1` | Concurrent Pilot tasks and enabled Runner timers on this machine (`1` or `2`; the fixed template has two instances) |
 | `skills` | no | `[]` | Optional Pi skill paths (absolute, `~`, or relative to the config file) |
 | `context_files` | no | `[]` | Optional Markdown context files injected into the prompt as paths |
 | `pi_providers` | no | unset | Path to a JSON file in Pi's `models.json` shape that adds or overrides providers in Pi's catalog for every run (Issue #157). Unset = Pi uses its own agent dir unchanged (step 4) |
@@ -405,24 +405,24 @@ For the label lifecycle, the journal fields and the recovery rules see
 
 ## 8. Verify the timers
 
-The setup step already installed the unit templates and enabled the two
-timer instances (`muyan-pilot@1.timer` and `muyan-pilot@2.timer`, each
-triggering its own service instance — see [Operations](/operations));
-verify them:
+The setup step installed the unit templates and enabled timer instances
+through `max_concurrency`: `@1` for `1`, or `@1` and `@2` for `2` (each
+triggers its own service instance — see [Operations](/operations)); verify
+them:
 
 ```bash
 systemctl --user list-timers 'muyan-pilot@*.timer'
 ```
 
-The setup output carries one line per instance (`timer=muyan-pilot@1.timer
-enabled active=true next=...`, `timer=muyan-pilot@2.timer ...`) with the
-next trigger time. Each timer fires every 5 minutes, 24 hours a day
+The setup output carries one line per instance; enabled instances have an
+active state and next trigger time, while surplus instances report disabled
+and inactive. Each timer fires every 5 minutes, 24 hours a day
 (00:00–23:55). While one service instance is active, systemd ignores
 further starts of THAT instance; the next real start picks up the latest
 code (the service fast-forwards `main` before starting — see
-[Operations](/operations)). Two instances may run concurrently; the
-capacity is the Runner's flock slots (`max_concurrency`), not the
-instance count.
+[Operations](/operations)). At capacity `2`, two instances may run concurrently; the capacity and the
+enabled timer count are both `max_concurrency`, while the flock slots remain
+the final safety boundary.
 
 <Note>
 The committed unit templates reference the author's clone layout via

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -63,8 +63,8 @@ The unit templates (`systemd/muyan-pilot@.service` and
 trigger's `ExecStartPre` fast-forwards the checkout, and the pre-start
 `unit_drift` check self-heals: it runs the SAME idempotent install
 (copy both templates into the user unit directory, daemon-reload,
-enable the two timer instances — it never starts, stops or restarts a
-running Runner), re-verifies with the SAME hash check, and the tick
+enable or disable timer instances through `max_concurrency` — it never
+starts, stops or restarts a running Runner), re-verifies with the SAME hash check, and the tick
 continues with one structured `unit_drift auto_synced` line per unit
 (before and after sha256, deployed commit). There is no per-tick drift
 loop until human intervention (the #131/#140 scene: every start failed
@@ -217,7 +217,7 @@ on the machine. A slot is an exclusive `flock(2)` lock on
 for the whole delivery lifecycle (implement → review → merge); the kernel
 releases it when the process exits, however it exits. A Runner that
 cannot take a slot logs `capacity_full` and exits without claiming an
-Issue. The two timer instances may start two Runner instances in the
-same tick; they compete for the SAME slots — the capacity is
-`max_concurrency` (with the default 1 the behavior is exactly the
-pre-#149 one), never the instance count.
+Issue. At `max_concurrency = 2`, both timer instances may start two Runner
+instances in the same tick; at `1`, only `@1.timer` is enabled. They compete
+for the SAME slots — the capacity and enabled timer count are both
+`max_concurrency` (the fixed template permits `1` or `2`).

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -55,9 +55,9 @@ non-zero exit code.
    (`systemd/muyan-pilot@.service`, `systemd/muyan-pilot@.timer`) are
    installed idempotently into the user unit directory (the same
    install `install-units` performs: copy, migrate the pre-#149
-   non-templated units away once, `daemon-reload`, enable the two timer
-   instances `muyan-pilot@1.timer` / `muyan-pilot@2.timer` — the
-   service is never started, stopped or restarted), then each timer
+   non-templated units away once, `daemon-reload`, then enables `@1` for
+   `max_concurrency = 1` or `@1` and `@2` for `2` (and disables surplus
+   timers) — the service is never started, stopped or restarted), then each timer
    instance's enabled/active state and next trigger time are reported.
 6. **Checkout + git transport** — check of the configured `repo_dir`:
    the `origin` remote's **transport** (Issue #114): git data
@@ -107,7 +107,7 @@ cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-timer=muyan-pilot@2.timer enabled active=true next="Thu 2026-08-27 10:05:00 +08"
+timer=muyan-pilot@2.timer disabled active=false next="-"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
@@ -140,7 +140,7 @@ cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-timer=muyan-pilot@2.timer enabled active=true next="Thu 2026-08-27 10:05:00 +08"
+timer=muyan-pilot@2.timer disabled active=false next="-"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
 ```
@@ -171,8 +171,9 @@ without a clear signal.
 
 Re-running setup on an already-initialized machine is a no-op for the
 external state: labels that already match are not rewritten, the unit
-templates are re-copied from the repo (drift repair), the timer stays
-enabled, and no Issues or business data are created or modified. The
+templates are re-copied from the repo (drift repair), the configured timers
+retain their enabled or disabled states, and no Issues or business data are
+created or modified. The
 reported hashes and states are stable across runs. The HTTPS→SSH
 migration is one-shot: after the first run the `origin` remote is SSH
 and re-runs only re-verify it (`migrated=false`).

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -108,7 +108,7 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 | `prompt_review` | 否 | `prompt_review.md` | PR 后独立审查 session 的 review prompt 模板 |
 | `base_branch` | 否 | `main` | 交付 base 分支；每个任务 worktree 都从冻结的 `origin/<base_branch>` SHA 创建 |
 | `active_milestone` | 否 | 未设置 | 新领取扫描的领取范围（Issue #139）：当前活跃的 GitHub Milestone 标题（如 `v0.2.0`）。设置后 p0/bug/普通三个 ready 扫描只领取该 Milestone 的 Issue（`milestone:"<title>"` 限定词直接进 gh 搜索查询——其他 Milestone 或无 Milestone 的 Issue 永远进不了队列）；`ai-ready` 仍是执行开关，领取顺序（p0 → bug → 普通）不变，P0 不跨 Milestone，恢复态（已开 PR、在途重启）不受 Milestone 限制。未设置 = 所有 `ai-ready` Issue 都可领取（#139 之前的行为） |
-| `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数（正整数；本地模型/GPU 通常只稳定服务一个任务） |
+| `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数和启用的 Runner timer 数（`1` 或 `2`；固定模板有两个实例） |
 | `skills` | 否 | `[]` | 可选 Pi skill 路径（绝对、`~`，或相对配置文件） |
 | `context_files` | 否 | `[]` | 可选 Markdown 上下文文件，以路径形式注入 prompt |
 | `pi_providers` | 否 | 未设置 | 指向 Pi `models.json` 形状 JSON 文件的路径，为每个 run 向 Pi 目录添加或覆盖 provider（Issue #157）。未设置 = Pi 原样使用自己的 agent 目录（第 4 步） |
@@ -365,20 +365,20 @@ review/merge 契约见[工作流](/zh/workflow)。
 
 ## 8. 验证 timers
 
-setup 已经安装 unit 模板并 enable 了两个 timer 实例
-（`muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`，各自触发自己的
-service 实例——见[运维](/zh/operations)）；验证一下：
+setup 已经安装 unit 模板，并按 `max_concurrency` enable timer 实例：
+`1` 时只启用 `@1`，`2` 时启用 `@1` 和 `@2`（各自触发自己的 service
+实例——见[运维](/zh/operations)）；验证一下：
 
 ```bash
 systemctl --user list-timers 'muyan-pilot@*.timer'
 ```
 
-setup 输出每个实例一行（两个实例各一行），形如
-`timer=muyan-pilot@1.timer enabled active=true next=...`，带下次触发时间。每个 timer 每 5 分钟触发一次，全天 24 小时（00:00–23:55）。一个
+setup 输出每个实例一行；启用的实例有 active 状态和下次触发时间，
+多余实例报告 disabled 和 inactive。每个 timer 每 5 分钟触发一次，全天 24 小时（00:00–23:55）。一个
 service 实例 active 时，systemd 忽略对**该实例**的后续启动请求；下一
 次真正启动会取到最新代码（service 启动前先 fast-forward `main`——见
-[运维](/zh/operations)）。两个实例可以同时运行；容量由 Runner 的
-flock slot（`max_concurrency`）决定，而不是实例数。
+[运维](/zh/operations)）。容量为 `2` 时两个实例可以同时运行；容量和
+启用的 timer 数都由 `max_concurrency` 决定，flock slot 仍是最终安全边界。
 
 <Note>
 提交的 unit 模板通过 `%h` 占位符引用作者的 clone 布局

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -51,8 +51,8 @@ systemctl --user status 'muyan-pilot@*.service'
 unit 模板（`systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`）
 是部署配置，不是普通代码——但模板变更合并后**不需要任何人工步骤**。下一次 timer 触发时 `ExecStartPre` 同步 checkout，启动前
 `unit_drift` 检查自动自愈：用同一个幂等安装（把两个模板复制到用户
-unit 目录、daemon-reload、enable 两个 timer 实例——从不启动、停止或
-重启运行中的 Runner）、再用同一个哈希检查复核，tick 继续，每个 unit
+unit 目录、daemon-reload、按 `max_concurrency` enable 或 disable timer
+实例——从不启动、停止或重启运行中的 Runner）、再用同一个哈希检查复核，tick 继续，每个 unit
 记录一行结构化 `unit_drift auto_synced`（before/after sha256、部署
 commit）。不再出现“每 5 分钟重复同一个 `unit_drift` 错误直到人工
 介入”的循环（#131/#140 实例：每次启动都因 `unit_drift` 失败，直到
@@ -177,6 +177,7 @@ run 产物（plan、test log、session JSONL）留在任务 worktree 作为本�
 `<repo_dir>/.muyan-pilot/slots/slot-N` 上的排他 `flock(2)` 锁，在任何
 领取之前取得，整个交付生命周期（implement → review → merge）持有；
 进程无论如何退出，内核都会释放它。拿不到 slot 的 Runner 记录
-`capacity_full` 后退出，不领取 Issue。两个 timer 实例可能在同一 tick
-启动两个 Runner 实例，它们竞争同一组 slot——容量仍是
-`max_concurrency`（默认 1 时行为与 #149 之前完全一致），而不是实例数。
+`capacity_full` 后退出，不领取 Issue。`max_concurrency = 2` 时两个 timer
+实例可能在同一 tick 启动两个 Runner 实例；为 `1` 时只启用 `@1.timer`。
+它们竞争同一组 slot——容量和启用的 timer 数都由 `max_concurrency` 决定
+（固定模板只允许 `1` 或 `2`）。

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -44,9 +44,9 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
 5. **Systemd units** — 仓库模板（`systemd/muyan-pilot@.service`、
    `systemd/muyan-pilot@.timer`）幂等安装到 user unit 目录（与
    `install-units` 相同的安装：复制、一次性迁移 #149 之前的非模板
-   unit、`daemon-reload`、enable 两个 timer 实例
-   `muyan-pilot@1.timer` / `muyan-pilot@2.timer`——从不启动、停止或
-   重启 service），然后报告每个 timer 实例的 enabled/active 状态和
+   unit、`daemon-reload`、按 `max_concurrency` 启用 `@1`（值为 `1`）或
+   `@1`/`@2`（值为 `2`），并停掉多余 timer——从不启动、停止或重启
+   service），然后报告每个 timer 实例的 enabled/active 状态和
    下次触发时间。
 6. **Checkout + git transport** — 检查配置的 `repo_dir`：`origin`
    remote 的**传输协议**（Issue #114）：git 数据操作（fetch、push——
@@ -90,7 +90,7 @@ cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-timer=muyan-pilot@2.timer enabled active=true next="Thu 2026-08-27 10:05:00 +08"
+timer=muyan-pilot@2.timer disabled active=false next="-"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
@@ -120,7 +120,7 @@ cli=verified source=/path/to/checkout/muyan_pilot.py
 repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
-timer=muyan-pilot@2.timer enabled active=true next="Thu 2026-08-27 10:05:00 +08"
+timer=muyan-pilot@2.timer disabled active=false next="-"
 checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
 ```
@@ -148,7 +148,7 @@ setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable
 ## 幂等性
 
 在已初始化的机器上重跑 setup，对外部状态是 no-op：已一致的标签不重写，
-unit 模板从仓库重新复制（漂移修复），timer 保持 enabled，不创建或修改
-任何 Issue 或业务数据。报告的 hash 和状态跨运行稳定。HTTPS→SSH 迁移
+unit 模板从仓库重新复制（漂移修复），配置的 timer 保持其 enabled 或
+disabled 状态，不创建或修改任何 Issue 或业务数据。报告的 hash 和状态跨运行稳定。HTTPS→SSH 迁移
 是一次性的：第一次运行后 `origin` remote 已是 SSH，重跑只重新验证
 （`migrated=false`）。

--- a/muyan_pilot.py
+++ b/muyan_pilot.py
@@ -349,7 +349,8 @@ def install_units_command(config: dict, installed_dir: Path | None) -> str:
     installed sha256 of each unit (Issue #103).
     """
     result = systemd_deploy.install_units(
-        config["repo_dir"], installed_dir, run_command=run_command,
+        config["repo_dir"], installed_dir,
+        max_concurrency=config["max_concurrency"], run_command=run_command,
     )
     lines = [
         (

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -425,7 +425,8 @@ def timer_next_trigger(list_timers_output: str, unit_name: str) -> str:
 
 
 def install_units_step(repo_dir: Path, installed_dir: Path | None,
-                       *, run_command) -> dict:
+                       *, max_concurrency: int = len(systemd_deploy.TIMER_INSTANCES),
+                       run_command) -> dict:
     """Install the repo's user units and report their live state.
 
     Reuses the idempotent ``systemd_deploy.install_units`` (copy the
@@ -438,7 +439,8 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     """
     try:
         result = systemd_deploy.install_units(
-            repo_dir, installed_dir, run_command=run_command,
+            repo_dir, installed_dir, max_concurrency=max_concurrency,
+            run_command=run_command,
         )
     except Exception as exc:
         raise SetupError(
@@ -615,7 +617,10 @@ def run_setup(config: dict, installed_dir: Path | None, *,
             **info,
             "labels": {"aligned": labels["aligned"], "total": labels["total"]},
         })
-    units = install_units_step(repo_dir, installed_dir, run_command=run_command)
+    units = install_units_step(
+        repo_dir, installed_dir, max_concurrency=config["max_concurrency"],
+        run_command=run_command,
+    )
     checkout = check_checkout(
         repo_dir, config["base_branch"], config["source_repos"],
         run_command=run_command,

--- a/pilot_setup.py
+++ b/pilot_setup.py
@@ -18,8 +18,8 @@ initialization entry for a new machine or new task-pool repository:
   ever touched;
 - installs the repo's user systemd service/timer templates idempotently
   (reusing ``systemd_deploy.install_units``: copy, daemon-reload,
-  enable the two timer instances ``muyan-pilot@1.timer`` /
-  ``muyan-pilot@2.timer`` — never start/stop/restart the service) and
+  sync timer instances through ``max_concurrency`` — never start/stop/restart
+  the service) and
   reports each instance's enable/active state plus next trigger time;
 - checks the local checkout read-only (remote, current branch, clean
   status, base freshness);
@@ -431,7 +431,7 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
 
     Reuses the idempotent ``systemd_deploy.install_units`` (copy the
     repo templates, migrate the pre-#149 non-templated units away,
-    ``daemon-reload``, enable the two timer instances — never
+    ``daemon-reload``, sync timer instances through ``max_concurrency`` — never
     start/stop/restart the service), then reports EACH timer
     instance's enabled state (``systemctl --user is-enabled``),
     active state (``show -p ActiveState``) and next trigger time

--- a/systemd_deploy.py
+++ b/systemd_deploy.py
@@ -5,9 +5,9 @@ The repo templates ``systemd/muyan-pilot@.service`` and
 user-level units. This module provides:
 
 - an idempotent install (overwrite-copy the templates into the user
-  unit directory, ``systemctl --user daemon-reload``, enable the two
-  timer instances ``muyan-pilot@1.timer`` and ``muyan-pilot@2.timer``)
-  that NEVER starts/stops/restarts the service: a currently running
+  unit directory, ``systemctl --user daemon-reload``, enable timer
+  instances through the configured ``max_concurrency`` and disable
+  surplus timers) that NEVER starts/stops/restarts the service: a currently running
   Runner keeps running, and the new config takes effect at the next
   service start. The install also migrates the pre-#149
   non-templated units away once (stop the legacy timer — a timer stop
@@ -172,7 +172,8 @@ def check_unit_drift(repo_dir: Path,
 
 def sync_drifted_units(repo_dir: Path,
                        installed_dir: Path | None = None,
-                       *, run_command) -> list[dict]:
+                       *, max_concurrency: int = len(TIMER_INSTANCES),
+                       run_command) -> list[dict]:
     """Pre-start self-heal for drifted units (Issue #142).
 
     The normal scene: a template change merged to main, the
@@ -196,7 +197,10 @@ def sync_drifted_units(repo_dir: Path,
     before = unit_status(repo_dir, installed_dir)
     if not any(entry["drifted"] for entry in before):
         return []
-    result = install_units(repo_dir, installed_dir, run_command=run_command)
+    result = install_units(
+        repo_dir, installed_dir, max_concurrency=max_concurrency,
+        run_command=run_command,
+    )
     after = unit_status(repo_dir, installed_dir)
     lines = drift_lines(after)
     if lines:
@@ -257,20 +261,26 @@ def migrate_legacy_units(installed_dir: Path, *, run_command) -> bool:
 
 
 def install_units(repo_dir: Path, installed_dir: Path | None = None,
-                  *, run_command) -> dict:
+                  *, max_concurrency: int = len(TIMER_INSTANCES),
+                  run_command) -> dict:
     """Idempotently install the repo templates as the user units.
 
     Overwrites BOTH installed template units with the repo templates
     (the repo is the single source of truth), migrates the pre-#149
     non-templated units away once (see ``migrate_legacy_units``), runs
-    ``systemctl --user daemon-reload`` and enables the two timer
-    instances (``enable --now`` is idempotent and activates only the
-    timers, never the services). The services are NEVER started,
+    ``systemctl --user daemon-reload``, enables instances through
+    ``max_concurrency`` and disables surplus timers. These operations
+    activate or stop only timers, never services. The services are NEVER started,
     stopped or restarted: a currently running Runner keeps running,
     and the new config takes effect at the next service start.
     Returns the deployed commit (the deployment checkout's HEAD) and
     the installed units' hashes.
     """
+    if not 1 <= max_concurrency <= len(TIMER_INSTANCES):
+        raise ValueError(
+            "max_concurrency must have a matching Runner timer instance "
+            f"(1..{len(TIMER_INSTANCES)})"
+        )
     repo_dir = Path(repo_dir)
     if installed_dir is None:
         installed_dir = installed_unit_dir()
@@ -289,8 +299,10 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
             (repo_unit_dir(repo_dir) / name).read_bytes(),
         )
     run_command(["systemctl", "--user", "daemon-reload"])
-    for instance in TIMER_INSTANCES:
+    for instance in TIMER_INSTANCES[:max_concurrency]:
         run_command(["systemctl", "--user", "enable", "--now", instance])
+    for instance in TIMER_INSTANCES[max_concurrency:]:
+        run_command(["systemctl", "--user", "disable", "--now", instance])
     commit = run_command(["git", "rev-parse", "HEAD"], cwd=repo_dir)
     units = {
         name: {

--- a/systemd_deploy.py
+++ b/systemd_deploy.py
@@ -180,7 +180,7 @@ def sync_drifted_units(repo_dir: Path,
     ExecStartPre-synced checkout carries the new templates, and the
     installed units are still the old ones. Runs the SAME idempotent
     install (``install_units``: copy the templates, daemon-reload,
-    enable the timer — never start/stop/restart the service, so a
+    sync the configured timer instances — never start/stop/restart the service, so a
     currently running Runner is untouched) and re-verifies with the
     SAME hash check (``unit_status``). Clean after the sync: logs one
     structured ``unit_drift auto_synced`` line per unit (unit,
@@ -315,7 +315,7 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
         "units_installed commit=%s installed_dir=%s units=%s "
         "instances=%s",
         commit, installed_dir, ",".join(UNIT_NAMES),
-        ",".join(TIMER_INSTANCES),
+        ",".join(TIMER_INSTANCES[:max_concurrency]),
     )
     return {
         "commit": commit,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -5946,7 +5946,7 @@ def test_load_config_derives_slot_dir_from_repo_dir(tmp_path):
 
 @pytest.mark.parametrize(
     "value",
-    ["0", "-1", "1.5", '"1"', "true", "false"],
+    ["0", "-1", "1.5", '"1"', "true", "false", "3"],
 )
 def test_load_config_rejects_invalid_max_concurrency(tmp_path, value):
     config_path = tmp_path / "muyan-pilot.toml"
@@ -6145,17 +6145,18 @@ def test_main_unit_drift_blocks_claim_before_slot(monkeypatch, tmp_path,
     with caplog.at_level("ERROR"):
         with pytest.raises(runner.UnitDriftError, match="unit_drift"):
             runner.main(["--config", str(config)])
-    # The self-heal ran the idempotent install (daemon-reload, enable
-    # the timer) before the re-verify failed — and never touched the
-    # service itself.
+    # The self-heal follows default capacity one: it enables @1 and
+    # stops only surplus @2.timer, never a service instance.
     assert ["systemctl", "--user", "daemon-reload"] in calls
-    for instance in systemd_deploy.TIMER_INSTANCES:
-        assert [
-            "systemctl", "--user", "enable", "--now", instance,
-        ] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot@1.timer",
+    ] in calls
+    assert [
+        "systemctl", "--user", "disable", "--now", "muyan-pilot@2.timer",
+    ] in calls
     for command in calls:
         if command[:2] == ["systemctl", "--user"]:
-            assert command[2] in ("daemon-reload", "enable")
+            assert command[2] in ("daemon-reload", "enable", "disable")
     # The structured line carries what the Issue requires.
     assert "unit_drift unit=muyan-pilot@.timer" in caplog.text
     assert f"repo={repo / 'systemd' / 'muyan-pilot@.timer'}" in caplog.text
@@ -6198,15 +6199,17 @@ def test_main_unit_drift_auto_syncs_and_proceeds_to_claim(
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
-    # The self-heal ran the idempotent install (and never the service).
+    # The self-heal follows default capacity one and never a service.
     assert ["systemctl", "--user", "daemon-reload"] in calls
-    for instance in systemd_deploy.TIMER_INSTANCES:
-        assert [
-            "systemctl", "--user", "enable", "--now", instance,
-        ] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot@1.timer",
+    ] in calls
+    assert [
+        "systemctl", "--user", "disable", "--now", "muyan-pilot@2.timer",
+    ] in calls
     for command in calls:
         if command[:2] == ["systemctl", "--user"]:
-            assert command[2] in ("daemon-reload", "enable")
+            assert command[2] in ("daemon-reload", "enable", "disable")
     # The repo template won: the installed unit matches it again.
     status = systemd_deploy.unit_status(repo, installed)
     assert all(entry["drifted"] is False for entry in status)

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -1138,9 +1138,10 @@ def test_install_units_command_reports_commit_and_hashes(monkeypatch,
     installed = tmp_path / "elsewhere"
     captured = {}
 
-    def fake_install(repo_dir, installed_dir, *, run_command):
+    def fake_install(repo_dir, installed_dir, *, max_concurrency, run_command):
         captured["repo_dir"] = repo_dir
         captured["installed_dir"] = installed_dir
+        captured["max_concurrency"] = max_concurrency
         captured["run_command"] = run_command
         return {
             "commit": "0123456789abcdef0123456789abcdef01234567",
@@ -1156,6 +1157,7 @@ def test_install_units_command_reports_commit_and_hashes(monkeypatch,
     report = muyan_pilot.install_units_command(config, installed)
     assert captured["repo_dir"] == config["repo_dir"]
     assert captured["installed_dir"] == installed
+    assert captured["max_concurrency"] == 1
     assert captured["run_command"] is muyan_pilot.run_command
     lines = report.splitlines()
     assert lines[0] == (

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -106,12 +106,14 @@ def make_repo(tmp_path: Path) -> Path:
 
 
 def make_config(tmp_path: Path, repo_dir: Path,
-                source_repos: list[str] | None = None) -> Path:
+                source_repos: list[str] | None = None,
+                max_concurrency: int = 1) -> Path:
     config = tmp_path / "muyan-pilot.toml"
     config.write_text(
         "source_repos = ["
         + ", ".join(f'"{r}"' for r in (source_repos or ["xqliu/muyan-pilot"]))
-        + f']\nrepo_dir = "{repo_dir}"\nbase_branch = "main"\n',
+        + f']\nrepo_dir = "{repo_dir}"\nbase_branch = "main"\n'
+        + f'max_concurrency = {max_concurrency}\n',
         encoding="utf-8",
     )
     return config
@@ -166,6 +168,14 @@ def fake_run_factory(state: dict):
                     f"active_state:{unit}", state.get("active_state", "active"),
                 )
             return "loaded"
+        if head[:3] == ["systemctl", "--user", "enable"]:
+            state[f"is_enabled:{command[-1]}"] = "enabled"
+            state[f"active_state:{command[-1]}"] = "active"
+            return ""
+        if head[:3] == ["systemctl", "--user", "disable"]:
+            state[f"is_enabled:{command[-1]}"] = "disabled"
+            state[f"active_state:{command[-1]}"] = "inactive"
+            return ""
         if head[:3] == ["systemctl", "--user", "is-enabled"]:
             unit = command[-1]
             return state.get(
@@ -531,7 +541,7 @@ def test_install_units_step_reports_install_state(tmp_path):
     repo = make_repo(tmp_path)
     installed = tmp_path / "units"
     result = pilot_setup.install_units_step(
-        repo, installed, run_command=fake_run,
+        repo, installed, max_concurrency=1, run_command=fake_run,
     )
     assert result["service"]["installed"] is True
     assert result["service"]["installed_path"] == str(
@@ -540,11 +550,13 @@ def test_install_units_step_reports_install_state(tmp_path):
     assert result["service"]["sha256"] == systemd_deploy.sha256_hex(
         installed / "muyan-pilot@.service",
     )
-    # Issue #149: EACH timer instance is reported.
+    # Issue #189: setup follows the configured default capacity (one).
     instances = result["timer"]["instances"]
     assert sorted(instances) == sorted(systemd_deploy.TIMER_INSTANCES)
     assert instances["muyan-pilot@1.timer"]["enabled"] is True
     assert instances["muyan-pilot@1.timer"]["active"] is True
+    assert instances["muyan-pilot@2.timer"]["enabled"] is False
+    assert instances["muyan-pilot@2.timer"]["active"] is False
     assert instances["muyan-pilot@1.timer"]["next"] == (
         "Thu 2026-08-27 10:00:00 +08"
     )
@@ -553,42 +565,29 @@ def test_install_units_step_reports_install_state(tmp_path):
     )
     # The install itself is the systemd_deploy idempotent install.
     assert ["systemctl", "--user", "daemon-reload"] in calls
-    for instance in systemd_deploy.TIMER_INSTANCES:
-        assert [
-            "systemctl", "--user", "enable", "--now", instance,
-        ] in calls
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot@1.timer",
+    ] in calls
+    assert [
+        "systemctl", "--user", "disable", "--now", "muyan-pilot@2.timer",
+    ] in calls
 
 
-def test_install_units_step_reports_a_disabled_inactive_timer(tmp_path):
-    state = {"is_enabled": "disabled", "active_state": "inactive"}
+def test_install_units_step_reports_the_disabled_surplus_timer(tmp_path):
+    state = {}
     fake_run, calls = fake_run_factory(state)
     repo = make_repo(tmp_path)
     result = pilot_setup.install_units_step(
-        repo, tmp_path / "units", run_command=fake_run,
-    )
-    instances = result["timer"]["instances"]
-    for instance in systemd_deploy.TIMER_INSTANCES:
-        assert instances[instance]["enabled"] is False
-        assert instances[instance]["active"] is False
-
-
-def test_install_units_step_reports_per_instance_state(tmp_path):
-    # Issue #149: one instance can be enabled/active while the other
-    # is not — the per-instance report must not collapse them.
-    state = {
-        "is_enabled:muyan-pilot@2.timer": "disabled",
-        "active_state:muyan-pilot@2.timer": "inactive",
-    }
-    fake_run, calls = fake_run_factory(state)
-    repo = make_repo(tmp_path)
-    result = pilot_setup.install_units_step(
-        repo, tmp_path / "units", run_command=fake_run,
+        repo, tmp_path / "units", max_concurrency=1, run_command=fake_run,
     )
     instances = result["timer"]["instances"]
     assert instances["muyan-pilot@1.timer"]["enabled"] is True
     assert instances["muyan-pilot@1.timer"]["active"] is True
     assert instances["muyan-pilot@2.timer"]["enabled"] is False
     assert instances["muyan-pilot@2.timer"]["active"] is False
+    assert [
+        "systemctl", "--user", "disable", "--now", "muyan-pilot@2.timer",
+    ] in calls
 
 
 def test_install_units_step_reports_a_missing_next_trigger(tmp_path):
@@ -1017,12 +1016,14 @@ def test_run_setup_success_reports_all_steps(tmp_path):
         },
     ]
     assert result["service"]["installed"] is True
-    # Issue #149: the timer report is per instance.
+    # Issue #189: setup reports the configured timer set, not merely
+    # the fixed template instance list.
     instances = result["timer"]["instances"]
     assert sorted(instances) == sorted(systemd_deploy.TIMER_INSTANCES)
-    for instance in systemd_deploy.TIMER_INSTANCES:
-        assert instances[instance]["enabled"] is True
-        assert instances[instance]["active"] is True
+    assert instances["muyan-pilot@1.timer"]["enabled"] is True
+    assert instances["muyan-pilot@1.timer"]["active"] is True
+    assert instances["muyan-pilot@2.timer"]["enabled"] is False
+    assert instances["muyan-pilot@2.timer"]["active"] is False
     assert result["checkout"]["clean"] is True
     assert result["checkout"]["base_fresh"] is True
     assert result["optional_proxy"]["optional"] is True
@@ -1034,6 +1035,19 @@ def test_run_setup_success_reports_all_steps(tmp_path):
     )
     # No uv call: an existing editable install is never reinstalled.
     assert [c for c in calls if c[:2] == ["uv", "tool"]] == []
+
+
+def test_run_setup_capacity_two_enables_both_timers(tmp_path):
+    repo, installed, state = make_run_state(tmp_path)
+    fake_run, calls = fake_run_factory(state)
+    config = runner.load_config(make_config(tmp_path, repo, max_concurrency=2))
+    result = pilot_setup.run_setup(config, installed, run_command=fake_run)
+    for instance in systemd_deploy.TIMER_INSTANCES:
+        assert result["timer"]["instances"][instance]["enabled"] is True
+        assert result["timer"]["instances"][instance]["active"] is True
+        assert ["systemctl", "--user", "enable", "--now", instance] in calls
+    assert not any(command[2] == "disable" for command in calls
+                   if command[:2] == ["systemctl", "--user"])
 
 
 def test_run_setup_repo_override_limits_the_target(tmp_path):

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -284,6 +284,37 @@ def test_install_units_copies_templates_and_reloads(monkeypatch, tmp_path):
         )
 
 
+def test_install_units_enables_only_configured_timer_instances(tmp_path):
+    """Issue #189: capacity one enables only @1 and stops surplus
+    timers without issuing any command for a service instance."""
+    repo = make_repo(tmp_path)
+    calls: list[list[str]] = []
+    systemd_deploy.install_units(
+        repo, tmp_path / "install", max_concurrency=1,
+        run_command=lambda command, **kwargs: calls.append(command) or "",
+    )
+    assert [
+        "systemctl", "--user", "enable", "--now", "muyan-pilot@1.timer",
+    ] in calls
+    assert [
+        "systemctl", "--user", "disable", "--now", "muyan-pilot@2.timer",
+    ] in calls
+    assert not any(".service" in command[-1] for command in calls)
+
+
+def test_install_units_rejects_capacity_without_a_timer_instance(tmp_path):
+    """Issue #189: configured capacity cannot silently exceed the
+    fixed template instance set."""
+    repo = make_repo(tmp_path)
+    calls: list[list[str]] = []
+    with pytest.raises(ValueError, match="max_concurrency"):
+        systemd_deploy.install_units(
+            repo, tmp_path / "install", max_concurrency=3,
+            run_command=lambda command, **kwargs: calls.append(command) or "",
+        )
+    assert calls == []
+
+
 def test_install_units_migrates_the_legacy_units_once(
     monkeypatch, tmp_path, caplog,
 ):


### PR DESCRIPTION
Fixes #189

按 max_concurrency 启用对应 Runner timer；降并发时仅停多余 timer，不触碰 service，slot 锁保持最终安全边界。

验证：1333 passed，100% line/branch coverage；systemd-analyze --user verify 通过。

<!-- muyan-pilot:run=21e5ae77 -->
run_id=21e5ae77