### PR TITLE
v0.3.0：Orbi 品牌 rebrand、GitHub org 与官网/文档入口统一

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# Muyan Pilot
+# Orbi
 
-最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并（见下方「自动审查、修复与合并」）。
+Orbi 是本地 AI 开发 Worker（v0.3.0 起对外品牌为 Orbi，GitHub 项目为 [`orbi-build/orbi`](https://github.com/orbi-build/orbi)，官网 <https://orbi.build>，文档站 <https://docs.orbi.build>）。最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并（见下方「自动审查、修复与合并」）。
+
+**品牌与兼容（v0.3.0 rebrand，Issue #183）**：对外品牌统一为 Orbi（README、文档站、仓库描述、package metadata、对外链接）；但已有用户的使用方式不变——CLI 仍是 `muyan-pilot`（console script 与 `muyan_pilot.py` 入口）、配置文件仍是 `muyan-pilot.toml`、systemd unit 仍是 `muyan-pilot@*`、运行时 label（`ai-*`/`p0`）与 run marker（`<!-- muyan-pilot:run=... -->`）均不改动；旧 GitHub 地址（`xqliu/muyan-pilot`、`xqliu/orbi`）由 GitHub 自动 redirect 到 `orbi-build/orbi`。
 
 开发契约见 [AGENTS.md](AGENTS.md)：每次本地 Pi 自举开发前先读 Issue、context files、README 和相关代码，TDD、100% 覆盖率、UI 用 Playwright、失败 fail fast、不 merge、不 push 保护分支、不引入数据库/队列/daemon/fallback、不设业务任务 timeout。
 
 ## 文档站
 
-面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。Mintlify 默认地址为 <https://muyan-pilot.mintlify.site>（若绑定了自定义域名，以 Mintlify 控制台配置的地址为准）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
+面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。文档站地址为 <https://docs.orbi.build>（Mintlify 自定义域名，绑定到本仓库 `docs/`）；旧的 Mintlify 默认子域 <https://muyan-pilot.mintlify.site> 作为旧文档入口保留跳转（Mintlify 控制台自定义域名设置中保留默认子域并指向 `docs.orbi.build`，不制造失效链接）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
 
 两张总览图（Mintlify 渲染 Mermaid，仓库内保留可读源码）：
 
@@ -190,23 +192,23 @@ setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略�
 
 ```bash
 for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
-  gh label create "$l" --repo xqliu/muyan-pilot --force
-  gh label edit "$l" --repo xqliu/muyan-pilot \
-    --description "Muyan Pilot delivery state (see README)"
+  gh label create "$l" --repo orbi-build/orbi --force
+  gh label edit "$l" --repo orbi-build/orbi \
+    --description "Orbi delivery state (see README)"
 done
 # p0 是紧急优先级 label（不是交付状态，见「领取优先级（P0）」）
-gh label create p0 --repo xqliu/muyan-pilot --force --color "fbca04" \
-  --description "Muyan Pilot urgent priority: picked up before bugs and features"
+gh label create p0 --repo orbi-build/orbi --force --color "fbca04" \
+  --description "Orbi urgent priority: picked up before bugs and features"
 # ai-epic 是 Epic 协调 label（不是交付状态，见「Epic Issue（ai-epic）」）
-gh label create ai-epic --repo xqliu/muyan-pilot --force --color "bfdadc" \
+gh label create ai-epic --repo orbi-build/orbi --force --color "bfdadc" \
   --description "Epic coordination issue; not directly executable by Runner"
 # ai-release 是 Release task 标记（不是交付状态，见「Release task（ai-release）」）
-gh label create ai-release --repo xqliu/muyan-pilot --force --color "5319e7" \
+gh label create ai-release --repo orbi-build/orbi --force --color "5319e7" \
   --description "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
 # ai-ticket-only 是内容交付标记（不是 Git 交付状态）
-gh label create ai-ticket-only --repo xqliu/muyan-pilot --force --color "0e8a16" \
+gh label create ai-ticket-only --repo orbi-build/orbi --force --color "0e8a16" \
   --description "Content task: Agent posts the deliverable directly to the Issue without Git delivery"
-gh label list --repo xqliu/muyan-pilot
+gh label list --repo orbi-build/orbi
 ```
 
 | Label | 含义 | 进入条件 | 离开条件 |
@@ -228,9 +230,9 @@ gh label list --repo xqliu/muyan-pilot
 
 ```bash
 # 派发新 Issue 后标注依赖（N = 新 Issue，M = 前置 Issue）
-gh issue edit N --repo xqliu/muyan-pilot --add-blocked-by M
+gh issue edit N --repo orbi-build/orbi --add-blocked-by M
 # 解除依赖
-gh issue edit N --repo xqliu/muyan-pilot --remove-blocked-by M
+gh issue edit N --repo orbi-build/orbi --remove-blocked-by M
 ```
 
 Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引入 DAG、拓扑排序或多 worker 调度）：
@@ -317,18 +319,18 @@ idle 卡死自动恢复（Issue #94，Issue #169 起基于证据）：非 `model
 
 ```bash
 journalctl --user -u 'muyan-pilot@*.service' -f
-# Aug 25 14:30:01 host muyan-pilot[123]: INFO [e07383c2] run_start run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement branch=muyan-pilot/... worktree=/home/.../.worktrees/... session=sess-1 session_file=/home/.../.pi-session/sess-1.jsonl phase=starting last_activity=- action=- result=-
-# Aug 25 14:30:16 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=- state=- idle=6s
-# Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=- elapsed=30s idle=15s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait
-# Aug 25 14:39:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=xqliu/muyan-pilot#18 role=implement phase=test state=model_wait elapsed=9m idle=9m
-# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] activity issue=xqliu/muyan-pilot#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
-# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] resumed issue=xqliu/muyan-pilot#18 role=implement phase=test state=resumed
-# Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle issue=xqliu/muyan-pilot#18 role=implement phase=pr stale_seconds=5m
-# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_idle_wait run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement pid=4242 cmdline="timeout 240 pytest tests/" deadline=2025-08-25T16:05:30Z
-# Aug 25 16:06:00 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=xqliu/muyan-pilot#18 role=implement phase=pr
-# Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=xqliu/muyan-pilot#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/xqliu/muyan-pilot/pull/19 commit=0123456789abcdef0123456789abcdef01234567
+# Aug 25 14:30:01 host muyan-pilot[123]: INFO [e07383c2] run_start run=e07383c2 issue=orbi-build/orbi#18 role=implement branch=muyan-pilot/... worktree=/home/.../.worktrees/... session=sess-1 session_file=/home/.../.pi-session/sess-1.jsonl phase=starting last_activity=- action=- result=-
+# Aug 25 14:30:16 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="bash pytest tests/" result=- state=- idle=6s
+# Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=orbi-build/orbi#18 role=implement phase=test state=- elapsed=30s idle=15s
+# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
+# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait issue=orbi-build/orbi#18 role=implement phase=test state=model_wait
+# Aug 25 14:39:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=orbi-build/orbi#18 role=implement phase=test state=model_wait elapsed=9m idle=9m
+# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
+# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] resumed issue=orbi-build/orbi#18 role=implement phase=test state=resumed
+# Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle issue=orbi-build/orbi#18 role=implement phase=pr stale_seconds=5m
+# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_idle_wait run=e07383c2 issue=orbi-build/orbi#18 role=implement pid=4242 cmdline="timeout 240 pytest tests/" deadline=2025-08-25T16:05:30Z
+# Aug 25 16:06:00 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=orbi-build/orbi#18 role=implement phase=pr
+# Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=orbi-build/orbi#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/orbi-build/orbi/pull/19 commit=0123456789abcdef0123456789abcdef01234567
 ```
 
 每行都带 issue、run id、role（implement / review / merge）、phase、
@@ -376,12 +378,12 @@ muyan-pilot status --config muyan-pilot.toml
 # capacity: 1
 # slots: 1/1
 #   slot-1: pid=4321
-# source: xqliu/muyan-pilot
+# source: orbi-build/orbi
 #   base: main abc123def456
-#   current: #24 Stream live Pi activity ... https://github.com/xqliu/muyan-pilot/issues/24
+#   current: #24 Stream live Pi activity ... https://github.com/orbi-build/orbi/issues/24
 #     live: phase=test last_activity=2026-08-25T02:30:00Z action=bash pytest tests/ result=ok
-#     session: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>/.pi-session/<session>.jsonl
-#     worktree: .../.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-24-<run-id>
+#     session: .../.worktrees/muyan-pilot-orbi-build-orbi-issue-24-<run-id>/.pi-session/<session>.jsonl
+#     worktree: .../.worktrees/muyan-pilot-orbi-build-orbi-issue-24-<run-id>
 #   ready: -
 #   result: -
 ```
@@ -471,7 +473,7 @@ pi_model = "qwen/qwen3.8-27b"
 
 - 该 attempt 的每条 journal 日志首字段：`[e07383c2] command=...`；
 - start / PR opened / failed 等 Issue 评论：可见字段 `run_id=e07383c2` + 隐藏 marker `<!-- muyan-pilot:run=e07383c2 -->`；
-- feature branch 与 worktree 名（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`）；
+- feature branch 与 worktree 名（例如 `.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`）；
 - Pi session 目录（worktree 内 `.pi-session/`）与 plan/test/verify/review 等 run artifacts 的路径；
 - 注入 Pi 的 prompt context（`Run id: ...`）；
 - PR body 的稳定 machine-readable marker `<!-- muyan-pilot:run=e07383c2 -->`——Runner 验收时校验，缺失即 fail fast，拒绝该 PR；
@@ -484,7 +486,7 @@ pi_model = "qwen/qwen3.8-27b"
 journalctl --user -u 'muyan-pilot@*.service' | grep e07383c2
 
 # GitHub 上搜索一个 run 的 progress / milestone / review / merge 记录
-gh search issues "e07383c2" --repo xqliu/muyan-pilot
+gh search issues "e07383c2" --repo orbi-build/orbi
 
 # 本地在 repo 中搜索 run_id 找到 worktree、session 和 run artifacts
 grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
@@ -494,7 +496,7 @@ grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
 
 ## 任务 base 与 worktree
 
-每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-xqliu-muyan-pilot-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。任务 worktree 共享部署 checkout 的单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree 内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
+每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。任务 worktree 共享部署 checkout 的单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree 内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
 
 ### 重启恢复（kill 后自动续跑）
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Orbi 是本地 AI 开发 Worker（v0.3.0 起对外品牌为 Orbi，GitHub 项目
 
 ## 文档站
 
-面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。文档站地址为 <https://docs.orbi.build>（Mintlify 自定义域名，绑定到本仓库 `docs/`）；旧的 Mintlify 默认子域 <https://muyan-pilot.mintlify.site> 作为旧文档入口保留跳转（Mintlify 控制台自定义域名设置中保留默认子域并指向 `docs.orbi.build`，不制造失效链接）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
+面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。文档站地址为 <https://docs.orbi.build>（Mintlify 自定义域名，绑定到本仓库 `docs/`）；旧的 Mintlify 默认子域 <https://muyan-pilot.mintlify.site> 在绑定自定义域名后已停用（实测 404，2026-08-31），旧文档入口以 <https://docs.orbi.build> 为准；如需恢复旧子域跳转，在 Mintlify 控制台 Settings → Custom domain 保留默认子域并指向 `docs.orbi.build`（一次性控制台操作，无代码变更）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
 
 两张总览图（Mintlify 渲染 Mermaid，仓库内保留可读源码）：
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,6 +1,6 @@
 # Contributing
 
-Muyan Pilot is developed the same way it runs: tasks are GitHub Issues,
+Orbi is developed the same way it runs: tasks are GitHub Issues,
 deliveries are PRs, and the repository contract (`AGENTS.md`) applies to
 human contributors too.
 
@@ -19,7 +19,7 @@ the desired behavior is pinned — not as a vague wish.
 
 ## Minimal implementation (KISS/LEAN)
 
-The Pilot implements the **smallest complete change** that satisfies the
+Orbi implements the **smallest complete change** that satisfies the
 Issue's acceptance criteria — KISS and LEAN are the development contract
 (`AGENTS.md`, Issue #118):
 
@@ -36,7 +36,7 @@ Issue's acceptance criteria — KISS and LEAN are the development contract
 
 ## Creating an Issue
 
-Dispatch a task for the Pilot by creating an Issue and labeling it
+Dispatch a task for Orbi by creating an Issue and labeling it
 `ai-ready` (the CLI does both in one step):
 
 ```bash
@@ -51,7 +51,7 @@ gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 ```
 
 A good body states the background, the expected behavior, the acceptance
-criteria, and (for bugs) the reproduction. The Pilot reads the Issue, the
+criteria, and (for bugs) the reproduction. Orbi reads the Issue, the
 repository's `AGENTS.md`, README and code before changing anything.
 
 ## Reporting a bug
@@ -91,7 +91,7 @@ first.
    `Fixes #<issue-number>` (it may be on the first line) so GitHub closes
    the Issue natively on merge.
 6. CI must be green (same contract as local). The independent review and
-   merge are performed by the Runner for Pilot-dispatched work; for
+   merge are performed by the Runner for Orbi-dispatched work; for
    human PRs, review and merge follow the repository's normal GitHub
    flow.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "name": "Muyan Pilot",
+  "name": "Orbi",
   "theme": "mint",
   "colors": {
     "primary": "#1d76db"

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -53,8 +53,8 @@ prefix reuse for local llama.cpp models), not a core prerequisite — see
 ## 1. Clone the repository
 
 ```bash
-git clone https://github.com/xqliu/muyan-pilot.git
-cd muyan-pilot
+git clone https://github.com/orbi-build/orbi.git
+cd orbi
 ```
 
 ## 2. Install the CLI
@@ -127,7 +127,7 @@ directory):
 | `prompt_review` | no | `prompt_review.md` | Review prompt template for the independent post-PR review session |
 | `base_branch` | no | `main` | Delivery base branch; every task worktree is created from the frozen `origin/<base_branch>` SHA |
 | `active_milestone` | no | unset | Claim scope for the fresh-claim scans (Issue #139): the active GitHub Milestone title (e.g. `v0.2.0`). Set it to restrict the p0/bug/plain ready scans to that Milestone (the `milestone:"<title>"` qualifier is part of the gh search query — an Issue of another or no Milestone never enters the queue); `ai-ready` stays the execution switch, the pickup order is unchanged, P0 does not cross milestones, and resume states (opened PRs, in-flight restarts) are never gated by it. Unset = every `ai-ready` Issue is claimable (pre-#139 behavior) |
-| `max_concurrency` | no | `1` | Concurrent Pilot tasks and enabled Runner timers on this machine (`1` or `2`; the fixed template has two instances) |
+| `max_concurrency` | no | `1` | Concurrent Orbi tasks and enabled Runner timers on this machine (`1` or `2`; the fixed template has two instances) |
 | `skills` | no | `[]` | Optional Pi skill paths (absolute, `~`, or relative to the config file) |
 | `context_files` | no | `[]` | Optional Markdown context files injected into the prompt as paths |
 | `pi_providers` | no | unset | Path to a JSON file in Pi's `models.json` shape that adds or overrides providers in Pi's catalog for every run (Issue #157). Unset = Pi uses its own agent dir unchanged (step 4) |
@@ -159,7 +159,7 @@ The Runner never starts or manages the model process — it launches Pi,
 and Pi needs a provider it can actually use. There are two paths, and
 you need only one:
 
-### Path A: Pi's own providers (no Muyan Pilot config)
+### Path A: Pi's own providers (no Orbi config)
 
 Leave `pi_providers` unset and the Runner launches Pi exactly as you
 would run it by hand — Pi uses its own agent directory and the
@@ -171,7 +171,7 @@ pi auth check --provider <provider-id>
 pi --print "reply with the single word: ok"
 ```
 
-### Path B: a `pi_providers` file (Muyan Pilot manages the selection)
+### Path B: a `pi_providers` file (Orbi manages the selection)
 
 Point `pi_providers` at a JSON file in Pi's own `models.json` shape.
 At every run the Runner materializes a per-run agent dir
@@ -279,7 +279,7 @@ shape check).
 The documented and tested path is an **OpenAI-compatible** endpoint
 (`api: "openai-completions"`) — a local `llama.cpp` server or any
 compatible API. The file is passed to Pi verbatim, so other Pi catalog
-entries keep working through Pi's own agent dir; Muyan Pilot does not
+entries keep working through Pi's own agent dir; Orbi does not
 test or guarantee per-provider integrations beyond that boundary.
 
 ## 5. Run the one-time setup

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
-# Muyan Pilot
+# Orbi
 
-Muyan Pilot is a local AI development worker. You put work into GitHub
+Orbi is a local AI development worker. You put work into GitHub
 Issues; it automatically claims an `ai-ready` Issue, develops it in an
 isolated worktree, runs the real test suite, opens a PR, then completes an
 independent review (with in-session fixes) and merges a clean PR — with the
@@ -46,7 +46,7 @@ prerequisite.
 
 Small and medium development tasks (a bug, a feature, a docs change, a
 workflow fix) usually follow the same loop: read the context, plan,
-implement, test, open a PR, review, fix, merge. Muyan Pilot runs that loop
+implement, test, open a PR, review, fix, merge. Orbi runs that loop
 locally and unattended:
 
 - **GitHub Issues are the task pool.** No Web Kanban, no database, no
@@ -71,7 +71,7 @@ locally and unattended:
 
 ## MVP boundary
 
-Muyan Pilot is intentionally an MVP. The boundary is part of the design:
+Orbi is intentionally an MVP. The boundary is part of the design:
 
 - GitHub Issues and labels are the **only** state store — no database, no
   message queue, no web UI.

--- a/docs/optional-kv-cache.mdx
+++ b/docs/optional-kv-cache.mdx
@@ -6,10 +6,10 @@ a two-level KV cache (in-memory hot session cache + disk-backed cold
 prefix cache) so coding agents do not re-prefill the stable system prompt
 and tool schemas on every new session. It is a separate project with its
 own repository, tests and README — this page only records how it
-connects to Muyan Pilot. It is **not** a core prerequisite: the Pilot
-works directly against any OpenAI-compatible endpoint without it.
+connects to Orbi. It is **not** a core prerequisite: Orbi works
+directly against any OpenAI-compatible endpoint without it.
 
-## What it changes for the Pilot
+## What it changes for Orbi
 
 - The proxy listens on `127.0.0.1:18082` when installed with the
   committed systemd unit (the proxy's own code default port is `8081`)
@@ -17,7 +17,7 @@ works directly against any OpenAI-compatible endpoint without it.
   `127.0.0.1:8080`).
 - Point Pi's (and any other agent's) provider URL at the proxy
   (`http://127.0.0.1:18082/v1`) instead of the llama server directly.
-- The Pilot itself is unchanged: it only ever talks to the configured
+- Orbi itself is unchanged: it only ever talks to the configured
   OpenAI-compatible endpoint.
 
 ## Installation

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,6 +1,6 @@
 # Security
 
-Muyan Pilot runs an autonomous coding agent with a GitHub token on your
+Orbi runs an autonomous coding agent with a GitHub token on your
 machine. The security model is deliberately simple: hard boundaries in
 the delivery contract, local-only secrets, and no remote state store.
 
@@ -30,7 +30,7 @@ the delivery contract, local-only secrets, and no remote state store.
 - **GitHub API operations** (Issue, PR, label, comment, merge)
   authenticate with `gh` (`gh auth status` must succeed). Use a
   **fine-grained personal access token** scoped to the repositories the
-  Pilot actually works on, with the minimum permissions: contents
+  Orbi actually works on, with the minimum permissions: contents
   (read/write), pull requests (read/write), issues (read/write), and
   metadata (read). Avoid organization-wide or classic broad-scope tokens.
 - **Git data operations** (fetch, push — including
@@ -54,7 +54,7 @@ the delivery contract, local-only secrets, and no remote state store.
 
 ## Local state files
 
-The Pilot keeps local state that never leaves the machine:
+Orbi keeps local state that never leaves the machine:
 
 - **Config** (`muyan-pilot.toml`): local, gitignored. The repository only
   ships the example (`.muyan-pilot.example.toml`).
@@ -69,6 +69,6 @@ The Pilot keeps local state that never leaves the machine:
   sensitive local data, keep it on the same machine, and delete it if you
   no longer need the cached sessions.
 
-If you run the Pilot on a shared machine, give the Runner user its own
+If you run Orbi on a shared machine, give the Runner user its own
 home directory so the config, worktrees and KV files stay private to that
 user.

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -82,7 +82,7 @@ non-zero exit code.
 7. **Optional model proxy** — the `local-llm-kv-cache` proxy health
    endpoint (`http://127.0.0.1:18082/health`) is checked and reported
    as **optional**: its absence or unhealthiness is a warning in the
-   output and never blocks the core GitHub/Pilot setup.
+   output and never blocks the core GitHub/Orbi setup.
 
 Setup never creates business Issues, never claims a task, never starts
 Pi, and never modifies a protected branch.
@@ -104,11 +104,11 @@ containing spaces are quoted), so agents and scripts can parse it:
 ```text
 setup=ok version=2 base_branch=main
 cli=verified source=/path/to/checkout/muyan_pilot.py
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
+repo=orbi-build/orbi permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 timer=muyan-pilot@2.timer disabled active=false next="-"
-checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:orbi-build/orbi.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
@@ -137,11 +137,11 @@ Success (exit code `0`):
 $ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=2 base_branch=main
 cli=verified source=/path/to/checkout/muyan_pilot.py
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
+repo=orbi-build/orbi permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 timer=muyan-pilot@2.timer disabled active=false next="-"
-checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:orbi-build/orbi.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
 ```
 

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -1,6 +1,6 @@
 # Workflow
 
-One Muyan Pilot task is one runtime outcome: when X, should Y, actually Z.
+One Orbi task is one runtime outcome: when X, should Y, actually Z.
 A task starts as a GitHub Issue and ends as a merged PR (or an
 `ai-blocked` scene that needs a human). This page covers the complete
 automatic chain and the project's GitHub workflow vocabulary.
@@ -105,7 +105,7 @@ commits — initialize them per repository (see
 
 | Label | Meaning |
 |---|---|
-| `ai-ready` | Explicitly dispatched to the Pilot; may be claimed |
+| `ai-ready` | Explicitly dispatched to Orbi; may be claimed |
 | `ai-in-progress` | Claimed and running. The Runner idempotently backfills it before continuing a resumed opened-PR delivery (Issue #178); a leftover after a kill is resumed by the next tick |
 | `ai-pr-opened` | PR created and verified; awaiting the independent review |
 | `ai-fix-needed` | The PR head is not mergeable yet, or an AI-recoverable failure of the run/PR (Issue #50); the next tick resumes the same run, branch, worktree and PR |

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -1,6 +1,6 @@
 # 贡献
 
-Muyan Pilot 用和它运行一样的方式开发：任务是 GitHub Issue，交付是
+Orbi 用和它运行一样的方式开发：任务是 GitHub Issue，交付是
 PR，仓库契约（`AGENTS.md`）同样适用于人类贡献者。
 
 ## Issue 粒度
@@ -17,7 +17,7 @@ PR，仓库契约（`AGENTS.md`）同样适用于人类贡献者。
 
 ## 最小实现（KISS/LEAN）
 
-Pilot 只实现满足 Issue 验收标准的**最小完整变更**——KISS 和 LEAN 是
+Orbi 只实现满足 Issue 验收标准的**最小完整变更**——KISS 和 LEAN 是
 开发契约（`AGENTS.md`，Issue #118）：
 
 - 不做 speculative feature、无收益抽象、额外框架层、fallback、未来功能
@@ -30,7 +30,7 @@ Pilot 只实现满足 Issue 验收标准的**最小完整变更**——KISS 和 
 
 ## 创建 Issue
 
-通过创建 Issue 并加 `ai-ready` 标签来给 Pilot 派活（CLI 一步完成两
+通过创建 Issue 并加 `ai-ready` 标签来给 Orbi 派活（CLI 一步完成两
 件事）：
 
 ```bash
@@ -44,7 +44,7 @@ gh issue create --repo OWNER/PILOT-REPO --title "task title" --body "task body"
 gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 ```
 
-好的 body 写清背景、期望行为、验收标准，（bug 时）复现步骤。Pilot 在
+好的 body 写清背景、期望行为、验收标准，（bug 时）复现步骤。Orbi 在
 改任何东西之前会读 Issue、仓库的 `AGENTS.md`、README 和代码。
 
 ## 报告 bug
@@ -79,7 +79,7 @@ gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 
 5. 一个 Issue 一个 PR。PR 描述必须包含 `Fixes #<issue-number>`（可以
    放在首行），merge 时 GitHub 原生关闭 Issue。
-6. CI 必须绿（与本地同一契约）。Pilot 派发的任务由 Runner 执行独立
+6. CI 必须绿（与本地同一契约）。Orbi 派发的任务由 Runner 执行独立
    审查和合并；人类 PR 的 review 和 merge 走仓库正常的 GitHub 流程。
 
 ## 不要加什么

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -47,8 +47,8 @@ prefix 复用），不是核心前提——见[可选组件](/zh/optional-kv-cac
 ## 1. Clone 仓库
 
 ```bash
-git clone https://github.com/xqliu/muyan-pilot.git
-cd muyan-pilot
+git clone https://github.com/orbi-build/orbi.git
+cd orbi
 ```
 
 ## 2. 安装 CLI
@@ -108,7 +108,7 @@ cp .muyan-pilot.example.toml muyan-pilot.toml
 | `prompt_review` | 否 | `prompt_review.md` | PR 后独立审查 session 的 review prompt 模板 |
 | `base_branch` | 否 | `main` | 交付 base 分支；每个任务 worktree 都从冻结的 `origin/<base_branch>` SHA 创建 |
 | `active_milestone` | 否 | 未设置 | 新领取扫描的领取范围（Issue #139）：当前活跃的 GitHub Milestone 标题（如 `v0.2.0`）。设置后 p0/bug/普通三个 ready 扫描只领取该 Milestone 的 Issue（`milestone:"<title>"` 限定词直接进 gh 搜索查询——其他 Milestone 或无 Milestone 的 Issue 永远进不了队列）；`ai-ready` 仍是执行开关，领取顺序（p0 → bug → 普通）不变，P0 不跨 Milestone，恢复态（已开 PR、在途重启）不受 Milestone 限制。未设置 = 所有 `ai-ready` Issue 都可领取（#139 之前的行为） |
-| `max_concurrency` | 否 | `1` | 本机并发 Pilot 任务数和启用的 Runner timer 数（`1` 或 `2`；固定模板有两个实例） |
+| `max_concurrency` | 否 | `1` | 本机并发 Orbi 任务数和启用的 Runner timer 数（`1` 或 `2`；固定模板有两个实例） |
 | `skills` | 否 | `[]` | 可选 Pi skill 路径（绝对、`~`，或相对配置文件） |
 | `context_files` | 否 | `[]` | 可选 Markdown 上下文文件，以路径形式注入 prompt |
 | `pi_providers` | 否 | 未设置 | 指向 Pi `models.json` 形状 JSON 文件的路径，为每个 run 向 Pi 目录添加或覆盖 provider（Issue #157）。未设置 = Pi 原样使用自己的 agent 目录（第 4 步） |
@@ -139,7 +139,7 @@ context_files = []
 Runner 从不启动或管理模型进程——它启动 Pi，而 Pi 需要一个能真正
 使用的 provider。有两条路径，只需要其中一条：
 
-### 路径 A：Pi 自己的 provider（不配置 Muyan Pilot）
+### 路径 A：Pi 自己的 provider（不配置 Orbi）
 
 `pi_providers` 不设，Runner 就和你手工运行 Pi 完全一样地启动它——
 Pi 用自己的 agent 目录和你在那里配置的 provider。派活之前先用 Pi
@@ -150,7 +150,7 @@ pi auth check --provider <provider-id>
 pi --print "reply with the single word: ok"
 ```
 
-### 路径 B：`pi_providers` 文件（由 Muyan Pilot 管理选择）
+### 路径 B：`pi_providers` 文件（由 Orbi 管理选择）
 
 把 `pi_providers` 指向一个 Pi 自己的 `models.json` 形状的 JSON 文件。
 每个 run 开始时 Runner 会物化一个 per-run agent 目录
@@ -254,7 +254,7 @@ chmod 600 .muyan-pilot/env
 文档化且经过测试的路径是 **OpenAI-compatible** endpoint
 （`api: "openai-completions"`）——本地 `llama.cpp` server 或任意
 兼容 API。文件原样传给 Pi，所以 Pi 目录里的其他 catalog 条目继续
-可用；Muyan Pilot 不测试、也不保证该边界之外的逐 provider 集成。
+可用；Orbi 不测试、也不保证该边界之外的逐 provider 集成。
 
 ## 5. 运行一次性 setup
 

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Muyan Pilot"
+title: "Orbi"
 ---
 
-# Muyan Pilot
+# Orbi
 
-Muyan Pilot 是一个本地 AI 开发 Worker：把任务放进 GitHub Issue，它自动领取
+Orbi 是一个本地 AI 开发 Worker：把任务放进 GitHub Issue，它自动领取
 `ai-ready` Issue，在隔离 worktree 中开发、运行真实测试套件、创建 PR，随后
 完成独立审查（会话内修复）并合并干净的 PR——整个交付过程记录在 GitHub
 Issue、评论和 PR 本身中。
@@ -47,8 +47,8 @@ proxy：它只为本地 llama.cpp 模型增加更快的 prefix 复用，**不是
 ## 它解决的问题
 
 中小型开发任务（bug、feature、文档修改、workflow 修复）通常走同一个
-循环：读上下文、规划、实现、测试、开 PR、review、修复、合并。Muyan
-Pilot 在本地无人值守地跑完这个循环：
+循环：读上下文、规划、实现、测试、开 PR、review、修复、合并。Orbi
+在本地无人值守地跑完这个循环：
 
 - **GitHub Issue 就是任务池。** 没有 Web Kanban、没有数据库、没有第二套
   任务系统——Issue、它的标签、评论和 PR 就是完整的交付记录。
@@ -70,7 +70,7 @@ Pilot 在本地无人值守地跑完这个循环：
 
 ## MVP 边界
 
-Muyan Pilot 刻意是一个 MVP，边界是设计的一部分：
+Orbi 刻意是一个 MVP，边界是设计的一部分：
 
 - GitHub Issue 和标签是**唯一**状态存储——没有数据库、没有消息队列、
   没有 Web UI。

--- a/docs/zh/optional-kv-cache.mdx
+++ b/docs/zh/optional-kv-cache.mdx
@@ -4,18 +4,18 @@
 是本地 llama.cpp 配置的**可选增强**：它加了两级 KV cache（内存热
 session cache + 磁盘冷 prefix cache），让 coding agent 不必在每个新
 session 重新 prefill 稳定的 system prompt 和 tool schemas。它是独立项
-目，有自己的仓库、测试和 README——这一页只记录它如何接入 Muyan
-Pilot。它**不是**核心前提：没有它，Pilot 直接对接任意
+目，有自己的仓库、测试和 README——这一页只记录它如何接入 Orbi。
+它**不是**核心前提：没有它，Orbi 直接对接任意
 OpenAI-compatible endpoint 就能工作。
 
-## 它改变了 Pilot 的什么
+## 它改变了 Orbi 的什么
 
 - proxy 用提交的 systemd unit 安装时监听 `127.0.0.1:18082`（proxy 自己
   代码的默认端口是 `8081`），转发到 llama.cpp server（默认 upstream
   `127.0.0.1:8080`）。
 - 把 Pi（和任何其他 agent）的 provider URL 指向 proxy
   （`http://127.0.0.1:18082/v1`），而不是直接指向 llama server。
-- Pilot 本身不变：它永远只和配置的 OpenAI-compatible endpoint 说话。
+- Orbi 本身不变：它永远只和配置的 OpenAI-compatible endpoint 说话。
 
 ## 安装
 

--- a/docs/zh/security.mdx
+++ b/docs/zh/security.mdx
@@ -1,6 +1,6 @@
 # 安全
 
-Muyan Pilot 在你的机器上运行一个带 GitHub token 的自主 coding agent。
+Orbi 在你的机器上运行一个带 GitHub token 的自主 coding agent。
 安全模型刻意简单：交付契约里的硬边界、本地密钥、没有远端状态存储。
 
 ## AI 从不 merge 或 push 保护分支
@@ -23,7 +23,7 @@ Muyan Pilot 在你的机器上运行一个带 GitHub token 的自主 coding agen
 
 - **GitHub API 操作**（Issue、PR、label、comment、merge）用 `gh`
   认证（`gh auth status` 必须成功）。使用**细粒度 personal access
-  token**，限定在 Pilot 实际工作的仓库，最小权限：contents
+  token**，限定在 Orbi 实际工作的仓库，最小权限：contents
   （read/write）、pull requests（read/write）、issues（read/write）、
   metadata（read）。避免组织级或经典宽 scope token。
 - **Git 数据操作**（fetch、push——包括 `.github/workflows/*.yml`）用
@@ -42,7 +42,7 @@ Muyan Pilot 在你的机器上运行一个带 GitHub token 的自主 coding agen
 
 ## 本地状态文件
 
-Pilot 保留从不出机的本地状态：
+Orbi 保留从不出机的本地状态：
 
 - **配置**（`muyan-pilot.toml`）：本地、gitignored。仓库只提交
   example（`.muyan-pilot.example.toml`）。
@@ -56,5 +56,5 @@ Pilot 保留从不出机的本地状态：
   prompt 派生的序列化模型状态——当作敏感本地数据处理，留在同一台
   机器，不再需要缓存的 session 时删除。
 
-如果你在共享机器上运行 Pilot，给 Runner 用户独立的 home 目录，让
+如果你在共享机器上运行 Orbi，给 Runner 用户独立的 home 目录，让
 配置、worktree 和 KV 文件只属于该用户。

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -66,7 +66,7 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    checkout fast-forward）。
 7. **可选模型 proxy** — 检查 `local-llm-kv-cache` proxy 的 health
    endpoint（`http://127.0.0.1:18082/health`），报告为**可选**：它的
-   缺失或不健康只是输出里的 warning，从不阻塞核心 GitHub/Pilot setup。
+   缺失或不健康只是输出里的 warning，从不阻塞核心 GitHub/Orbi setup。
 
 setup 从不创建业务 Issue、从不领取任务、从不启动 Pi、从不修改保护分支。
 
@@ -87,11 +87,11 @@ agent 和脚本可以解析：
 ```text
 setup=ok version=2 base_branch=main
 cli=verified source=/path/to/checkout/muyan_pilot.py
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
+repo=orbi-build/orbi permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 timer=muyan-pilot@2.timer disabled active=false next="-"
-checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:orbi-build/orbi.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=healthy url=http://127.0.0.1:18082/health
 ```
 
@@ -117,11 +117,11 @@ muyan-pilot setup --config muyan-pilot.toml --json
 $ muyan-pilot setup --config muyan-pilot.toml
 setup=ok version=2 base_branch=main
 cli=verified source=/path/to/checkout/muyan_pilot.py
-repo=xqliu/muyan-pilot permission=ADMIN default_branch=main labels=8/8
+repo=orbi-build/orbi permission=ADMIN default_branch=main labels=8/8
 service=installed path=~/.config/systemd/user/muyan-pilot@.service sha256=9f2c...
 timer=muyan-pilot@1.timer enabled active=true next="Thu 2026-08-27 10:00:00 +08"
 timer=muyan-pilot@2.timer disabled active=false next="-"
-checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:xqliu/muyan-pilot.git protocol=ssh migrated=false ssh_reachable=true
+checkout=remote=origin branch=main clean=true base_fresh=true remote_url=git@github.com:orbi-build/orbi.git protocol=ssh migrated=false ssh_reachable=true
 model_endpoint=optional optional_proxy=unhealthy url=http://127.0.0.1:18082/health
 ```
 

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -1,6 +1,6 @@
 # 工作流
 
-一个 Muyan Pilot 任务是一个 runtime outcome：当 X，应该 Y，实际 Z。
+一个 Orbi 任务是一个 runtime outcome：当 X，应该 Y，实际 Z。
 任务从一个 GitHub Issue 开始，以一个已合并的 PR 结束（或一个需要人工
 的 `ai-blocked` 现场）。这一页覆盖完整的自动链路和项目的 GitHub 工作流
 词汇。
@@ -89,7 +89,7 @@ GitHub 标签是外部状态机。它们不是 commit 创建的——每个仓�
 
 | 标签 | 含义 |
 |---|---|
-| `ai-ready` | 明确派发给 Pilot；可以被领取 |
+| `ai-ready` | 明确派发给 Orbi；可以被领取 |
 | `ai-in-progress` | 已领取、正在执行。resume opened-PR 交付时 Runner 先幂等回填该标签再继续（Issue #178）；被杀后的残留由下一 tick 接回 |
 | `ai-pr-opened` | PR 已创建并验收；等待独立审查 |
 | `ai-fix-needed` | PR head 尚不可合并，或已有 run/PR 的可恢复失败（Issue #50）；下一 tick 在同一 run、branch、worktree、PR 上继续 |

--- a/labels.toml
+++ b/labels.toml
@@ -1,10 +1,13 @@
-# Muyan Pilot platform labels — the single source of truth (Issue #117).
+# Orbi platform labels (CLI: `muyan-pilot`) — the single source of truth
+# (Issue #117; v0.3.0 rebrand Issue #183: the label NAMES are runtime
+# state and stay unchanged, only the visible descriptions carry the
+# Orbi brand).
 #
 # `muyan_pilot.py setup` aligns every configured source repo with this
 # file declaratively: a missing label is created and a drifted label is
 # updated (name, color, description); nothing is ever deleted and no
 # business label (bug, enhancement, ...) is touched. The values below
-# match the live xqliu/muyan-pilot labels (verified against the GitHub
+# match the live orbi-build/orbi labels (verified against the GitHub
 # API); a commit never creates labels — only the setup entry does.
 #
 # Color: 6-character hex (GitHub normalizes case). Description: one
@@ -13,12 +16,12 @@
 [[label]]
 name = "ai-ready"
 color = "1d76db"
-description = "Issue is explicitly dispatched to Muyan Pilot"
+description = "Issue is explicitly dispatched to Orbi"
 
 [[label]]
 name = "ai-in-progress"
 color = "fbca04"
-description = "Issue currently being handled by Muyan Pilot"
+description = "Issue currently being handled by Orbi"
 
 [[label]]
 name = "ai-pr-opened"
@@ -33,17 +36,17 @@ description = "Existing PR needs automatic review/fix continuation"
 [[label]]
 name = "ai-merged"
 color = "0e8a16"
-description = "Muyan Pilot automatically reviewed and merged the task PR"
+description = "Orbi automatically reviewed and merged the task PR"
 
 [[label]]
 name = "ai-blocked"
 color = "d73a4a"
-description = "Muyan Pilot stopped and needs human attention"
+description = "Orbi stopped and needs human attention"
 
 [[label]]
 name = "p0"
 color = "fbca04"
-description = "Muyan Pilot urgent priority: picked up before bugs and features"
+description = "Orbi urgent priority: picked up before bugs and features"
 
 [[label]]
 name = "ai-epic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,8 @@
-# Standard Python packaging for the Muyan Pilot CLI (Issue #140).
+# Standard Python packaging for the Orbi CLI (Issue #140).
+#
+# v0.3.0 rebrand (Issue #183): the product brand is Orbi (GitHub
+# orbi-build/orbi, docs.orbi.build), but the distribution name and the
+# `muyan-pilot` console script stay unchanged for existing users.
 #
 # The official usage is the installed console script, installed as an
 # EDITABLE uv tool (Issue #152): the tool env imports the modules
@@ -25,7 +29,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "muyan-pilot"
 version = "0.2.0"
-description = "Local AI development worker: claims GitHub Issues, runs Pi in isolated worktrees, and delivers PRs (GitHub Issues + labels are the only state store)."
+description = "Orbi (CLI: muyan-pilot) — local AI development worker: claims GitHub Issues, runs Pi in isolated worktrees, and delivers PRs (GitHub Issues + labels are the only state store)."
 readme = "README.md"
 requires-python = ">=3.14"
 license = { text = "Apache-2.0" }

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -140,9 +140,9 @@ def test_chinese_homepage_carries_a_real_frontmatter_title():
     assert title.lower() != "zh", (
         f"the title must not be the internal language code, got: {title!r}"
     )
-    assert "Muyan Pilot" in title, (
-        "the Chinese home title must name the project, "
-        f"got: {title!r}"
+    assert "Orbi" in title, (
+        "the Chinese home title must name the project (Orbi, the "
+        f"v0.3.0 rebrand name), got: {title!r}"
     )
 
 
@@ -478,11 +478,27 @@ def test_chinese_docs_only_reference_existing_labels_everywhere():
 def test_readme_points_at_the_chinese_docs_entry():
     """The README keeps the project home and the documentation site
     entry; since Issue #116 it must also point at the Chinese docs
-    (docs/zh/) so Chinese users find the entry from GitHub too."""
+    (docs/zh/) so Chinese users find the entry from GitHub too.
+    Issue #183: the site entry is the bound custom domain
+    docs.orbi.build."""
     text = README.read_text(encoding="utf-8")
     assert "docs/zh/" in text, (
         "README must point at the Chinese docs entry (docs/zh/)"
     )
-    assert "muyan-pilot.mintlify.site" in text, (
-        "README must keep the Mintlify documentation site entry"
+    assert "docs.orbi.build" in text, (
+        "README must keep the documentation site entry (docs.orbi.build)"
+    )
+
+
+def test_chinese_getting_started_clones_the_orbi_build_org_repo():
+    """Issue #183: same clone-URL contract as the English page — the
+    repository moved to the orbi-build org, and the Chinese smoke
+    walkthrough must clone the new address (the old one only survives
+    as a GitHub redirect)."""
+    text = zh_page_text("getting-started")
+    assert "git clone https://github.com/orbi-build/orbi.git" in text, (
+        "Chinese getting-started must clone the orbi-build/orbi repository"
+    )
+    assert "xqliu/muyan-pilot" not in text, (
+        "Chinese getting-started keeps the stale xqliu/muyan-pilot reference"
     )

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -163,14 +163,18 @@ def language_page_entries(config: dict) -> list[tuple[str, list[str]]]:
     return entries
 
 
-def test_docs_config_is_a_mintlify_config_named_muyan_pilot():
+def test_docs_config_is_a_mintlify_config_named_orbi():
+    """Issue #183 (v0.3.0 rebrand): the docs site (docs.orbi.build) is
+    branded Orbi — the Mintlify config name is the site title shown in
+    the navigation and page headers."""
     config = load_docs_config()
     schema = str(config.get("$schema", ""))
     assert "mintlify" in schema.lower(), (
         f"docs.json must point at the Mintlify schema, got: {schema!r}"
     )
-    assert config.get("name") == "Muyan Pilot", (
-        f"docs.json name must be 'Muyan Pilot', got: {config.get('name')!r}"
+    assert config.get("name") == "Orbi", (
+        f"docs.json name must be 'Orbi' (v0.3.0 rebrand), "
+        f"got: {config.get('name')!r}"
     )
     # The official Mintlify schema (mintlify.com/docs.json) and settings
     # reference mark `theme` as required: a config without it does not
@@ -623,14 +627,43 @@ def test_docs_kv_cache_page_matches_the_upstream_port_contract():
 
 
 def test_readme_keeps_the_docs_site_entry():
-    """The root README stays the GitHub homepage and must carry the
-    documentation site entry (Mintlify default subdomain for this repo,
-    with the custom-domain caveat)."""
+    """Issue #183 (v0.3.0 rebrand): the root README stays the GitHub
+    homepage and must carry the documentation site entry — the bound
+    custom domain docs.orbi.build (Mintlify builds it from the in-repo
+    docs/ directory)."""
     text = README.read_text(encoding="utf-8")
-    assert "muyan-pilot.mintlify.site" in text, (
-        "README must link the Mintlify documentation site"
+    assert "docs.orbi.build" in text, (
+        "README must link the documentation site (docs.orbi.build)"
     )
     assert "docs/" in text, "README must point at the in-repo docs/ source"
+
+
+def test_readme_titles_the_project_orbi():
+    """Issue #183: the README (the GitHub homepage) no longer carries
+    Muyan Pilot as the primary brand — the title is Orbi."""
+    text = README.read_text(encoding="utf-8")
+    first_line = text.splitlines()[0]
+    assert first_line.strip() == "# Orbi", (
+        f"the README title must be '# Orbi' (v0.3.0 rebrand), "
+        f"got: {first_line!r}"
+    )
+
+
+def test_docs_getting_started_clones_the_orbi_build_org_repo():
+    """Issue #183: the repository moved to the orbi-build org — the
+    smoke walkthrough clone URL must be the new address, and no doc
+    page may keep the stale xqliu/muyan-pilot clone URL (the old
+    addresses still redirect on GitHub, but the docs must teach the
+    current one)."""
+    text = page_text("getting-started")
+    assert "git clone https://github.com/orbi-build/orbi.git" in text, (
+        "getting-started must clone the orbi-build/orbi repository"
+    )
+    for path in docs_files():
+        content = path.read_text(encoding="utf-8")
+        assert "xqliu/muyan-pilot" not in content, (
+            f"{path.name} keeps the stale xqliu/muyan-pilot reference"
+        )
 
 
 def test_docs_only_reference_existing_labels_everywhere():


### PR DESCRIPTION
<!-- muyan-pilot:run=17baeb4f -->

Fixes #183

v0.3.0：Orbi 品牌 rebrand、GitHub org 与官网/文档入口统一 (run_id=17baeb4f)
