### PR TITLE
文档整治：统一事实源、删除重复内容并压缩 README/AGENTS/站点文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,12 @@
 # AGENTS.md
 
 Development contract for this repository. Every local Pi bootstrap run must
-follow it before changing code.
+follow it before changing code. This file carries only the contract the
+implementer, reviewer and Runner must obey — the full operational
+explanation of each mechanism (timer, unit drift, transport check,
+observability fields, label lifecycle, claim scans) lives in the docs site
+(`docs/`, <https://docs.orbi.build>); this file points at the owning page
+instead of restating it.
 
 Four audiences, one file:
 
@@ -95,7 +100,7 @@ acceptance criteria.
 - Command errors fail fast: log the command, return code, stdout and stderr,
   then raise. Never swallow an error or add a fallback path.
 
-## Automatic observability
+## Automatic observability (contract)
 
 - Normal operation publishes progress automatically: no human status
   command, no polling, no supervision. `muyan-pilot status` is a debug
@@ -108,46 +113,33 @@ acceptance criteria.
   for 5 minutes logs an idle warning; the first new activity after it logs
   a resumed event. A stalled (non-`model_wait`) session is recovered
   automatically, not only warned (Issue #94, evidence-based since Issue
-  #169): one step per idle window of `PI_IDLE_WARN_SECONDS` since the
-  stall was first seen — window 1 checks the Pi descendants that already
-  existed before the window (the hung tools: ppid chain + start time from
-  `/proc/<pid>/stat`, never a name guess; only Pi descendants, never
-  other system processes, never a process spawned after the window began,
-  never a zombie that has already exited). If one of them is a coreutils
-  `timeout <seconds> ...` command still inside its deadline (start time +
-  duration, computed in the monotonic clock domain so NTP realtime steps
-  cannot skew it), it is a legitimate long-running command, not a hang:
-  the Runner logs one `pi_idle_wait` line (run id, pid, cmdline,
-  deadline), reports `recovery=wait` in the progress comment, and pauses
-  the escalation — every later window re-evaluates. The nominal deadline
-  is BEST-EFFORT (Issue #181): the wrapper's own deadline handling
-  (alarm → signal delivery → exit) is best-effort and can be delayed by
-  scheduling, so a single "past deadline and still alive" observation is
-  not evidence the wrapper failed. The grace is measured in idle windows,
-  not polls: a target first observed past its deadline in cycle N is
-  recorded (the grace window — nothing is signaled, `recovery=wait` stays
-  visible) and signaled only if it is STILL alive in a LATER window (one
-  full idle window of grace, cycle > N) — that is when the wrapper failed
-  to end the command and the evidence flips and the escalation proceeds.
-  Otherwise
-  window 1 SIGTERMs the descendants, so the tool gets a non-zero exit and
-  the failure signal reaches the model; window 2 SIGKILLs a target that
-  survived; after `PI_IDLE_RECOVERY_CYCLES` (default 3) consecutive idle
-  windows the Runner kills the Pi session itself and fails fast through
-  the normal failure path (the slot is never held forever). Every step
-  logs a `pi_idle_wait` / `pi_idle_term` / `pi_idle_kill` line (run id,
-  pid, cmdline, deadline/TERM/KILL, result) and the progress comment shows
-  the recovery state via its `recovery` field (`wait` / `term` / `kill`);
-  the first new activity resets the whole recovery state. A session frozen
-  in `model_wait` (the newest event is a tool result) past the
-  configured `model_wait_dead_seconds` (default
+  #169): one step per idle window of `PI_IDLE_WARN_SECONDS` since the stall
+  was first seen. Window 1 inspects the Pi descendants that already existed
+  before the window (the hung tools: ppid chain + start time from
+  `/proc/<pid>/stat`, never a name guess; only Pi descendants, never other
+  system processes, never a process spawned after the window began, never a
+  zombie) and SIGTERMs them, so the tool gets a non-zero exit and the
+  failure signal reaches the model. A coreutils `timeout <seconds> ...`
+  wrapper still inside its deadline is a legitimate long-running command,
+  not a hang (the deadline is best-effort, Issue #181: one full idle window
+  of grace before escalation — every later window re-evaluates): the Runner
+  logs a `pi_idle_wait` line and reports `recovery=wait` in the progress
+  comment. Window 2 SIGKILLs a target that survived; after
+  `PI_IDLE_RECOVERY_CYCLES` (default 3) consecutive idle windows the Runner
+  kills the Pi session itself and fails fast through the normal failure path
+  (the slot is never held forever). Every step logs a structured
+  `pi_idle_wait` / `pi_idle_term` / `pi_idle_kill` line (run id, pid,
+  cmdline, deadline/TERM/KILL, result) and the progress comment shows the
+  recovery state via its `recovery` field (`wait` / `term` / `kill`); the
+  first new activity resets the whole recovery state.
+- A session frozen in `model_wait` (the newest event is a tool result) past
+  the configured `model_wait_dead_seconds` (default
   `PI_MODEL_WAIT_DEAD_SECONDS` = 1800 s, Issue #228: the TOML field
-  overrides the default — the threshold measures silence between
-  COMPLETE session events, never token-level model progress, so a slow
-  local model survives a 10-minute complete message under the default;
-  the pre-#228 default of 600 s killed them at exactly 10 minutes)
-  is a HUNG model request (Issue #75, safe recovery since Issue #218):
-  the model service process
+  overrides the default — the threshold measures silence between COMPLETE
+  session events, never token-level model progress, so a slow local model
+  survives a 10-minute complete message under the default; the pre-#228
+  default of 600 s killed them at exactly 10 minutes) is a HUNG model request
+  (Issue #75, safe recovery since Issue #218): the model service process
   being alive and the Pi connection to it still ESTABLISHED (a
   `socket:[...]` inode of the Pi process in `/proc/net/tcp` or
   `/proc/net/tcp6` in state ESTABLISHED, SYN_SENT or SYN_RECV with a
@@ -157,35 +149,38 @@ acceptance criteria.
   `model_wait_dead issue=... role=... idle_seconds=... threshold=...
   action=kill_pi session=... run_id=... upstream_alive=true|false
   reason=hung_model_request` line (`upstream_alive` is evidence for the
-  journal, never a veto), kills the Pi session, and fails fast through
-  the normal failure path with
-  `run_failed ... reason=model_wait_dead_stale_...` (the Issue is marked
-  `ai-blocked` in the implement phase and `ai-fix-needed` in the review
-  phase, with the scene in the Issue comment; the slot is released by the
-  kernel when the process exits, and the next tick resumes the same
-  run/branch/worktree/PR or claims the next `ai-fix-needed`). It never
-  fires while events keep arriving (a slow generation is not a hung
-  request) and it is NOT a business task timeout.
+  journal, never a veto), kills the Pi session, and fails fast through the
+  normal failure path with `run_failed ... reason=model_wait_dead_stale_...`
+  (the Issue is marked `ai-blocked` in the implement phase and
+  `ai-fix-needed` in the review phase, with the scene in the Issue comment;
+  the slot is released by the kernel when the process exits, and the next
+  tick resumes the same run/branch/worktree/PR or claims the next
+  `ai-fix-needed`). It never fires while events keep arriving (a slow
+  generation is not a hung request) and it is NOT a business task timeout.
 - GitHub: exactly one progress comment per run, carrying a hidden run
   marker. It is PATCHed in place (at most every 30 seconds or on progress
   change) and never replaced by new heartbeat comments. Milestones (started,
-  plan ready, tests passed/failed, review findings, PR opened,
-  merged, blocked) are short standalone comments so GitHub Mobile pushes a
+  plan ready, tests passed/failed, review findings, PR opened, merged,
+  blocked) are short standalone comments so GitHub Mobile pushes a
   notification. After a process restart the same comment is found by the
   run marker and kept — no database. On success the comment becomes the
-  final delivery summary (PR, tests, review evidence); on failure it becomes
-  the blocked scene with the next-step reason.
+  final delivery summary (PR, tests, review evidence); on failure it
+  becomes the blocked scene with the next-step reason.
 - The GitHub progress comment is a pure bypass (Issue #79): every
   `ProgressPublisher` step (ensure / live patch / milestone / finish, in
-  the implement and review roles alike) fails as
-  `progress_publish_failed` and never fails the delivery, never marks the
-  Issue `ai-blocked`, and never skips `run_pi` / `wait_for_delivery` —
-  the journal is the record, the comment is observability (Issue #60
-  first applied this to the post-PR record). The `Muyan Pilot opened PR:`
-  scene comment is NOT a bypass: the next tick's resume parses it
-  (Issue #45/#89), so a failure there fails the delivery fail-fast.
+  the implement and review roles alike) fails as `progress_publish_failed`
+  and never fails the delivery, never marks the Issue `ai-blocked`, and
+  never skips `run_pi` / `wait_for_delivery` — the journal is the record,
+  the comment is observability (Issue #60 first applied this to the
+  post-PR record). The `Muyan Pilot opened PR:` scene comment is NOT a
+  bypass: the next tick's resume parses it (Issue #45/#89), so a failure
+  there fails the delivery fail-fast.
+- The full journal field reference (every line type, the idle-recovery
+  sequence, the stop sequence) is documented in
+  `docs/operations.mdx` (EN) / `docs/zh/operations.mdx` (ZH) — that page
+  is the source of truth for the fields; this section is the contract.
 
-## Base freshness
+## Base freshness and deployment (contract)
 
 - Every task worktree is created from the frozen `origin/<base_branch>` SHA
   (default `main`), never from the main worktree's current HEAD.
@@ -207,403 +202,377 @@ acceptance criteria.
   lock, fetches, and releases it), and the implement/review prompts
   instruct Pi to run the base-freshness fetch as
   `flock <BASE_SYNC_LOCK> git fetch origin <base_branch>` (the lock path is
-  rendered into both prompts from the configured `repo_dir`). Two concurrent
-  Runners (or a Runner and a Pi session) therefore never race the shared
-  ref — no `cannot lock ref ... is at <X> but expected <Y>` failures — and
-  a lock or fetch error fails fast with the concrete error, never a retry
-  or a fallback fetch.
-- The runner rejects a delivery whose HEAD does not contain the latest remote
-  base. No auto conflict resolution, no force push, no merge or push of the
-  protected branch.
-- A delivery is acceptable only when its HEAD contains the latest remote base;
-  base updates use a plain `git merge` on the task branch.
-- The Runner's own code updates at the next service start (Issue #52):
-  the service template `muyan-pilot@.service` (deployed as the two
-  instances `muyan-pilot@1.service` / `muyan-pilot@2.service`) runs
-  `ExecStartPre` = the `git fetch origin main && git merge --ff-only
-  origin/main` in the main checkout wrapped in a short-lived `flock` on
-  the shared state-dir lock file (`base-sync.lock`, the Python-side
-  sync takes the SAME lock) before `ExecStart`. A dirty checkout, a
-  failed fetch or a non-fast-forwardable state fails the preflight: the
-  service does not start and the reason lands in the systemd journal
-  (fail fast). A currently running long task is never hot-updated or
-  killed — while one service instance is active, systemd ignores
-  further starts of THAT instance, and the next real start runs the
-  latest code. Two instances may run concurrently; the capacity is the
-  Runner's flock slots (`max_concurrency`), never the instance count.
-  No refresh service, worker, dispatcher or resident process is added;
-  the 5-minute timers are unchanged.
+  rendered into both prompts from the configured `repo_dir`). Two
+  concurrent Runners (or a Runner and a Pi session) therefore never race
+  the shared ref — no `cannot lock ref ... is at <X> but expected <Y>`
+  failures — and a lock or fetch error fails fast with the concrete error,
+  never a retry or a fallback fetch.
+- The runner rejects a delivery whose HEAD does not contain the latest
+  remote base. No auto conflict resolution, no force push, no merge or push
+  of the protected branch. A delivery is acceptable only when its HEAD
+  contains the latest remote base; base updates use a plain `git merge` on
+  the task branch.
+- The Runner's own code updates at the next service start (Issue #52): the
+  service template `muyan-pilot@.service` (deployed as the two instances
+  `muyan-pilot@1.service` / `muyan-pilot@2.service`) runs `ExecStartPre` =
+  the `git fetch origin main && git merge --ff-only origin/main` in the main
+  checkout wrapped in a short-lived `flock` on the shared state-dir lock
+  file (`base-sync.lock`, the Python-side sync takes the SAME lock) before
+  `ExecStart`. A dirty checkout, a failed fetch or a non-fast-forwardable
+  state fails the preflight: the service does not start and the reason
+  lands in the systemd journal (fail fast). A currently running long task is
+  never hot-updated or killed — while one service instance is active,
+  systemd ignores further starts of THAT instance, and the next real start
+  runs the latest code. Two instances may run concurrently; the capacity is
+  the Runner's flock slots (`max_concurrency`), never the instance count.
+  No refresh service, worker, dispatcher or resident process is added; the
+  5-minute timers are unchanged.
 - Deployment consistency (Issue #103, #142): the repo templates
   `systemd/muyan-pilot@.service` and `systemd/muyan-pilot@.timer` are the
   single source of truth for the installed user units. The idempotent
-  install is `muyan-pilot install-units` (copy both templates into the
-  user unit dir, migrate the pre-#149 non-templated units away once —
+  install is `muyan-pilot install-units` (copy both templates into the user
+  unit dir, migrate the pre-#149 non-templated units away once —
   `systemctl --user disable --now muyan-pilot.timer` (a timer stop, never
   the service) plus removing the legacy files — `systemctl --user
-  daemon-reload`, enable the two timer instances, print the deployed
-  commit and unit hashes): it NEVER starts/stops/restarts the
-  service — a running Runner is never killed or restarted by an install,
-  the new config takes effect at the next service start. Every Runner start
-  checks BOTH installed units against the templates BEFORE any slot or
-  claim: drift is self-healed with the SAME idempotent install (the
-  pre-start sync, Issue #142) and re-verified with the SAME hash check —
-  clean logs one structured `unit_drift auto_synced` line per unit (before
-  and after sha256, deployed commit) and the start continues. Drift that
-  survives the sync — or a failing install step — logs a structured
-  `unit_drift` line per unit (repo path, installed path, sha256s, the
-  install fix command) and fails fast — no slot, no claim, no label
-  change. The read-only report is `muyan-pilot doctor` (repo commit,
-  unit drift, timer/service active, slots, Pi session, current Issue,
-  recent journal). Full sequence:
-  merge to main -> timer next trigger -> ExecStartPre syncs origin/main ->
-  drift check (auto-sync + re-verify when drifted) -> Runner starts one
-  Issue.
+  daemon-reload`, enable the two timer instances, print the deployed commit
+  and unit hashes): it NEVER starts/stops/restarts the service — a running
+  Runner is never killed or restarted by an install, the new config takes
+  effect at the next service start. Every Runner start checks BOTH installed
+  units against the templates BEFORE any slot or claim: drift is
+  self-healed with the SAME idempotent install (the pre-start sync,
+  Issue #142) and re-verified with the SAME hash check — clean logs one
+  structured `unit_drift auto_synced` line per unit (before and after
+  sha256, deployed commit) and the start continues. Drift that survives the
+  sync — or a failing install step — logs a structured `unit_drift` line per
+  unit (repo path, installed path, sha256s, the install fix command) and
+  fails fast — no slot, no claim, no label change. The read-only report is
+  `muyan-pilot doctor` (repo commit, unit drift, timer/service active,
+  slots, Pi session, current Issue, recent journal). Full sequence: merge
+  to main -> timer next trigger -> ExecStartPre syncs origin/main -> drift
+  check (auto-sync + re-verify when drifted) -> Runner starts one Issue.
+- A template change is a deployment change (Issue #131, #142): a PR that
+  modifies `systemd/muyan-pilot@.service` or `systemd/muyan-pilot@.timer`
+  takes effect without a human step — the NEXT timer trigger's
+  `ExecStartPre` syncs the checkout, and the pre-start drift check
+  self-heals the installed units with the same idempotent install (copy,
+  legacy migration, daemon-reload, enable the two timer instances — never
+  touches a running Runner) before the tick continues. `muyan-pilot
+  install-units` stays the manual entry (setup, immediate sync); a drift the
+  self-heal cannot resolve is still caught by the pre-start check
+  (structured `unit_drift`, fail fast, no slot, no claim) — the gate stays
+  the canary for the deployment, not a bug to be bypassed.
 - The service `ExecStart` is the installed `muyan-pilot` CLI (Issue #140,
   #152): the official usage is the EDITABLE `uv tool`-installed console
   script (`uv tool install --force --reinstall --editable --python
   /usr/bin/python3 <deployment checkout>` — the tool env imports
-  `muyan_pilot` from the deployment checkout, so the ExecStartPre
-  checkout sync is picked up by the next CLI process automatically and
-  ordinary source/template changes need NO reinstall or upgrade), and
-  the unit uses the explicit deployable entry
-  `%h/.local/bin/muyan-pilot` (verifiable with
-  `systemd-analyze --user verify`); the direct-execution entry of
-  `muyan_pilot.py` stays a development/compatibility path, never the
-  documented usage. A non-editable (site-packages) or stale CLI source
-  is reported by `muyan-pilot doctor` as `cli_source: DRIFT` with the
-  structured `cli_source_drift` line (actual import path, expected
+  `muyan_pilot` from the deployment checkout, so the ExecStartPre checkout
+  sync is picked up by the next CLI process automatically and ordinary
+  source/template changes need NO reinstall or upgrade), and the unit uses
+  the explicit deployable entry `%h/.local/bin/muyan-pilot` (verifiable with
+  `systemd-analyze --user verify`). A non-editable (site-packages) or stale
+  CLI source is reported by `muyan-pilot doctor` as `cli_source: DRIFT`
+  with the structured `cli_source_drift` line (actual import path, expected
   repo_dir, the exact editable reinstall command) and repaired by
   `muyan-pilot setup` (the CLI step verifies or force-reinstalls the
-  editable install).
-- The Runner refreshes the editable install at start (Issue #158):
-  the editable finder's module MAPPING is generated at INSTALL time
-  from the checkout's `pyproject.toml` (`py-modules`, entry points,
-  version, dependencies), so a merged PACKAGING change (e.g. a new
-  runtime module in `py-modules`) leaves a stale finder and the next
-  CLI process dies with `ModuleNotFoundError` before the Runner can
-  start (the #158 incident: `cli_source` merged to main, the installed
-  finder still mapped the pre-#152 module set, the systemd start
-  failed). The Runner tick entry (BEFORE any slot or claim; the CLI
-  subcommands never install) compares the packaging fingerprint (the
-  sha256 of the checkout's `pyproject.toml`) with the last successful
-  install's fingerprint, stored in the shared state dir
-  (`<repo_dir>/.muyan-pilot/cli-install.json` — the same gitignored
-  dir as `base-sync.lock` and the slots; it is NOT a second release
-  state): unchanged -> NO uv call at all (no per-tick unconditional
-  reinstall); changed or no state yet (first install) -> ONE
-  lock-protected `uv tool install --force --reinstall --editable
-  --python /usr/bin/python3 <repo_dir>` (the SAME base-sync flock the
-  service template's `ExecStartPre` uses — two instances starting in
-  the same tick serialize, the second re-reads the state under the
-  lock and reuses the first's result, never a concurrent uv install),
-  the fingerprint is recorded only after a successful install, and a
-  failing install fails the start fast with the structured
-  `cli_install_failed` line (reason + the exact fix command): no
+  editable install). The direct-execution entry of `muyan_pilot.py` stays a
+  development/compatibility path, never the documented usage.
+- The Runner refreshes the editable install at start (Issue #158): the
+  editable finder's module MAPPING is generated at INSTALL time from the
+  checkout's `pyproject.toml`, so a merged PACKAGING change leaves a stale
+  finder and the next CLI process dies with `ModuleNotFoundError` before the
+  Runner can start. The Runner tick entry (BEFORE any slot or claim; the CLI
+  subcommands never install) compares the packaging fingerprint (the sha256
+  of the checkout's `pyproject.toml`) with the last successful install's
+  fingerprint in the shared state dir (`<repo_dir>/.muyan-pilot/cli-install.json`):
+  unchanged -> NO uv call at all; changed or no state yet (first install) ->
+  ONE lock-protected `uv tool install --force --reinstall --editable --python
+  /usr/bin/python3 <repo_dir>` (the SAME base-sync flock the service
+  template's `ExecStartPre` uses); the fingerprint is recorded only after a
+  successful install, and a failing install fails the start fast with the
+  structured `cli_install_failed` line (reason + the exact fix command): no
   slot, no claim, no label change, no state recorded (the next start
-  retries). Ordinary Python source content is NOT part of the
-  fingerprint (the editable finder maps the live files — a content
-  change needs no reinstall), and systemd template changes stay with
-  the unit drift mechanism above. The refresh IMPLEMENTATION lives in
-  `bootstrap_runner` itself, NOT in a separate new module: the
-  bootstrap chain (`muyan_pilot` -> `bootstrap_runner`) must still
-  LOAD and REFRESH in a tool env whose installed finder predates this
-  PR's packaging change (the #158 scene) — a new module for the
-  refresh would not be importable there, and the very refresh that
-  reinstalls the tool env could never run (the #158 incident, one
-  module later). `cli_install` is a thin re-export of the
-  implementation for the tests' single import point; the bootstrap
-  chain never imports it (a regression test pins this: a fresh
-  `bootstrap_runner` loads with `cli_install` blocked from the import
-  system and its `refresh_cli_install` gate still runs).
-- A template change is a deployment change (Issue #131, #142): a PR
-  that modifies `systemd/muyan-pilot@.service` or `systemd/muyan-pilot@.timer`
-  takes effect without a human step — the NEXT timer trigger's
-  `ExecStartPre` syncs the checkout, and the pre-start drift check
-  self-heals the installed units with the same idempotent install
-  (copy, legacy migration, daemon-reload, enable the two timer
-  instances — never touches a running Runner) before the tick continues. No per-tick drift loop until human
-  intervention (the #131/#140 scene). `muyan-pilot install-units` stays
-  the manual entry (setup, immediate sync); a drift the self-heal cannot
-  resolve is still caught by the pre-start check (structured
-  `unit_drift`, fail fast, no slot, no claim) — the gate stays the
-  canary for the deployment, not a bug to be bypassed.
+  retries). Ordinary Python source content is NOT part of the fingerprint
+  (the editable finder maps the live files — a content change needs no
+  reinstall). The refresh implementation lives in `bootstrap_runner`
+  itself, NOT in a separate new module: the bootstrap chain
+  (`muyan_pilot` -> `bootstrap_runner`) must still LOAD and REFRESH in a tool
+  env whose installed finder predates the packaging change — a new module
+  for the refresh would not be importable there. `cli_install` is a thin
+  re-export of the implementation for the tests' single import point; the
+  bootstrap chain never imports it (a regression test pins this).
+- The full operational explanation (timer instances, the pre-start
+  preflight sequence, the unit-drift self-heal, the slots) is documented in
+  `docs/operations.mdx` (EN) / `docs/zh/operations.mdx` (ZH) — that page is
+  the source of truth for the mechanics; this section is the contract.
 
 ## Git transport (Issue #114)
 
-- Two authentication channels with distinct responsibilities: **Git
-  data operations** (fetch, push — including pushing
-  `.github/workflows/*.yml`) go over **SSH**
-  (`git@github.com:owner/repo.git`, the machine's SSH key); **GitHub
-  API operations** (Issue, PR, label, comment, merge) stay on the
-  existing `gh` token. SSH is never used as API authentication and the
-  `gh` token is never used for git data. A workflow push must never
-  depend on the OAuth App `workflow` scope (the HTTPS/OAuth transport
-  that blocked Issue #106).
-- The deployment checkout's single `origin` remote is the transport:
-  a task worktree created with `git worktree add` shares the main
-  repository's remote configuration (verified against real git), so
-  the transport is configured once on the checkout and every worktree
-  inherits it. New bootstrap worktrees therefore have an SSH
-  `git remote -v` by construction.
+- Two authentication channels with distinct responsibilities: **Git data
+  operations** (fetch, push — including pushing `.github/workflows/*.yml`)
+  go over **SSH** (`git@github.com:owner/repo.git`, the machine's SSH key);
+  **GitHub API operations** (Issue, PR, label, comment, merge) stay on the
+  existing `gh` token. SSH is never used as API authentication and the `gh`
+  token is never used for git data. A workflow push must never depend on the
+  OAuth App `workflow` scope (the HTTPS/OAuth transport that blocked Issue
+  #106).
+- The deployment checkout's single `origin` remote is the transport: a task
+  worktree created with `git worktree add` shares the main repository's
+  remote configuration (verified against real git), so the transport is
+  configured once on the checkout and every worktree inherits it. New
+  bootstrap worktrees therefore have an SSH `git remote -v` by construction.
 - Pre-start check: BEFORE any slot or claim (right after the unit-drift
-  preflight) the Runner verifies the checkout's transport — the
-  CONFIGURED `origin` URL (`git config remote.origin.url`, never the
-  insteadOf-rewritten data-plane URL) is SSH for the first configured
-  source repo, and `git ls-remote <ssh-url>` exits 0 (SSH reachable and
+  preflight) the Runner verifies the checkout's transport — the CONFIGURED
+  `origin` URL (`git config remote.origin.url`, never the
+  insteadOf-rewritten data-plane URL) is SSH for the first configured source
+  repo, and `git ls-remote <ssh-url>` exits 0 (SSH reachable and
   authenticated — verified against the real CLI). A failure logs the
   structured `transport_check_failed ... reason=...` line and fails the
   start: no slot, no claim, no label change, **no HTTPS fallback, no
   silent skip**.
-- An existing HTTPS remote is never rewritten silently and never read
-  from a comment or Issue body: only the human-run setup entry
-  (`muyan-pilot setup`) migrates it with the plain
-  `git remote set-url origin git@github.com:owner/repo.git`; every
-  other path fails fast with the exact migration command. A remote
-  that does not point at the first configured source repo is never
-  migrated (the rewrite would re-target the checkout at a different
-  repository) — it fails with the mismatch scene whether or not the
-  setup entry authorizes the migration. `muyan-pilot doctor` reports
-  the transport read-only (protocol, expected URL, SSH probe) — a
-  failed transport is REPORTED there, not raised (the pre-start check
-  is the fail-fast gate).
+- An existing HTTPS remote is never rewritten silently and never read from a
+  comment or Issue body: only the human-run setup entry (`muyan-pilot
+  setup`) migrates it with the plain `git remote set-url origin
+  git@github.com:owner/repo.git`; every other path fails fast with the exact
+  migration command. A remote that does not point at the first configured
+  source repo is never migrated (the rewrite would re-target the checkout at
+  a different repository) — it fails with the mismatch scene whether or not
+  the setup entry authorizes the migration. `muyan-pilot doctor` reports the
+  transport read-only (protocol, expected URL, SSH probe) — a failed
+  transport is REPORTED there, not raised (the pre-start check is the
+  fail-fast gate). The full explanation is documented in
+  `docs/operations.mdx` and `docs/setup.mdx` (EN/ZH).
 
 ## Task dependencies (blockedBy)
 
-- Task dependencies use GitHub's native `blockedBy` relation
-  (`gh issue edit N --add-blocked-by M`); never write `Depends on #N`
-  in the Issue body — the body is not part of `blockedBy` and the
-  runner does not parse body dependencies.
-- Before claiming an `ai-ready` Issue the runner reads `blockedBy`
-  (`gh issue list --json blockedBy`). Open blockers (blocker nodes with
-  `state: "OPEN"`) mean the Issue is not claimed: no `ai-in-progress`,
-  no label change, no worktree; a structured
-  `blocked_by issue=N repo=... blockers=M1,M2` log line is written and
-  the next ready Issue of the same repo is considered. A closed blocker
-  no longer blocks: GitHub keeps the relation listed with
-  `state: "CLOSED"` (inert, verified against the live API) and the
-  runner counts only open blockers — the next tick claims the Issue
-  with no bookkeeping.
+- Task dependencies use GitHub's native `blockedBy` relation (`gh issue edit
+  N --add-blocked-by M`); never write `Depends on #N` in the Issue body —
+  the body is not part of `blockedBy` and the runner does not parse body
+  dependencies.
+- Before claiming an `ai-ready` Issue the runner reads `blockedBy` (`gh
+  issue list --json blockedBy`). Open blockers (blocker nodes with
+  `state: "OPEN"`) mean the Issue is not claimed: no `ai-in-progress`, no
+  label change, no worktree; a structured `blocked_by issue=N repo=...
+  blockers=M1,M2` log line is written and the next ready Issue of the same
+  repo is considered. A closed blocker no longer blocks: GitHub keeps the
+  relation listed with `state: "CLOSED"` (inert, verified against the live
+  API) and the runner counts only open blockers — the next tick claims the
+  Issue with no bookkeeping.
 - A failed `blockedBy` query fails open (treated as unblocked: the tick
-  claims nothing from that repo, logs `blocked_by_check_failed`, and
-  the next tick retries) — an API error must never deadlock the queue.
-- No DAG, topological sort, or multi-worker scheduling: single-slot
-  serial execution only reads the field, skips, and waits.
+  claims nothing from that repo, logs `blocked_by_check_failed`, and the
+  next tick retries) — an API error must never deadlock the queue.
+- No DAG, topological sort, or multi-worker scheduling: single-slot serial
+  execution only reads the field, skips, and waits. The user-facing
+  explanation is documented in `docs/workflow.mdx` (EN/ZH).
 
 ## Pickup priority (P0)
 
-- Emergency priority is the plain GitHub label `p0` — NOT a delivery
-  state: it only orders the ready pickup, never changes the Issue
-  granularity (one Issue = one runtime outcome), any delivery state, or
-  the terminal-state semantics. The Runner never adds or removes it.
-- The ready pickup order is fixed: `ai-ready`+`p0` → `ai-ready`+`bug`
-  → plain `ai-ready` (three `gh issue list` scans sharing the exact
-  same exclusions and blockedBy semantics). P0 obeys every existing
-  exclusion rule (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`,
-  `ai-merged`, `ai-blocked`) and the single-slot constraint: a blocked
-  P0 is skipped (falling back to the bug/plain scans) and an in-flight
-  P0 is resumed by the restart scan (which fetches `labels` too, so the
-  progress comment keeps showing `p0`).
+- Emergency priority is the plain GitHub label `p0` — NOT a delivery state:
+  it only orders the ready pickup, never changes the Issue granularity (one
+  Issue = one runtime outcome), any delivery state, or the terminal-state
+  semantics. The Runner never adds or removes it.
+- The ready pickup order is fixed: `ai-ready`+`p0` → `ai-ready`+`bug` →
+  plain `ai-ready` (three `gh issue list` scans sharing the exact same
+  exclusions and blockedBy semantics). P0 obeys every existing exclusion
+  rule (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`, `ai-merged`,
+  `ai-blocked`) and the single-slot constraint: a blocked P0 is skipped
+  (falling back to the bug/plain scans) and an in-flight P0 is resumed by
+  the restart scan (which fetches `labels` too, so the progress comment
+  keeps showing `p0`).
 - Active Milestone claim scope (Issue #139): the optional config field
   `active_milestone` (a Milestone TITLE, e.g. `v0.2.0`) restricts the
-  FRESH-claim scans to one version: with it set, all three ready scans
-  carry the `milestone:"<title>"` qualifier in the gh search query
-  (the quoted form — milestone titles may contain spaces or special
-  characters), so an Issue of another Milestone or of no Milestone
-  never enters the queue, and a Milestone Issue without `ai-ready`
-  never does either. The Milestone is a version scope, NOT a
-  replacement for the `ai-ready` execution switch. P0 does NOT cross
-  milestones (the active Milestone is the claim scope of every fresh
-  claim; `p0` only orders the pickup inside it). The scope is
-  query-layer only (the `is_epic` code-layer skip and the blockedBy
-  skip are the unchanged second layer), a failed scan still fails open
-  (never a silent claim of the wrong version), and resume states are
-  never gated by it: the opened-PR resume and the in-flight restart
-  scans run work to completion regardless of Milestone changes. The
-  value is explicit — never guessed from the repo's Milestone list;
-  absent it keeps the pre-#139 behavior exactly (compat), and an
-  empty/non-string value fails the start fast.
-- The pickup log line carries the explicit `priority=p0` /
-  `priority=normal` field; the GitHub progress comment shows the
-  `priority` field; the run scene (`run_info`) and the started
-  milestone carry `priority=...`.
-- A failed P0 run enters `ai-blocked` ALONE (the claim label is
-  removed; the `ai-ready` residue is excluded by every ready scan) —
-  no tick re-claims it, so there is no infinite retry; the failure
-  comment and blocked scene keep the concrete reason and the
-  recoverable scene.
+  FRESH-claim scans to one version: with it set, all three ready scans carry
+  the `milestone:"<title>"` qualifier in the gh search query (the quoted
+  form — milestone titles may contain spaces or special characters), so an
+  Issue of another Milestone or of no Milestone never enters the queue, and
+  a Milestone Issue without `ai-ready` never does either. The Milestone is a
+  version scope, NOT a replacement for the `ai-ready` execution switch. P0
+  does NOT cross milestones (the active Milestone is the claim scope of
+  every fresh claim; `p0` only orders the pickup inside it). The scope is
+  query-layer only (the `is_epic` code-layer skip and the blockedBy skip are
+  the unchanged second layer), a failed scan still fails open (never a
+  silent claim of the wrong version), and resume states are never gated by
+  it: the opened-PR resume and the in-flight restart scans run work to
+  completion regardless of Milestone changes. The value is explicit — never
+  guessed from the repo's Milestone list; absent it keeps the pre-#139
+  behavior exactly (compat), and an empty/non-string value fails the start
+  fast.
+- The pickup log line carries the explicit `priority=p0` / `priority=normal`
+  field; the GitHub progress comment shows the `priority` field; the run
+  scene (`run_info`) and the started milestone carry `priority=...`.
+- A failed P0 run enters `ai-blocked` ALONE (the claim label is removed; the
+  `ai-ready` residue is excluded by every ready scan) — no tick re-claims
+  it, so there is no infinite retry; the failure comment and blocked scene
+  keep the concrete reason and the recoverable scene.
 - review/merge failures of a P0 PR follow the existing same-PR, bounded
-  review-round mechanism (no new loop).
+  review-round mechanism (no new loop). The user-facing explanation is
+  documented in `docs/workflow.mdx` (EN/ZH).
 
 ## Epic Issues (ai-epic)
 
 - An Epic is a coordination Issue that groups related tasks (a release
-  checklist, a multi-task grouping). It carries the plain `ai-epic`
-  label and is NOT an executable task: the actual work is split into
-  independent `ai-ready` sub-Issues, each with one runtime outcome, one
-  PR, one independent review and one merge. Preconditions between
-  sub-Issues use the native `blockedBy` relation (see Task
-  dependencies) — the Runner never parses body checkboxes or
-  `Depends on` lines to infer dependencies.
+  checklist, a multi-task grouping). It carries the plain `ai-epic` label
+  and is NOT an executable task: the actual work is split into independent
+  `ai-ready` sub-Issues, each with one runtime outcome, one PR, one
+  independent review and one merge. Preconditions between sub-Issues use the
+  native `blockedBy` relation (see Task dependencies) — the Runner never
+  parses body checkboxes or `Depends on` lines to infer dependencies.
 - The ready claim scan NEVER claims an `ai-epic` Issue (Issue #93): no
   `ai-in-progress`, no label change, no worktree, no run, no slot — a
-  structured `epic_not_claimed issue=N repo=...` line is written and
-  the next ready Issue is considered. The Epic check precedes the
-  blockedBy check: "it is an Epic" is the recorded cause, never a
-  `blocked_by` line. The restart-resume scan excludes `ai-epic` too:
-  a legacy Epic left behind with `ai-in-progress` (the #80 scene,
-  before the Epic mechanism existed) is never resumed into a run.
-- The Epic's completion is judged from GitHub evidence — sub-Issues
-  done, their PRs merged, the release tag/artifacts on the remote, no
-  leftover `ai-in-progress` — and the Epic is closed by a human or a
-  release task (an `ai-ready`+`ai-release` Issue, see Release tasks
-  below). The Runner never marks an Epic complete or closes it: while
-  any completion condition is unmet the Epic stays open. No database,
-  queue or resident service tracks the Epic — GitHub Issues/labels,
-  native `blockedBy`, PRs and the remote tag are the only state.
+  structured `epic_not_claimed issue=N repo=...` line is written and the
+  next ready Issue is considered. The Epic check precedes the blockedBy
+  check: "it is an Epic" is the recorded cause, never a `blocked_by` line.
+  The restart-resume scan excludes `ai-epic` too: a legacy Epic left behind
+  with `ai-in-progress` (the #80 scene, before the Epic mechanism existed)
+  is never resumed into a run.
+- The Epic's completion is judged from GitHub evidence — sub-Issues done,
+  their PRs merged, the release tag/artifacts on the remote, no leftover
+  `ai-in-progress` — and the Epic is closed by a human or a release task
+  (an `ai-ready`+`ai-release` Issue, see Release tasks below). The Runner
+  never marks an Epic complete or closes it: while any completion condition
+  is unmet the Epic stays open. No database, queue or resident service
+  tracks the Epic — GitHub Issues/labels, native `blockedBy`, PRs and the
+  remote tag are the only state. The user-facing explanation is documented
+  in `docs/workflow.mdx` (EN/ZH).
 
 ## Release tasks (ai-release)
 
-- A Release task is an `ai-ready` Issue additionally marked with the
-  plain `ai-release` label (Issue #98). It is NOT a development task
-  and NEVER enters the `run_pi` path: the ready scan picks it up like
-  any task, but `process_issue` routes it to the Runner's deterministic
-  release state machine — no Pi session, no PR. The three task types
-  stay distinct: an Epic (`ai-epic`) is coordination only and never
-  claimed; a normal task (`ai-ready`) delivers through `run_pi` → PR
-  → review → merge; a Release task (`ai-ready`+`ai-release`) delivers
-  through the release state machine.
-- The state machine is idempotent and resumable (a restart resumes the
-  same run id/worktree, the same resume rule as normal tasks) and runs
-  these steps in order:
+- A Release task is an `ai-ready` Issue additionally marked with the plain
+  `ai-release` label (Issue #98). It is NOT a development task and NEVER
+  enters the `run_pi` path: the ready scan picks it up like any task, but
+  `process_issue` routes it to the Runner's deterministic release state
+  machine — no Pi session, no PR. The three task types stay distinct: an
+  Epic (`ai-epic`) is coordination only and never claimed; a normal task
+  (`ai-ready`) delivers through `run_pi` → PR → review → merge; a Release
+  task (`ai-ready`+`ai-release`) delivers through the release state machine.
+- The state machine is idempotent and resumable (a restart resumes the same
+  run id/worktree, the same resume rule as normal tasks) and runs these
+  steps in order:
   1. Strictly parse the `## Release` declaration from the Issue body:
-     `version`, `base_branch`, `test_command`, `scope` (a list of
-     `#N` items). Missing, duplicated or unknown fields fail fast.
-  2. Freeze the base — the release commit is exactly
-     `origin/<base_branch>` (fetched under the base-sync lock).
-  3. Enforce the pre-release gates: no leftover open
-     `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed` Issues (the
-     release Issue itself excluded), CI green on the release commit
-     (no check runs passes with explicit evidence), and no open PRs
-     targeting the base branch. A gate that cannot be checked because
-     of a real `gh` failure is a failed gate.
+     `version`, `base_branch`, `test_command`, `scope` (a list of `#N`
+     items). Missing, duplicated or unknown fields fail fast.
+  2. Freeze the base — the release commit is exactly `origin/<base_branch>`
+     (fetched under the base-sync lock).
+  3. Enforce the pre-release gates: no leftover open `ai-in-progress` /
+     `ai-pr-opened` / `ai-fix-needed` Issues (the release Issue itself
+     excluded), CI green on the release commit (no check runs passes with
+     explicit evidence), and no open PRs targeting the base branch. A gate
+     that cannot be checked because of a real `gh` failure is a failed gate.
   4. Verify the scope item by item: `gh pr view` must report `MERGED`,
-     otherwise `gh issue view` must report `CLOSED`. Checkbox parsing
-     is forbidden — every scope item is checked against the live API.
-  5. Run the declared `test_command` in a clean worktree at the
-     release commit (`timeout`-wrapped, Issue #95).
-  6. Tag: when the remote tag is absent, create an annotated tag at
-     the release commit and push it with a plain push (never
-     `--force`). When it exists it must point EXACTLY at the release
-     commit — a mismatch fails fast. An existing tag is never moved,
-     overwritten or force-pushed.
-  7. Publish the GitHub Release (idempotent) whose notes carry the
-     full verification evidence: version, tag, release commit,
-     per-item scope evidence, gate evidence, test evidence and the run
-     marker.
+     otherwise `gh issue view` must report `CLOSED`. Checkbox parsing is
+     forbidden — every scope item is checked against the live API.
+  5. Run the declared `test_command` in a clean worktree at the release
+     commit (`timeout`-wrapped, Issue #95).
+  6. Tag: when the remote tag is absent, create an annotated tag at the
+     release commit and push it with a plain push (never `--force`). When it
+     exists it must point EXACTLY at the release commit — a mismatch fails
+     fast. An existing tag is never moved, overwritten or force-pushed.
+  7. Publish the GitHub Release (idempotent) whose notes carry the full
+     verification evidence: version, tag, release commit, per-item scope
+     evidence, gate evidence, test evidence and the run marker.
   8. Close the Milestone whose title is EXACTLY the released version
-     (Issue #214) — on the success path, after the release Issue is
-     closed with `ai-merged`. Exact title match only (no guessing, no
-     fuzzy match, never a different Milestone): closed when it has 0
-     open Issues; already-closed is an idempotent success (no reopen);
-     a missing Milestone or remaining open Issues fail fast with the
-     version, the Milestone number/url and the open issue list (never a
-     silent skip).
-  9. Success: `ai-merged` (terminal) and the release Issue is closed,
-     with the success comment (release URL, tag, commit, evidence,
-     Milestone evidence). Any failure: `ai-blocked` ALONE (a release is
-     a human decision point — no automatic retry), the failure comment
-     carries the run marker and the concrete reason, and the exception
-     propagates so the tick fails fast.
-- The `ai-release` label is a type marker, NOT a delivery state: it is
-  not part of the delivery-state machine, not an exclusion of the
-  ready scan, and the Runner never adds or removes it — only the
-  human does (at dispatch time, together with `ai-ready`).
+     (Issue #214) — on the success path, after the release Issue is closed
+     with `ai-merged`. Exact title match only (no guessing, no fuzzy match,
+     never a different Milestone): closed when it has 0 open Issues;
+     already-closed is an idempotent success (no reopen); a missing
+     Milestone or remaining open Issues fail fast with the version, the
+     Milestone number/url and the open issue list (never a silent skip).
+  9. Success: `ai-merged` (terminal) and the release Issue is closed, with
+     the success comment (release URL, tag, commit, evidence, Milestone
+     evidence). Any failure: `ai-blocked` ALONE (a release is a human
+     decision point — no automatic retry), the failure comment carries the
+     run marker and the concrete reason, and the exception propagates so the
+     tick fails fast.
+- The `ai-release` label is a type marker, NOT a delivery state: it is not
+  part of the delivery-state machine, not an exclusion of the ready scan,
+  and the Runner never adds or removes it — only the human does (at dispatch
+  time, together with `ai-ready`). The user-facing explanation is documented
+  in `docs/workflow.mdx` (EN/ZH).
 
 ## Review, in-session fix and merge (same PR)
 
-- The review session is independent (a new Pi process, `prompt_review.md`,
-  a new JSONL) and, since Issue #82, ALSO the fixer: the reviewer may
-  modify code, run the full test suite with 100% line/branch coverage,
-  commit, and push ONLY the task branch — then re-emit the
-  `REVIEW_VERDICT` for the fixed head. There is no cold-start Fixer and
-  no third review session: a `pass` verdict means zero Blocker/Major
-  findings AFTER the in-session fixes. The review prompt never attaches
-  the `review-fix-loop` or `tdd-dev` skills: the reviewer applies the
-  code-review R1–R9 criteria directly and fixes findings in-session
-  (no nested review/fix loop).
-- After a PR is opened the Issue is in a recoverable review state, not
-  done: `ai-pr-opened` means awaiting review. `ai-fix-needed` marks a
-  delivery whose head is not mergeable yet (the review found a finding
-  the session could not fix, the PR is behind the latest base / has a
-  merge conflict, or an AI-recoverable failure of the existing run/PR
-  — a Pi execution failure, a verification failure, an unpushed local
-  commit (the #158 scene: the local commit is preserved and the next
-  review session pushes the task branch on the same PR), or a missing
-  worktree — Issue #50): the NEXT tick resumes the SAME run_id, branch,
-  worktree and PR and runs the next independent review session, which
-  merges the latest `origin/<base>` into the branch IN-SESSION, resolves
-  any conflict, re-runs the full suite and re-emits the verdict. A
-  recoverable failure is reported on the Issue AND the PR with the full
-  scene (run_id, PR, branch, worktree, session, phase, last activity and
-  the concrete error). Both opened-PR states are scanned (Issue #70).
-  The `ai-pr-opened` scan exists because the delivery that opened the
-  PR can be gone (a killed runner, or the progress failure behind Issue
-  #70 that used to block the Issue before the review started): without
+- The review session is independent (a new Pi process, `prompt_review.md`, a
+  new JSONL) and, since Issue #82, ALSO the fixer: the reviewer may modify
+  code, run the full test suite with 100% line/branch coverage, commit, and
+  push ONLY the task branch — then re-emit the `REVIEW_VERDICT` for the
+  fixed head. There is no cold-start Fixer and no third review session: a
+  `pass` verdict means zero Blocker/Major findings AFTER the in-session
+  fixes. The review prompt never attaches the `review-fix-loop` or `tdd-dev`
+  skills: the reviewer applies the code-review R1–R9 criteria directly and
+  fixes findings in-session (no nested review/fix loop).
+- After a PR is opened the Issue is in a recoverable review state, not done:
+  `ai-pr-opened` means awaiting review. `ai-fix-needed` marks a delivery
+  whose head is not mergeable yet (the review found a finding the session
+  could not fix, the PR is behind the latest base / has a merge conflict, or
+  an AI-recoverable failure of the existing run/PR — a Pi execution failure,
+  a verification failure, an unpushed local commit (the #158 scene: the
+  local commit is preserved and the next review session pushes the task
+  branch on the same PR), or a missing worktree — Issue #50): the NEXT tick
+  resumes the SAME run_id, branch, worktree and PR and runs the next
+  independent review session, which merges the latest `origin/<base>` into
+  the branch IN-SESSION, resolves any conflict, re-runs the full suite and
+  re-emits the verdict. A recoverable failure is reported on the Issue AND
+  the PR with the full scene (run_id, PR, branch, worktree, session, phase,
+  last activity and the concrete error). Both opened-PR states are scanned
+  (Issue #70). The `ai-pr-opened` scan exists because the delivery that
+  opened the PR can be gone (a killed runner, or the progress failure behind
+  Issue #70 that used to block the Issue before the review started): without
   it a valid MERGEABLE PR is stranded with no owner. `ai-fix-needed` is
-  never a reason to close the PR, re-claim the Issue, or open a
-  replacement PR; a successful merge moves the Issue to `ai-merged`.
-- `ai-blocked` Issues are excluded (they need a human decision first),
-  as are merged and in-flight Issues; the fresh-claim scan excludes
-  both opened-PR states, so an opened-PR Issue is never re-claimed as
-  new work. The resume scene (run id, base, PR URL) is
-  recovered from the latest `Muyan Pilot opened PR:` comment posted by
-  a trusted maintainer (OWNER/MAINTAINER/MEMBER/COLLABORATOR; a public
-  comment is never trusted). Branch and worktree are derived from the
-  configured repo_dir, source repo, Issue number and run id — never
-  read from a comment, so no comment can steer the runner into an
-  arbitrary local path. A scene that cannot be recovered (missing
-  field, no trusted comment) fails fast: the Issue is marked
-  `ai-blocked` with the concrete reason, the tick stops, and no fresh
-  task starts ahead of it — never guessed. Before any git/Pi mutation
-  the configured base and the open PR (head repo, head branch, base,
-  run marker, exact URL) are validated.
-- The Harness merge gate is unchanged: it re-fetches the latest remote
-  base and requires the PR head to contain it, the PR to be mergeable,
-  and the remote head to still be the reviewed head. After a clean
-  verdict the PR is RE-FROZEN (the reviewer may have pushed an
-  in-session fix, advancing the head) and the gate runs against the
-  re-frozen head; `gh pr merge --match-head-commit` then lands exactly
-  that head. No auto conflict resolution by the Runner, no `--abort`,
-  no force push, no merge or push of the protected branch.
-- A RECOVERABLE failure of the existing run/PR (Issue #50: a Pi
-  execution failure, a verification failure, an unpushed local commit,
-  a missing worktree, a finding the session could not fix) keeps the PR,
-  branch and worktree intact and marks the Issue `ai-fix-needed` (the
-  opened-PR state label is removed) with the failure comment on the
-  Issue AND the PR carrying the full scene (run_id, PR, branch,
-  worktree, session, phase, last activity, concrete error); the next
-  tick resumes the same run, branch, worktree and PR — no replacement
-  PR, no re-claim, never `ai-blocked`.
+  never a reason to close the PR, re-claim the Issue, or open a replacement
+  PR; a successful merge moves the Issue to `ai-merged`.
+- `ai-blocked` Issues are excluded (they need a human decision first), as
+  are merged and in-flight Issues; the fresh-claim scan excludes both
+  opened-PR states, so an opened-PR Issue is never re-claimed as new work.
+  The resume scene (run id, base, PR URL) is recovered from the latest
+  `Muyan Pilot opened PR:` comment posted by a trusted maintainer
+  (OWNER/MAINTAINER/MEMBER/COLLABORATOR; a public comment is never trusted).
+  Branch and worktree are derived from the configured repo_dir, source repo,
+  Issue number and run id — never read from a comment, so no comment can
+  steer the runner into an arbitrary local path. A scene that cannot be
+  recovered (missing field, no trusted comment) fails fast: the Issue is
+  marked `ai-blocked` with the concrete reason, the tick stops, and no fresh
+  task starts ahead of it — never guessed. Before any git/Pi mutation the
+  configured base and the open PR (head repo, head branch, base, run marker,
+  exact URL) are validated.
+- The Harness merge gate is unchanged: it re-fetches the latest remote base
+  and requires the PR head to contain it, the PR to be mergeable, and the
+  remote head to still be the reviewed head. After a clean verdict the PR is
+  RE-FROZEN (the reviewer may have pushed an in-session fix, advancing the
+  head) and the gate runs against the re-frozen head; `gh pr merge
+  --match-head-commit` then lands exactly that head. No auto conflict
+  resolution by the Runner, no `--abort`, no force push, no merge or push of
+  the protected branch.
+- A RECOVERABLE failure of the existing run/PR (Issue #50: a Pi execution
+  failure, a verification failure, an unpushed local commit, a missing
+  worktree, a finding the session could not fix) keeps the PR, branch and
+  worktree intact and marks the Issue `ai-fix-needed` (the opened-PR state
+  label is removed) with the failure comment on the Issue AND the PR
+  carrying the full scene (run_id, PR, branch, worktree, session, phase,
+  last activity, concrete error); the next tick resumes the same run,
+  branch, worktree and PR — no replacement PR, no re-claim, never
+  `ai-blocked`.
 - An UNRECOVERABLE failure (Issue #50: an external precondition the AI
-  cannot safely judge or fix — an unrecoverable scene, a base-branch
-  config change, an exhausted review round budget, a PR closed without
-  merge) keeps the PR, branch and worktree intact and marks the Issue
-  `ai-blocked` ALONE (the opened-PR state label is removed, and a
-  leftover `ai-fix-needed` too) with the explicit reason why automatic
-  recovery is impossible.
+  cannot safely judge or fix — an unrecoverable scene, a base-branch config
+  change, an exhausted review round budget, a PR closed without merge) keeps
+  the PR, branch and worktree intact and marks the Issue `ai-blocked` ALONE
+  (the opened-PR state label is removed, and a leftover `ai-fix-needed` too)
+  with the explicit reason why automatic recovery is impossible.
+- The complete chain, the state semantics and the label lifecycle are
+  documented in `docs/workflow.mdx` (EN/ZH) — that page is the source of
+  truth for the user-facing flow; this section is the contract.
 
 ## Run correlation
 
 - One task attempt generates one run_id (8 hex chars) and reuses it for
   every later step of the attempt; a retry generates a new one. No new id
-  system is introduced: no trace_id, no log_id, no second UUID, no
-  tracing backend.
+  system is introduced: no trace_id, no log_id, no second UUID, no tracing
+  backend.
 - Every journal line of the attempt starts with `[run_id]`, so one grep
   reconstructs the full timeline; every Issue/PR comment and the PR body
   carry the stable marker `<!-- muyan-pilot:run=<run_id> -->` plus the
   visible `run_id=` field; branch, worktree, Pi session dir and run
   artifacts carry it in their paths. A run-scoped event without a valid
-  run_id fails fast.
+  run_id fails fast. The user-facing explanation is documented in
+  `docs/workflow.mdx` (EN/ZH).
 
 ## Git
 
@@ -611,12 +580,12 @@ acceptance criteria.
 - Pi (the implementer) does not merge and does not push `main` or `master`.
   It delivers through exactly one PR linked to the Issue; the Runner is the
   only merge actor (the Runner is the only merge actor; see below).
-- The PR description must contain `Fixes #<issue-number>` (it may be on
-  the first line), pointing at the source Issue so GitHub closes the Issue
-  natively when the PR merges into the default branch. The keyword works
-  in the PR body and in commit messages, but not in the PR title. The
-  runner rejects a PR whose body is missing it, so a merge can never
-  leave the source Issue open.
+- The PR description must contain `Fixes #<issue-number>` (it may be on the
+  first line), pointing at the source Issue so GitHub closes the Issue
+  natively when the PR merges into the default branch. The keyword works in
+  the PR body and in commit messages, but not in the PR title. The runner
+  rejects a PR whose body is missing it, so a merge can never leave the
+  source Issue open.
 
 ## Auto review, fix and merge
 
@@ -624,35 +593,34 @@ acceptance criteria.
   base/head SHA and runs an independent review session (code-review R1–R9)
   against those SHAs. Since Issue #82 the reviewer is also the fixer: it may
   modify code, run the full suite with 100% line/branch coverage, commit and
-  push ONLY the task branch, then re-emit the verdict for the fixed head. The
-  reviewer ends with one machine-readable `REVIEW_VERDICT` line; a missing or
-  malformed verdict fails fast and is never treated as a pass.
+  push ONLY the task branch, then re-emit the verdict for the fixed head.
+  The reviewer ends with one machine-readable `REVIEW_VERDICT` line; a
+  missing or malformed verdict fails fast and is never treated as a pass.
 - A `pass` verdict means zero Blocker/Major findings AFTER the in-session
   fixes: the Runner re-freezes the PR (the head may have advanced), runs the
   merge gate against the re-frozen head, and merges with `gh pr merge
-  --match-head-commit` so only the reviewed head lands. A finding the session
-  could not fix (or a PR behind the latest base / with a merge conflict)
-  leaves the head unmergeable: the Issue is marked `ai-fix-needed` and the
-  NEXT tick runs the next independent review session on the same PR, which
-  absorbs the latest base in-session, resolves conflicts, re-runs the suite
-  and re-emits the verdict. The review loop is bounded (5 rounds); if it
-  exhausts rounds with findings it fails fast and marks the Issue
+  --match-head-commit` so only the reviewed head lands. A finding the
+  session could not fix (or a PR behind the latest base / with a merge
+  conflict) leaves the head unmergeable: the Issue is marked `ai-fix-needed`
+  and the NEXT tick runs the next independent review session on the same PR,
+  which absorbs the latest base in-session, resolves conflicts, re-runs the
+  suite and re-emits the verdict. The review loop is bounded (5 rounds); if
+  it exhausts rounds with findings it fails fast and marks the Issue
   `ai-blocked`.
-- The merge gate re-fetches the latest remote base and requires the PR head to
-  contain it, the PR to be mergeable, and the remote head to still be the
-  reviewed head. A PR behind the latest base is rejected, never
-  merged. The Runner confirms the PR is MERGED and the merge commit is on the
-  protected branch before marking the Issue `ai-merged`.
+- The merge gate re-fetches the latest remote base and requires the PR head
+  to contain it, the PR to be mergeable, and the remote head to still be the
+  reviewed head. A PR behind the latest base is rejected, never merged. The
+  Runner confirms the PR is MERGED and the merge commit is on the protected
+  branch before marking the Issue `ai-merged`.
 - A review finding or an AI-recoverable failure of the existing run/PR
   (Issue #50: a Pi execution failure, a verification failure, an unpushed
-  local commit, a missing worktree) is NOT `ai-blocked`: it is fixed in
-  the next review session on the same PR (the Issue stays `ai-fix-needed`
-  and the next tick resumes the same run, branch, worktree and PR).
-  Only an unrecoverable external precondition (an exhausted review round
-  budget, an unrecoverable scene, a base-branch config change, a PR
-  closed without merge) fails fast and marks `ai-blocked` — and the
-  blocked comment must state the explicit reason why automatic recovery
-  is impossible.
+  local commit, a missing worktree) is NOT `ai-blocked`: it is fixed in the
+  next review session on the same PR (the Issue stays `ai-fix-needed` and
+  the next tick resumes the same run, branch, worktree and PR). Only an
+  unrecoverable external precondition (an exhausted review round budget, an
+  unrecoverable scene, a base-branch config change, a PR closed without
+  merge) fails fast and marks `ai-blocked` — and the blocked comment must
+  state the explicit reason why automatic recovery is impossible.
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,76 @@
 # Orbi
 
-Orbi 是本地 AI 开发 Worker（v0.3.0 起对外品牌为 Orbi，GitHub 项目为 [`orbi-build/orbi`](https://github.com/orbi-build/orbi)，官网 <https://orbi.build>，文档站 <https://docs.orbi.build>）。最小 bootstrap：从配置文件中的 source repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并（见下方「自动审查、修复与合并」）。
+Orbi 是本地 AI 开发 Worker（v0.3.0 起对外品牌为 Orbi，GitHub 项目为
+[`orbi-build/orbi`](https://github.com/orbi-build/orbi)，官网 <https://orbi.build>，
+文档站 <https://docs.orbi.build>）。最小 bootstrap：从配置文件中的 source
+repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发
+并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并。
 
-**品牌与兼容（v0.3.0 rebrand，Issue #183）**：对外品牌统一为 Orbi（README、文档站、仓库描述、package metadata、对外链接）；但已有用户的使用方式不变——CLI 仍是 `muyan-pilot`（console script 与 `muyan_pilot.py` 入口）、配置文件仍是 `muyan-pilot.toml`、systemd unit 仍是 `muyan-pilot@*`、运行时 label（`ai-*`/`p0`）与 run marker（`<!-- muyan-pilot:run=... -->`）均不改动；旧 GitHub 地址（`xqliu/muyan-pilot`、`xqliu/orbi`）由 GitHub 自动 redirect 到 `orbi-build/orbi`。
+**品牌与兼容（v0.3.0 rebrand，Issue #183）**：对外品牌统一为 Orbi（README、
+文档站、仓库描述、package metadata、对外链接）；已有用户的使用方式不变——CLI
+仍是 `muyan-pilot`、配置文件仍是 `muyan-pilot.toml`、systemd unit 仍是
+`muyan-pilot@*`、运行时 label（`ai-*`/`p0`）与 run marker
+（`<!-- muyan-pilot:run=... -->`）均不改动。
 
-开发契约见 [AGENTS.md](AGENTS.md)：每次本地 Pi 自举开发前先读 Issue、AGENTS.md、变更文件及其调用方和相关测试（README、context files、构建文件与历史只在任务确实相关时读，Issue #180 收窄上下文读取、定义 compact 后恢复协议与 CI 失败优先的测试阶梯，并禁止 `tail` 等管道吞掉测试退出码），TDD、100% 覆盖率、UI 用 Playwright、失败 fail fast、不 merge、不 push 保护分支、不引入数据库/队列/daemon/fallback、不设业务任务 timeout。
+开发契约见 [AGENTS.md](AGENTS.md)；面向新用户的完整操作说明（安装前提、
+配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在文档站
+<https://docs.orbi.build>（仓库内 [`docs/`](docs/) 是唯一事实源，Mintlify 只
+构建、搜索和托管；中文入口 [`docs/zh/`](docs/zh/)）。本 README 只保留项目定位、
+快速开始、核心工作流和关键入口；每条规则的完整说明只在一个事实源里，其余位置
+只做短引用。
 
-## 文档站
-
-面向新用户的完整开源文档（安装前提、配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在仓库 [`docs/`](docs/) 目录：`docs/docs.json` + `docs/*.mdx`，由 Mintlify 构建和托管（连接默认分支 `main`，Git Settings 的 documentation path 配置为 `/docs`，每次合并后自动构建发布）。文档站地址为 <https://docs.orbi.build>（Mintlify 自定义域名，绑定到本仓库 `docs/`）；旧的 Mintlify 默认子域 <https://muyan-pilot.mintlify.site> 在绑定自定义域名后已停用（实测 404，2026-08-31），旧文档入口以 <https://docs.orbi.build> 为准；如需恢复旧子域跳转，在 Mintlify 控制台 Settings → Custom domain 保留默认子域并指向 `docs.orbi.build`（一次性控制台操作，无代码变更）。文档站提供英文（默认）和中文（[`docs/zh/`](docs/zh/)，Mintlify i18n 语言切换）两个语言版本，两种语言共享同一事实源（同一套命令、标签、配置字段和端口，不复制出互相漂移的实现说明）。仓库内的 Markdown/MDX 是唯一事实源，Mintlify 只负责构建、搜索和托管，不产生第二份内容；本 README 保留 GitHub 首页与运行契约概览。
-
-两张总览图（Mintlify 渲染 Mermaid，仓库内保留可读源码）：
-
-- **系统架构总览**（GitHub Issues、systemd timer/service、Runner、Pi、worktree、llama-server、可选 `local-llm-kv-cache` proxy、PR/review/merge）：文档站首页 [index](docs/index.mdx) / [zh/index](docs/zh/index.mdx)；
-- **任务生命周期状态机**（`ai-ready` → `ai-in-progress` → `ai-pr-opened` → `ai-fix-needed` → `ai-merged` / `ai-blocked`，标出 Epic/Release task/P0 边界）：[workflow](docs/workflow.mdx) / [zh/workflow](docs/zh/workflow.mdx)。
-
-## CLI 安装与升级（Issue #140、#152、#158）
-
-正式使用方式是 **editable** `uv tool` 安装的可执行 CLI（console script `muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）——这是官方本地部署方式：
+## 快速开始
 
 ```bash
-# 在部署 checkout 目录安装（如 /home/xqianliu/Documents/muyan/muyan-pilot）：
-# --python 固定生产解释器（本机 /usr/bin/python3，3.14）
-# --editable：tool 环境直接从部署 checkout 导入 muyan_pilot（不是复制到 site-packages）
-uv tool install --force --reinstall --editable --python /usr/bin/python3 /home/xqianliu/Documents/muyan/muyan-pilot
-# 验证安装：
+# 1. clone
+git clone https://github.com/orbi-build/orbi.git
+cd orbi
+
+# 2. 安装 CLI（editable uv tool 安装，官方本地部署方式）
+uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 muyan-pilot --help
-muyan-pilot --version
+
+# 3. 创建配置（仓库只提交 example，真实配置本地维护）
+cp .muyan-pilot.example.toml muyan-pilot.toml
+
+# 4. 一次性 setup（gh auth + 仓库权限、平台 labels、systemd user units、
+#    checkout 检查含 Git transport；幂等、fail-fast）
+muyan-pilot setup --config muyan-pilot.toml
+
+# 5. 手动跑一个 tick（首次验证/排查；日常由 timer 调度）
+python3 bootstrap_runner.py --config muyan-pilot.toml
+
+# 6. 验证 timer 与部署健康
+systemctl --user list-timers 'muyan-pilot@*.timer'
+muyan-pilot doctor --config muyan-pilot.toml
 ```
 
-**为什么必须 editable（Issue #152）**：非 editable 安装会把源码复制进 tool 环境的 site-packages；`ExecStartPre` 把 checkout 同步到最新 main 之后，CLI 仍在执行旧副本——这正是 #152 的 P0 启动死锁（旧 CLI 检查旧的非模板 unit 路径，永远跑不到新的迁移代码）。editable 安装下，下一个 CLI 进程（下一个 timer 启动的 Runner）自动从 checkout 取到最新代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。
-
-**打包元数据变更的自动刷新（Issue #158）**：editable finder 的模块映射是在**安装时**从 checkout 的 `pyproject.toml`（`py-modules`、入口点、版本、依赖）生成的——所以合并了打包输入变更（例如 `py-modules` 新增运行时模块）后，已安装的 finder 会过期，下一个 CLI 进程在 Runner 启动前就 `ModuleNotFoundError`（#158 事故：`cli_source` 合入 main 后，已安装 finder 仍映射 #152 之前的模块集，systemd 启动失败）。现在 Runner 每次启动（tick 入口，在任何 slot/claim 之前）自动刷新：
-
-- 打包指纹 = checkout `pyproject.toml` 的 sha256，与**上次成功安装**记录的指纹（共享状态目录 `.muyan-pilot/cli-install.json`，与 `base-sync.lock`、slots 同目录，gitignored，随 checkout 同步存活）比较；
-- **未变**：完全不跑 `uv`（不做每 tick 无条件重装）；
-- **变更或首次安装**（无状态记录）：在 base-sync flock 保护下跑一次上面的 force editable 重装（与服务模板 `ExecStartPre` 同一把锁——两个 instance 同 tick 启动时串行化，第二个等待并复用第一个的结果，绝不并发 `uv`）；安装成功后才记录新指纹；
-- **安装失败**：fail fast（非零退出，结构化 `cli_install_failed` 行：原因 + 精确的修复命令），不取 slot、不 claim、不改标签，不记录状态（下次启动重试）；
-- 普通 Python 源码内容变更**不**触发重装（editable finder 映射的就是活文件，这正是 editable 的意义）。
-
-上面的 force editable 命令仍是人工 setup 入口（`muyan-pilot setup` 的 CLI 步骤）；Runner 启动时的自动刷新只在打包输入变更时执行同一条命令。
-
-`uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件在 `~/.local/bin/muyan-pilot`（systemd unit 的 PATH 已包含该目录，见「部署一致性」）。`muyan-pilot doctor` 报告 CLI 源码一致性：`cli_source: clean source=...`（运行进程从配置的 checkout 导入）或 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行（实际导入路径、期望 repo_dir、精确的 editable 重装命令）。发布包不携带第三方运行时依赖、token 或用户目录：配置（`muyan-pilot.toml`）和用户 systemd 目录保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为开发/兼容路径，不是正式使用方式。
+新用户从 [Getting started](docs/getting-started.mdx) 可以完整走完安装、配置、
+setup、首次运行和 doctor 验证（含从 0 开始的 smoke walkthrough 与故障排查表）；
+一次性 setup 的完整输出契约与失败现场见
+[One-time setup](docs/setup.mdx)。
 
 ## 当前运行
 
-```bash
-python3 bootstrap_runner.py --config muyan-pilot.toml
-```
-
-正常运行使用 systemd user timer，全天 24 小时运行，每 5 分钟自动执行一次（触发点覆盖 00:00–23:55）：
+正常运行使用 systemd user timer，全天 24 小时运行，每 5 分钟自动执行一次
+（触发点覆盖 00:00–23:55）：
 
 ```bash
 # 幂等安装用户级 service/timer 模板（仓库模板复制到用户 systemd 目录、
-# daemon-reload，并按 max_concurrency 启用对应的 timer 实例），并输出部署 commit/hash：
+# daemon-reload，并按 max_concurrency 启用对应的 timer 实例），并输出部署
+# commit 和每个 unit 的 sha256：
 muyan-pilot install-units --config muyan-pilot.toml
 systemctl --user list-timers 'muyan-pilot@*.timer'
 ```
 
-安装按 `max_concurrency` 同步 timer：`1` 只启用 `muyan-pilot@1.timer`，`2` 启用 `muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`。降低并发只停止多余 timer，不触碰正在运行的 service；两个实例各自仍触发自己的 service，slot 仍是最终并发安全边界（Issue #189）。
+安装按 `max_concurrency` 同步 timer：`1` 只启用 `muyan-pilot@1.timer`，`2`
+启用 `muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`。`install-units` 是幂等的：
+重复执行只会把仓库模板重新复制到位并 `daemon-reload`，**不会**启动、停止或重启
+正在运行的 Runner（新配置从下一次 service 启动生效）。timer、`ExecStartPre`
+代码同步、unit 漂移自愈、slot 并发与故障恢复的完整说明见
+[Operations](docs/operations.mdx)。
 
-`install-units` 是幂等的：重复执行只会把仓库模板重新复制到位并 `daemon-reload`，**不会**启动、停止或重启正在运行的 Runner（新配置从下一次 service 启动生效）。手工命令只用于首次验证或立即执行一个 tick，不是日常调度方式。
-
-## 代码更新（Issue #52）
+## 代码更新与部署一致性
 
 service 每次真正启动时，先由 `ExecStartPre` 在 Python Runner 进程外执行：
 
@@ -70,28 +78,26 @@ service 每次真正启动时，先由 `ExecStartPre` 在 Python Runner 进程�
 timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main
 ```
 
-本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动。当前正在运行的长任务不会被热更新、不会被杀、也不会启动第二个 Runner（service active 时 systemd 忽略 timer 的 start 请求；下一次 service 真正启动时生效）。main 工作区不干净、fetch 失败或无法 fast-forward 时，preflight 命令失败，service 不启动，原因写入 systemd journal（fail fast）。不新增 refresh service、worker、dispatcher 或常驻进程；5 分钟 timer 配置保持不变。
-
-Issue #149：两个实例可能在同一 tick 启动，所以 `ExecStartPre` 的 fetch + fast-forward 包在一个短生命周期的 `flock`（共享状态目录下的 `base-sync.lock`，Python 侧 `sync_base_checkout` 取同一把锁）里：main worktree 不会被并发写入；flock 拿到后执行 git 命令，退出时自动释放，不新增常驻进程。
-
-Issue #171：两个 Runner（或 Runner 与 Pi 会话）并发 `git fetch` 会争抢共享的 remote-tracking ref（`refs/remotes/origin/main`），产生 `cannot lock ref ... is at <X> but expected <Y>` 的 CAS 失败，使 review Pi 会话非零退出。修复：所有更新共享 remote-tracking ref 的 fetch 都走同一把 `base-sync.lock`——Runner 侧的 `freeze_base` / `verify_pr` / `merge_gate` / `confirm_merged` 统一经 `fetch_base_ref`（先取锁、再 fetch、finally 释放，锁或 fetch 出错即 fail fast，不重试、不降级）；implement/review 两个 prompt 把锁路径渲染为 `BASE_SYNC_LOCK`，并指示 Pi 用 `flock <BASE_SYNC_LOCK> git fetch origin <base>` 执行 base 新鲜度 fetch。不新增进程、锁或常驻服务。
-
-## 部署一致性（Issue #103）
-
-仓库中的 `systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是已安装 unit 的**唯一事实源**：代码和实际运行配置必须一致，漂移必须能被明确发现。两个可用 timer 实例 `muyan-pilot@1.timer` / `muyan-pilot@2.timer` 各自触发自己的 service 实例；安装按 `max_concurrency` 启用前 1 或 2 个实例。
-
-**幂等安装**：`muyan-pilot install-units` 把两个模板复制到用户 systemd 目录（`~/.config/systemd/user/`，可用 `--installed-dir` 覆盖）、执行 `systemctl --user daemon-reload`，并按 `max_concurrency` 启用 `@1` 或 `@1`/`@2` timer；降低并发时以 `disable --now` 停掉多余 **timer**，绝不停止 service。安装**不会**启动、停止或重启正在运行的 Runner：新配置从下一次 timer 调度生效；slot 锁语义不变。安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` / `systemd/muyan-pilot.timer`）：`systemctl --user disable --now muyan-pilot.timer`（停的是 timer，绝不停/启/重启 service，运行中的 Runner 不受影响）并删除旧文件，旧单实例调度不会再拉起旧 service（模板变更即部署变更，无需人工步骤）；已迁移过的机器上这一步是 no-op。service 模板的 `ExecStart` 使用已安装 `muyan-pilot` CLI 的明确绝对入口（`%h/.local/bin/muyan-pilot`，即 `uv tool install` 之后 `~/.local/bin` 下的可执行文件；`WorkingDirectory` 仍是部署 checkout，`ExecStartPre` 在 Runner 启动前同步 `origin/main`）。
-
-**启动前漂移检查（含自愈，Issue #142）**：Runner 每次启动时（`ExecStartPre` 同步完 checkout 之后、领取任何 Issue 之前）对比已安装 unit 与仓库模板（service 和 timer 模板都覆盖）。一致时记录 `unit_drift clean`；发现漂移时用**同一个幂等安装**自愈（复制模板、`daemon-reload`，按 `max_concurrency` 同步 timer——不启动、停止或重启 service，运行中的 Runner 不受影响），再用**同一个哈希检查**复核：复核通过时每个 unit 记录一行结构化 `unit_drift auto_synced`（before/after sha256、部署 commit），本次启动继续；复核后仍然漂移（或安装步骤本身失败）时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签）：
+本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动；
+当前正在运行的长任务不会被热更新、不会被杀。仓库中的
+`systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是
+已安装 unit 的**唯一事实源**；Runner 每次启动在领取任何 Issue 之前对比已安装
+unit 与模板，漂移用同一个幂等安装自愈并复核（`unit_drift auto_synced`），
+复核后仍漂移则记录结构化日志并 fail fast（不取 slot、不领取）：
 
 ```text
 unit_drift auto_synced unit=muyan-pilot@.timer before_sha256=... after_sha256=... commit=<deployed HEAD>
 unit_drift unit=muyan-pilot@.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=muyan-pilot install-units
 ```
 
-**只读诊断**：`muyan-pilot doctor`（可用 `--installed-dir` 指定检查目录）报告 repo commit、unit drift（clean 或具体漂移 + 修复命令）、CLI 源码一致性（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行，见「CLI 安装与升级」）、Git transport（配置的 origin URL、protocol、SSH 探测；见「Git transport」）、timer/service active 状态、Runner slot、Pi session、每个 source repo 的当前 Issue 和最近 journal 活动。只读：不改标签、不改 unit、不做 git 变更。
+安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` /
+`systemd/muyan-pilot.timer`：`systemctl --user disable --now muyan-pilot.timer`
+停的是 timer，绝不停/启/重启 service）并删除旧文件；已迁移过的机器上是 no-op。
+`muyan-pilot doctor` 是只读诊断（repo commit、unit drift、timer/service active、
+slot、Pi session、当前 Issue、最近 journal 活动），不改标签、不改 unit、不做
+git 变更。
 
-**完整部署时序**（从代码合并到下一次 Runner 启动）：
+**完整部署时序**（模板变更的 PR 合并到 main 后不需要任何人工步骤）：
 
 ```text
 git merge 到 main（含 unit 模板变更）
@@ -102,93 +108,82 @@ git merge 到 main（含 unit 模板变更）
   -> Runner 启动并执行一个 Issue
 ```
 
-**模板变更不再需要人工同步（Issue #142）**：`systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer` 仍是部署配置，但模板变更的 PR 合并到 main 后**不需要任何人工步骤**：下一次 timer 触发时 `ExecStartPre` 同步 checkout，启动前漂移检查发现已安装 unit 落后于模板，就用同一个幂等安装自愈（不碰运行中的 Runner）并复核，tick 继续——不再出现“每 5 分钟重复同一个 `unit_drift` 错误直到人工介入”的循环（#131、#140 两次实例的根因）。`muyan-pilot install-units --config muyan-pilot.toml` 保留为手工入口（首次 setup、需要立即同步时）；自愈后仍漂移（例如安装步骤失败、模板缺失）时，启动前检查仍然 fail fast（结构化 `unit_drift` 行、非零退出、不取 slot、不领取 Issue）——哈希校验和哨兵边界不变。
-
 ## Git transport（Issue #114）
 
-两条认证通道，职责边界清晰：
+两条认证通道，职责边界清晰：**Git 数据操作**（fetch、push——包括推送
+`.github/workflows/*.yml`）走 **SSH**（`git@github.com:owner/repo.git`，本机
+SSH key）；**GitHub API 操作**（Issue、PR、label、comment、merge）走 `gh`
+token。SSH 从不作为 API 认证，`gh` token 也从不用于 git 数据。
 
-- **Git 数据操作**（fetch、push——包括推送 `.github/workflows/*.yml`）走 **SSH**（`git@github.com:owner/repo.git`，用本机 SSH key 认证）。workflow 文件推送不再依赖 OAuth App 的 `workflow` scope（#106 被 HTTPS/OAuth 通道阻塞的根因）；
-- **GitHub API 操作**（Issue、PR、label、comment、merge）继续走现有 `gh` token。SSH 从不作为 API 认证，`gh` token 也从不用于 git 数据。
+Runner 每次启动（取 slot/领取任何 Issue 之前）校验 checkout 的 transport：
+配置的 `origin` URL 必须是第一个配置 source repo 的 SSH 形式，且
+`git ls-remote <ssh-url>` 退出码 0。失败时记录结构化日志并 fail fast
+（`transport_check_failed ... reason=...`，不取 slot、不领取、不改标签），
+**不自动降级到 HTTPS，也不静默跳过 workflow 文件**。已有 HTTPS remote 的迁移只
+由人工执行的一次性 setup 入口完成（`muyan-pilot setup`，内部执行
+`git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到
+HTTPS remote 时 fail fast 并携带确切的迁移命令。完整说明见
+[Operations](docs/operations.mdx) 与 [One-time setup](docs/setup.mdx)。
 
-部署 checkout 的单一 `origin` remote 就是 transport：`git worktree add` 创建的任务 worktree 共享主仓库的 remote 配置（已对真实 git 验证），所以 transport 只在 checkout 上配置一次，所有 worktree 天然继承——**新 bootstrap worktree 的 `git remote -v` 默认就是 SSH**。
+## CLI 安装与升级（Issue #140、#152、#158）
 
-**启动前检查**：Runner 每次启动时（unit 漂移检查之后、取 slot/领取任何 Issue 之前）校验 checkout 的 transport——**配置的** `origin` URL（`git config remote.origin.url`，不是 insteadOf 重写后的数据面 URL）必须是第一个配置 source repo 的 SSH 形式，且 `git ls-remote <ssh-url>` 退出码 0（SSH 可达且已认证，已对真实 CLI 验证）。失败时记录结构化日志并 fail fast（非零退出，不取 slot、不领取 Issue、不改任何标签），**不自动降级到 HTTPS，也不静默跳过 workflow 文件**：
-
-```text
-transport_check_failed repo_dir=<repo path> source_repos=<...> reason=ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — ...
-```
-
-**已有 HTTPS remote 的迁移路径**：Runner 从不静默改写 remote，也从不从评论或 Issue 内容读取 remote。迁移只由人工执行的一次性 setup 入口完成（`muyan-pilot setup`，内部执行 `git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到 HTTPS remote 时 fail fast，失败信息携带确切的迁移命令。指向其他仓库的 remote 从不被迁移（改写会把 checkout 指向另一个仓库），无论 setup 是否授权迁移都直接以 mismatch 现场 fail fast。手工等价命令：
+正式使用方式是 **editable** `uv tool` 安装的可执行 CLI（console script
+`muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）：
 
 ```bash
-git remote set-url origin git@github.com:OWNER/REPO.git
+uv tool install --force --reinstall --editable --python /usr/bin/python3 <deployment checkout>
+muyan-pilot --help
+muyan-pilot --version
 ```
 
-**只读诊断**：`muyan-pilot doctor` 报告 transport 行（remote、配置的 URL、protocol、期望 URL、SSH 探测结果）；SSH 不可用时 doctor 把失败现场写进报告（`transport: FAILED ...`），不中断其余报告——fail-fast 门禁是启动前检查，doctor 是诊断报告。
-
-## 远程 CI（GitHub Actions）
-
-仓库契约（全量 pytest + 100% line/branch coverage）不只在本机 Runner 上跑：`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次 `push` 到 `main` 时跑同一份契约，测试失败或覆盖率低于 100% 时 CI 变红。单个 job，不加 lint、矩阵或缓存（Issue #56）。CI 还在干净环境里 `pip install .` 安装 console script 并验证入口（`muyan-pilot --help` / `muyan-pilot --version` 退出码 0，Issue #140）——「干净环境安装后 `muyan-pilot --help` 成功」是永久门禁，不是一次性本地检查。
-
-与本地的差异：生产运行时是 Runner 机器的 `/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以 workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过 PATH 上固定的 `python3` 执行（命令与本地相同，只有解释器路径不同）。
-
-Checkout 用 `fetch-depth: 0`（完整历史 + 全部 tags）：发布对账测试（`tests/test_release_v01.py`）用 `git cat-file` / `git rev-parse` 对 checkout 里的真实 annotated tag object（`v0.1.0`）及其 commit 关系做校验，而默认浅 checkout（`fetch-depth: 1`）以 `--no-tags` 抓取，CI 环境里没有 tag object，测试会以 `could not get object info` 失败（Issue #126）。现有 tags 只是在 CI 里可见，不被移动、覆盖或重写。
+editable 安装下 tool 环境直接从部署 checkout 导入 `muyan_pilot`，
+`ExecStartPre` 把 checkout 同步到最新 main 后下一个 CLI 进程自动取到最新代码：
+**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。打包
+元数据变更（`pyproject.toml` 的 `py-modules`、入口点、版本、依赖）会让已安装的
+finder 过期——Runner 每次启动在任何 slot/claim 之前自动刷新：打包指纹（checkout
+`pyproject.toml` 的 sha256）未变则完全不跑 `uv`；变更或首次安装时在 base-sync
+flock 保护下跑一次上面的 force editable 重装；安装失败 fail fast（结构化
+`cli_install_failed` 行：原因 + 精确的修复命令），不取 slot、不 claim、不改标签。
+`muyan-pilot doctor` 报告 CLI 源码一致性（`cli_source: clean` 或
+`cli_source: DRIFT` + 结构化 `cli_source_drift` 行）。`muyan_pilot.py` 的直接
+执行入口保留为开发/兼容路径，不是正式使用方式。完整说明（为什么必须 editable、
+#152/#158 事故背景）见 [Getting started](docs/getting-started.mdx)。
 
 ## 任务派发与状态
 
-`muyan-pilot` 是最小 CLI（`uv tool` 安装，见「CLI 安装与升级」），用于手工派活和查看队列。GitHub Issue 与标签是唯一状态存储，不引入数据库或 Web UI：
+`muyan-pilot` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一
+状态存储，不引入数据库或 Web UI：
 
 ```bash
 # 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
 muyan-pilot add "任务标题" --body "任务描述" --config muyan-pilot.toml
 
-# 派发到指定 source repo（必须在配置 source_repos 中）
-muyan-pilot add "任务标题" --repo xqliu/muyan-ceo --config muyan-pilot.toml
-
-# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和最近结果（ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked）
+# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和
+# 最近结果（ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked）
 muyan-pilot status --config muyan-pilot.toml
-```
 
-`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何标签。命令失败立即报错，不做回退。
-
-```bash
-# 打印当前 run 的 Pi session 文件路径（repo_dir/.worktrees 下最新的 .pi-session/*.jsonl）
+# 打印当前 run 的 Pi session 文件路径（repo_dir/.worktrees 下最新的
+# .pi-session/*.jsonl）；--follow 持续跟随该文件
 muyan-pilot session --config muyan-pilot.toml
-
-# 持续跟随该文件（等价 tail -f；跟的是命令启动时选中的文件，不中途跳到更新的文件）
-muyan-pilot session --follow --config muyan-pilot.toml
 ```
 
-`session` 是排查附件（日常仍看 journal / GitHub），不是日常入口：没有 session 文件时 fail fast（退出码非零，说明没有正在跑的 Pi），不猜路径；`--pretty` 把 JSONL 打一行摘要（timestamp / role / tool|text|thinking 截断），默认仍是原始 JSONL。不开 tmux、不新包装脚本、不新增 systemd unit（Issue #74）。
-
-```bash
-# 幂等安装 systemd unit 模板 + 按 max_concurrency 同步 timer 实例（见「部署一致性」）：
-# 输出部署 commit 和每个 unit 的 sha256
-muyan-pilot install-units --config muyan-pilot.toml
-
-# 只读部署/健康报告：repo commit、unit drift、timer/service active、
-# Runner slot、Pi session、当前 Issue、最近 journal 活动
-muyan-pilot doctor --config muyan-pilot.toml
-
-# 一次性 setup（新机器/新仓库）：gh auth + 仓库权限、平台 labels
-# （labels.toml 为唯一事实源）、systemd user units、checkout 检查
-# （含 Git transport：HTTPS origin 迁移为 SSH + SSH 连通性探测）、
-# 可选模型 proxy（warning only）；幂等、fail-fast，--json 输出等价 JSON
-muyan-pilot setup --config muyan-pilot.toml
-```
+`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何
+标签；`session` 是排查附件（跟的是命令启动时选中的文件，不中途跳到更新的文件），
+没有 session 文件时 fail fast。命令失败立即报错，不做回退。
 
 ## GitHub Issue 标签（外部状态）
 
-GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的 label 只做声明式对齐，业务 label 从不被改动；同时完成 Git transport 初始化：HTTPS `origin` 迁移为 SSH 并探测 SSH 连通性，见「Git transport」）：
+GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默
+漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、
+fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的
+label 只做声明式对齐，业务 label 从不被改动）：
 
 ```bash
-# 一次性 setup：gh auth + 仓库权限、平台 labels、systemd user units、
-# checkout 检查、可选模型 proxy（warning only）；输出 key=value（--json 等价 JSON）
 muyan-pilot setup --config muyan-pilot.toml
 ```
 
-setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略或先 `gh label list` 检查）：
+setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略或先 `gh label list`
+检查）：
 
 ```bash
 for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
@@ -199,10 +194,10 @@ done
 # p0 是紧急优先级 label（不是交付状态，见「领取优先级（P0）」）
 gh label create p0 --repo orbi-build/orbi --force --color "fbca04" \
   --description "Orbi urgent priority: picked up before bugs and features"
-# ai-epic 是 Epic 协调 label（不是交付状态，见「Epic Issue（ai-epic）」）
+# ai-epic 是 Epic 协调 label（不是交付状态，见 Workflow 文档）
 gh label create ai-epic --repo orbi-build/orbi --force --color "bfdadc" \
   --description "Epic coordination issue; not directly executable by Runner"
-# ai-release 是 Release task 标记（不是交付状态，见「Release task（ai-release）」）
+# ai-release 是 Release task 标记（不是交付状态，见 Workflow 文档）
 gh label create ai-release --repo orbi-build/orbi --force --color "5319e7" \
   --description "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
 # ai-ticket-only 是内容交付标记（不是 Git 交付状态）
@@ -224,293 +219,30 @@ gh label list --repo orbi-build/orbi
 | `ai-release` | Release task 标记（**不是交付状态**）：带它的 `ai-ready` Issue 由 Runner 的确定性 release 状态机处理（tag + GitHub Release），**从不进 `run_pi` 开发路径**（Issue #98） | 人工加 label（派发 release task 时，与 `ai-ready` 同时） | 成功发布后 Runner 加 `ai-merged`（终态）并关闭 Issue；任何失败单独转 `ai-blocked`（不自动重试，人工决策点）；Runner 从不增删该 label 本身 |
 | `ai-ticket-only` | 内容任务标记（**不是 Git 交付状态**）：Agent 仅生成最终内容并直接评论到 source Issue，绝不创建 worktree、branch、commit、PR 或内容文件（Issue #209） | 人工与 `ai-ready` 一起添加；任务类型只由此 label 明确指定，绝不从标题或正文推断 | 成功后 Runner 关闭 Issue 并移除 `ai-in-progress`；失败转 `ai-blocked`，评论保留 run_id 和具体失败现场；Runner 从不添加或移除此 type label |
 
-## 任务依赖（blockedBy）
-
-任务之间的依赖一律用 GitHub **原生依赖关系**（`blockedBy`/`blocking`，gh 2.94+）标注；**不要**在 Issue 正文写 `Depends on #N`——正文不进入 `blockedBy`，Runner 不解析正文依赖：
-
-```bash
-# 派发新 Issue 后标注依赖（N = 新 Issue，M = 前置 Issue）
-gh issue edit N --repo orbi-build/orbi --add-blocked-by M
-# 解除依赖
-gh issue edit N --repo orbi-build/orbi --remove-blocked-by M
-```
-
-Runner 行为（单 slot 串行，只做“读字段-跳过-等待”，不引入 DAG、拓扑排序或多 worker 调度）：
-
-- 领取 `ai-ready` Issue 前，Runner 读取原生 `blockedBy`（`gh issue list --json blockedBy`）；
-- 存在未关闭 blocker（blocker 节点 `state=OPEN`）→ **不领取**：不加 `ai-in-progress`、不改任何标签、不建 worktree，记录结构化日志 `blocked_by issue=N repo=... blockers=M1,M2`，继续检查同 repo 后面的 ready Issue；
-- blocker 关闭后不再阻塞：GitHub 会把该关系保留在列表中（节点 `state=CLOSED`，惰性，已对真实 API 验证），Runner 只统计未关闭 blocker——无需人工操作，下一 tick 该 Issue 自然可领；
-- `blockedBy` 查询失败 → **fail open**（视为未阻塞：本 tick 不从该 repo 领取，记录 `blocked_by_check_failed`，下一 tick 重试查询），API 异常不会死锁队列。
+标签语义与领取扫描的完整行为（blockedBy 依赖、P0 领取顺序、Epic 跳过、Release
+状态机）见 [Workflow](docs/workflow.mdx)。
 
 ## 领取优先级（P0）
 
-紧急优先级用普通 GitHub label `p0` 表示（**不是交付状态**）：它只表达处理优先级，不改变 Issue 粒度（仍要求一个 Issue 对应一个 runtime outcome），不改变任何交付状态或终态语义，Runner 也从不增删该 label。
+紧急优先级用普通 GitHub label `p0` 表示（**不是交付状态**）：它只表达处理
+优先级，不改变 Issue 粒度、任何交付状态或终态语义，Runner 也从不增删该 label。
 
-- ready 领取顺序固定为：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`（三次 `gh issue list` 扫描，共享同一组排除条件和 `blockedBy` 语义）；
-- P0 仍遵守全部现有排除规则（`ai-in-progress`、`ai-pr-opened`、`ai-fix-needed`、`ai-merged`、`ai-blocked`）和单 slot 约束：P0 被阻塞（open blocker）时跳过并回退到 bug/普通扫描，P0 已在途（`ai-in-progress`）时由重启恢复扫描接回（扫描同样携带 `labels`，恢复后进度评论继续显示 `p0`）；
-- active Milestone 领取范围（Issue #139）：可选配置 `active_milestone`（Milestone 标题，如 `v0.2.0`）把**新领取**扫描限制在一个版本内——设置后 p0/bug/普通三次扫描的 gh 搜索查询都携带 `milestone:"<title>"` 限定词（带引号形式，Milestone 标题可含空格/特殊字符），其他 Milestone 或无 Milestone 的 Issue 永远进不了队列，没有 `ai-ready` 的 Milestone Issue 也进不了（`ai-ready` 仍是执行开关，Milestone 只是版本范围）；**P0 不跨 Milestone**（active Milestone 是所有新领取的范围，`p0` 只在其内部排序）；范围只在查询层（`is_epic` 代码层跳过和 blockedBy 跳过是不变的第二层），扫描失败仍按 fail open 契约处理（绝不静默领取错误版本）；**恢复态不受 Milestone 限制**：已开 PR 的恢复扫描和在途重启扫描把任务跑完，不受 Milestone 变更影响；值必须显式配置（绝不从 repo 的 Milestone 列表猜），未设置时保持 #139 之前的行为（兼容），空串/非字符串启动即 fail fast；
-- 领取日志行携带明确的 `priority=p0` / `priority=normal` 字段；GitHub 进度评论显示 `priority` 字段；run 现场（`run_info`）与 started milestone 携带 `priority=...`；
-- P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；失败评论和 blocked 现场保留具体失败原因和可恢复现场；
-- P0 的 review/merge 失败沿用现有同一 PR、有限 review round（`MAX_REVIEW_ROUNDS=5`）机制，不引入新的循环。
+- ready 领取顺序固定为：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`
+  （三次 `gh issue list` 扫描，共享同一组排除条件和 `blockedBy` 语义）；
+- P0 仍遵守全部现有排除规则（`ai-in-progress`、`ai-pr-opened`、`ai-fix-needed`、
+  `ai-merged`、`ai-blocked`）和单 slot 约束：P0 被阻塞（open blocker）时跳过并
+  回退到 bug/普通扫描，P0 已在途时由重启恢复扫描接回；
+- P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被
+  所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；
+- 可选配置 `active_milestone`（Milestone 标题）把新领取扫描限制在一个版本内，
+  P0 不跨 Milestone；恢复态（已开 PR、在途重启）不受 Milestone 限制。
 
-## Epic Issue（ai-epic）
-
-多任务工作（发布清单、跨任务聚合）用 `ai-epic` 标签的协调 Issue 表达（例如 v0.1 发布清单 #80、0.2.0 工作区 #133）——**不是**可执行任务，也不引入 DAG、数据库、队列或常驻服务：
-
-- **职责边界**：Epic 只负责聚合和发布门禁；实际开发项必须拆成独立的 `ai-ready` 子 Issue，每个子 Issue 一个 runtime outcome、一个 PR、一次独立审查、一次合并。子 Issue 之间的前置条件用 GitHub 原生 `blockedBy` 表达（见「任务依赖（blockedBy）」），Runner 不解析正文复选框或 `Depends on` 行；
-- **Runner 行为（Issue #93）**：普通领取扫描（P0/bug/普通三次扫描）**从不领取**带 `ai-epic` 的 Issue——不加 `ai-in-progress`、不改任何标签、不建 worktree、不启动 `run_pi`、不占执行 slot，记录结构化日志 `epic_not_claimed issue=N repo=...` 后继续检查下一个 ready Issue（Epic 检查先于 blockedBy 检查：「它是 Epic」才是被记录的原因）；重启恢复扫描同样排除 `ai-epic`——遗留 `ai-in-progress` 的 Epic（#80 场景）绝不会被恢复进 run；
-- **完成条件**：子 Issue 已完成、相关 PR 已合并、发布 tag/交付物已存在于远端、没有遗留 `ai-in-progress`。这些条件由 GitHub Issue/label、原生 `blockedBy`、PR 和远端 tag 证据确定；
-- **关闭门禁**：任一完成条件未满足时，Epic 不得被标记完成或自动关闭。Epic 由人工或 release task（带 `ai-release` 标签的 `ai-ready` Issue，由 Runner 的 release 状态机执行，见「Release task（ai-release）」）关闭——Runner 的 release 状态机只关闭 release task 自己，从不标记 Epic 完成，也从不自动关闭 Epic。
-
-## Release task（ai-release）
-
-Release task 是 `ai-ready` + `ai-release` 双标签的 Issue（Issue #98）——**不是**开发任务：Runner 通过普通 ready 扫描领取，但 `process_issue` 把它路由到确定性的 release 状态机而不是 `run_pi`（没有 Pi 会话、没有 PR）。状态机幂等且可恢复（重启后恢复同一 run id/worktree），步骤：
-
-1. 严格解析 Issue 正文的 `## Release` 声明（`version`、`base_branch`、`test_command`、`scope`；缺失/重复/未知字段 fail fast）；
-2. 冻结 base——release commit 就是 `origin/<base_branch>`（base-sync 锁下 fetch）；
-3. 发布前门禁：无遗留 `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`（release Issue 自身除外）、release commit 的 CI 全绿（无 check run 时以证据放行）、base 分支无 open PR；
-4. 逐项验证 scope：`gh pr view` 必须 `MERGED`，否则 `gh issue view` 必须 `CLOSED`（绝不解析复选框）；
-5. 在 release commit 的干净 worktree 里跑声明的 `test_command`（`timeout` 包裹）；
-6. tag：远端 tag 不存在时在 release commit 上创建 annotated tag 并**普通 push**（绝不 `--force`）；已存在时必须精确指向 release commit（指向别处 fail fast——已存在的 tag 绝不移动/覆盖）；
-7. 发布 GitHub Release（幂等），notes 带完整验证证据（scope/门禁/测试/run marker）；
-8. 关闭与发布 `version` **title 精确一致**的 GitHub Milestone（Issue #214）——在成功路径上、release Issue 已 `ai-merged` 关闭之后：open Issues 为 0 时关闭它（`state=closed`，官方 REST 契约 `PATCH /repos/{owner}/{repo}/milestones/{number}`）；已关闭则幂等成功（不重开）；找不到同名 Milestone 或仍有 open Issues 时 fail fast（带上 version、Milestone number/url 和 open issue 列表，不静默跳过、不误关别的 Milestone）；
-9. 成功：`ai-merged`（终态）+ 关闭 Issue + 成功评论（release URL、tag、commit、证据、Milestone 证据）；任何失败：单独 `ai-blocked`（release 是人工决策点，不自动重试）+ 失败评论（run marker + 具体原因）+ fail fast。
-
-可选的 `auto_repair_issues = true` 只覆盖有捕获输出的 Release 测试命令失败：Runner 按 source Issue、run_id、commit、命令和输出生成稳定签名，在 Issue body 搜索该签名后创建或复用一个 `ai-ready` + `bug` 修复 Issue。新 Issue 包含可复现命令和原始输出，照常走 PR/review/merge；Release 仍保持 `ai-blocked`，不会自动重试或发布，必须在修复合并后显式重跑 gate。没有具体测试输出、其他歧义/外部失败或创建修复 Issue 失败时，Runner 记录该失败并保留原始 Release 失败。
-
-三类任务的边界：Epic（`ai-epic`）只协调、从不被领取；普通任务（`ai-ready`）走 `run_pi` → PR → review → merge；Release task（`ai-ready` + `ai-release`）走 Runner 的 release 状态机，不产生 PR。
-
-## 自动可观测（正常运行不需要执行任何命令）
-
-正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。
-任务进入 GitHub Issue 池后，Runner 自己完成领取 → plan → implement → test →
-verify → independent review（会话内修复）→ merge，并主动发布过程和最终结果。
-`muyan-pilot status` 只保留为开发/故障排查附件，不是产品入口，也不能作为
-自动可观测性的验收证据。
-
-### journal（本地，systemd）
-
-Pi 长时间运行时，Runner 不再只留下启动命令和最终结果。`bootstrap_runner.py` 运行 Pi 期间每 15 秒读取任务 worktree 里的 Pi session JSONL（`.pi-session/*.jsonl`），把简短活动写入 journal（systemd 日志）；已经打开 `journalctl -f` 时内容持续自动刷新。完整不变现场（branch / worktree / session 文件）只在 run 开始和失败时各记录一次，运行中只输出短的变化字段，避免每 15–30 秒重复整段上下文：
-
-- `run_start run=... issue=owner/repo#n role=implement branch=... worktree=... session=... session_file=... phase=... last_activity=... action=... result=...`——run 开始时记录一次完整现场；
-- `activity issue=... role=... phase=... action="..." result=... state=-|model_wait|model_wait_slow idle=...s`——phase/action/result 变化时输出（tool_result 只更新 result，不覆盖真实动作）；
-- `heartbeat issue=... role=... phase=... state=-|model_wait|model_wait_slow elapsed=...m idle=...s`——没有变化时按轮询间隔输出，idle 直接写在行上；
-- `model_wait issue=... role=... phase=... state=model_wait`——最近一条 session 事件是 tool result（模型正在等待响应）时输出一次；等待期间只按轮询间隔输出带 `state=model_wait` 的 heartbeat，不升级 WARNING（慢模型不等于卡死）；等待静默超过 `PI_MODEL_WAIT_DEAD_SECONDS` 后 heartbeat 的 state 变为 `model_wait_slow`（同一轮询内即触发下面的 `model_wait_dead` 回收，见下）；
-- `resumed issue=... role=... phase=... state=resumed`——下一条 session 事件到达时输出一次。
-- `model_wait_dead issue=... role=... idle_seconds=... threshold=... action=kill_pi session=... run_id=... upstream_alive=true|false reason=hung_model_request`——`model_wait` 静默超过配置的 `model_wait_dead_seconds`（默认 `PI_MODEL_WAIT_DEAD_SECONDS` = 1800 秒，Issue #228 前默认 600 秒）时输出一次 WARNING 并杀掉 Pi 会话（Issue #218）：`upstream_alive` 是证据不是否决（进程活着 ≠ 在回话），`threshold` 是实际配置的阈值，`run_id` 是低频行字段（见下）；
-- `pi_idle issue=... role=... phase=... stale_seconds=...`——超过 5 分钟（`PI_IDLE_WARN_SECONDS=300`）没有 model/session 活动且不在 `model_wait` 时输出一次 WARNING；卡住的 session 不会每个 heartbeat 重复告警，`model_wait` 期间永不告警（慢模型不等于卡死）；
-- `pi_idle_wait run=... issue=... role=... pid=... cmdline=... deadline=...`——idle 窗口内发现挂死后代正在跑 coreutils `timeout <seconds> ...` 且还没到 deadline 时输出一次（每个卡死一次）：这是合法运行中的长命令（如 `timeout 240 pytest tests/`），不是挂死——Runner 等 deadline，不杀（Issue #169 修复 #105 误杀）；deadline 过后仍存活时再等一个完整 idle 窗口（grace window，Issue #181：wrapper 自己的 deadline 处理是 best-effort，可能被调度延迟，单次“past deadline 仍存活”观察不是 wrapper 失败的证据），下一个窗口仍存活时证据翻转，升级照常进行；
-- `pi_idle_term run=... issue=... role=... pid=... cmdline=... result=sent|failed: ...`（或无 pid 的 `result=no_target`）——idle 告警后第一个 idle 窗口内，对 idle 窗口开始前就已存在、仍在运行的 Pi 后代（挂死的 bash/pytest 等工具）逐个发 SIGTERM（保留现场），让工具拿到非零退出、失败信号回到模型（Issue #94）；找不到挂死后代时记 `no_target`（Pi 自身卡住）；
-- `pi_idle_kill run=... issue=... role=... pid=... cmdline=... result=sent|already_dead|failed: ...`——再过一个 idle 窗口仍无新活动且被 TERM 的后代仍存活时发 SIGKILL；TERM 已生效（进程已退出）时记 `already_dead`，不再发信号；
-- `pi_resumed issue=... role=... phase=...`——idle 告警后第一条新 session 事件到达时输出一次（恢复后输出 resumed），整个 idle 恢复状态同时复位；
-- `run_failed run=... issue=... role=... branch=... worktree=... session=... session_file=... phase=... ... reason=pi_exit_N|timeout_...s|model_wait_dead_stale_...s|idle_recovery_stale_...s`——进程异常退出、超时、模型请求挂死（Issue #75/#218）或连续 3 个 idle 窗口（`PI_IDLE_RECOVERY_CYCLES=3`）仍无新活动（Issue #94，Runner 杀掉 Pi 会话本身）时先记录完整现场再抛出错误；
-- `run_end run=... issue=... role=... result=pr_opened elapsed=...m pr=... commit=...`——验收通过后记录结果和完整排查入口。
-- `run_stopping issue=N title="..." signal=SIGTERM phase=... branch=... worktree=... session=...`——systemd 停止 service（SIGTERM）时若 run 正在进行，先记录完整停止现场（复用现有 run_id 前缀和 activity 快照的 phase/session，不引入新 id），再对活着的 Pi 子进程发 SIGTERM 并等待其退出，绝不留下孤儿 Pi；
-- `run_stopped issue=N result=interrupted`——Pi 子进程退出后记录停止结果；
-- `run_stopped result=idle`——在领取 Issue 之前被停止时只记录 idle 结果，不虚构任何 Issue 字段。
-
-停止顺序（Issue #48）：`run_stopping` → Pi 子进程退出 → `run_stopped` → 进程以 128+信号值（SIGTERM 为 143）退出。systemd 的 generic `Stopped` 行之后，journal 里始终能查到是哪个 Issue 在跑、跑到哪个 phase、branch/worktree/session 是什么。systemd unit 的 `Description` 保持静态，不做动态描述。
-
-模型请求挂死检测与安全回收（Issue #75，Issue #218 起不再以连接活着为豁免，Issue #228 起阈值可配置）：`model_wait` 期间 session JSONL 冻结超过配置的 `model_wait_dead_seconds`（默认 `PI_MODEL_WAIT_DEAD_SECONDS` = 1800 秒，TOML 字段可覆盖；Issue #228 前默认 600 秒，慢本地模型在 10 分钟处被误杀，#176/#175/#173/#168）即判定该次模型请求挂死——模型服务进程活着、连接还 ESTABLISHED（fd 表里的 `socket:[...]` 在 `/proc/net/tcp`/`tcp6` 中处于 ESTABLISHED/SYN_SENT/SYN_RECV 状态且带远端地址）都不是豁免：进程活着 ≠ 在回话（#183 现场：llama-server 活着、`/health` ok，但那次请求被挂住，slot 被占用数小时）。阈值度量的是**完整** session 事件之间的静默（Pi 不向 JSONL 写 token 级进度），不是 token 级模型进度：慢本地模型（如 ~17 tokens/s 的 Qwen 27B，llama-server 请求超时 1200 秒）在默认配置下可以存活超过 10 分钟的完整消息。Runner 先记一行结构化 `model_wait_dead issue=... role=... idle_seconds=... threshold=... action=kill_pi session=... run_id=... upstream_alive=true|false reason=hung_model_request`（`threshold` 是实际配置的阈值，`upstream_alive` 是证据，写进日志供排查，永不否决 kill），再杀掉 Pi 会话，记录 `run_failed ... reason=model_wait_dead_stale_...s` 后 fail fast（implement 阶段 Issue 标记 `ai-blocked`、review 阶段标记 `ai-fix-needed`，现场留在 journal 和 Issue 评论，slot 随进程退出由内核释放，下一拍在同一 run/branch/worktree/PR 上 resume 或领取下一个 `ai-fix-needed`）。事件持续到达时永不触发：慢生成（session 事件不断刷新 stale 计时）不是挂死请求。它也不是业务任务 timeout。
-
-idle 卡死自动恢复（Issue #94，Issue #169 起基于证据）：非 `model_wait` 的卡死（Pi 的 bash 工具子进程永久阻塞，如 TDD red 阶段的死循环测试、`next(generator)` 永久等待）不再只告警。Runner 在现有轮询循环里按 idle 窗口（`idle_warn_seconds`，默认 5 分钟）逐级恢复：第一个窗口检查 idle 窗口开始前就已存在、仍在运行的 Pi 后代（判定依据是 `/proc/<pid>/stat` 的 ppid 链 + 进程启动时间早于 idle 起点，不靠猜；只动 Pi 的后代，不碰系统其他进程，也不碰窗口开始后新起的进程；已退出未收割的僵尸不算目标）——如果某个后代的命令行是 coreutils `timeout <seconds> ...` 且 deadline（进程启动时间 + duration，用 monotonic 时钟域计算，NTP 校时不影响）还没到，它是合法运行中的长命令：Runner 记一次 `pi_idle_wait`（带 pid、cmdline、deadline）、`recovery=wait`，不杀，升级暂停，后续每个窗口重新评估；deadline 过后仍存活时再等一个完整 idle 窗口（grace window，Issue #181：wrapper 自己的 deadline 处理（alarm → 信号投递 → 退出）是 best-effort，可能被调度延迟，单次“past deadline 仍存活”观察不是 wrapper 失败的证据），下一个窗口仍存活（wrapper 没能结束命令）时证据翻转，照常 SIGTERM——工具拿到非零退出，失败信号回到模型，会话自行继续；第二个窗口对被 TERM 后仍存活的后代 SIGKILL；连续 `PI_IDLE_RECOVERY_CYCLES`（默认 3）个窗口仍无新活动时杀掉 Pi 会话本身，按现有 `ai-blocked`/可恢复流程收尾（Issue 标记 `ai-blocked`，slot 随进程退出释放）——slot 绝不被无限占用。每一步写 `pi_idle_wait` / `pi_idle_term` / `pi_idle_kill` journal 行（带 run_id、pid、cmdline、deadline/TERM/KILL、结果），GitHub 进度评论通过 `recovery` 字段（`wait` / `term` / `kill`）同步现场；第一条新 session 事件到达时整个恢复状态复位（`pi_resumed`）。不引入常驻进程/守护线程。
-
-所有行都是稳定 `key=value`（含空格或双引号的值加双引号，内嵌双引号转义为 `\\"`，可用 `pi_activity.parse_scene` 解析）；systemd journal 已提供时间、host 和进程，Python 日志不再重复打印自己的时间戳。每条行都带 `[run_id]` 前缀（见下文全链路 run_id 一节），它是高频行（`activity` / `heartbeat` / `model_wait` / `resumed` / `pi_idle` / `pi_resumed`）唯一的 run id 载体：这些行不再重复 `run=` 字段，同一个 8-hex run id 在一行里只出现一次（Issue #57）。低频场景行（`run_start` / `run_failed` / `run_end` / `pi_idle_term` / `pi_idle_kill`）保留 `run=` 字段，`pi_activity.parse_scene` 仍能从这些行解析出 `run`；`model_wait_dead`（Issue #218）是低频行，按 Issue 契约保留显式 `run_id=` 字段。默认 tail 示例（仅用于查看，不是产品步骤）：
-
-```bash
-journalctl --user -u 'muyan-pilot@*.service' -f
-# Aug 25 14:30:01 host muyan-pilot[123]: INFO [e07383c2] run_start run=e07383c2 issue=orbi-build/orbi#18 role=implement branch=muyan-pilot/... worktree=/home/.../.worktrees/... session=sess-1 session_file=/home/.../.pi-session/sess-1.jsonl phase=starting last_activity=- action=- result=-
-# Aug 25 14:30:16 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="bash pytest tests/" result=- state=- idle=6s
-# Aug 25 14:30:31 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=orbi-build/orbi#18 role=implement phase=test state=- elapsed=30s idle=15s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="bash pytest tests/" result=ok state=- idle=0s
-# Aug 25 14:30:32 host muyan-pilot[123]: INFO [e07383c2] model_wait issue=orbi-build/orbi#18 role=implement phase=test state=model_wait
-# Aug 25 14:39:40 host muyan-pilot[123]: INFO [e07383c2] heartbeat issue=orbi-build/orbi#18 role=implement phase=test state=model_wait elapsed=9m idle=9m
-# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] activity issue=orbi-build/orbi#18 role=implement phase=test action="assistant text" result=- state=- idle=0s
-# Aug 25 14:40:19 host muyan-pilot[123]: INFO [e07383c2] resumed issue=orbi-build/orbi#18 role=implement phase=test state=resumed
-# Aug 25 16:02:10 host muyan-pilot[123]: WARNING [e07383c2] pi_idle issue=orbi-build/orbi#18 role=implement phase=pr stale_seconds=5m
-# Aug 25 16:03:05 host muyan-pilot[123]: INFO [e07383c2] pi_idle_wait run=e07383c2 issue=orbi-build/orbi#18 role=implement pid=4242 cmdline="timeout 240 pytest tests/" deadline=2025-08-25T16:05:30Z
-# Aug 25 16:06:00 host muyan-pilot[123]: INFO [e07383c2] pi_resumed issue=orbi-build/orbi#18 role=implement phase=pr
-# Aug 25 15:12:40 host muyan-pilot[123]: INFO [e07383c2] run_end run=e07383c2 issue=orbi-build/orbi#18 role=implement result=pr_opened elapsed=42m pr=https://github.com/orbi-build/orbi/pull/19 commit=0123456789abcdef0123456789abcdef01234567
-```
-
-每行都带 issue、run id、role（implement / review / merge）、phase、
-elapsed、last activity、last action、session、branch。implementer、reviewer
-两种 Pi session 用同一个机制观测，role 由 Runner 在启动 session 时传入。
-
-### Prometheus / Grafana（可选，只读，独立）
-
-`monitoring/` 下是一套只读、独立、版本管理的观测栈（Issue #162）：
-`monitoring/prometheus/muyan-pilot-exporter.py` 只读 journal 和
-`systemctl --user is-active`，在 `127.0.0.1:9106/metrics` 暴露
-`muyan_pilot_*` 指标（service active、每 slot 当前
-issue/role/phase/state、idle 秒数、run 时长、`run_failed` by reason、
-idle 恢复、`progress_publish_failed`、model_wait）；
-`monitoring/grafana/dashboards/muyan-pilot.json` 是配套 Dashboard（复用
-已有 llama 指标）。Runner 完全不知道它存在：不 push、不写状态，观测栈
-任意一环挂掉不影响领取/运行/merge；标签只用低基数集合（无 `run_id`、
-无命令/prompt 文本）。安装与验证步骤见 `monitoring/grafana/README.md`。
-
-### GitHub（手机，自动更新）
-
-领取任务后，Runner 在 source Issue 上创建一条带隐藏 run marker
-（`<!-- muyan-pilot:run=<run_id> -->`）的进度评论，之后只 PATCH 同一条
-评论（进度变化时立即，且间隔不超过 30 秒），不新增 heartbeat 垃圾评论。
-**Pi 运行期间就是活的**：implementer、reviewer 两种 session 的每次
-活动变化/心跳都会渲染当前状态并 PATCH 同一条评论（不是等 Pi 退出后才
-回写），手机用户看到的始终是进行中的进展，而不是一条静态的 starting
-评论。评论始终显示：当前阶段、role、优先级（`p0`/`normal`，见「领取
-优先级（P0）」）、已运行时间、最近活动时间、最近动作、
-测试状态、review/fix round、branch、PR/merge 状态。进程重启后按 run marker
-找回同一条评论继续更新，不需要数据库。
-
-关键 milestone 单独发布简短评论（`Muyan Pilot: ...`），让 GitHub Mobile
-主动推送通知：started、plan ready、tests passed/failed、review findings、
-PR opened、merged、blocked。完成后进度评论更新为最终交付摘要
-（PR、测试、审查证据）；真正失败时更新为 blocked 现场和下一步原因，同时
-Issue 标记 `ai-blocked`。
-
-### 调试附件
-
-`muyan-pilot status` 只读展示当前（`ai-in-progress`）任务的实时状态（仅供开发/故障排查）：
-
-```bash
-muyan-pilot status --config muyan-pilot.toml
-# capacity: 1
-# slots: 1/1
-#   slot-1: pid=4321
-# source: orbi-build/orbi
-#   base: main abc123def456
-#   current: #24 Stream live Pi activity ... https://github.com/orbi-build/orbi/issues/24
-#     live: phase=test last_activity=2026-08-25T02:30:00Z action=bash pytest tests/ result=ok
-#     session: .../.worktrees/muyan-pilot-orbi-build-orbi-issue-24-<run-id>/.pi-session/<session>.jsonl
-#     worktree: .../.worktrees/muyan-pilot-orbi-build-orbi-issue-24-<run-id>
-#   ready: -
-#   result: -
-```
-
-顶部的 `capacity` / `slots` 是当前机器的并发容量（`max_concurrency`）与已占用 slot（含持有者 PID），见下一节。
-
-journal、`status` 和 GitHub 进度评论只暴露脱敏摘要：完整 prompt、Issue body 和 token 不会写入日志或评论（命令日志固定为 `<redacted>`，工具摘要截断到 200 字符并屏蔽常见 token 形状）。关键阶段继续回写 GitHub Issue 评论：Pi 启动（含 branch 和 worktree）、PR 创建、失败现场（含完整 run 现场）。session JSONL 完整保留在 worktree 中，作为本地完整记录。
-
-前置条件：
-
-- `gh auth status` 成功；
-- `pi --version` 成功；
-- 配置文件存在且包含 `source_repos`；
-- 配置中的 repo、workspace、prompt 和 context 路径正确。
-
-配置使用 TOML，由人维护，AI 通过 PR 修改。开源仓库只提交 example，真实配置不提交：
-
-```toml
-cp .muyan-pilot.example.toml muyan-pilot.toml
-# 编辑 muyan-pilot.toml
-```
-
-Runner 每次处理一个 delivery：领取（或恢复）一个 Issue 后，在整个 implement → review（会话内修复）→ merge 期间持有并发 slot，PR 合并或终态失败后退出，由 systemd timer 再次触发；不在 Python 内实现 daemon，不引入数据库、队列、重试或复杂恢复。没有人为的任务时长上限；命令错误立即失败，真正卡死时通过 systemd/journal 排查并人工停止。`max_concurrency` 同时决定已启用 timer 的数量（1 或 2）；slot 仍是最终安全边界，拿不到 slot 的 Runner 仍记录 `capacity_full` 后正常退出，不领取 Issue。
-
-## 并发限制（max_concurrency）
-
-本机允许的 Pilot 并发任务数由 `muyan-pilot.toml` 的 `max_concurrency` 配置：必须是 1 或 2 的整数，缺失时默认 1（固定模板只有两个实例）；非整数、布尔值、0、负数或大于 2 的值启动即 fail fast。slot 状态在 `<repo_dir>/.muyan-pilot/slots/slot-N`（N = 1..max_concurrency）：每个 slot 文件是一个普通的锁目标，**文件上的排他 `flock(2)` 锁就是所有权**——内核保证同一时刻至多一个进程持有某个 slot 的锁。持有者 PID 只作为 `status` 展示的观察性元数据写入文件，不是所有权依据；没有 stale PID/超时回收启发式，没有 atexit/信号清理协议。
-
-- 并发额度按完整任务生命周期计算：Runner 在领取 Issue 之前取得 slot，implement → review（会话内修复）→ merge 期间始终占用；PR 打开后任务没有结束，Runner 持有 slot 轮询 PR 状态（15 秒一次，与 Pi 活动轮询同频）：PR `MERGED` 或终态失败（PR 未合并被关闭 → Issue 标记 `ai-blocked`）才释放 slot 退出；期间 Issue 进入 `ai-fix-needed`（review finding、base 冲突，或已有 run/PR 的**可恢复失败**——Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）时，**下一个 tick 在同一 run_id、同一 branch、同一 worktree、同一 PR 上启动下一个独立审查会话**（会话内吸收最新 base 并修复 finding，见下节），不会冷启动 Fixer，也不会让新 Runner 插队领取新 Issue；
-- 同一任务内部 implement/review 串行执行，共用同一个 slot，任意时刻最多一个 Pi 子进程；
-- 达到 `max_concurrency` 时，新 Runner 不领取 Issue、不修改标签、不调用 Pi，记录结构化日志 `capacity_full max_concurrency=... slot_dir=...` 后正常退出（退出码 0），等 systemd timer 下次触发；
-- slot 锁由打开的文件描述符持有：进程正常结束、SIGTERM/SIGINT（systemd stop / Ctrl+C）或被 SIGKILL 时，内核自动释放锁——活着的持有者永远不会因为时间或 PID 检查丢失 slot，死掉的持有者永远不会占住 slot，异常退出不会造成永久锁死；slot 文件本身保留（它是锁目标，不是令牌），`status` 按锁的实际状态报告占用；
-- `muyan-pilot status` 显示配置容量和当前已占用 slot（`capacity: N`、`slots: k/N`、`slot-N: pid=...`）；占用判定用非阻塞 `flock` 探测（探测成功即空闲并立即解锁），PID 仅用于展示；
-- 直接在 Pilot 外手工运行的任意 `pi` 命令不属于该配置控制范围：`max_concurrency` 只约束 Runner 领取任务时启动的 Pi，手工 `pi` 不受 slot 管理，也不会释放或占用任何 slot。
-
-## Pi 默认 provider/model（pi_provider / pi_model / pi_thinking，Issue #119）
-
-部署者可以在 `muyan-pilot.toml` 中可选声明 Pi 的 provider、model 和 thinking level，不必修改全局 Pi 配置或启动脚本：
-
-```toml
-pi_provider = "openai"
-pi_model = "gpt-5.6-sol"
-pi_thinking = "medium"
-```
-
-- Runner 启动 implement 和 review 的 Pi 时都显式传递 `--provider <pi_provider> --model <pi_model> --thinking <pi_thinking>`（flag 契约以 `pi --help` 为准）；
-- 三个键彼此独立：未配置某项时不传对应参数，Pi 继续使用自身默认值；配置值以 TOML 为准，不依赖 `~/.pi/agent/settings.json`；
-- 配置值按原样传给 Pi 启动入口，并记录在 journal 的 `command=` 行（redacted 命令的一部分）——provider/model/thinking 是非敏感的模型标识，prompt 和 Issue 内容仍保持 redacted；
-- 键存在但为空字符串或非字符串时 `load_config` fail fast（`<key> must be a non-empty string`）；Pi 启动失败沿用现有 fail-fast 契约（非零退出/超时 → `run_failed` + 异常）；
-- 不按任务类型、label 或角色自动选择模型，不做动态路由、benchmark、成本路由或 fallback，不支持一个 run 中途切换模型；token/密钥不进入配置、日志、Issue 或 PR。
-
-## 可配置 Pi provider（pi_providers，Issue #157）
-
-`pi_provider`/`pi_model` 只能选择 Pi 已认识的 provider。要接入任意 OpenAI-compatible 端点（如 Groq），在 `muyan-pilot.toml` 中可选声明一个 provider 文件（路径，JSON，与 Pi 的 `~/.pi/agent/models.json` 同构）：
-
-```toml
-pi_providers = ".muyan-pilot/pi-providers.json"
-pi_provider = "groq"
-pi_model = "qwen/qwen3.8-27b"
-```
-
-```json
-{
-  "providers": {
-    "groq": {
-      "baseUrl": "https://api.groq.com/openai/v1",
-      "api": "openai-completions",
-      "apiKey": "$GROQ_API_KEY",
-      "models": [{ "id": "qwen/qwen3.8-27b" }]
-    }
-  }
-}
-```
-
-- `baseUrl`（provider 端点）只允许出现在这个 provider 文件里；`muyan-pilot.toml` 只选择运行时 provider/model/thinking，不携带端点；
-- `apiKey` 是环境变量引用（`$VAR` 或 `${VAR}`，Pi 的 value 语法），绝不写密钥值；密钥只存在于进程环境（如 systemd `Environment=`）；
-- Runner 在启动 Pi 前把文件物化到任务 worktree 的 `.muyan-pilot/pi-agent/`（gitignored，每 run 一份）：`models.json` = 用户 `~/.pi/agent/models.json` 的 providers 与文件的 providers 合并（同 id 时文件优先，用户已有 provider 继续可用），`settings.json`/`auth.json` 以符号链接指向用户目录（其余行为不变），并通过 `PI_CODING_AGENT_DIR` 指向该目录（已对真实 Pi 0.84.3 验证）——implement 与 review 的 Pi 走同一条路径、同一份 provider 配置；
-- `load_config` fail fast：文件不存在/不是合法 JSON/没有 `providers` 对象；带 `models` 的 provider 缺 `baseUrl` 或 `api`（provider 级或每个 model 级）；`pi_provider` 未在文件中定义；`pi_model` 不在该 provider 的 models 里（Pi 对未知 model id 只告警仍发请求，不存在 fail fast，所以由 Runner 在启动前校验）；选中 provider 的 `apiKey` 引用的环境变量缺失或为空（只报告变量名，不报告值）；
-- 未配置 `pi_providers` 时行为与 #157 之前完全一致（不物化目录、不设置 `PI_CODING_AGENT_DIR`、Pi 命令与环境不变）；
-- 日志/Issue/PR 只出现 provider、model、thinking 等非敏感标识；`baseUrl` 与 API key 不进入 journal（redacted `command=` 行只含 `--provider/--model/--thinking`）、不进入 Issue/PR 评论。
-
-## 全链路 run_id（correlation ID）
-
-每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同 trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成新的 run_id，Issue number 是多个 run 的共同父标识。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
-
-同一个 run_id 出现在：
-
-- 该 attempt 的每条 journal 日志首字段：`[e07383c2] command=...`；
-- start / PR opened / failed 等 Issue 评论：可见字段 `run_id=e07383c2` + 隐藏 marker `<!-- muyan-pilot:run=e07383c2 -->`；
-- feature branch 与 worktree 名（例如 `.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`）；
-- Pi session 目录（worktree 内 `.pi-session/`）与 plan/test/verify/review 等 run artifacts 的路径；
-- 注入 Pi 的 prompt context（`Run id: ...`）；
-- PR body 的稳定 machine-readable marker `<!-- muyan-pilot:run=e07383c2 -->`——Runner 验收时校验，缺失即 fail fast，拒绝该 PR；
-- Pi 自己发出的 progress / review / 最终评论（prompt 要求携带同一 marker 和 `run_id=` 字段）。
-
-查询方式（不依赖内存映射，进程重启后仍可恢复关联）：
-
-```bash
-# journal 中还原一个 run 的完整时间线
-journalctl --user -u 'muyan-pilot@*.service' | grep e07383c2
-
-# GitHub 上搜索一个 run 的 progress / milestone / review / merge 记录
-gh search issues "e07383c2" --repo orbi-build/orbi
-
-# 本地在 repo 中搜索 run_id 找到 worktree、session 和 run artifacts
-grep -r e07383c2 .worktrees/   # 在 clone 根目录执行
-```
-
-缺少合法 run_id 的 run-scoped 事件（绑定 run、构建 GitHub marker、PR body 校验）会 fail fast，不做回退。
-
-## 任务 base 与 worktree
-
-每次领取任务前，Runner 在配置 repo 中执行 `git fetch origin <base_branch>`，并冻结 `origin/<base_branch>` 的精确 SHA（`base_branch` 在 TOML 中配置，默认 `main`）。任务 worktree 和 feature branch 都从该 SHA 创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如 `.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`），同一个 Issue 返工时会生成新的独立 run，旧现场原样保留。base branch、base SHA 和 run 标识会写入 Issue 评论和 `status` 输出。任务 worktree 共享部署 checkout 的单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree 内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
-
-### 重启恢复（kill 后自动续跑）
-
-Runner 被 SIGKILL 时无法执行任何清理：任务 worktree 和 `ai-in-progress` 领取标签会留在 GitHub 上（Issue 仍带 `ai-ready`）。下一个 tick 的领取扫描在 ready 队列之前先扫描 `ai-ready`+`ai-in-progress`（且未处于其他交付状态）的 open Issue——**仅当没有其他 Runner 活着时**（其他 slot 被占用证明有活着的 Runner 在处理，此时 `ai-in-progress` 是“进行中”而不是“孤儿”，绝不为活着的 run 启动第二个 Pi；flock 锁是唯一事实源）。找到后走 `process_issue` 的恢复分支：复用最新 worktree 的 run id（branch、worktree、进度评论都由它驱动），按隐藏 run marker 找回同一条进度评论继续 PATCH，不新建 run、不新建 worktree、不新建评论。已完成 run 的 worktree 保留为证据但标签已移除，重新领取永远新 run。
-
-Agent 在提交处停止（代码、测试、commit 都在 task branch 上）；创建 PR 前的 base 新鲜度是 Runner 的确定性收口（Issue #186，`deliver_pr`）：Runner 在 base-sync 锁下重新 fetch `origin/<base_branch>`，若已前进则用 plain `git merge` 合入最新 base（冲突时 abort，PR 在 Agent 的 head 上打开，由既有审查会话在会话内吸收 base），然后 plain push task branch 并创建 PR。不自动解决冲突，不 force push，不 merge 或 push 保护分支。
-
-同一 worktree 下 Pi 新旧 `.pi-session` 的识别：恢复的 run（同一 worktree）会创建**新的** session JSONL，journal 只跟踪当前这次调用的 session（启动前已存在的 JSONL 永不跟随），避免把上一个 run 的 session 报告成活着的会话（Issue #45）。
-
-`.worktrees/` 已加入 `.gitignore`，不会进入版本库。
+完整说明见 [Workflow](docs/workflow.mdx)。
 
 ## 自动 loop 与恢复现场（Issue #49）
 
-自动 loop 的完整状态链（systemd timer 是唯一自动入口，不需要人工触发 CLI；一个本地 Pi slot 内始终只有一个执行进程）：
+自动 loop 的完整状态链（systemd timer 是唯一自动入口；一个本地 Pi slot 内始终
+只有一个执行进程）：
 
 ```text
 ai-ready
@@ -525,61 +257,196 @@ ai-ready
 
 规则：
 
-- 只有两个 opened-PR 状态会被自动拾取：`ai-fix-needed`（下一个审查会话）和 `ai-pr-opened`（独立审查）；`ai-ready` 走领取，`ai-blocked` **不会自动恢复**（先要人工决策：修复现场后转 `ai-fix-needed` 或重新领取）；
-- 修复必须沿用同一 PR number、branch、worktree、run_id（PR number 永远不变，head 可以前进）；
-- base 前进时先 merge 最新 `origin/<base>`（冲突交给 Pi 解决），重跑全量测试后再继续；
-- review 结论、测试、覆盖率、验证和结果都要回写 GitHub Issue/PR（`REVIEW_VERDICT` 评论、milestone、进度评论），不只留在本地；
-- malformed recovery scene（缺少完整现场、无可信评论）fail fast：Issue 标记 `ai-blocked` 并写明具体原因，本 tick 停止，不做猜测。
+- 只有两个 opened-PR 状态会被自动拾取：`ai-fix-needed`（下一个审查会话）和
+  `ai-pr-opened`（独立审查）；`ai-ready` 走领取，`ai-blocked` **不会自动恢复**
+  （先要人工决策：修复现场后转 `ai-fix-needed` 或重新领取）；
+- 修复必须沿用同一 PR number、branch、worktree、run_id（PR number 永远不变，
+  head 可以前进）；
+- base 前进时先 merge 最新 `origin/<base>`（冲突交给 Pi 解决），重跑全量测试
+  后再继续；
+- review 结论、测试、覆盖率、验证和结果都要回写 GitHub Issue/PR
+  （`REVIEW_VERDICT` 评论、milestone、进度评论），不只留在本地。
 
 恢复现场（resume scene）契约：
 
-- Runner 开 PR 后在源 Issue 发布 `Muyan Pilot opened PR:` 评论，携带 run marker `<!-- muyan-pilot:run=<8 hex> -->`、可见 `run_id=` 字段、`base_branch`、`base_sha` 和 PR URL——这是恢复的唯一现场（这条 scene 评论不是旁路：它失败仍 fail fast，因为 resume 靠它）；
-- 只有 **trusted maintainer**（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的评论才可信；公开评论（authorAssociation=NONE）永远不可信，无法把 Runner 指向任意本地路径；
-- branch 和 worktree 由配置的 repo、source repo、Issue 编号和 run_id **推导**，绝不从公开 comment 读取；
-- **PR body 也必须包含稳定的 run marker**，否则恢复 fail fast（Runner 验收时校验）；
-- **历史兼容**：统一 run_id 机制之前创建的旧 PR 可能只有 Issue comment marker、没有 PR body marker——恢复前需要**补齐 PR body marker**（编辑 PR body 加入 `<!-- muyan-pilot:run=<run_id> -->`），不能只改 label。
+- Runner 开 PR 后在源 Issue 发布 `Muyan Pilot opened PR:` 评论，携带 run marker
+  `<!-- muyan-pilot:run=<8 hex> -->`、可见 `run_id=` 字段、`base_branch`、
+  `base_sha` 和 PR URL——这是恢复的唯一现场（这条 scene 评论不是旁路：它失败仍
+  fail fast，因为 resume 靠它）；
+- 只有 **trusted maintainer**（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的评论
+  才可信；公开评论（authorAssociation=NONE）永远不可信，无法把 Runner 指向任意
+  本地路径；
+- branch 和 worktree 由配置的 repo、source repo、Issue 编号和 run_id **推导**，
+  绝不从公开 comment 读取；
+- **PR body 也必须包含稳定的 run marker**，否则恢复 fail fast（Runner 验收时
+  校验）；
+- **历史兼容**：统一 run_id 机制之前创建的旧 PR 可能只有 Issue comment marker、
+  没有 PR body marker——恢复前需要**补齐 PR body marker**（编辑 PR body 加入
+  `<!-- muyan-pilot:run=<run_id> -->`），不能只改 label。
+
+同一 worktree 下 Pi 新旧 `.pi-session` 的识别：恢复的 run（同一 worktree）会
+创建**新的** session JSONL，journal 只跟踪当前这次调用的 session（启动前已存在
+的 JSONL 永不跟随），避免把上一个 run 的 session 报告成活着的会话（Issue #45）。
 
 ## PR body 契约：`Fixes #N`（Issue #53）
 
-Pi 创建的 PR description 必须包含 `Fixes #<issue-number>`（可以放在首行），指向其源 Issue。GitHub 原生行为：PR merge 到默认分支（`main`）时，body（或 commit message）中的 `Fixes`/`Closes`/`Resolves #<n>` 关键词会自动关闭对应 Issue；PR title 不支持该关键词。没有这个关键词，merge 后 Issue 仍然 OPEN（例如 #45 的遗留状态），需要人工补关。
-
-- prompt（`prompt.md`）在 PR 创建步骤要求携带 `Fixes #<issue-number>`（模板里的 `{{ISSUE_NUMBER}}` 由 Runner 渲染成真实 Issue 编号）；
-- Runner 验收（`verify_pr`）校验 PR body 含 `Fixes #<issue-number>`，缺失即 fail fast 拒绝该 PR（`pr_fixes_missing`），与 run marker 校验同级；
-- 开发契约见 `AGENTS.md`（Git 一节）。
-
-## PR 创建后的 review/修复 循环（Issue #45、#82）
-
-PR 创建后任务没有结束：Issue 进入可恢复的 review 状态。`ai-pr-opened` 表示**等待 review**；`ai-fix-needed` 表示当前 head 尚不可合并（审查会话未能修复的 finding，或 PR 落后最新 base / 存在 merge conflict）——下一个 tick 在同一 run、同一 PR 上启动**下一个独立审查会话**，由审查会话在会话内吸收最新 base 并修复 finding（Issue #82：不再冷启动 Fixer，也没有第三次 review）。Review finding、base 前进或 merge conflict 都是可修复状态，不等于任务失败，也不重新进入 ready 队列。
-
-- 每个 tick 先按顺序扫描 source repos 中两个 opened-PR 状态的 open Issue（Issue #70）：`ai-fix-needed`（finding 或 base 冲突 → 同一 PR 的下一个审查会话）和 `ai-pr-opened`（等待 review → 同一 PR 的独立审查）。`ai-pr-opened` 被扫描是因为开 PR 的那次 delivery 可能已经不在（Runner 被杀，或 Issue #70 背后的进度 PATCH 404 曾把已交付的 Issue 在审查开始前就标成 `ai-blocked`）：没有这个扫描，一个有效的 MERGEABLE PR 会永远没有 owner。`ai-blocked` 的 Issue 被排除（先要人工决策），`ai-merged` 同样被排除；`ai-in-progress` 不排除（Issue #178：review 中被杀的 Runner 会留下回填的在途标签，同一扫描必须能接回——正向限定 `label:ai-fix-needed,ai-pr-opened` 已保证 implement 阶段的 Issue 不会匹配）；找到时，Runner 只信任由维护者（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的最新 `Muyan Pilot opened PR:` 评论（公开评论永远不可信），从中恢复 run 现场（`run_id`、base_branch、base_sha、PR URL），branch 和 worktree 由配置的 repo、Issue 编号和 run_id **推导**（绝不从评论读取，评论无法指定任意本地路径），在**原 worktree、原 branch、同一 PR** 上继续（`ai-fix-needed` 与 `ai-pr-opened` 都直接进入审查等待），而不是领取新 Issue。现场无法恢复（评论缺少完整现场、无可信评论）时 fail fast：Issue 标记 `ai-blocked` 并写明具体原因，本 tick 停止，不做猜测，也不让新任务插队。任何 git/Pi 变更前，Runner 先校验配置的 base 和 open PR（head repo、head branch、base、run marker、精确 URL）。
-- 审查会话（journal 中 `role=review`）在会话内完成修复：修改代码、重跑完整测试与 100% 行/分支覆盖率、commit 并**只 push 原 task branch**，然后对修复后的 head 重新输出 `REVIEW_VERDICT`。PR 头分支前进，**PR number 保持不变**。
-- 审查会话无法修复的 finding（或 PR 落后最新 base / merge conflict）：Issue 标记 `ai-fix-needed`，等待下一个 tick 的下一个审查会话（会话内 `git merge origin/<base>` 吸收最新 base、解决冲突、全量回归后重新输出 verdict）。Runner 自己不自动解决冲突、不 `--abort`、不 force push、不 push 保护分支。
-- **可恢复失败留在自动修复循环**（Issue #50）：审查 Pi 执行失败、验证失败、未推送本地 commit（#158 场景：本地 commit 保留，下一次审查会话在同一 PR 上继续 push 和验证）、worktree 缺失等已有 run/PR 的失败**不**是终态——Issue 标记 `ai-fix-needed`（移除 opened-PR 状态），失败 comment 同时写入 Issue 和 PR，带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误；下一个 tick 自动拾取并在同一 run、branch、worktree、PR 上继续。PR、branch、worktree 原样保留，不删除、不关闭、不重建，也不重新创建 PR。
-- 审查/修复循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）：**只有**超轮仍有 Blocker/Major 时 Issue 才标记 `ai-blocked`（移除 opened-PR 状态，超轮是人工决策），评论写明为什么不能自动恢复和完整现场；`ai-blocked` 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50）。
-- Runner/服务重启后，仅凭 Issue 标签、评论 marker、PR head、branch 和 worktree 即可恢复该循环；implement/review/merge 串行占用同一个并发 slot，不会为同一个 run 启动第二个 Pi。
-
-状态语义：
-
-```text
-ai-in-progress → PR opened (ai-pr-opened) → review（会话内修复）
-  → 未修复的 finding / base 冲突 (ai-fix-needed) → 下一个审查会话
-  → clean verdict → merge → ai-merged
-```
+PR description 必须包含 `Fixes #<issue-number>`（可以放在首行），指向其源
+Issue。GitHub 原生行为：PR merge 到默认分支（`main`）时，body（或 commit
+message）中的 `Fixes`/`Closes`/`Resolves #<n>` 关键词会自动关闭对应 Issue；PR
+title 不支持该关键词。prompt（`prompt.md`）在 PR 创建步骤要求携带
+`Fixes #<issue-number>`；Runner 验收（`verify_pr`）校验 PR body 含
+`Fixes #<issue-number>`，缺失即 fail fast 拒绝该 PR（`pr_fixes_missing`），与
+run marker 校验同级。开发契约见 `AGENTS.md`（Git 一节）。
 
 ## 自动审查、修复与合并（Issue #34、#82）
 
-Pi 不直接 push 保护分支。实现 Agent 在提交处停止（不 fetch、不 push、不创建 PR）；Runner 完成确定性收口（Issue #186：base fetch 与吸收、plain push task branch、创建 PR），PR 打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
+实现 Agent 在提交处停止（不 fetch、不 push、不创建 PR）；Runner 完成确定性
+收口（Issue #186：base fetch 与吸收、plain push task branch、创建 PR），PR
+打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
 
-1. **冻结 PR 的 base/head SHA**（`gh pr list` 取唯一 open PR 的 `baseRefOid`/`headRefOid`）。
-2. **独立审查（同时是修复者，Issue #82）**：启动一个独立的 Review Agent（code-review R1–R9，不附加 `review-fix-loop`/`tdd-dev` skill），对精确 base/head SHA 审查需求、diff、调用链、测试与运行证据；审查会话与 implementer 一样通过 live activity 管道输出（journal 中 `role=review`）。审查者**可以修改代码**：发现 Blocker/Major 时在同一会话内修复、重跑完整测试与 100% 行/分支覆盖率、commit 并只 push task branch，然后对修复后的 head 重新输出 verdict——没有冷启动 Fixer，也没有第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT {"verdict":"pass|findings","blockers":N,"majors":N,"minors":N,"findings":[...]}` 结尾；`pass` 表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，绝不当作通过。
-3. **重新冻结并合并门禁**：clean verdict 后 Runner 重新冻结 PR（审查者可能已 push 修复，head 前进），重新 fetch 最新 `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，只有被审查的 head 能落地。
-4. **确认合并并同步部署 checkout**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在 `origin/<base>`；随后把配置 `repo_dir` 的 base checkout `git merge --ff-only origin/<base>` 并验证本地 HEAD == `origin/<base>`，下一个 systemd tick 加载的就是刚合并的新代码。Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动 CLOSED（见上方「PR body 契约」）。
-5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。已有 run/PR 的**可恢复失败**（审查 Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）同样标记 `ai-fix-needed`：失败 comment 写入 Issue 和 PR（带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误），下一个 tick 在同一 run、branch、worktree、PR 上继续，不重新创建 PR、不重复领取。审查循环最多 5 轮（见 `MAX_REVIEW_ROUNDS`）；**只有**超轮仍有 Blocker/Major 时 fail fast 并标记 `ai-blocked`（超轮是人工决策，comment 写明为什么不能自动恢复）。
+1. **冻结 PR 的 base/head SHA**；
+2. **独立审查（同时是修复者，Issue #82）**：独立的 Review Agent
+   （code-review R1–R9）对精确 base/head SHA 审查；发现 Blocker/Major 时在同一
+   会话内修复、重跑完整测试与 100% 行/分支覆盖率、commit 并只 push task
+   branch，然后对修复后的 head 重新输出 verdict——没有冷启动 Fixer，也没有
+   第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT` 结尾；`pass`
+   表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，
+   绝不当作通过；
+3. **重新冻结并合并门禁**：clean verdict 后 Runner 重新冻结 PR，重新 fetch 最新
+   `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是
+   被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，
+   只有被审查的 head 能落地；
+4. **确认合并**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在
+   `origin/<base>`；Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动
+   CLOSED；
+5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge
+   conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个
+   审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。已有
+   run/PR 的**可恢复失败**（Pi 执行失败、验证失败、未推送本地 commit、worktree
+   缺失等，Issue #50）同样标记 `ai-fix-needed`：失败 comment 写入 Issue 和
+   PR（带完整现场），下一个 tick 在同一 run、branch、worktree、PR 上继续，不
+   重新创建 PR。审查循环最多 5 轮（`MAX_REVIEW_ROUNDS`）；**只有**超轮仍有
+   Blocker/Major 时 fail fast 并标记 `ai-blocked`（超轮是人工决策）。
 
-成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、merge commit、审查轮次和 base/run 信息。下一任务只从新的 `origin/<base>` 创建。不 force push、不直接 push 保护分支、不设业务 timeout；审查 finding 不是 `ai-blocked`，而是在同一 PR 的审查会话内修复（或交给下一个审查会话）。
+成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、
+merge commit、审查轮次和 base/run 信息。不 force push、不直接 push 保护分支、
+不设业务 timeout。完整链路与状态语义见 [Workflow](docs/workflow.mdx)。
 
-两个 prompt 由配置提供（默认 `prompt.md` 实现、`prompt_review.md` 审查+会话内修复）；审查 prompt 不附加 `review-fix-loop`/`tdd-dev` skill。
+## 自动可观测（正常运行不需要执行任何命令）
+
+正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。
+Runner 自己完成领取 → plan → implement → test → verify → independent review
+（会话内修复）→ merge，并主动发布过程和最终结果（journal + GitHub 进度评论）。
+`muyan-pilot status` 只保留为开发/故障排查附件，不是产品入口，也不能作为自动
+可观测性的验收证据。
+
+journal（本地，systemd）是运行中的实时记录：每条行都带 `[run_id]` 前缀、
+issue、role（implement/review/merge）、phase、elapsed、last activity、last
+action、session、branch；`journalctl --user -u 'muyan-pilot@*.service' -f`
+持续自动刷新。模型请求挂死检测（Issue #75/#218，阈值可配置，Issue #228）：
+`model_wait` 期间 session JSONL 冻结超过配置的 `model_wait_dead_seconds`
+（默认 `PI_MODEL_WAIT_DEAD_SECONDS` = 1800 秒；Issue #228 前默认 600 秒）即
+判定该次模型请求挂死——模型服务进程活着、连接还 ESTABLISHED 都不是豁免
+（进程活着 ≠ 在回话）。Runner 先记一行结构化
+`model_wait_dead issue=... role=... idle_seconds=... threshold=...
+action=kill_pi session=... run_id=... upstream_alive=true|false
+reason=hung_model_request`（`upstream_alive` 是证据，写进日志供排查，永不
+否决 kill），再杀掉 Pi 会话，记录 `run_failed ... reason=model_wait_dead_stale_...s`
+后 fail fast（implement 阶段 Issue 标记 `ai-blocked`、review 阶段标记
+`ai-fix-needed`）。事件持续到达时永不触发：慢生成（session 事件不断刷新 stale
+计时）不是挂死请求。它也不是业务任务 timeout。
+
+所有 journal 行（`run_start`/`activity`/`heartbeat`/`model_wait`/`resumed`/
+`pi_idle`/`pi_idle_wait`/`pi_idle_term`/`pi_idle_kill`/`pi_resumed`/
+`run_failed`/`run_end`/`run_stopping`/`run_stopped`）、idle 卡死自动恢复
+（Issue #94/#169/#181）和停止顺序的完整字段说明见
+[Operations](docs/operations.mdx)。
+
+GitHub（手机，自动更新）：领取任务后，Runner 在 source Issue 上创建一条带隐藏
+run marker（`<!-- muyan-pilot:run=<run_id> -->`）的进度评论，之后只 PATCH 同一
+条评论（进度变化时立即，且间隔不超过 30 秒），不新增 heartbeat 垃圾评论；关键
+milestone（started、plan ready、tests passed/failed、review findings、PR
+opened、merged、blocked）单独发布简短评论，让 GitHub Mobile 主动推送通知。
+进度评论是纯旁路（Issue #79）：它失败只记 `progress_publish_failed`，绝不改变
+交付结果；`Muyan Pilot opened PR:` scene 评论不是旁路（resume 靠它）。
+
+Prometheus / Grafana（可选，只读，独立）：`monitoring/` 下是一套只读、独立、
+版本管理的观测栈（Issue #162），Runner 完全不知道它存在；安装与验证步骤见
+`monitoring/grafana/README.md`。
+
+## 配置
+
+配置使用 TOML，由人维护，AI 通过 PR 修改。开源仓库只提交 example，真实配置不
+提交（`cp .muyan-pilot.example.toml muyan-pilot.toml`）。完整字段表（含
+`active_milestone`、`max_concurrency`、`model_wait_dead_seconds`、
+`pi_providers`/`pi_provider`/`pi_model`/`pi_thinking` 的模型 provider 配置）见
+[Getting started](docs/getting-started.mdx)。
+
+## 并发限制（max_concurrency）
+
+`max_concurrency`（默认 1，只允许 1 或 2）同时决定本机允许的 Pilot 并发任务数
+和已启用 timer 的数量（1 或 2）；slot 仍是最终安全边界——拿不到 slot 的 Runner
+记录 `capacity_full` 后正常退出，不领取 Issue。slot 是
+`<repo_dir>/.muyan-pilot/slots/slot-N` 文件上的排他 `flock(2)` 锁，内核在进程
+退出时自动释放，活着的持有者永远不会丢失 slot，死掉的持有者永远不会占住
+slot。完整说明见 [Operations](docs/operations.mdx)。
+
+## 任务 base 与 worktree
+
+每次领取任务前，Runner 冻结 `origin/<base_branch>` 的精确 SHA（`base_branch`
+在 TOML 中配置，默认 `main`）；任务 worktree 和 feature branch 都从该 SHA
+创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如
+`.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`），同一个 Issue
+返工时会生成新的独立 run，旧现场原样保留。任务 worktree 共享部署 checkout 的
+单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree
+内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
+
+Agent 在提交处停止；创建 PR 前的 base 新鲜度是 Runner 的确定性收口（Issue
+#186）：Runner 在 base-sync 锁下重新 fetch `origin/<base_branch>`，若已前进则
+用 plain `git merge` 合入最新 base（冲突时 abort，PR 在 Agent 的 head 上打开，
+由既有审查会话在会话内吸收 base），然后 plain push task branch 并创建 PR。不
+自动解决冲突，不 force push，不 merge 或 push 保护分支。
+
+Runner 被 SIGKILL 时任务 worktree 和 `ai-in-progress` 领取标签会留在 GitHub
+上；下一个 tick 的领取扫描在 ready 队列之前先扫描 `ai-ready`+`ai-in-progress`
+（且未处于其他交付状态）的 open Issue——**仅当没有其他 Runner 活着时**
+（flock 锁是唯一事实源）——复用最新 worktree 的 run id（branch、worktree、
+进度评论都由它驱动），按隐藏 run marker 找回同一条进度评论继续 PATCH，不新建
+run、不新建 worktree、不新建评论。`.worktrees/` 已加入 `.gitignore`。
+
+## 全链路 run_id（correlation ID）
+
+每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同
+trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成
+新的 run_id。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
+
+同一个 run_id 出现在：该 attempt 的每条 journal 日志首字段（`[e07383c2]`）；
+Issue/PR 评论（可见字段 `run_id=e07383c2` + 隐藏 marker
+`<!-- muyan-pilot:run=e07383c2 -->`）；feature branch 与 worktree 名；Pi
+session 目录与 run artifacts 的路径；注入 Pi 的 prompt context；PR body 的稳定
+machine-readable marker（Runner 验收时校验，缺失即 fail fast，拒绝该 PR）。
+缺少合法 run_id 的 run-scoped 事件会 fail fast，不做回退。查询方式（不依赖
+内存映射，进程重启后仍可恢复关联）：
+
+```bash
+journalctl --user -u 'muyan-pilot@*.service' | grep e07383c2
+gh search issues "e07383c2" --repo orbi-build/orbi
+```
+
+## 远程 CI（GitHub Actions）
+
+仓库契约（全量 pytest + 100% line/branch coverage）不只在本机 Runner 上跑：
+`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次
+`push` 到 `main` 时跑同一份契约，测试失败或覆盖率低于 100% 时 CI 变红。单个
+job，不加 lint、矩阵或缓存（Issue #56）。生产运行时是 Runner 机器的
+`/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以
+workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过
+PATH 上固定的 `python3` 执行。CI 还在干净环境里用 `uv tool install` 安装
+console script 并验证入口（`muyan-pilot --help` / `muyan-pilot --version`
+退出码 0，Issue #140/#152）。「干净环境安装后 `muyan-pilot --help` 成功」是
+永久门禁，不是一次性本地检查。完整说明见 [Testing](docs/testing.mdx)。
 
 ## 许可证
 
-本项目以 [Apache License 2.0](LICENSE)（SPDX 标识 `Apache-2.0`）发布，完整文本见根目录 [LICENSE](LICENSE) 文件。
+本项目以 [Apache License 2.0](LICENSE)（SPDX 标识 `Apache-2.0`）发布，完整
+文本见根目录 [LICENSE](LICENSE) 文件。

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -84,27 +84,17 @@ code automatically: **ordinary Python source and systemd
 template/migration changes need NO reinstall and no upgrade command**.
 When the PACKAGING inputs change (a new runtime module in
 `py-modules`, a dependency, the entry point, the package name, the
-build backend or the Python version), the editable finder's module
-mapping is stale and the next CLI process dies with
-`ModuleNotFoundError` before the Runner can start (Issue #158) — the
-Runner now refreshes this automatically: at every start (before any
-slot or claim) it compares the sha256 of the checkout's
-`pyproject.toml` with the fingerprint of the last successful install
-(recorded in the shared state dir, `.muyan-pilot/cli-install.json`):
-unchanged → no `uv` call at all (no per-tick reinstall); changed or
-first install → ONE lock-protected run of the exact force editable
-reinstall command above (the same base-sync flock the service
-`ExecStartPre` uses, so two instances starting in the same tick
-serialize and the second reuses the first's result); a failing install
-fails the start fast with the structured `cli_install_failed` line
-(reason + the exact fix command). `muyan-pilot
-doctor` reports the consistency (`cli_source: clean` or
-`cli_source: DRIFT` with the structured `cli_source_drift` line), and
-`muyan-pilot setup` verifies or reinstalls it idempotently. The release
-package carries no third-party runtime dependency, no token and no user
-directory — the config file and the user systemd dir stay
-machine-local. The direct-execution entry of `muyan_pilot.py` (running
-the file with the interpreter) stays a development/compatibility path.
+build backend or the Python version), the Runner refreshes the install
+automatically at every start (before any slot or claim) — a failing
+refresh fails the start fast with the structured `cli_install_failed`
+line (reason + the exact fix command). `muyan-pilot doctor` reports the
+consistency (`cli_source: clean` or `cli_source: DRIFT` with the
+structured `cli_source_drift` line), and `muyan-pilot setup` verifies or
+reinstalls it idempotently. The release package carries no third-party
+runtime dependency, no token and no user directory — the config file
+and the user systemd dir stay machine-local. The direct-execution entry
+of `muyan_pilot.py` (running the file with the interpreter) stays a
+development/compatibility path.
 
 ## 3. Create the configuration
 

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -165,25 +165,24 @@ DAG, no priority numbers, no separate queues:
   Runner picks it up through the normal ready scan, but `process_issue`
   routes it to the deterministic release state machine instead of
   `run_pi` — no Pi session, no PR. The state machine is idempotent and
-  resumable (a restart resumes the same run id/worktree): strictly parse
-  the `## Release` declaration from the Issue body (`version`,
-  `base_branch`, `test_command`, `scope`), freeze the base (the release
-  commit is exactly `origin/<base_branch>`), enforce the pre-release
-  gates (no leftover `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`,
-  CI green on the release commit, no open PRs against the base branch),
-  verify the scope item by item with `gh pr view` / `gh issue view`
-  (never checkbox parsing), run the declared test command in a clean
-  worktree at the release commit, then create the annotated tag at the
-  release commit and push it with a plain push (an existing tag must
-  point exactly at the release commit — it is never moved, overwritten
-  or force-pushed), and finally publish the GitHub Release with the full
-  verification evidence, then close the Milestone whose title is EXACTLY
-  the released version (Issue #214 — exact title match only: closed when
-  it has 0 open Issues, idempotent when already closed, fail fast when
-  missing or when open Issues remain). Success: `ai-merged` (terminal)
-  and the Issue is closed. Any failure: `ai-blocked` ALONE (a release
-  is a human decision point — no automatic retry) with the run marker
-  and the concrete reason on the Issue.
+  resumable (a restart resumes the same run id/worktree): it strictly
+  parses the `## Release` declaration from the Issue body (`version`,
+  `base_branch`, `test_command`, `scope`), freezes the base (the release
+  commit is exactly `origin/<base_branch>`), enforces the pre-release
+  gates (no leftover open delivery-state Issues, CI green on the release
+  commit, no open PRs against the base branch), verifies the scope item
+  by item against the live API (never checkbox parsing), runs the
+  declared test command in a clean worktree at the release commit, then
+  creates the annotated tag at the release commit and pushes it with a
+  plain push (an existing tag must point exactly at the release commit —
+  it is never moved, overwritten or force-pushed), publishes the GitHub
+  Release with the full verification evidence, and closes the Milestone
+  whose title is EXACTLY the released version (Issue #214 — exact title
+  match only). Success: `ai-merged` (terminal) and the Issue is closed.
+  Any failure: `ai-blocked` ALONE (a release is a human decision point —
+  no automatic retry) with the run marker and the concrete reason on the
+  Issue. The full step-by-step contract lives in `AGENTS.md` (Release
+  tasks section).
 - **P0 priority**: the plain `p0` GitHub label marks an urgent Issue
   (a production outage). It is NOT a delivery state — it only orders the
   ready pickup, never changes the Issue granularity, any delivery state,

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -74,20 +74,14 @@ Issue #152）。editable 安装下 tool 环境直接从 clone 目录导入
 merge 后的代码：**普通 Python 源码与 systemd 模板/迁移代码变更不需要
 任何重装或升级命令**。
 当**打包输入**变化（`py-modules` 新增运行时模块、依赖、入口点、包名、
-构建后端或 Python 版本）时，editable finder 的模块映射会过期，下一个
-CLI 进程在 Runner 启动前就 `ModuleNotFoundError`（Issue #158）——现在
-Runner 自动刷新：每次启动（在任何 slot/claim 之前）比较 checkout
-`pyproject.toml` 的 sha256 与**上次成功安装**记录的指纹（共享状态目录
-`.muyan-pilot/cli-install.json`）：未变 → 完全不跑 `uv`（不做每 tick
-重装）；变更或首次安装 → 在 base-sync flock 保护下跑一次上面的 force
-editable 重装（与服务 `ExecStartPre` 同一把锁，两个 instance 同 tick
-启动时串行化，第二个复用第一个的结果）；安装失败 → fail fast（结构化
-`cli_install_failed` 行：原因 + 精确修复命令）。`muyan-pilot doctor`
-报告一致性（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化
-`cli_source_drift` 行），`muyan-pilot setup` 幂等地校验或重装。发布包
-不携带第三方运行时依赖、token 或用户目录——配置文件和用户 systemd 目录
-保持机器本地。`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）
-保留为开发/兼容路径。
+构建后端或 Python 版本）时，Runner 每次启动（在任何 slot/claim 之前）
+自动刷新安装——刷新失败会 fail fast（结构化 `cli_install_failed`
+行：原因 + 精确修复命令）。`muyan-pilot doctor` 报告一致性
+（`cli_source: clean` 或 `cli_source: DRIFT` + 结构化 `cli_source_drift`
+行），`muyan-pilot setup` 幂等地校验或重装。发布包不携带第三方运行时
+依赖、token 或用户目录——配置文件和用户 systemd 目录保持机器本地。
+`muyan_pilot.py` 的直接执行入口（用解释器直接运行该文件）保留为
+开发/兼容路径。
 
 ## 3. 创建配置
 

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -146,18 +146,16 @@ PR 验收时校验该关键词，缺失即 fail fast。
   run id/worktree）：严格解析 Issue 正文的 `## Release` 声明
   （`version`、`base_branch`、`test_command`、`scope`），冻结 base
   （release commit 就是 `origin/<base_branch>`），执行发布前门禁
-  （无遗留 `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed`、release
-  commit 的 CI 全绿、base 分支无 open PR），用 `gh pr view` /
-  `gh issue view` 逐项验证 scope（绝不解析复选框），在 release commit
-  的干净 worktree 里跑声明的测试命令，然后在 release commit 上创建
-  annotated tag 并普通 push（已存在的 tag 必须精确指向 release commit——
-  绝不移动、覆盖或 force-push），最后发布带完整验证证据的 GitHub
-  Release，然后关闭 title 与发布 version 精确一致的 Milestone（Issue
-  #214——只按 title 精确匹配：open Issues 为 0 时关闭、已关闭则幂等
-  成功、找不到同名或仍有 open Issues 时 fail fast）。成功：
-  `ai-merged`（终态）并关闭 Issue。任何失败：单独进入
-  `ai-blocked`（release 是人工决策点——不自动重试），Issue 上带 run
-  marker 和具体原因。
+  （无遗留 open 交付状态 Issue、release commit 的 CI 全绿、base 分支
+  无 open PR），对照 live API 逐项验证 scope（绝不解析复选框），在
+  release commit 的干净 worktree 里跑声明的测试命令，然后在 release
+  commit 上创建 annotated tag 并普通 push（已存在的 tag 必须精确指向
+  release commit——绝不移动、覆盖或 force-push），发布带完整验证证据
+  的 GitHub Release，最后关闭 title 与发布 version 精确一致的
+  Milestone（Issue #214——只按 title 精确匹配）。成功：`ai-merged`
+  （终态）并关闭 Issue。任何失败：单独进入 `ai-blocked`（release 是
+  人工决策点——不自动重试），Issue 上带 run marker 和具体原因。完整
+  的逐步契约见 `AGENTS.md`（Release tasks 一节）。
 - **P0 优先级**：普通 `p0` GitHub 标签标记紧急 Issue（生产故障）。它
   **不是**交付状态——只决定 ready 领取顺序，从不改变 Issue 粒度、任何
   交付状态或终态语义，Runner 也从不增删它。ready 领取顺序固定：


### PR DESCRIPTION
<!-- muyan-pilot:run=4d523246 -->

Fixes #160

文档整治：统一事实源、删除重复内容并压缩 README/AGENTS/站点文档 (run_id=4d523246)
