### PR TITLE
Runner 接管确定性 Git/GitHub 收尾 (deliver_pr)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,10 @@ acceptance criteria.
 
 ## Implement vs review
 
-- Implementer session: plan, TDD, tests, push one PR.
+- Implementer session: plan, TDD, tests, commit the delivery; the Runner
+  pushes the task branch and opens one PR (Issue #186: the deterministic
+  Git/GitHub closeout — base fetch and absorb, push, PR creation — is the
+  Runner's job, not the agent's).
 - After the PR exists, the Runner starts independent review: a new
   `pi --print` with `prompt_review.md` and a new JSONL on the same worktree.
 
@@ -168,10 +171,14 @@ acceptance criteria.
   (default `main`), never from the main worktree's current HEAD.
 - Branch and worktree names carry the unique run id, so a retried Issue gets
   a new independent run and the old scene is preserved.
-- Before creating the PR, re-fetch `origin/<base_branch>`; if the base
-  advanced, merge it into the task branch, resolve conflicts manually, rerun
-  the full tests, then push the task branch (the independent review runs
-  after the PR is opened and absorbs any further base advance in-session).
+- The Runner re-fetches `origin/<base_branch>` before creating the PR
+  (Issue #186: the agent stops at the committed delivery; the base fetch
+  and absorb, the push and the PR creation are the Runner's deterministic
+  closeout); if the base advanced, the Runner merges it into the task
+  branch with a plain `git merge` (a conflict is aborted and the PR opens
+  on the agent's head), then pushes the task branch (the independent review
+  runs after the PR is opened and absorbs any further base advance
+  in-session).
 - Every fetch that updates the shared remote-tracking ref
   (`refs/remotes/origin/<base_branch>`) runs under the SAME shared
   state-dir lock (`base-sync.lock`) that `ExecStartPre` uses (Issue #171):

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
 
 Runner 被 SIGKILL 时无法执行任何清理：任务 worktree 和 `ai-in-progress` 领取标签会留在 GitHub 上（Issue 仍带 `ai-ready`）。下一个 tick 的领取扫描在 ready 队列之前先扫描 `ai-ready`+`ai-in-progress`（且未处于其他交付状态）的 open Issue——**仅当没有其他 Runner 活着时**（其他 slot 被占用证明有活着的 Runner 在处理，此时 `ai-in-progress` 是“进行中”而不是“孤儿”，绝不为活着的 run 启动第二个 Pi；flock 锁是唯一事实源）。找到后走 `process_issue` 的恢复分支：复用最新 worktree 的 run id（branch、worktree、进度评论都由它驱动），按隐藏 run marker 找回同一条进度评论继续 PATCH，不新建 run、不新建 worktree、不新建评论。已完成 run 的 worktree 保留为证据但标签已移除，重新领取永远新 run。
 
-Pi 创建 PR 前必须重新 fetch：若 `origin/<base_branch>` 已前进，需合入最新 base、手工解决冲突、重跑完整测试后再推送。Runner 在验收时用 `git merge-base --is-ancestor origin/<base_branch> HEAD` 验证最新远端 base 是交付 HEAD 的祖先；不满足则 fail fast，不接受 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
+Agent 在提交处停止（代码、测试、commit 都在 task branch 上）；创建 PR 前的 base 新鲜度是 Runner 的确定性收口（Issue #186，`deliver_pr`）：Runner 在 base-sync 锁下重新 fetch `origin/<base_branch>`，若已前进则用 plain `git merge` 合入最新 base（冲突时 abort，PR 在 Agent 的 head 上打开，由既有审查会话在会话内吸收 base），然后 plain push task branch 并创建 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
 
 同一 worktree 下 Pi 新旧 `.pi-session` 的识别：恢复的 run（同一 worktree）会创建**新的** session JSONL，journal 只跟踪当前这次调用的 session（启动前已存在的 JSONL 永不跟随），避免把上一个 run 的 session 报告成活着的会话（Issue #45）。
 
@@ -564,7 +564,7 @@ ai-in-progress → PR opened (ai-pr-opened) → review（会话内修复）
 
 ## 自动审查、修复与合并（Issue #34、#82）
 
-Pi 不直接 push 保护分支。实现 Agent 只 push feature branch 并创建 PR；PR 打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
+Pi 不直接 push 保护分支。实现 Agent 在提交处停止（不 fetch、不 push、不创建 PR）；Runner 完成确定性收口（Issue #186：base fetch 与吸收、plain push task branch、创建 PR），PR 打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
 
 1. **冻结 PR 的 base/head SHA**（`gh pr list` 取唯一 open PR 的 `baseRefOid`/`headRefOid`）。
 2. **独立审查（同时是修复者，Issue #82）**：启动一个独立的 Review Agent（code-review R1–R9，不附加 `review-fix-loop`/`tdd-dev` skill），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implementer 一样通过 live activity 管道输出（journal 中 `role=review`）。审查者**可以修改代码**：发现 Blocker/Major 时在同一会话内修复、重跑完整测试与 100% 行/分支覆盖率、commit 并只 push task branch，然后对修复后的 head 重新输出 verdict——没有冷启动 Fixer，也没有第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；`pass` 表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，绝不当作通过。

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -3305,9 +3305,9 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
             "BASE_BRANCH": config["base_branch"],
             "BASE_SHA": config["base_sha"],
             "RUN_ID": config["run_id"],
-            # Issue #171: the absolute path of the shared base-sync
-            # lock — the prompt's base freshness fetch must run under
-            # it (flock <lock> git fetch origin <base>).
+            # Issue #186: the implementer prompt no longer carries the
+            # base-sync lock (the base fetch is the Runner's operation);
+            # the value stays available for custom prompt templates.
             "BASE_SYNC_LOCK": str(base_sync_lock_path(config["repo_dir"])),
         },
     )

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -3515,6 +3515,148 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     return url
 
 
+def deliver_pr(worktree: Path, branch: str, base_branch: str,
+               base_sha: str, run_id: str, *, issue: int,
+               issue_title: str, repo_dir: Path) -> str:
+    """The Runner completes the deterministic delivery closeout.
+
+    Issue #186: the Agent stops at the committed delivery (code, tests,
+    commit on the task branch). Everything after is deterministic and
+    owned by the Runner — the Agent no longer fetches the base, merges
+    it, pushes or creates the PR:
+
+    1. commit boundary: the worktree is clean and HEAD advanced past
+       the frozen base — the Runner never commits uncommitted changes
+       or expands the Agent's commit boundary (fail fast);
+    2. base freshness: fetch under the base-sync lock (Issue #171); when
+       the base advanced, a plain `git merge origin/<base>` absorbs it;
+       a conflict is aborted (the worktree returns to the Agent's exact
+       commit boundary) and the PR opens on the Agent's head — the
+       existing review loop absorbs the base in-session, the state
+       machine is unchanged;
+    3. push: a plain push of the task branch (never a force push),
+       verified against the remote head;
+    4. PR: exactly one open PR of the branch — created by the Runner
+       with the run marker and `Fixes #<issue>` in the body when absent,
+       verified by `verify_pr` with `require_latest_base=False` (this
+       function just fetched and merged the base itself).
+    """
+    current_branch = run_command(
+        ["git", "branch", "--show-current"], cwd=worktree,
+    )
+    if current_branch != branch:
+        raise RuntimeError(
+            f"Pi changed branch: expected={branch} actual={current_branch}"
+        )
+    # Commit boundary (Issue #186): the Agent's delivery is the
+    # committed worktree state. Uncommitted changes stay uncommitted —
+    # the Runner never commits them and never expands the Agent's
+    # commit boundary; a dirty worktree is a delivery failure.
+    dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    if dirty:
+        LOGGER.error(
+            "delivery_uncommitted_changes branch=%s status=%s",
+            branch, " ".join(dirty.splitlines()),
+        )
+        raise RuntimeError(
+            f"the agent left uncommitted changes in the worktree "
+            f"({dirty.strip()}); the runner never commits uncommitted "
+            "changes or expands the agent's commit boundary"
+        )
+    local_head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
+    if local_head == base_sha:
+        LOGGER.error(
+            "delivery_no_commit branch=%s head=%s",
+            branch, local_head,
+        )
+        raise RuntimeError(
+            f"the agent delivered no commit on the task branch (HEAD "
+            f"{local_head} is still the frozen base {base_sha})"
+        )
+    # Base freshness (Issue #171): the fetch updates the shared
+    # remote-tracking ref, so it runs under the base-sync lock with the
+    # deployment checkout as the lock location. A lock timeout or a
+    # fetch error fails fast — no retry, no lock bypass.
+    fetch_base_ref(repo_dir, base_branch, cwd=worktree)
+    try:
+        run_command(
+            ["git", "merge-base", "--is-ancestor",
+             f"origin/{base_branch}", "HEAD"],
+            cwd=worktree,
+        )
+    except subprocess.CalledProcessError:
+        # The base advanced while the agent worked: absorb it with a
+        # plain merge (the same base update the old agent prompt
+        # required). A conflict is rolled back: the worktree returns
+        # to the agent's exact commit boundary, the PR opens on the
+        # agent's head, and the existing review loop (ai-fix-needed ->
+        # the review session absorbs the base in-session) handles the
+        # rest — the state machine is unchanged.
+        try:
+            run_command(
+                ["git", "merge", f"origin/{base_branch}"], cwd=worktree,
+            )
+            LOGGER.info(
+                "base_absorbed base_branch=%s branch=%s", base_branch,
+                branch,
+            )
+        except subprocess.CalledProcessError as exc:
+            run_command(["git", "merge", "--abort"], cwd=worktree)
+            LOGGER.error(
+                "base_merge_conflict base_branch=%s branch=%s "
+                "returncode=%s stderr=%s; the merge was aborted and the "
+                "PR opens on the agent's head — the review session "
+                "absorbs the base in-session",
+                base_branch, branch, exc.returncode,
+                (exc.stderr or "").strip(),
+            )
+    # Plain push of the task branch (never a force push), then verify
+    # the remote head: the PR must be created from exactly this head.
+    # The head is re-read after the absorb step: a successful base
+    # merge advanced it to the merge commit.
+    local_head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
+    run_command(["git", "push", "origin", f"HEAD:{branch}"], cwd=worktree)
+    remote_head = run_command(
+        ["git", "rev-parse", f"origin/{branch}"], cwd=worktree,
+    )
+    if remote_head != local_head:
+        LOGGER.error(
+            "remote_head_mismatch expected=%s actual=%s branch=%s",
+            local_head, remote_head, branch,
+        )
+        raise RuntimeError(
+            f"remote head {remote_head} does not match the local head "
+            f"{local_head} after push origin {branch}"
+        )
+    # Exactly one open PR of the branch: create it when absent (the PR
+    # body contract is the Runner's obligation now, Issue #186) and
+    # verify it with the full PR contract (exactly one open PR, base,
+    # head, run marker, `Fixes #<issue>`, URL). The verify step skips
+    # its own base re-fetch: this function just fetched and merged it.
+    raw = run_command([
+        "gh", "pr", "list", "--state", "open", "--head", branch,
+        "--json", "url",
+    ], cwd=worktree)
+    if not json.loads(raw):
+        body = (
+            f"{run_marker(run_id)}\n\n"
+            f"Fixes #{issue}\n\n"
+            f"{issue_title} (run_id={run_id})\n"
+        )
+        run_command([
+            "gh", "pr", "create", "--base", base_branch, "--head", branch,
+            "--title", issue_title, "--body", body,
+        ], cwd=worktree)
+        LOGGER.info(
+            "pr_created branch=%s base_branch=%s issue=%s",
+            branch, base_branch, issue,
+        )
+    return verify_pr(
+        worktree, branch, base_branch, run_id, issue=issue,
+        repo_dir=repo_dir, require_latest_base=False,
+    )
+
+
 def verify_resumed_pr(scene: dict, issue: dict, config: dict,
                       source_repo: str) -> str:
     """Verify the PR of a resumed delivery BEFORE any git/Pi mutation.
@@ -5106,8 +5248,13 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             role=ROLE_IMPLEMENT,
             action=lambda: _publish_test_milestone(publisher, worktree),
         )
-        pr_url = verify_pr(
-            worktree, branch, base_branch, run_id, issue=number,
+        # Issue #186: the deterministic closeout (commit boundary, base
+        # freshness + absorb, plain push, PR creation, PR verification)
+        # is the Runner's job — the agent stopped at the committed
+        # delivery.
+        pr_url = deliver_pr(
+            worktree, branch, base_branch, base_sha, run_id,
+            issue=number, issue_title=title,
             repo_dir=config["repo_dir"],
         )
         commit = run_command(

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -191,12 +191,13 @@ checkout and every worktree inherits it: new bootstrap worktrees have
 an SSH `git remote -v` by construction, and their fetch/push —
 including `.github/workflows/*.yml` — go over SSH (Issue #114).
 
-Before creating the PR, the implementer re-fetches the base: if
-`origin/<base_branch>` advanced, it merges the latest base into the task
-branch, resolves conflicts manually, reruns the full test suite, and only
-then pushes. The Runner verifies with
-`git merge-base --is-ancestor origin/<base_branch> HEAD` and rejects a
-delivery whose head does not contain the latest remote base.
+The agent stops at the committed delivery; the base freshness before the
+PR is the Runner's deterministic closeout (Issue #186, `deliver_pr`):
+the Runner re-fetches `origin/<base_branch>` under the base-sync lock,
+absorbs an advanced base with a plain `git merge` (a conflict is aborted
+and the PR opens on the agent's head — the existing review session
+absorbs the base in-session), then pushes the task branch and creates the
+PR.
 
 ## Failure recovery
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -6,9 +6,11 @@ the delivery contract, local-only secrets, and no remote state store.
 
 ## The AI never merges or pushes protected branches
 
-- The implementer Pi **only pushes its feature branch** and opens one PR.
-  It does not merge, does not push `main`/`master`, does not force push,
-  and never auto-resolves conflicts.
+- The implementer Pi **stops at the committed delivery**: it does not
+  fetch the base, does not push, and does not create the PR — the Runner
+  pushes the task branch (plain push, never force) and opens one PR
+  (Issue #186). The Pi does not merge, does not push `main`/`master`,
+  does not force push, and never auto-resolves conflicts.
 - The **Runner is the only merge actor**, and it merges only through the
   reviewed PR: a clean `REVIEW_VERDICT`, the merge gate (PR head contains
   the latest remote base, PR mergeable, remote head still the reviewed

--- a/prompt.md
+++ b/prompt.md
@@ -13,7 +13,6 @@ Runtime context supplied by the runner:
   `{{SKILLS}}`
 - Delivery base branch: `{{BASE_BRANCH}}`
 - Delivery base SHA (frozen `origin/{{BASE_BRANCH}}` at claim time): `{{BASE_SHA}}`
-- Base sync lock: `{{BASE_SYNC_LOCK}}`
 - Run id: `{{RUN_ID}}`
 
 Run correlation (Issue #41):
@@ -22,9 +21,9 @@ Run correlation (Issue #41):
 it is already part of the feature branch and worktree names. Never create
 another id (no `trace_id`, no new UUID) for this run.
 
-- The PR you create must contain the stable machine-readable marker
-  `<!-- muyan-pilot:run={{RUN_ID}} -->` in its body; the runner rejects a PR
-  without it.
+- The PR the Runner opens for this run must contain the stable
+  machine-readable marker `<!-- muyan-pilot:run={{RUN_ID}} -->` in its
+  body; the runner rejects a delivery whose PR body is missing it.
 - Every Issue or PR comment you post (progress, review, fix, final) must
   contain the same marker and the visible field `run_id={{RUN_ID}}`.
 - Keep all run artifacts (plan, test, verify, review report) inside the task
@@ -93,26 +92,18 @@ Work through this exact loop:
 4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts.
 5. Run the real project tests/build/smoke checks and record the commands and results in `test.log` inside the task worktree (the automatic `tests passed/failed` milestone and the progress comment's tests field read that file).
 6. Verify the result yourself.
-7. Commit the change, push only the current feature branch, and open exactly one draft or normal PR for this Issue. The PR body must contain `Fixes #{{ISSUE_NUMBER}}` (it may be on the first line) so GitHub natively closes the source Issue when the PR merges into the default branch — the runner rejects a PR whose body is missing it. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.
+7. Commit the change on the task branch. Your job ends at the committed delivery: you do not fetch the base, push, or create the PR. The Runner then completes the deterministic closeout (Issue #186): it re-fetches the base under the shared base-sync lock, absorbs a base advance with a plain merge, pushes the task branch, and opens exactly one PR for this Issue whose body contains the run marker and `Fixes #{{ISSUE_NUMBER}}` (it may be on the first line) so GitHub natively closes the source Issue when the PR merges into the default branch. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.
 
-Base freshness before creating the PR:
+Base freshness and the push are the Runner's job (Issue #186):
 
 Your worktree was created from `{{BASE_SHA}}` (the frozen
-`origin/{{BASE_BRANCH}}` at claim time). Before creating the PR:
-
-1. Run `flock {{BASE_SYNC_LOCK}} git fetch origin {{BASE_BRANCH}}` in the
-   worktree (Issue #171: the worktree shares the deployment checkout's git
-   common dir, so an unlocked concurrent fetch races on the shared
-   `refs/remotes/origin/{{BASE_BRANCH}}` ref and fails with `cannot lock
-   ref`; the Runner's own fetches hold the same lock). A fetch error or a
-   lock timeout fails fast — do not retry the bare fetch and do not bypass
-   the lock.
-2. If `git merge-base --is-ancestor origin/{{BASE_BRANCH}} HEAD` fails, the
-   base advanced while you worked: merge `origin/{{BASE_BRANCH}}` into your
-   task branch, resolve conflicts manually, rerun the full test suite, then
-   push the updated task branch.
-3. The runner rejects a delivery whose HEAD does not contain the latest
-   remote base, so do not create the PR until the check passes.
+`origin/{{BASE_BRANCH}}` at claim time). After your commit the Runner
+re-fetches `origin/{{BASE_BRANCH}}` under the shared base-sync lock, merges
+an advanced base into the task branch with a plain merge (a conflict is
+aborted and the review session absorbs the base in-session), pushes the
+task branch, and opens the PR. Do not fetch the base, push the task branch,
+or create the PR yourself — the Runner owns those deterministic operations
+and fails fast with the full command error when one of them fails.
 
 Post-PR fixes are NOT your job (Issue #82): once the PR is opened the
 runner runs the independent review session (`prompt_review.md`), which
@@ -123,8 +114,8 @@ PR` context is ever injected into this prompt.
 Rules:
 
 - Do not merge.
-- Do not push `main` or `master`.
+- Do not push `main` or `master` (you do not push at all — the Runner pushes the task branch).
 - Do not force push or auto-resolve conflicts.
-- Do not claim success without a real commit, successful verification, and a PR.
+- Do not claim success without a real commit and successful verification (the PR is opened by the Runner).
 - If the request is unclear or the environment cannot be verified, stop and explain the blocker.
-- The final response must summarize changed files, tests, UI screenshots when applicable, commit, and PR URL.
+- The final response must summarize changed files, tests, UI screenshots when applicable, and the commit (the PR is opened by the Runner).

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -23,7 +23,7 @@ REQUIRED_ITEMS = (
     ("issue-one-outcome", "one runtime outcome"),
     ("issue-pin-root-cause", "root cause is pinned"),
     # 2c. Implement vs review: new review session after the PR.
-    ("implement-then-pr", "plan, tdd, tests, push one pr"),
+    ("implement-then-pr", "plan, tdd, tests, commit the delivery"),
     ("review-after-pr", "after the pr exists"),
     ("review-new-jsonl", "new jsonl"),
     ("review-prompt-review", "prompt_review.md"),
@@ -127,15 +127,16 @@ def test_agents_md_keeps_every_required_contract_item():
 
 
 def test_agents_md_does_not_require_implementer_review_fix_loop():
-    """Issue #78: the implementer only does plan -> TDD -> tests -> push
-    one PR; the independent review runs AFTER the PR is opened (the
-    Runner's review session). The implement-phase wording must not demand
-    a complete review — the old base-freshness bullet ("rerun the full
-    tests and the complete review-fix loop, then push the task branch")
-    made the local Pi self-review for hours (#18/#34)."""
+    """Issue #78: the implementer only does plan -> TDD -> tests -> commit
+    the delivery (the Runner pushes and opens the PR, Issue #186); the
+    independent review runs AFTER the PR is opened (the Runner's review
+    session). The implement-phase wording must not demand a complete
+    review — the old base-freshness bullet ("rerun the full tests and the
+    complete review-fix loop, then push the task branch") made the local
+    Pi self-review for hours (#18/#34)."""
     text = CONTRACT.read_text(encoding="utf-8").lower()
     assert "complete review" not in text
     # The implementer session is pinned to the delivery-only flow, and the
     # review is explicitly positioned after the PR exists.
-    assert "plan, tdd, tests, push one pr" in text
+    assert "plan, tdd, tests, commit the delivery" in text
     assert "after the pr exists" in text

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -361,9 +361,10 @@ def test_prompt_does_not_require_review_fix_loop_before_pr():
 
 
 def test_prompt_template_requires_fixes_keyword_for_the_source_issue():
-    """Issue #53: the Pi prompt must require `Fixes #<issue>` in the PR
-    body so GitHub closes the source Issue natively on merge; the
-    requirement renders with the real issue number."""
+    """Issue #53: the Pi prompt must carry `Fixes #<issue>` (the PR body
+    contract the Runner fulfils when it opens the PR, Issue #186) so
+    GitHub closes the source Issue natively on merge; the requirement
+    renders with the real issue number."""
     template = (
         Path(__file__).resolve().parent.parent / "prompt.md"
     ).read_text(encoding="utf-8")
@@ -383,7 +384,9 @@ def test_prompt_template_requires_fixes_keyword_for_the_source_issue():
         "BASE_SYNC_LOCK": "/checkout/.muyan-pilot/base-sync.lock",
     })
     assert "Fixes #53" in rendered
-    assert "/checkout/.muyan-pilot/base-sync.lock" in rendered
+    # Issue #186: the implementer prompt no longer carries the base-sync
+    # lock path — the base fetch is the Runner's operation.
+    assert "/checkout/.muyan-pilot/base-sync.lock" not in rendered
     assert "{{" not in rendered
 
 
@@ -3150,7 +3153,7 @@ def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, c
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
-    monkeypatch.setattr(runner, "verify_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
+    monkeypatch.setattr(runner, "deliver_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
     gh_calls, posted = make_fake_gh(monkeypatch)
 
@@ -9736,7 +9739,7 @@ def test_process_issue_keeps_normal_flow_without_release_label(monkeypatch):
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
     monkeypatch.setattr(runner, "run_pi",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
-    monkeypatch.setattr(runner, "verify_pr",
+    monkeypatch.setattr(runner, "deliver_pr",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
     monkeypatch.setattr(runner, "run_command",
                         lambda c, **k: "abc123")
@@ -10840,3 +10843,294 @@ def test_release_process_env_fake_answers_the_real_tag_fetch(tmp_path,
 
     monkeypatch.setattr(runner, "run_command", fake)
     assert runner.release_tag_commit(tmp_path, "v0.3.0") == "abc123"
+
+
+# --- Issue #186: deliver_pr — the Runner owns the deterministic closeout ----
+
+DELIVER_BRANCH = f"muyan-pilot/issue-4-{FAKE_RUN_ID}"
+
+
+def fake_deliver_run(command, **kwargs):
+    """Complete fake for deliver_pr: git commands answered, gh returns
+    the PR of the task branch (the production `gh pr list` shape)."""
+    if command[:3] == ["git", "branch", "--show-current"]:
+        return DELIVER_BRANCH
+    if command[:3] == ["git", "status", "--porcelain"]:
+        return ""
+    if command[:3] == ["git", "rev-parse", "HEAD"]:
+        return FAKE_HEAD_SHA
+    if command[:3] == ["git", "fetch", "origin"]:
+        return ""
+    if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+        return ""
+    if command[:3] == ["git", "merge", "origin/main"]:
+        return ""
+    if command[:3] == ["git", "merge", "--abort"]:
+        return ""
+    if command[:3] == ["git", "push", "origin"]:
+        return ""
+    if command[:3] == ["git", "rev-parse", f"origin/{DELIVER_BRANCH}"]:
+        return FAKE_HEAD_SHA
+    if command[:2] == ["gh", "pr"]:
+        return fake_verify_pr_payload()
+    raise AssertionError(f"unexpected command: {command}")
+
+
+def test_fake_deliver_run_rejects_unexpected_command():
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_deliver_run(["gh", "release", "list"])
+
+
+def test_deliver_pr_rejects_wrong_branch(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        assert command[:3] == ["git", "branch", "--show-current"], command
+        return "other-branch"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="Pi changed branch"):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", FAKE_HEAD_SHA, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_rejects_uncommitted_changes(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return " M leaked.py\n?? junk.txt"
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="uncommitted changes"):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_rejects_delivery_without_a_commit(monkeypatch, tmp_path):
+    # HEAD is still the frozen base: the agent delivered no commit.
+    base_sha = "9" * 40
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return base_sha
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="no commit"):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", base_sha, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_completes_the_closeout(monkeypatch, tmp_path):
+    """The happy path: clean commit boundary, base not advanced, plain
+    push, the PR of the branch is verified, the URL is returned."""
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.deliver_pr(
+        tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+        issue=4, issue_title="t", repo_dir=tmp_path,
+    ) == FAKE_PR_URL
+    # The closeout order: commit boundary, locked base fetch, ancestry,
+    # plain push, remote-head verification, PR list.
+    assert ["git", "status", "--porcelain"] in calls
+    assert ["git", "fetch", "origin", "main"] in calls
+    assert ["git", "merge-base", "--is-ancestor", "origin/main", "HEAD"] in calls
+    assert ["git", "push", "origin", f"HEAD:{DELIVER_BRANCH}"] in calls
+    assert ["git", "rev-parse", f"origin/{DELIVER_BRANCH}"] in calls
+    assert any(
+        command[:2] == ["gh", "pr"] and command[2] == "list"
+        for command in calls
+    )
+    # The PR already exists (the fake answers pr list with it): the
+    # Runner never creates a second PR.
+    assert not any(
+        command[:3] == ["gh", "pr", "create"] for command in calls
+    )
+    # No merge: the base did not advance.
+    assert not any(
+        command[:3] == ["git", "merge", "origin/main"] for command in calls
+    )
+
+
+def test_deliver_pr_rolls_back_a_conflicting_base_absorb(
+    monkeypatch, tmp_path, caplog,
+):
+    """Base advanced and the plain merge conflicts: the Runner aborts
+    the merge (the worktree returns to the agent's exact commit
+    boundary), logs `base_merge_conflict`, and continues — the PR opens
+    on the agent's head and the existing review loop absorbs the base
+    in-session (the state machine is unchanged)."""
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            # origin/main is NOT an ancestor of HEAD: base advanced.
+            raise subprocess.CalledProcessError(1, command)
+        if command[:3] == ["git", "merge", "origin/main"]:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="CONFLICT (content): Merge conflict",
+            )
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        ) == FAKE_PR_URL
+    assert ["git", "merge", "origin/main"] in calls
+    assert ["git", "merge", "--abort"] in calls
+    # The abort happens before the push: the pushed head is the
+    # agent's exact commit boundary.
+    assert calls.index(["git", "merge", "--abort"]) < calls.index(
+        ["git", "push", "origin", f"HEAD:{DELIVER_BRANCH}"],
+    )
+    assert "base_merge_conflict" in caplog.text
+
+
+def test_deliver_pr_absorbs_an_advanced_base(monkeypatch, tmp_path, caplog):
+    """Base advanced and the plain merge succeeds: the absorbed base is
+    pushed with the delivery (`base_absorbed`), so the PR head contains
+    the latest remote base."""
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            # origin/main is NOT an ancestor of HEAD: base advanced.
+            raise subprocess.CalledProcessError(1, command)
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        ) == FAKE_PR_URL
+    assert calls.index(["git", "merge", "origin/main"]) < calls.index(
+        ["git", "push", "origin", f"HEAD:{DELIVER_BRANCH}"],
+    )
+    assert "base_absorbed" in caplog.text
+
+
+def test_deliver_pr_creates_the_pr_when_absent(monkeypatch, tmp_path):
+    """No open PR of the branch: the Runner creates it with the run
+    marker and `Fixes #<issue>` in the body (the PR body contract is
+    the Runner's obligation now, Issue #186)."""
+    calls = []
+
+    created = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:2] == ["gh", "pr"] and command[2] == "list":
+            # Stateful: empty until the Runner creates the PR, then the
+            # created PR of the task branch (like the real GitHub state).
+            if not created:
+                return "[]"
+            return json.dumps([created[0]])
+        if command[:2] == ["gh", "pr"] and command[2] == "create":
+            created.append({
+                "url": FAKE_PR_URL,
+                "baseRefName": "main",
+                "headRefName": DELIVER_BRANCH,
+                "headRefOid": FAKE_HEAD_SHA,
+                "body": command[command.index("--body") + 1],
+            })
+            return FAKE_PR_URL
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.deliver_pr(
+        tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+        issue=4, issue_title="Closeout title", repo_dir=tmp_path,
+    ) == FAKE_PR_URL
+    create = [
+        command for command in calls
+        if command[:3] == ["gh", "pr", "create"]
+    ]
+    assert len(create) == 1
+    command = create[0]
+    assert command[command.index("--base") + 1] == "main"
+    assert command[command.index("--head") + 1] == DELIVER_BRANCH
+    assert command[command.index("--title") + 1] == "Closeout title"
+    body = command[command.index("--body") + 1]
+    assert f"<!-- muyan-pilot:run={FAKE_RUN_ID} -->" in body
+    assert "Fixes #4" in body
+
+
+def test_deliver_pr_fails_fast_when_pr_create_fails(monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"] and command[2] == "list":
+            return "[]"
+        if command[:2] == ["gh", "pr"] and command[2] == "create":
+            raise subprocess.CalledProcessError(
+                1, command, stderr="no matching pull request",
+            )
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_rejects_remote_head_mismatch_after_push(
+    monkeypatch, tmp_path,
+):
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "rev-parse", f"origin/{DELIVER_BRANCH}"]:
+            return "f" * 40
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="remote head"):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_verifies_the_pr_with_the_latest_base_check_skipped(
+    monkeypatch, tmp_path,
+):
+    """deliver_pr just fetched and merged the base itself, so the
+    verify step must not fetch it again (require_latest_base=False):
+    no second `git fetch` after the push, and a delivery that is behind
+    the base (the conflict-rollback scene) still passes verification."""
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "merge-base", "--is-ancestor"]:
+            # origin/main is NOT an ancestor of HEAD: base advanced.
+            raise subprocess.CalledProcessError(1, command)
+        if command[:3] == ["git", "merge", "origin/main"]:
+            raise subprocess.CalledProcessError(1, command)
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    runner.deliver_pr(
+        tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+        issue=4, issue_title="t", repo_dir=tmp_path,
+    )
+    fetches = [
+        index for index, command in enumerate(calls)
+        if command[:3] == ["git", "fetch", "origin"]
+    ]
+    push = calls.index(["git", "push", "origin", f"HEAD:{DELIVER_BRANCH}"])
+    # Exactly one fetch (the deliver fetch); nothing after the push.
+    assert len(fetches) == 1
+    assert fetches[0] < push

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -348,6 +348,29 @@ if "INDEPENDENT REVIEW" in system_prompt:
         "verdict": "pass", "blockers": 0, "majors": 0,
         "minors": 0, "findings": [],
     }))
