### PR TITLE
Release 成功后关闭对应 GitHub Milestone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ muyan-pilot.toml
 # frozen base never inherits the previous run's plan or test log.
 plan.md
 test.log
+verify.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,12 +482,20 @@ acceptance criteria.
      full verification evidence: version, tag, release commit,
      per-item scope evidence, gate evidence, test evidence and the run
      marker.
-  8. Success: `ai-merged` (terminal) and the release Issue is closed,
-     with the success comment (release URL, tag, commit, evidence).
-     Any failure: `ai-blocked` ALONE (a release is a human decision
-     point — no automatic retry), the failure comment carries the run
-     marker and the concrete reason, and the exception propagates so
-     the tick fails fast.
+  8. Close the Milestone whose title is EXACTLY the released version
+     (Issue #214) — on the success path, after the release Issue is
+     closed with `ai-merged`. Exact title match only (no guessing, no
+     fuzzy match, never a different Milestone): closed when it has 0
+     open Issues; already-closed is an idempotent success (no reopen);
+     a missing Milestone or remaining open Issues fail fast with the
+     version, the Milestone number/url and the open issue list (never a
+     silent skip).
+  9. Success: `ai-merged` (terminal) and the release Issue is closed,
+     with the success comment (release URL, tag, commit, evidence,
+     Milestone evidence). Any failure: `ai-blocked` ALONE (a release is
+     a human decision point — no automatic retry), the failure comment
+     carries the run marker and the concrete reason, and the exception
+     propagates so the tick fails fast.
 - The `ai-release` label is a type marker, NOT a delivery state: it is
   not part of the delivery-state machine, not an exclusion of the
   ready scan, and the Runner never adds or removes it — only the

--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ Release task 是 `ai-ready` + `ai-release` 双标签的 Issue（Issue #98）—�
 5. 在 release commit 的干净 worktree 里跑声明的 `test_command`（`timeout` 包裹）；
 6. tag：远端 tag 不存在时在 release commit 上创建 annotated tag 并**普通 push**（绝不 `--force`）；已存在时必须精确指向 release commit（指向别处 fail fast——已存在的 tag 绝不移动/覆盖）；
 7. 发布 GitHub Release（幂等），notes 带完整验证证据（scope/门禁/测试/run marker）；
-8. 成功：`ai-merged`（终态）+ 关闭 Issue + 成功评论（release URL、tag、commit、证据）；任何失败：单独 `ai-blocked`（release 是人工决策点，不自动重试）+ 失败评论（run marker + 具体原因）+ fail fast。
+8. 关闭与发布 `version` **title 精确一致**的 GitHub Milestone（Issue #214）——在成功路径上、release Issue 已 `ai-merged` 关闭之后：open Issues 为 0 时关闭它（`state=closed`，官方 REST 契约 `PATCH /repos/{owner}/{repo}/milestones/{number}`）；已关闭则幂等成功（不重开）；找不到同名 Milestone 或仍有 open Issues 时 fail fast（带上 version、Milestone number/url 和 open issue 列表，不静默跳过、不误关别的 Milestone）；
+9. 成功：`ai-merged`（终态）+ 关闭 Issue + 成功评论（release URL、tag、commit、证据、Milestone 证据）；任何失败：单独 `ai-blocked`（release 是人工决策点，不自动重试）+ 失败评论（run marker + 具体原因）+ fail fast。
 
 可选的 `auto_repair_issues = true` 只覆盖有捕获输出的 Release 测试命令失败：Runner 按 source Issue、run_id、commit、命令和输出生成稳定签名，在 Issue body 搜索该签名后创建或复用一个 `ai-ready` + `bug` 修复 Issue。新 Issue 包含可复现命令和原始输出，照常走 PR/review/merge；Release 仍保持 `ai-blocked`，不会自动重试或发布，必须在修复合并后显式重跑 gate。没有具体测试输出、其他歧义/外部失败或创建修复 Issue 失败时，Runner 记录该失败并保留原始 Release 失败。
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -1682,17 +1682,104 @@ def publish_release(*, repo: str, tag: str, version: str,
     return json.loads(raw)["url"]
 
 
+def close_release_milestone(repo: str, version: str) -> str:
+    """Close the Milestone whose title is exactly `version` (Issue #214).
+
+    Runs on the release success path (after the tag is pushed, the
+    GitHub Release is published and the release Issue is closed with
+    `ai-merged`). The Milestone is matched by EXACT title — never
+    guessed, never fuzzy-matched, never a different Milestone:
+
+    - no Milestone with that exact title -> fail fast (the release
+      must not be reported as fully successful);
+    - several Milestones with that exact title -> fail fast
+      (ambiguous — GitHub allows duplicate titles, so guessing one is
+      forbidden);
+    - already `closed` -> idempotent success (no mutation, no reopen);
+    - `open` with open issues -> fail fast with the version, the
+      Milestone number/url and the open issue list;
+    - `open` with 0 open issues -> closed via the official REST
+      contract `PATCH /repos/{owner}/{repo}/milestones/{number}`
+      with `state=closed` (OpenAPI `issues/update-milestone`).
+
+    The list query asks for `state=all`: the default `state=open`
+    would hide already-closed Milestones and break the idempotent
+    case. Returns a short evidence string for the success path. A
+    real `gh` failure (auth, rate limit, API error) propagates
+    unchanged — like the release gates, a check that cannot be made
+    is a failed check.
+    """
+    raw = run_command([
+        "gh", "api", f"repos/{repo}/milestones?state=all", "--paginate",
+    ])
+    milestones = parse_issue_array(raw)
+    matches = [
+        m for m in milestones
+        if isinstance(m, dict) and m.get("title") == version
+    ]
+    if not matches:
+        raise RuntimeError(
+            f"release {version}: no Milestone with the exact title "
+            f"{version!r} in {repo} — the Milestone is missing, never "
+            "guessed or fuzzy-matched"
+        )
+    if len(matches) > 1:
+        numbers = ", ".join(
+            f"#{m.get('number')} ({m.get('html_url') or m.get('url')})"
+            for m in matches
+        )
+        raise RuntimeError(
+            f"release {version}: {len(matches)} Milestones share the "
+            f"exact title {version!r} in {repo} — ambiguous, refusing "
+            f"to guess which to close: {numbers}"
+        )
+    milestone = matches[0]
+    number = milestone.get("number")
+    html_url = milestone.get("html_url") or milestone.get("url")
+    if milestone.get("state") == "closed":
+        return (
+            f"Milestone #{number} ({html_url}) already closed — "
+            "idempotent success, nothing to do"
+        )
+    open_issues = milestone.get("open_issues")
+    if not isinstance(open_issues, int) or open_issues > 0:
+        raw = run_command([
+            "gh", "issue", "list", "--repo", repo, "--milestone", version,
+            "--state", "open", "--json", "number,title", "--limit", "100",
+        ])
+        issues = parse_issue_array(raw)
+        listing = ", ".join(
+            f"#{i.get('number')} {i.get('title')}" for i in issues
+        ) or "(the API returned no list)"
+        raise RuntimeError(
+            f"release {version}: Milestone #{number} ({html_url}) still "
+            f"has {open_issues} open issue(s) — closing it would hide "
+            f"unfinished work; open issues: {listing}"
+        )
+    run_command([
+        "gh", "api", f"repos/{repo}/milestones/{number}",
+        "--method", "PATCH", "-f", "state=closed",
+    ])
+    return (
+        f"Milestone #{number} ({html_url}) closed after release "
+        f"{version} (0 open issues)"
+    )
+
+
 def release_success_comment_body(run_id: str, run_info: str,
                                  release_url: str, tag: str,
                                  release_commit: str,
                                  scope_evidence: list[str],
                                  gate_evidence: list[str],
-                                 test_evidence: str) -> str:
+                                 test_evidence: str,
+                                 milestone_evidence: str) -> str:
     """The terminal success comment: the full verification evidence.
 
     (Issue #98) The comment is the auditable record of the release:
     run marker, release URL, version/tag/release commit, the
-    per-item scope evidence, the gate evidence and the test evidence.
+    per-item scope evidence, the gate evidence, the test evidence and
+    the Milestone evidence (Issue #214: the Milestone whose title is
+    the released version is closed on the success path).
     """
     return "\n".join([
         run_marker(run_id),
@@ -1711,6 +1798,10 @@ def release_success_comment_body(run_id: str, run_info: str,
         "## Tests",
         "",
         f"- {test_evidence}",
+        "",
+        "## Milestone",
+        "",
+        f"- {milestone_evidence}",
         "",
         f"run_id={run_id}",
     ])
@@ -1762,7 +1853,12 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        verification evidence.
     9. Success: `ai-merged` (terminal, the Issue is closed, the
        success comment carries the evidence).
-    10. Any failure: `ai-blocked` ALONE (no automatic retry — a
+    10. Close the Milestone whose title is EXACTLY the released
+       version (Issue #214): closed when it has 0 open Issues
+       (idempotent when already closed); fail fast — never a silent
+       skip, never a different Milestone — when no Milestone carries
+       that exact title or open Issues remain.
+    11. Any failure: `ai-blocked` ALONE (no automatic retry — a
         release is a human decision point), the failure comment
         carries the run marker and the concrete reason, and the
         exception propagates so the tick fails fast.
@@ -1931,11 +2027,15 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         run_command(
             ["gh", "issue", "close", str(number), "--repo", source_repo],
         )
+        milestone_evidence = close_release_milestone(
+            source_repo, tag,
+        )
         comment_issue(
             number, repo=source_repo,
             body=release_success_comment_body(
                 run_id, run_info, release_url, tag, release_commit,
                 scope_evidence, gate_evidence, test_evidence,
+                milestone_evidence,
             ),
         )
         _safe_publish(

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -177,10 +177,13 @@ DAG, no priority numbers, no separate queues:
   release commit and push it with a plain push (an existing tag must
   point exactly at the release commit — it is never moved, overwritten
   or force-pushed), and finally publish the GitHub Release with the full
-  verification evidence. Success: `ai-merged` (terminal) and the Issue
-  is closed. Any failure: `ai-blocked` ALONE (a release is a human
-  decision point — no automatic retry) with the run marker and the
-  concrete reason on the Issue.
+  verification evidence, then close the Milestone whose title is EXACTLY
+  the released version (Issue #214 — exact title match only: closed when
+  it has 0 open Issues, idempotent when already closed, fail fast when
+  missing or when open Issues remain). Success: `ai-merged` (terminal)
+  and the Issue is closed. Any failure: `ai-blocked` ALONE (a release
+  is a human decision point — no automatic retry) with the run marker
+  and the concrete reason on the Issue.
 - **P0 priority**: the plain `p0` GitHub label marks an urgent Issue
   (a production outage). It is NOT a delivery state — it only orders the
   ready pickup, never changes the Issue granularity, any delivery state,

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -152,7 +152,10 @@ PR 验收时校验该关键词，缺失即 fail fast。
   的干净 worktree 里跑声明的测试命令，然后在 release commit 上创建
   annotated tag 并普通 push（已存在的 tag 必须精确指向 release commit——
   绝不移动、覆盖或 force-push），最后发布带完整验证证据的 GitHub
-  Release。成功：`ai-merged`（终态）并关闭 Issue。任何失败：单独进入
+  Release，然后关闭 title 与发布 version 精确一致的 Milestone（Issue
+  #214——只按 title 精确匹配：open Issues 为 0 时关闭、已关闭则幂等
+  成功、找不到同名或仍有 open Issues 时 fail fast）。成功：
+  `ai-merged`（终态）并关闭 Issue。任何失败：单独进入
   `ai-blocked`（release 是人工决策点——不自动重试），Issue 上带 run
   marker 和具体原因。
 - **P0 优先级**：普通 `p0` GitHub 标签标记紧急 Issue（生产故障）。它

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -10415,6 +10415,22 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             )
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command == ["gh", "api",
+                       "repos/o/r/milestones?state=all", "--paginate"]:
+            return json.dumps([
+                {"number": 1, "title": "v0.2.0", "state": "closed",
+                 "open_issues": 0, "closed_issues": 28,
+                 "url": "https://api.github.com/repos/o/r/milestones/1",
+                 "html_url": "https://github.com/o/r/milestone/1"},
+                {"number": 5, "title": "v0.3.0", "state": "open",
+                 "open_issues": 0, "closed_issues": 2,
+                 "url": "https://api.github.com/repos/o/r/milestones/5",
+                 "html_url": "https://github.com/o/r/milestone/5"},
+            ])
+        if command == ["gh", "api", "repos/o/r/milestones/5",
+                       "--method", "PATCH", "-f", "state=closed"]:
+            return json.dumps({"number": 5, "title": "v0.3.0",
+                               "state": "closed", "open_issues": 0})
         if command[:2] == ["gh", "api"]:
             return json.dumps([
                 {"name": "tests", "status": "completed",
@@ -10485,6 +10501,17 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert not any("--force" in c or "-f" == c for c in commands)
     # The release Issue is closed.
     assert ["gh", "issue", "close", "99", "--repo", "o/r"] in commands
+    # Issue #214: the Milestone whose title is EXACTLY the released
+    # version (v0.3.0 here) is closed via the official REST contract
+    # AFTER the release Issue is closed — and no other Milestone is
+    # touched.
+    close_milestone = ["gh", "api", "repos/o/r/milestones/5",
+                       "--method", "PATCH", "-f", "state=closed"]
+    assert close_milestone in commands
+    assert commands.index(close_milestone) > commands.index(
+        ["gh", "issue", "close", "99", "--repo", "o/r"])
+    assert not [c for c in commands
+                if c[:2] == ["gh", "api"] and "milestones/1" in c[2]]
     # The declared test command ran timeout-wrapped in the worktree.
     assert (["timeout", str(runner.RELEASE_TEST_TIMEOUT_SECONDS),
              "bash", "-c",
@@ -10556,6 +10583,51 @@ def test_create_repair_issue_creates_a_reproducible_ready_bug(monkeypatch):
     assert "muyan-pilot-repair-signature=" in body
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["unexpected"])
+
+
+def test_process_release_milestone_failure_fails_fast_and_blocks(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    real = runner.run_command
+
+    def milestone_failing(command, **kwargs):
+        # The v0.3.0 Milestone still has an open Issue: the close must
+        # fail fast and the release must not be reported as successful.
+        if command[:2] == ["gh", "api"] and "?state=all" in command[2]:
+            return json.dumps([
+                {"number": 5, "title": "v0.3.0", "state": "open",
+                 "open_issues": 1, "closed_issues": 2,
+                 "url": "https://api.github.com/repos/o/r/milestones/5",
+                 "html_url": "https://github.com/o/r/milestone/5"},
+            ])
+        if command[:3] == ["gh", "issue", "list"] and "--milestone" in command:
+            return json.dumps(
+                [{"number": 101, "title": "leftover"}],
+            )
+        return real(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", milestone_failing)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    with pytest.raises(RuntimeError, match="Milestone #5"):
+        runner.process_release(
+            issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        )
+    commands = [c for c, _ in state["commands"]]
+    # The release itself succeeded (tag pushed, Release published,
+    # Issue closed with ai-merged)...
+    assert ["gh", "issue", "close", "99", "--repo", "o/r"] in commands
+    assert any(k.get("add") == "ai-merged" for _, k in state["edits"])
+    # ...but the Milestone close failed: no PATCH was issued, the run
+    # failed fast and the terminal state is ai-blocked with the
+    # concrete reason on the Issue.
+    assert not [c for c in commands if "PATCH" in c]
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+    (comment_number, comment_kwargs), = state["comments"]
+    assert "Muyan Pilot release failed (ai-blocked)" in comment_kwargs["body"]
+    assert "Milestone #5" in comment_kwargs["body"]
+    assert "#101" in comment_kwargs["body"]
 
 
 def test_process_release_reuses_the_run_id_on_resume(monkeypatch):
@@ -10736,6 +10808,177 @@ def test_process_release_fails_on_scope_violation(monkeypatch):
         )
     assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
                                        "remove": "ai-in-progress"})
+
+
+MILESTONE_LIST_COMMAND = [
+    "gh", "api", "repos/o/r/milestones?state=all", "--paginate",
+]
+
+
+def _milestone(number, title, state, open_issues):
+    return {
+        "number": number, "title": title, "state": state,
+        "open_issues": open_issues, "closed_issues": 0,
+        "url": f"https://api.github.com/repos/o/r/milestones/{number}",
+        "html_url": f"https://github.com/o/r/milestone/{number}",
+    }
+
+
+def test_close_release_milestone_closes_an_open_empty_milestone(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([
+                _milestone(4, "v0.2.0", "closed", 0),
+                _milestone(5, "v0.3.0", "open", 0),
+                _milestone(6, "v0.4.0", "open", 3),
+            ])
+        if command == ["gh", "api", "repos/o/r/milestones/5",
+                       "--method", "PATCH", "-f", "state=closed"]:
+            return json.dumps(_milestone(5, "v0.3.0", "closed", 0))
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    evidence = runner.close_release_milestone("o/r", "v0.3.0")
+    # The close uses the official REST contract
+    # (PATCH /repos/{owner}/{repo}/milestones/{number}, state=closed)
+    # and the list query asks for ALL states (the idempotent case needs
+    # the closed Milestones too).
+    assert calls[-1] == ["gh", "api", "repos/o/r/milestones/5",
+                        "--method", "PATCH", "-f", "state=closed"]
+    assert calls[0] == MILESTONE_LIST_COMMAND
+    assert "Milestone #5" in evidence
+    assert "https://github.com/o/r/milestone/5" in evidence
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_is_idempotent_when_already_closed(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([
+                _milestone(1, "v0.2.0", "closed", 0),
+                _milestone(2, "v0.3.0", "closed", 0),
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    evidence = runner.close_release_milestone("o/r", "v0.3.0")
+    # Already closed: no mutation at all (no PATCH, no reopen).
+    assert calls == [MILESTONE_LIST_COMMAND]
+    assert "already closed" in evidence
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_fails_fast_without_a_matching_title(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([
+                _milestone(1, "v0.2.0", "closed", 0),
+                _milestone(3, "v0.4.0", "open", 7),
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="no Milestone with the exact title"):
+        runner.close_release_milestone("o/r", "v0.3.0")
+    # No mutation, no fuzzy match against a different Milestone.
+    assert calls == [MILESTONE_LIST_COMMAND]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_fails_fast_when_open_issues_remain(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([
+                _milestone(5, "v0.3.0", "open", 2),
+            ])
+        if command == ["gh", "issue", "list", "--repo", "o/r",
+                       "--milestone", "v0.3.0", "--state", "open",
+                       "--json", "number,title", "--limit", "100"]:
+            return json.dumps([
+                {"number": 101, "title": "leftover one"},
+                {"number": 102, "title": "leftover two"},
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="Milestone #5") as excinfo:
+        runner.close_release_milestone("o/r", "v0.3.0")
+    # The error carries the version, the Milestone number/url and the
+    # open issue list — never a silent skip.
+    assert "v0.3.0" in str(excinfo.value)
+    assert "https://github.com/o/r/milestone/5" in str(excinfo.value)
+    assert "#101" in str(excinfo.value)
+    assert "#102" in str(excinfo.value)
+    # No close was attempted.
+    assert not [c for c in calls if "PATCH" in c]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_fails_fast_on_duplicate_titles(monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([
+                _milestone(5, "v0.3.0", "open", 0),
+                _milestone(7, "v0.3.0", "open", 0),
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="ambiguous") as excinfo:
+        runner.close_release_milestone("o/r", "v0.3.0")
+    # Both candidates are named; neither is closed.
+    assert "#5" in str(excinfo.value)
+    assert "#7" in str(excinfo.value)
+    assert calls == [MILESTONE_LIST_COMMAND]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_rejects_a_non_array_milestone_list(monkeypatch):
+    def fake_run(command, **kwargs):
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps({"number": 5, "title": "v0.3.0"})
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(ValueError, match="must be a JSON array"):
+        runner.close_release_milestone("o/r", "v0.3.0")
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_reraises_a_real_gh_failure(monkeypatch):
+    def fake_run(command, **kwargs):
+        if command == MILESTONE_LIST_COMMAND:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="HTTP 403: rate limit exceeded",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.close_release_milestone("o/r", "v0.3.0")
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
 
 
 def test_parse_release_declaration_rejects_non_string_body():

--- a/tests/test_run_artifacts.py
+++ b/tests/test_run_artifacts.py
@@ -1,7 +1,7 @@
 """Run artifacts stay out of version control (Issue #80 review round 1).
 
-`plan.md` and `test.log` are per-run artifacts written into the task
-worktree (prompt.md steps 2 and 5). A worktree is created from the
+`plan.md`, `test.log` and `verify.md` are per-run artifacts written
+into the task worktree (prompt.md steps 2 and 5). A worktree is created from the
 frozen base SHA (`git worktree add ... <base_sha>`): if these files
 were tracked in the base, every new worktree would inherit the
 PREVIOUS run's plan and test log, and a run that did not overwrite
@@ -49,6 +49,7 @@ def test_run_artifacts_are_gitignored():
     ]
     assert "plan.md" in patterns
     assert "test.log" in patterns
+    assert "verify.md" in patterns
 
 
 def test_git_helper_fails_fast_on_nonzero_exit():


### PR DESCRIPTION
<!-- muyan-pilot:run=a415aa9c -->

Fixes #214

Release 成功后关闭对应 GitHub Milestone (run_id=a415aa9c)