+else:
+    # Implementer session (Issue #186): the agent commits the delivery;
+    # the Runner pushes the task branch and opens the PR (the fake pi
+    # must NOT push or create the PR). A killed runner can leave the
+    # first pi orphaned in its startup sleep, so the commit retries over
+    # a concurrent index.lock holder (the resumed run's own pi).
+    with open(os.path.join(os.getcwd(), f"plan-{os.getpid()}.md"), "w",
+              encoding="utf-8") as handle:
+        handle.write(f"plan (pid {os.getpid()})\\n")
+    for attempt in range(20):
+        try:
+            subprocess.run(["git", "add", "."], check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=pilot@test.local",
+                 "-c", "user.name=Pilot", "commit",
+                 "-m", f"plan for the run (pid {os.getpid()})"],
+                check=True,
+            )
+            break
+        except subprocess.CalledProcessError:
+            if attempt == 19:
+                raise
+            time.sleep(0.1)
 """
 
 
@@ -573,9 +596,31 @@ def wait_for(predicate, timeout: float = 60.0, what: str = "condition") -> None:
     raise AssertionError(f"timed out waiting for {what}")
 
 
+def wait_for_pid_exit(pid: int, timeout: float = 30.0) -> None:
+    """Wait until `pid` is gone (reaped) — models the systemd cgroup
+    taking a killed runner's Pi child with it (a raw SIGKILL of the
+    runner alone orphans the child, which would otherwise commit into
+    the resumed run's worktree at an unpredictable moment)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"timed out waiting for pid {pid} to exit")
+
+
 def test_wait_for_raises_when_condition_never_holds():
     with pytest.raises(AssertionError, match="timed out waiting for the moon"):
         wait_for(lambda: False, timeout=0.1, what="the moon")
+
+
+def test_wait_for_pid_exit_times_out_on_a_live_pid():
+    # This test's own pid is alive: the wait must time out instead of
+    # hanging (the same contract as `wait_for`).
+    with pytest.raises(AssertionError, match="timed out waiting for pid"):
+        wait_for_pid_exit(os.getpid(), timeout=0.1)
 
 
 def test_cleanup_fixture_kills_a_leftover_runner(clone, tmp_path):
@@ -1087,6 +1132,12 @@ def test_killed_runner_is_resumed_by_the_next_claim_scan(clone, tmp_path):
     )
     first.kill()  # SIGKILL: no cleanup can run
     first.wait(timeout=10)
+    # The dead runner's Pi child was orphaned by the SIGKILL; in the
+    # systemd world the service cgroup takes it with the runner. Wait
+    # for the orphan to finish (its commit, if any, lands BEFORE the
+    # resumed run starts — never in the middle of it).
+    orphan_pid = int(pi_invocations(pi_log)[-1].split()[1])
+    wait_for_pid_exit(orphan_pid)
 
     # The kill left the claim label behind (the failure path never ran).
     snap = read_state(state)

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -95,7 +95,9 @@ def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
     else:
         monkeypatch.setattr(runner, "run_pi",
                             Mock(return_value="done"))
-    monkeypatch.setattr(runner, "verify_pr",
+    # Issue #186: the fresh-claim closeout is `deliver_pr` (the Runner
+    # pushes the task branch and opens the PR); the agent no longer does.
+    monkeypatch.setattr(runner, "deliver_pr",
                         lambda *args, **kwargs:
                         "https://github.com/xqliu/muyan-pilot/pull/40")
 
@@ -526,26 +528,28 @@ def test_process_issue_fails_fast_on_missing_issue_title(
                              "xqliu/muyan-pilot")
 
 
-def test_process_issue_passes_issue_number_to_verify_pr(
+def test_process_issue_passes_issue_number_to_deliver_pr(
     monkeypatch, tmp_path,
 ):
     """The fresh path verifies the `Fixes #<issue>` keyword against the
-    source Issue number (Issue #53)."""
+    source Issue number (Issue #53) — now inside the Runner's
+    `deliver_pr` closeout (Issue #186), which forwards it to
+    `verify_pr`."""
     make_fake_gh(monkeypatch)
     patch_process_deps(monkeypatch, tmp_path)
-    verify_calls = []
+    deliver_calls = []
 
-    def fake_verify_pr(*args, **kwargs):
-        verify_calls.append((args, kwargs))
+    def fake_deliver_pr(*args, **kwargs):
+        deliver_calls.append((args, kwargs))
         return "https://github.com/xqliu/muyan-pilot/pull/40"
 
-    monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
+    monkeypatch.setattr(runner, "deliver_pr", fake_deliver_pr)
     runner.process_issue(make_issue(), make_config(tmp_path),
                          "xqliu/muyan-pilot")
-    assert len(verify_calls) == 1
-    args, kwargs = verify_calls[0]
+    assert len(deliver_calls) == 1
+    args, kwargs = deliver_calls[0]
     assert kwargs.get("issue") == 18, (
-        f"verify_pr must verify the Fixes keyword against the source "
+        f"deliver_pr must verify the Fixes keyword against the source "
         f"Issue number, got args={args} kwargs={kwargs}"
     )
 

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -181,12 +181,23 @@ LOCK_FETCH_ITEMS = (
 )
 
 
-def test_prompt_md_fetches_the_base_under_the_base_sync_lock():
-    missing = _missing(_text(PROMPT), LOCK_FETCH_ITEMS)
-    assert not missing, (
-        f"prompt.md is missing the locked base fetch (Issue #171): "
-        f"{missing}"
-    )
+def test_prompt_md_does_not_make_the_agent_run_the_git_github_lifecycle():
+    """Issue #186: the deterministic Git/GitHub lifecycle (base fetch and
+    absorb, push, PR creation) belongs to the Runner, not the agent. The
+    implementer prompt must state that the Runner owns the closeout and
+    must NOT carry the locked base fetch instruction or tell the agent to
+    push or create the PR — the agent's job ends at the committed
+    delivery. The PR body contract (`Fixes #<issue>`) stays, as the
+    Runner's obligation."""
+    text = _text(PROMPT)
+    # The Runner owns the closeout (the contract wording the agent sees).
+    assert "the runner owns" in text
+    # The agent must not be told to run the lifecycle operations itself.
+    assert "flock {{base_sync_lock}} git fetch origin {{base_branch}}" not in text
+    assert "git push" not in text
+    assert "gh pr create" not in text
+    # The PR body contract still exists — as the Runner's obligation.
+    assert "fixes #{{issue_number}}" in text
 
 
 def test_prompt_review_md_fetches_the_base_under_the_base_sync_lock():

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -4,8 +4,9 @@ Real git (local bare origin + clone) plus a fake ``pi`` executable that
 behaves like the delivery agent in both modes:
 
 - implement mode (``Run id:`` in the system prompt): writes the
-  run-scoped plan artifact, commits and pushes — the first delivery
-  that opens the PR;
+  run-scoped plan artifact and commits — the first delivery (Issue
+  #186: the agent stops at the committed delivery; the Runner pushes
+  the task branch and opens the PR);
 - review mode (system prompt without the run id): Issue #82 — the
   independent review session fixes findings IN THE SAME SESSION: it
   absorbs the latest base (plain ``git merge origin/<base>``, resolves
@@ -82,7 +83,6 @@ with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
 for command in (
     ["git", "add", "."],
     ["git", "commit", "-m", f"plan for run {run_id}"],
-    ["git", "push", "origin", "HEAD"],
 ):
     subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 """

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -2,8 +2,11 @@
 
 Real git (local bare origin + clone) plus a fake ``pi`` executable that
 behaves like the delivery agent: it reads the run id from the injected
-system prompt, writes a run-scoped plan artifact, commits and pushes. A fake
-``gh`` answers the runner's issue/PR calls and captures every comment.
+system prompt, writes a run-scoped plan artifact and commits (Issue #186:
+the agent stops at the committed delivery — the Runner pushes the task
+branch and opens the PR). A stateful fake ``gh`` answers the runner's
+issue/PR calls: ``pr list`` is empty until the Runner's ``pr create``
+lands, and every comment is captured.
 
 Together these prove the acceptance criteria:
 
@@ -29,7 +32,9 @@ PR_URL = "https://github.com/owner/repo/pull/41"
 
 # The fake pi behaves like the delivery agent: it extracts the run id from
 # the injected system prompt (exactly where the real runner puts it), writes
-# the plan artifact with the stable marker, then commits and pushes.
+# the plan artifact with the stable marker, then commits. It does NOT push
+# and does NOT create the PR (Issue #186: the Runner owns the push and the
+# PR creation — the e2e proves the closeout lands without agent help).
 FAKE_PI = """#!/usr/bin/env python3
 import os, re, subprocess, sys
 args = sys.argv[1:]
@@ -46,7 +51,6 @@ with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
 for command in (
     ["git", "add", "."],
     ["git", "commit", "-m", f"plan for run {run_id}"],
-    ["git", "push", "origin", "HEAD"],
 ):
     subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 """
@@ -114,9 +118,12 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     labels: dict[int, list[str]] | None = None) -> None:
     """Answer the runner's ``gh`` calls; capture every Issue comment.
 
-    ``gh pr list`` answers with the local HEAD as ``headRefOid`` and a PR
-    body carrying the marker of the run id embedded in the task branch —
-    the same value the real delivery agent is told to use.
+    ``gh pr list`` / ``gh pr create`` are stateful (Issue #186): no PR
+    exists until the Runner's ``pr create`` lands, and the created PR
+    carries the local HEAD as ``headRefOid`` plus the exact body the
+    Runner passed (run marker + ``Fixes #<issue>``). This is what makes
+    the e2e prove the Runner — not the agent — completes the push/PR
+    closeout.
 
     ``labels`` (when given) tracks the Issue's labels: the runner's
     label edits are applied to it, and the restart-resume scan
@@ -124,6 +131,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
     like the real GitHub state (Issue #18).
     """
     comment_ids: list[int] = []
+    created_prs: list[dict] = []
     real_run = runner.run_command
 
     def fake_run(command, **kwargs):
@@ -185,21 +193,36 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     for comment_id, body in zip(comment_ids, comments)
                 ])
             if command[1] == "pr":
-                branch = command[command.index("--head") + 1]
-                run_id = branch.rsplit("-", 1)[1]
-                head = real_run(
-                    ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
-                )
-                return json.dumps([{
-                    "url": PR_URL,
-                    "baseRefName": "main",
-                    "headRefOid": head,
-                    "body": (
-                        f"<!-- muyan-pilot:run={run_id} -->\n\n"
-                        f"Fixes #{ISSUE_NUMBER}\n\n"
-                        f"Plan for {branch}"
-                    ),
-                }])
+                if command[2] == "list":
+                    # The runner always scopes the list to the task
+                    # branch (`--head`), so a second delivery of the
+                    # same Issue (a retry) never sees the first
+                    # delivery's PR.
+                    head = command[command.index("--head") + 1]
+                    return json.dumps(
+                        [pr for pr in created_prs
+                         if pr["headRefName"] == head]
+                    )
+                if command[2] == "create":
+                    base = command[command.index("--base") + 1]
+                    branch = command[command.index("--head") + 1]
+                    title = command[command.index("--title") + 1]
+                    body = command[command.index("--body") + 1]
+                    head = real_run(
+                        ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
+                    )
+                    created_prs.append({
+                        "url": PR_URL,
+                        "baseRefName": base,
+                        "headRefName": branch,
+                        "headRefOid": head,
+                        "headRepository": {"name": "repo"},
+                        "headRepositoryOwner": {"login": "owner"},
+                        "body": body,
+                        "title": title,
+                    })
+                    return PR_URL
+                raise AssertionError(f"unexpected gh pr command: {command}")
             raise AssertionError(f"unexpected gh command: {command}")
         return real_run(command, **kwargs)
 
@@ -250,6 +273,14 @@ def test_fake_gh_rejects_unexpected_command(monkeypatch, tmp_path):
     install_fake_gh(monkeypatch, [])
     with pytest.raises(AssertionError, match="unexpected gh command"):
         runner.run_command(["gh", "release", "list"])
+
+
+def test_fake_gh_rejects_unexpected_pr_command(monkeypatch, tmp_path):
+    # The runner only ever lists and creates PRs (Issue #186): any
+    # other pr subcommand is a contract violation and fails fast.
+    install_fake_gh(monkeypatch, [])
+    with pytest.raises(AssertionError, match="unexpected gh pr command"):
+        runner.run_command(["gh", "pr", "view", "1", "--repo", REPO])
 
 
 def test_fake_gh_ignores_unknown_api_methods(monkeypatch):


### PR DESCRIPTION
Fixes #186

Runner 接管确定性 Git/GitHub 收尾：Agent 在提交处停止（代码+测试+commit），新增 `deliver_pr` 由 Runner 完成 commit 边界检查、base-sync 锁下 fetch base、plain merge 吸收（冲突 abort 后交给既有 review 循环）、plain push + 远端 head 校验、`gh pr create`（run marker + `Fixes #N`）与 `verify_pr`。状态机、merge gate、review 循环、base 新鲜度契约均不变。

验证：1346 passed，100% line/branch coverage；run_id e2e 证明 Runner 在 Agent 只 commit（不 push）后完成 push 与 PR 创建；kill-resume e2e 覆盖孤儿 pi 场景。

<!-- muyan-pilot:run=9470abaa -->
run_id=9470abaa
