### PR TITLE
core: 中断后继续既有工作，而不是 fresh 重做

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -2735,13 +2735,19 @@ def worktree_path(repo_dir: Path, source_repo: str, number: int,
 
 
 def create_worktree(repo_dir: Path, source_repo: str, number: int,
-                    run_id: str, base_sha: str) -> Path:
+                    run_id: str, base_sha: str,
+                    existing: Path | None = None) -> Path:
     """Create the task worktree from the frozen base SHA, never HEAD.
 
     An existing path is reused: only a resumed run (same run id after a
     process restart) reaches that state, and its worktree is the scene
-    the run continues in (Issue #18).
+    the run continues in (Issue #18). `existing` is the VERIFIED resume
+    scene (Issue #219): after a repo rename the scene's path carries
+    the OLD slug, so the derived path would miss it and a second
+    worktree would be created — the verified scene is returned as-is.
     """
+    if existing is not None and existing.is_dir():
+        return existing
     path = worktree_path(repo_dir, source_repo, number, run_id)
     if path.exists():
         return path
@@ -2752,12 +2758,198 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
     return path
 
 
+def run_state_path(worktree: Path) -> Path:
+    """The run state file of one task worktree (Issue #219).
+
+    It lives in the gitignored `.muyan-pilot/` directory, so it never
+    dirties the commit boundary (Issue #186) and never reaches the
+    delivery commit.
+    """
+    return worktree / ".muyan-pilot" / "run-state.json"
+
+
+def write_run_state(worktree: Path, *, run_id: str, issue: int,
+                    source_repo: str, branch: str) -> None:
+    """Write (or refresh) the run state file of one task worktree.
+
+    The file is the explicit "same run" marker (Issue #219): the
+    worktree directory name alone is not stable across a repo rename
+    (the slug changes), but the state file carries the issue number
+    and the repo — the identity the next tick matches on. A resumed
+    run refreshes the SAME file (same run id): the file is per-run,
+    never per-session.
+    """
+    state = {
+        "run_id": run_id,
+        "issue": issue,
+        "repo": source_repo,
+        "branch": branch,
+        "worktree": str(worktree),
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    path = run_state_path(worktree)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def read_run_state(worktree: Path) -> dict | None:
+    """Read the run state file; None when absent, fail fast when corrupt.
+
+    A corrupt state file is a delivery failure, never a guess: the
+    resume must continue the SAME run, and a wrong continuation is
+    worse than a blocked Issue (Issue #219).
+    """
+    path = run_state_path(worktree)
+    if not path.is_file():
+        return None
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            f"run state file {path} is unreadable: {exc}"
+        ) from exc
+    if not isinstance(state, dict):
+        raise ValueError(
+            f"run state file {path} must be a JSON object"
+        )
+    required: dict[str, type] = {
+        "run_id": str, "issue": int, "repo": str,
+        "branch": str, "worktree": str,
+    }
+    for key, expected in required.items():
+        value = state.get(key)
+        if expected is int:
+            valid = isinstance(value, int) and not isinstance(value, bool)
+        else:
+            valid = isinstance(value, expected) and bool(value)
+        if not valid:
+            raise ValueError(
+                f"run state file {path} is malformed: missing or "
+                f"invalid field {key!r}"
+            )
+    return state
+
+
+def changed_files(worktree: Path) -> list[str]:
+    """The worktree's uncommitted changes (tracked + untracked paths)."""
+    raw = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    files: list[str] = []
+    for line in raw.splitlines():
+        if len(line) > 3 and line[:2].strip():
+            files.append(line[3:].strip())
+    return files
+
+
+def resume_context(worktree: Path) -> str | None:
+    """The resume context for a continued run (Issue #219), or None.
+
+    A worktree without uncommitted changes and without a previous
+    session is a fresh scene: the agent starts from the Issue alone
+    (the exact pre-#219 prompt). Otherwise the new session must
+    continue the existing work: the context carries the instruction
+    to continue (never redo, never discard), the previous session's
+    progress and the list of changed files — the agent inspects the
+    actual diff itself, it runs inside the worktree.
+    """
+    files = changed_files(worktree)
+    snapshot = activity_snapshot(worktree / ".pi-session")
+    if not files and snapshot is None:
+        return None
+    lines = [
+        "Resume context (Issue #219): this worktree already carries "
+        "work from an earlier session of the SAME run. Continue that "
+        "work — do not start from scratch, do not discard or rewrite "
+        "the existing changes, and do not create a new plan from "
+        "nothing.",
+    ]
+    if snapshot is not None:
+        lines.append(
+            "Previous session progress: "
+            f"session={snapshot.get('session_id') or '-'} "
+            f"events={snapshot.get('events', 0)} "
+            f"phase={snapshot.get('phase') or '-'} "
+            f"last_action={snapshot.get('action') or '-'} "
+            f"last_result={snapshot.get('result') or '-'}"
+        )
+    if files:
+        lines.append(
+            f"Uncommitted changed files ({len(files)}):"
+        )
+        lines.extend(f"- {path}" for path in files)
+    return "\n".join(lines)
+
+
+def worktree_resume_scene(repo_dir: Path, source_repo: str,
+                 number: int) -> tuple[str, Path] | None:
+    """Return the resume scene `(run_id, worktree)` for one Issue, or None.
+
+    The worktrees are matched by the RUN STATE FILE (Issue #219), not
+    by the directory name alone: the directory name carries the
+    source-repo slug, which changes when the repo is renamed, while
+    the state file carries the issue number and the repo NAME (the
+    part after the slash — stable across a rename). The newest
+    matching worktree (by mtime) wins, as before (Issue #18). The
+    scene's worktree path may carry the OLD slug (a rename): it is
+    the scene the run continues in, never a reason for a second
+    worktree.
+
+    A worktree that claims THIS issue number but has a MISSING or
+    CORRUPT run state file cannot be verified as the same run: it
+    fails fast with the exact reason — never a silent fresh redo
+    (Issue #219). A worktree of another issue without a state file
+    (a legacy completed run) is unrelated and skipped.
+    """
+    name = source_repo.rsplit("/", 1)[-1]
+    pattern = re.compile(
+        r"^muyan-pilot-.+-issue-" + str(number) + r"-[0-9a-f]{8}$",
+    )
+    candidates: list[Path] = []
+    worktrees = repo_dir / ".worktrees"
+    if worktrees.is_dir():
+        for path in worktrees.iterdir():
+            if not path.is_dir() or not pattern.match(path.name):
+                continue
+            try:
+                state = read_run_state(path)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"worktree {path} has a corrupt run state file "
+                    f"({exc}): the same run cannot be verified "
+                    "(Issue #219)"
+                ) from exc
+            if state is None:
+                raise RuntimeError(
+                    f"worktree {path} has no run state file "
+                    f"({run_state_path(path)}): the same run cannot "
+                    "be verified (Issue #219)"
+                )
+            if str(state["repo"]).rsplit("/", 1)[-1] != name:
+                continue
+            candidates.append(path)
+    if not candidates:
+        return None
+    newest = max(candidates, key=lambda path: path.stat().st_mtime)
+    return str(read_run_state(newest)["run_id"]), newest
+
+
+def resume_run_id(repo_dir: Path, source_repo: str,
+                  number: int) -> str | None:
+    """Return the run id to resume for one Issue, or None.
+
+    Delegates to `worktree_resume_scene` (the worktree is matched by its run
+    state file, not the directory name alone — Issue #219).
+    """
+    scene = worktree_resume_scene(repo_dir, source_repo, number)
+    return scene[0] if scene is not None else None
+
+
 def latest_run_id(repo_dir: Path, source_repo: str, number: int) -> str | None:
     """Return the run id of the newest task worktree for the issue.
 
-    The worktree directory name carries the run id — the only state
-    needed to resume the same GitHub progress comment (hidden run
-    marker) instead of creating a second one (Issue #18).
+    The worktree directory name carries the run id — the state the
+    release state machine (Issue #98) reuses to resume the same run
+    after a restart. Development runs use the stricter state-file
+    discovery (`worktree_resume_scene`, Issue #219) instead.
     """
     slug = source_repo.replace("/", "-")
     pattern = f".worktrees/muyan-pilot-{slug}-issue-{number}-*"
@@ -3650,12 +3842,20 @@ def process_ticket_only(issue: dict, config: dict, source_repo: str) -> str:
 
 def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
            *, timeout: int | None = None, branch: str | None = None,
-           progress: Callable[[dict], None] | None = None) -> str:
+           progress: Callable[[dict], None] | None = None,
+           resume_context: str | None = None) -> str:
     """Run the implementer Pi session for a freshly claimed Issue.
 
     Issue #82 removed the fixer reuse of this function: findings are
     fixed by the review session in the same session, so the implementer
     is the only user of `prompt.md` now.
+
+    `resume_context` (Issue #219): when the worktree already carries
+    the interrupted run's work (uncommitted changes and/or a previous
+    session), the context argument gains the resume section so the NEW
+    session continues the existing work instead of a fresh redo. The
+    prompt template itself is untouched; absent -> the exact
+    pre-#219 context.
     """
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
@@ -3686,6 +3886,8 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
         f"Worktree: {worktree}\n"
     )
     context += "Complete the delivery process in the system prompt."
+    if resume_context:
+        context += f"\n{resume_context}"
     command = [
         "pi", *_skill_args(_skills_for(config, IMPLEMENT_EXCLUDED_SKILLS)),
         *_pi_model_args(config),
@@ -5513,6 +5715,31 @@ class LiveProgressThrottle:
         self._publish(activity)
 
 
+def _report_resume_failure(*, number: int, source_repo: str, run_id: str,
+                           error: Exception) -> None:
+    """Report a failed resume decision through the terminal path.
+
+    The worktree of this issue exists but its run state cannot be
+    verified (Issue #219): continuing on a guessed identity risks a
+    silent fresh redo on top of unknown work, and a fresh run would
+    lose the existing work. The Issue goes `ai-blocked` ALONE (the
+    claim label removed) with the exact reason in the failure comment
+    — a human decides (restore or remove the worktree, then re-label).
+    """
+    edit_issue(
+        number, repo=source_repo, add=BLOCKED_LABEL,
+        remove=IN_PROGRESS_LABEL,
+    )
+    comment_issue(
+        number, repo=source_repo,
+        body=(
+            f"{run_marker(run_id)}\n"
+            f"Muyan Pilot failed: cannot continue the interrupted run: "
+            f"{_failure_detail(error)} (run_id={run_id})"
+        ),
+    )
+
+
 def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     number = int(issue["number"])
     # Issue #100: the progress comment's issue line shows the number
@@ -5542,12 +5769,28 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     # progress comment is found and kept instead of a second one.
     # Completed runs keep their worktrees as evidence but lose the
     # label, so re-claiming an issue always starts a fresh run.
+    existing_worktree: Path | None = None
     if has_in_progress_label(number, source_repo):
-        existing_run_id = latest_run_id(
-            config["repo_dir"], source_repo, number,
-        )
-        if existing_run_id is not None:
-            run_id = existing_run_id
+        try:
+            scene = worktree_resume_scene(
+                config["repo_dir"], source_repo, number,
+            )
+        except Exception as exc:
+            # Issue #219: the worktree of this issue exists but its run
+            # state is missing or corrupt: the same run cannot be
+            # verified. Fail fast through the terminal failure path
+            # (`ai-blocked` + the reason comment) — never a silent
+            # fresh redo on top of unknown work.
+            LOGGER.exception(
+                "issue=%s resume_continue_failed", number,
+            )
+            _report_resume_failure(
+                number=number, source_repo=source_repo, run_id=run_id,
+                error=exc,
+            )
+            raise
+        if scene is not None:
+            run_id, existing_worktree = scene
             # The attempt continues the dead run: re-bind the reused
             # id so every later line (including resuming_run) carries
             # it.
@@ -5558,6 +5801,16 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             )
     base_sha = freeze_base(config["repo_dir"], base_branch)
     branch = task_branch(source_repo, number, run_id)
+    if existing_worktree is not None:
+        # Issue #219: the resumed run keeps its ORIGINAL branch —
+        # after a repo rename the re-derived name would carry the NEW
+        # slug and no longer match the branch the worktree is on (a
+        # second branch would be a second delivery). The worktree's
+        # current branch IS the scene's branch.
+        branch = run_command(
+            ["git", "branch", "--show-current"],
+            cwd=existing_worktree,
+        )
     # Pickup priority (Issue #101): derived from the scanned issue's
     # labels (no extra gh call) and carried on every journal line and
     # scene comment of the attempt via `run_info`.
@@ -5577,7 +5830,12 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     # worktree creation below uses (bound before the worktree exists).
     set_active_run(
         number, title, branch,
-        str(worktree_path(config["repo_dir"], source_repo, number, run_id)),
+        # The verified resume scene keeps its own path (after a repo
+        # rename it carries the OLD slug — Issue #219); otherwise the
+        # derived path (the same value the worktree creation uses).
+        str(existing_worktree or worktree_path(
+            config["repo_dir"], source_repo, number, run_id,
+        )),
     )
     publisher = ProgressPublisher(
         number, source_repo, run_id, run_command=run_command,
@@ -5595,7 +5853,37 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     try:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, base_sha,
+            existing=existing_worktree,
         )
+        # Issue #219: the run state file is the same-run marker —
+        # written for EVERY run (a fresh one included, so a later
+        # interruption can be verified and resumed), refreshed for a
+        # resumed one (same run id, never a second marker).
+        write_run_state(
+            worktree, run_id=run_id, issue=number,
+            source_repo=source_repo, branch=branch,
+        )
+        # Issue #219: the new session starts from the existing work —
+        # the uncommitted changes and the previous session's progress —
+        # instead of a fresh redo. A clean worktree without a previous
+        # session is a fresh scene (None, the pre-#219 prompt).
+        resume_ctx = resume_context(worktree)
+        if resume_ctx is not None:
+            session_dir = worktree / ".pi-session"
+            previous_sessions = (
+                len([p for p in session_dir.glob("*.jsonl")
+                    if p.is_file()])
+                if session_dir.is_dir() else 0
+            )
+            snapshot = activity_snapshot(session_dir)
+            LOGGER.info(
+                "issue=%s resume_continue worktree=%s changed_files=%s "
+                "reused_runs=%s previous_session=%s",
+                number, worktree,
+                len(changed_files(worktree)),
+                previous_sessions,
+                (snapshot.get("session_id") if snapshot else None) or "-",
+            )
         config = {**config, "base_sha": base_sha, "run_id": run_id}
         comment_issue(
             number, repo=source_repo,
@@ -5625,6 +5913,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
         )
         run_pi(
             issue, worktree, config, source_repo, branch=branch,
+            resume_context=resume_ctx,
             progress=LiveProgressThrottle(
                 publisher, issue=number, title=title, run_id=run_id,
                 role=ROLE_IMPLEMENT, branch=branch, worktree=worktree,

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -97,6 +97,19 @@ Stable `key=value` lines you will see:
   file) at start, and the result (PR URL, commit) at the end;
 - `activity` / `heartbeat` / `model_wait` / `resumed` — live Pi activity
   while a session runs (phase, last action, elapsed, idle);
+- `resume_continue` — one INFO when a resumed run continues the
+  interrupted work (Issue #219): the worktree's run state file
+  (`.muyan-pilot/run-state.json`) verified the SAME run (issue number
+  + repo NAME — stable across a repo rename, so the old worktree is
+  found even when the slug changed) and the worktree carries
+  uncommitted changes or a previous session. The line carries the
+  worktree, `changed_files` (uncommitted paths), `reused_runs`
+  (previous session files) and `previous_session` (session id or `-`);
+  the new session receives the resume context in its prompt (continue
+  the existing work — never redo, never discard). When the same run
+  cannot be verified (the state file is missing or corrupt) the line
+  is `resume_continue_failed` instead: fail fast, the Issue goes
+  `ai-blocked` with the reason — never a silent fresh redo;
 - `pi_idle` — one WARNING when there is no model/session activity for
   more than 5 minutes (`PI_IDLE_WARN_SECONDS=300`) and the model is not
   expected to reply; a slow active model (`model_wait`) never warns;

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -83,6 +83,16 @@ journalctl --user -u muyan-pilot@1.service -u muyan-pilot@2.service | grep e0738
   session 文件），结束时的结果（PR URL、commit）；
 - `activity` / `heartbeat` / `model_wait` / `resumed` — session 运行
   期间的实时 Pi 活动（phase、最近动作、elapsed、idle）；
+- `resume_continue` — 恢复的 run 继续中断的工作（Issue #219）时的一次
+  INFO：worktree 的 run state 文件（`.muyan-pilot/run-state.json`）
+  验证了同一个 run（issue 编号 + 仓库名——仓库改名后 slug 变了也能
+  找到旧 worktree），且 worktree 带有未提交改动或之前的 session；
+  行带 worktree、`changed_files`（未提交路径）、`reused_runs`
+  （之前的 session 文件数）和 `previous_session`（session id 或 `-`）；
+  新 session 在 prompt 里收到 resume context（继续既有工作——从不
+  重做、从不丢弃）。同一个 run 无法验证（state 文件缺失或损坏）时
+  行是 `resume_continue_failed`：fail fast，Issue 进入 `ai-blocked`
+  并带原因——从不静默 fresh 重做；
 - `pi_idle` — 超过 300 秒（`PI_IDLE_WARN_SECONDS=300`）没有
   model/session 活动且模型不期望回复时的一次 WARNING；活跃的慢模型
   （`model_wait`）从不告警；

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2091,24 +2091,307 @@ def test_latest_run_id_returns_none_without_task_worktrees(tmp_path):
 
 def test_latest_run_id_returns_the_run_id_of_the_newest_worktree(tmp_path):
     slug = "owner-repo"
-    first = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-old11111"
-    second = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-new22222"
+    first = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-0d111111"
+    second = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-2e222222"
     first.mkdir(parents=True)
     second.mkdir(parents=True)
     # The newest by mtime wins, even when it was created first by name.
     os.utime(first, (200, 200))
     os.utime(second, (100, 100))
-    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "old11111"
+    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "0d111111"
     os.utime(second, (300, 300))
-    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "new22222"
+    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "2e222222"
     # A worktree of another issue (or another source repo) never counts.
     other_issue = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-4-ffff0000"
-    other_repo = tmp_path / ".worktrees" / f"muyan-pilot-other-repo-issue-3-ffff1111"
+    other_repo = tmp_path / ".worktrees" / f"muyan-pilot-other-other-issue-3-ffff1111"
     other_issue.mkdir()
     other_repo.mkdir()
     os.utime(other_issue, (400, 400))
     os.utime(other_repo, (400, 400))
-    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "new22222"
+    assert runner.latest_run_id(tmp_path, "owner/repo", 3) == "2e222222"
+
+
+# --- Issue #219: continue the interrupted run, never a fresh redo ---------
+
+
+def test_run_state_path_lives_in_the_gitignored_muyan_pilot_dir(tmp_path):
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-run1"
+    assert runner.run_state_path(worktree) == (
+        worktree / ".muyan-pilot" / "run-state.json"
+    )
+
+
+def test_write_run_state_writes_the_run_identity(tmp_path):
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runner.write_run_state(
+        worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
+        branch="muyan-pilot/owner-repo-issue-3-a1b2c3d4",
+    )
+    state = json.loads(runner.run_state_path(worktree).read_text())
+    assert state["run_id"] == "a1b2c3d4"
+    assert state["issue"] == 3
+    assert state["repo"] == "owner/repo"
+    assert state["branch"] == "muyan-pilot/owner-repo-issue-3-a1b2c3d4"
+    assert state["worktree"] == str(worktree)
+    assert isinstance(state["created_at"], str) and state["created_at"]
+
+
+def test_write_run_state_is_idempotent_for_a_resumed_run(tmp_path):
+    """A resumed run refreshes the SAME state file (same run id) — the
+    file is the same-run marker, never a per-session artifact."""
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runner.write_run_state(
+        worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
+        branch="muyan-pilot/owner-repo-issue-3-a1b2c3d4",
+    )
+    runner.write_run_state(
+        worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
+        branch="muyan-pilot/owner-repo-issue-3-a1b2c3d4",
+    )
+    state = json.loads(runner.run_state_path(worktree).read_text())
+    assert state["run_id"] == "a1b2c3d4"
+
+
+def test_read_run_state_returns_none_without_the_file(tmp_path):
+    assert runner.read_run_state(tmp_path) is None
+
+
+def test_read_run_state_round_trips_the_written_state(tmp_path):
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runner.write_run_state(
+        worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
+        branch="muyan-pilot/owner-repo-issue-3-a1b2c3d4",
+    )
+    state = runner.read_run_state(worktree)
+    assert state["run_id"] == "a1b2c3d4"
+    assert state["issue"] == 3
+    assert state["repo"] == "owner/repo"
+
+
+def test_read_run_state_fails_fast_on_unreadable_or_malformed_state(tmp_path):
+    """A corrupt state file is a delivery failure, never a guess: the
+    resume must continue the SAME run (Issue #219)."""
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    path = runner.run_state_path(worktree)
+    path.parent.mkdir(parents=True)
+    path.write_text("not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="run state"):
+        runner.read_run_state(worktree)
+    path.write_text("[1, 2]", encoding="utf-8")
+    with pytest.raises(ValueError, match="run state"):
+        runner.read_run_state(worktree)
+    path.write_text(json.dumps({"run_id": "a1b2c3d4"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="run state"):
+        runner.read_run_state(worktree)
+
+
+def make_session_jsonl(worktree: Path, session_id: str = "sess-1") -> Path:
+    """A minimal previous session file (Issue #219 resume context)."""
+    session_dir = worktree / ".pi-session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    path = session_dir / f"{session_id}.jsonl"
+    path.write_text(
+        json.dumps({"type": "session", "id": session_id}) + "\n"
+        + json.dumps({
+            "type": "message", "timestamp": "2026-09-02T04:00:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "toolCall", "name": "bash",
+                             "arguments": {"command": "pytest tests/"}}],
+            },
+        }) + "\n"
+        + json.dumps({
+            "type": "message", "timestamp": "2026-09-02T04:01:00Z",
+            "message": {"role": "toolResult", "toolName": "bash",
+                        "isError": False},
+        }) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_changed_files_lists_uncommitted_changes(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        # The third line has a blank XY column: it is not a change.
+        return " M src/a.py\n?? src/b.py\n   src/c.py\n"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.changed_files(tmp_path) == ["src/a.py", "src/b.py"]
+    assert calls == [(
+        ["git", "status", "--porcelain"], {"cwd": tmp_path},
+    )]
+
+
+def test_resume_context_is_none_for_a_fresh_worktree(tmp_path, monkeypatch):
+    """No uncommitted changes and no previous session: the agent starts
+    from the Issue alone (the exact pre-#219 prompt)."""
+    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "")
+    monkeypatch.setattr(runner, "activity_snapshot", lambda *a, **k: None)
+    assert runner.resume_context(tmp_path) is None
+
+
+def test_resume_context_carries_changes_and_session_progress(
+    tmp_path, monkeypatch,
+):
+    """The new session starts from the existing work: the instruction to
+    continue, the previous session's progress and the changed files —
+    never a fresh redo (Issue #219)."""
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda *a, **k: " M src/a.py\n?? src/b.py\n",
+    )
+    monkeypatch.setattr(
+        runner, "activity_snapshot",
+        lambda *a, **k: {
+            "session_id": "sess-1", "session_file": "x.jsonl",
+            "events": 7, "phase": "test", "last_activity": "2026-09-02T04:01:00Z",
+            "action": "bash pytest tests/", "result": "ok",
+            "model_wait": False, "changed": False, "stale_seconds": 1.0,
+        },
+    )
+    context = runner.resume_context(tmp_path)
+    assert "Continue" in context or "continue" in context
+    assert "redo" in context.lower() or "scratch" in context.lower()
+    assert "sess-1" in context
+    assert "7" in context
+    assert "test" in context
+    assert "bash pytest tests/" in context
+    assert "src/a.py" in context
+    assert "src/b.py" in context
+    assert "2" in context
+
+
+def test_resume_context_without_changes_carries_the_session_progress(
+    tmp_path, monkeypatch,
+):
+    """A clean worktree with a previous session (the agent committed
+    mid-run before the interruption) still continues the same run."""
+    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "")
+    monkeypatch.setattr(
+        runner, "activity_snapshot",
+        lambda *a, **k: {
+            "session_id": "sess-2", "session_file": "x.jsonl",
+            "events": 3, "phase": "commit", "last_activity": None,
+            "action": "git commit -m x", "result": None,
+            "model_wait": False, "changed": False, "stale_seconds": 1.0,
+        },
+    )
+    context = runner.resume_context(tmp_path)
+    assert context is not None
+    assert "sess-2" in context
+    assert "src/a.py" not in context
+
+
+def test_resume_run_id_returns_none_without_candidates(tmp_path):
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) is None
+    (tmp_path / ".worktrees").mkdir()
+    (tmp_path / ".worktrees" / "other").mkdir()
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) is None
+
+
+def test_resume_run_id_matches_by_issue_and_repo_name_across_a_rename(
+    tmp_path,
+):
+    """The repo was renamed (slug `xqliu-orbi` -> `orbi-build-orbi`):
+    the old worktree is found by issue number + repo NAME (the stable
+    identity) and the SAME run continues — no second run/branch/
+    worktree (Issue #219)."""
+    old = tmp_path / ".worktrees" / "muyan-pilot-xqliu-orbi-issue-42-aaaa1111"
+    old.mkdir(parents=True)
+    runner.write_run_state(
+        old, run_id="aaaa1111", issue=42, source_repo="xqliu/orbi",
+        branch="muyan-pilot/xqliu-orbi-issue-42-aaaa1111",
+    )
+    assert runner.resume_run_id(
+        tmp_path, "orbi-build/orbi", 42,
+    ) == "aaaa1111"
+    # A different repo name never matches, even with the same issue.
+    assert runner.resume_run_id(
+        tmp_path, "orbi-build/other", 42,
+    ) is None
+
+
+def test_resume_run_id_returns_newest_matching_worktree(tmp_path):
+    slug = "owner-repo"
+    first = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-0d111111"
+    second = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-3-2e222222"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    runner.write_run_state(
+        first, run_id="0d111111", issue=3, source_repo="owner/repo",
+        branch="b1",
+    )
+    runner.write_run_state(
+        second, run_id="2e222222", issue=3, source_repo="owner/repo",
+        branch="b2",
+    )
+    os.utime(first, (300, 300))
+    os.utime(second, (100, 100))
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) == "0d111111"
+    os.utime(second, (400, 400))
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) == "2e222222"
+
+
+def test_resume_run_id_excludes_other_issues_and_repos(tmp_path):
+    slug = "owner-repo"
+    other_issue = tmp_path / ".worktrees" / f"muyan-pilot-{slug}-issue-4-ffff0000"
+    other_repo = tmp_path / ".worktrees" / f"muyan-pilot-other-other-issue-3-ffff1111"
+    other_issue.mkdir(parents=True)
+    other_repo.mkdir(parents=True)
+    runner.write_run_state(
+        other_issue, run_id="ffff0000", issue=4, source_repo="owner/repo",
+        branch="b1",
+    )
+    runner.write_run_state(
+        other_repo, run_id="ffff1111", issue=3, source_repo="other/other",
+        branch="b2",
+    )
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) is None
+
+
+def test_resume_run_id_fails_fast_on_missing_state_file(tmp_path):
+    """A worktree that claims the issue number but has NO run state file
+    cannot be verified as the same run: fail fast with the exact reason,
+    never a silent fresh redo (Issue #219)."""
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-aaaa1111"
+    worktree.mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="run state"):
+        runner.resume_run_id(tmp_path, "owner/repo", 3)
+
+
+def test_resume_run_id_fails_fast_on_corrupt_state_file(tmp_path):
+    worktree = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-aaaa1111"
+    worktree.mkdir(parents=True)
+    state = runner.run_state_path(worktree)
+    state.parent.mkdir(parents=True)
+    state.write_text("corrupt", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="run state"):
+        runner.resume_run_id(tmp_path, "owner/repo", 3)
+
+
+def test_resume_run_id_skips_unrelated_worktrees_without_a_state_file(
+    tmp_path,
+):
+    """A worktree of ANOTHER issue without a state file (a legacy
+    completed run) is not the resume scene of this issue — it is
+    skipped, not a fail-fast (only a worktree claiming THIS issue
+    number must be verifiable)."""
+    other = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-4-ffff0000"
+    other.mkdir(parents=True)
+    mine = tmp_path / ".worktrees" / "muyan-pilot-owner-repo-issue-3-aaaa1111"
+    mine.mkdir(parents=True)
+    runner.write_run_state(
+        mine, run_id="aaaa1111", issue=3, source_repo="owner/repo",
+        branch="b1",
+    )
+    assert runner.resume_run_id(tmp_path, "owner/repo", 3) == "aaaa1111"
 
 
 def test_has_in_progress_label_checks_the_issue_label(monkeypatch, tmp_path):
@@ -2206,12 +2489,12 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
     # the newest worktree's run id.
     monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
     monkeypatch.setattr(
-        runner, "latest_run_id", lambda repo_dir, source_repo, number:
-        "a1b2c3d4",
+        runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
+        ("a1b2c3d4", tmp_path / "wt"),
     )
     monkeypatch.setattr(
         runner, "create_worktree",
-        lambda *args: tmp_path / "wt",
+        lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     issue = {"number": 4, "title": "Fix", "body": "Body"}
@@ -2297,11 +2580,11 @@ def test_process_issue_binds_run_id_before_the_resume_scan(
     # of this attempt (generated, then replaced by the resumed run).
     monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
     monkeypatch.setattr(
-        runner, "latest_run_id", lambda repo_dir, source_repo, number:
-        "a1b2c3d4",
+        runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
+        ("a1b2c3d4", tmp_path / "wt"),
     )
     monkeypatch.setattr(
-        runner, "create_worktree", lambda *args: tmp_path / "wt",
+        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     with caplog.at_level("INFO"):
@@ -2365,13 +2648,13 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
         runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
     monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
-    latest_calls = []
+    scene_calls = []
     monkeypatch.setattr(
-        runner, "latest_run_id",
-        lambda repo_dir, source_repo, number: latest_calls.append(1) or "a1b2c3d4",
+        runner, "worktree_resume_scene",
+        lambda repo_dir, source_repo, number: scene_calls.append(1) or None,
     )
     monkeypatch.setattr(
-        runner, "create_worktree", lambda *args: tmp_path / "wt",
+        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     runner.process_issue(
@@ -2382,7 +2665,7 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
     )
     # The fresh run id is used and the old worktree's run id is never
     # consulted (the label is the gate).
-    assert latest_calls == []
+    assert scene_calls == []
     progress_posts = [
         body for body in posted if "**Muyan Pilot progress**" in body
     ]
@@ -2433,9 +2716,9 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
     )
     monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
     # The label is on, but no task worktree survived the kill.
-    monkeypatch.setattr(runner, "latest_run_id", lambda *a: None)
+    monkeypatch.setattr(runner, "worktree_resume_scene", lambda *a: None)
     monkeypatch.setattr(
-        runner, "create_worktree", lambda *args: tmp_path / "wt",
+        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     with caplog.at_level("INFO"):
@@ -2452,6 +2735,208 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
     ]
     assert len(progress_posts) == 1
     assert "- run_id=ffffeeee" in progress_posts[0]
+
+
+def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
+                          latest_run_id_result="a1b2c3d4",
+                          git_status: str = ""):
+    """Shared fake-gh/git wiring for the Issue #219 process_issue tests.
+
+    Returns `(gh_calls, posted, worktree, comment_bodies)`: `posted`
+    carries the progress-comment bodies (`gh api` POST), `comment_bodies`
+    the plain `gh issue comment` bodies (scene + failure comments).
+    `git_status` is the `git status --porcelain` answer (the
+    worktree's uncommitted changes).
+    """
+    gh_calls, posted = make_fake_gh(monkeypatch, in_progress=in_progress)
+    # The branch carries the run id the attempt actually uses: the
+    # resumed one (label on + a worktree to resume) or the fresh one.
+    run_id = ("a1b2c3d4"
+              if in_progress and latest_run_id_result else "ffffeeee")
+    branch = f"muyan-pilot/xqliu-muyan-ceo-issue-4-{run_id}"
+    comment_bodies = []
+
+    def fake_run(command, **kwargs):
+        gh_calls.append(command)
+        if command[:2] == ["gh", "api"]:
+            return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps(
+                [{"number": 4}] if in_progress else [],
+            )
+        if command[:3] == ["gh", "issue", "comment"]:
+            comment_bodies.append(command[-1])
+            return ""
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return git_status
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return branch
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    )
+    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    worktree = tmp_path / "wt"
+    worktree.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        runner, "worktree_resume_scene",
+        lambda repo_dir, source_repo, number: (
+            (latest_run_id_result, worktree)
+            if latest_run_id_result else None
+        ),
+    )
+    monkeypatch.setattr(
+        runner, "create_worktree", lambda *args, **kwargs: worktree,
+    )
+    return gh_calls, posted, worktree, comment_bodies
+
+
+def test_process_issue_writes_run_state_and_resume_context(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #219: the interrupted run continues on the EXISTING work —
+    the run state file is written (the same-run marker), the resume
+    context (uncommitted changes + previous session progress) reaches
+    the new session, and the `resume_continue` line is logged."""
+    gh_calls, posted, worktree, comment_bodies = _resume_wiring_setup(
+        monkeypatch, tmp_path, in_progress=True,
+        git_status="?? src/a.py\n",
+    )
+    # The interrupted work: uncommitted changes + a previous session.
+    (worktree / "src").mkdir()
+    (worktree / "src" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    make_session_jsonl(worktree, "sess-1")
+    resume_contexts = []
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: resume_contexts.append(
+            kwargs.get("resume_context"),
+        ) or "done",
+    )
+    monkeypatch.setattr(
+        runner, "deliver_pr",
+        lambda *args, **kwargs:
+        "https://github.com/muyantech/muyan-pilot/pull/4",
+    )
+    caplog.set_level("INFO")
+    runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/muyan-ceo",
+    )
+    # The run state file marks the worktree as the same run.
+    state = runner.read_run_state(worktree)
+    assert state["run_id"] == "a1b2c3d4"
+    assert state["issue"] == 4
+    assert state["repo"] == "xqliu/muyan-ceo"
+    # The new session starts from the existing work.
+    assert len(resume_contexts) == 1
+    assert resume_contexts[0] is not None
+    assert "src/a.py" in resume_contexts[0]
+    assert "sess-1" in resume_contexts[0]
+    # The structured resume line is logged (auditable, Issue #219).
+    lines = [
+        m for m in caplog.messages if "resume_continue" in m
+    ]
+    assert len(lines) == 1
+    assert f"worktree={worktree}" in lines[0]
+    assert "changed_files=1" in lines[0]
+    assert "reused_runs=1" in lines[0]
+    assert "previous_session=sess-1" in lines[0]
+
+
+def test_process_issue_fresh_run_has_no_resume_context(
+    monkeypatch, tmp_path, caplog,
+):
+    """A fresh claim (no `ai-in-progress`) gets a run state file too
+    (so a later interruption can resume), but NO resume context and NO
+    `resume_continue` line — the prompt is the exact pre-#219 shape."""
+    gh_calls, posted, worktree, comment_bodies = _resume_wiring_setup(
+        monkeypatch, tmp_path, in_progress=False,
+    )
+    resume_contexts = []
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: resume_contexts.append(
+            kwargs.get("resume_context"),
+        ) or "done",
+    )
+    monkeypatch.setattr(
+        runner, "deliver_pr",
+        lambda *args, **kwargs:
+        "https://github.com/muyantech/muyan-pilot/pull/4",
+    )
+    caplog.set_level("INFO")
+    runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/muyan-ceo",
+    )
+    state = runner.read_run_state(worktree)
+    assert state["run_id"] == "ffffeeee"
+    assert resume_contexts == [None]
+    assert "resume_continue" not in caplog.text
+
+
+def test_process_issue_fails_fast_when_the_run_state_is_missing(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #219: the worktree of this issue exists but its run state
+    file is gone — the same run cannot be verified. The attempt fails
+    fast through the terminal failure path (`ai-blocked` + the reason
+    comment): no fresh run, no silent redo."""
+    gh_calls, posted, worktree, comment_bodies = _resume_wiring_setup(
+        monkeypatch, tmp_path, in_progress=True,
+    )
+
+    def failing_resume_scene(repo_dir, source_repo, number):
+        raise RuntimeError(
+            f"worktree {worktree} has no run state file "
+            "(.muyan-pilot/run-state.json): the same run cannot be "
+            "verified (Issue #219)"
+        )
+
+    monkeypatch.setattr(runner, "worktree_resume_scene", failing_resume_scene)
+    run_pi_calls = []
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: run_pi_calls.append(1) or "done",
+    )
+    edits = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append((args, kwargs)),
+    )
+    caplog.set_level("INFO")
+    with pytest.raises(RuntimeError, match="run state"):
+        runner.process_issue(
+            {"number": 4, "title": "Fix", "body": "Body"},
+            {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+             "base_branch": "main"},
+            "xqliu/muyan-ceo",
+        )
+    # No fresh run was started.
+    assert run_pi_calls == []
+    # The terminal state is `ai-blocked` (the claim label removed).
+    assert edits[-1] == ((4,), {
+        "repo": "xqliu/muyan-ceo", "add": "ai-blocked",
+        "remove": "ai-in-progress",
+    })
+    # The failure comment carries the reason and the run marker.
+    failed = [
+        body for body in comment_bodies
+        if body.startswith("<!-- muyan-pilot:run=")
+        and "Muyan Pilot failed" in body
+    ]
+    assert len(failed) == 1
+    assert "cannot continue the interrupted run" in failed[0]
+    assert "run state" in failed[0]
+    assert "resume_continue_failed" in caplog.text
 
 
 def test_worktree_path_lives_inside_repo_worktrees_and_includes_run_id():
@@ -2654,6 +3139,77 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
         str(tmp_path / ".pi-session"),
         "--system-prompt", "<redacted>", "<issue-context-redacted>",
     ]
+
+
+def test_run_pi_keeps_the_fresh_context_without_a_resume_context(
+    monkeypatch, tmp_path,
+):
+    """No resume context: the context argument is byte-identical to the
+    pre-#219 shape (a fresh claim is untouched)."""
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "done",
+    )
+    config = {
+        "prompt": prompt_path, "repo_dir": tmp_path,
+        "source_repos": ["owner/repo"], "workspace_root": tmp_path,
+        "context_files": [], "skills": [], "base_branch": "main",
+        "base_sha": "abc123def456", "run_id": "run1",
+    }
+    runner.run_pi(
+        {"number": 5, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-5-run1",
+    )
+    command = calls[0]
+    assert command[-1] == (
+        "Issue #5: t\n\nIssue body:\nb\n\nWorktree: "
+        + str(tmp_path) + "\n"
+        "Complete the delivery process in the system prompt."
+    )
+
+
+def test_run_pi_appends_the_resume_context_to_the_context_argument(
+    monkeypatch, tmp_path,
+):
+    """Issue #219: the continued run's new session starts from the
+    existing work — the resume context is appended to the context
+    argument (the prompt template itself is untouched)."""
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "stream_pi",
+        lambda command, **kwargs: calls.append(command) or "done",
+    )
+    config = {
+        "prompt": prompt_path, "repo_dir": tmp_path,
+        "source_repos": ["owner/repo"], "workspace_root": tmp_path,
+        "context_files": [], "skills": [], "base_branch": "main",
+        "base_sha": "abc123def456", "run_id": "run1",
+    }
+    resume = (
+        "Resume context (Issue #219): this worktree already carries "
+        "work from an earlier session of the SAME run. Continue that "
+        "work — do not start from scratch, do not discard or rewrite "
+        "the existing changes, and do not create a new plan from "
+        "nothing.\nPrevious session progress: session=sess-1 "
+        "events=7 phase=test last_action=bash pytest last_result=ok\n"
+        "Uncommitted changed files (2):\n- src/a.py\n- src/b.py"
+    )
+    runner.run_pi(
+        {"number": 5, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo", branch="muyan-pilot/owner-repo-issue-5-run1",
+        resume_context=resume,
+    )
+    command = calls[0]
+    context = command[-1]
+    assert context.startswith(
+        "Issue #5: t\n\nIssue body:\nb\n\nWorktree: " + str(tmp_path),
+    )
+    assert context.endswith(resume)
 
 
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
@@ -3240,7 +3796,7 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     issue = {"number": 4, "title": "Fix", "body": "Body"}
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}
@@ -3306,7 +3862,7 @@ def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, c
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "deliver_pr", lambda *args, **kwargs: "https://github.com/muyantech/muyan-pilot/pull/4")
     monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
@@ -3834,7 +4390,7 @@ def test_process_issue_failure_without_session_still_carries_scene(
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("pi died")),
@@ -3868,7 +4424,7 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -3914,7 +4470,7 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args: tmp_path / "wt")
+    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("git failed")),
@@ -3931,10 +4487,17 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(
-        runner, "activity_snapshot",
-        lambda session_dir: (_ for _ in ()).throw(OSError("disk error")),
-    )
+    # The main-path resume-context read (Issue #219) succeeds; the
+    # failure-scene lookup is the one that dies on the disk error.
+    snapshot_calls = []
+
+    def flaky_snapshot(session_dir):
+        snapshot_calls.append(1)
+        if len(snapshot_calls) == 1:
+            return None
+        raise OSError("disk error")
+
+    monkeypatch.setattr(runner, "activity_snapshot", flaky_snapshot)
     with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="git failed"):
         runner.process_issue({"number": 9, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/muyan-ceo")
     assert "activity scene failed" in caplog.text
@@ -10368,7 +10931,9 @@ def test_process_ticket_only_keeps_original_error_when_failure_reporting_fails(m
         runner.process_ticket_only(issue, {"repo_dir": Path("/repo")}, "o/r")
 
 
-def test_process_issue_keeps_normal_flow_without_release_label(monkeypatch):
+def test_process_issue_keeps_normal_flow_without_release_label(
+    monkeypatch, tmp_path,
+):
     issue = {"number": 99, "title": "Normal", "body": "",
              "labels": [{"name": "ai-ready"}]}
     monkeypatch.setattr(runner, "is_release", lambda i: False)
@@ -10378,16 +10943,18 @@ def test_process_issue_keeps_normal_flow_without_release_label(monkeypatch):
     monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
     monkeypatch.setattr(runner, "edit_issue", Mock())
     monkeypatch.setattr(runner, "set_active_run", Mock())
-    monkeypatch.setattr(runner, "create_worktree",
-                        lambda *a: Path("/wt"))
+    # The worktree exists: `create_worktree` always returns a real
+    # directory (the run state file is written into it, Issue #219).
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "create_worktree", lambda *a, **kwargs: worktree)
     monkeypatch.setattr(runner, "comment_issue", Mock())
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
     monkeypatch.setattr(runner, "run_pi",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
     monkeypatch.setattr(runner, "deliver_pr",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
-    monkeypatch.setattr(runner, "run_command",
-                        lambda c, **k: "abc123")
+    monkeypatch.setattr(runner, "run_command", lambda c, **k: "")
     monkeypatch.setattr(runner, "wait_for_delivery", Mock())
     monkeypatch.setattr(runner, "edit_issue", Mock())
     monkeypatch.setattr(runner, "LOGGER", Mock())
@@ -10397,7 +10964,9 @@ def test_process_issue_keeps_normal_flow_without_release_label(monkeypatch):
     monkeypatch.setattr(runner, "issue_context", lambda r, n: "#n")
     monkeypatch.setattr(runner, "format_run_scene", lambda *a, **k: "scene")
     monkeypatch.setattr(runner, "_finish_blocked_progress", Mock())
-    runner.process_issue(issue, {"base_branch": "main", "repo_dir": Path("/r")}, "o/r")
+    runner.process_issue(
+        issue, {"base_branch": "main", "repo_dir": tmp_path}, "o/r",
+    )
 
 
 def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -68,7 +68,7 @@ def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
                         lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
 
-    def fake_create_worktree(*args):
+    def fake_create_worktree(*args, **kwargs):
         path = tmp_path / "wt"
         path.mkdir(parents=True, exist_ok=True)
         return path

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -1,0 +1,571 @@
+"""E2E: an interrupted run continues on the existing work (Issue #219).
+
+Real git (local bare origin + clone) plus a fake ``pi`` executable:
+
+- interrupted mode (first attempt): writes UNCOMMITTED work and a
+  session JSONL, then dies with a non-zero exit — the runner is killed
+  before the failure path could remove the ``ai-in-progress`` label;
+- continue mode (the restart): the new session receives the resume
+  context (the uncommitted changes + the previous session's progress)
+  in its context argument and CONTINUES the existing work (it commits
+  what is there and appends — it never rewrites from scratch).
+
+The acceptance criteria proven here:
+
+- after the interruption the restart continues on the SAME run id,
+  branch and worktree — no second run/branch/worktree;
+- the new session's context carries the resume context (changed files
+  + previous session progress) — the agent continues the existing work
+  instead of a fresh redo;
+- the ``resume_continue`` journal line carries worktree, changed_files
+  and reused_runs;
+- after a repo rename (slug change) the old worktree is found by issue
+  number + repo NAME and the same run continues;
+- a worktree whose run state file is missing or corrupt fails fast
+  (the Issue goes ``ai-blocked`` with the reason) — never a silent
+  fresh redo.
+"""
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import bootstrap_runner as runner
+
+REPO = "owner/repo"
+RENAME_OLD = "xqliu/orbi"
+RENAME_NEW = "orbi-build/orbi"
+ISSUE_NUMBER = 219
+PR_URL = "https://github.com/owner/repo/pull/219"
+
+# First attempt: the interrupted run. It leaves UNCOMMITTED work and a
+# previous session file behind, then dies (the runner is killed before
+# the failure path runs).
+FAKE_PI_INTERRUPTED = """#!/usr/bin/env python3
+import json, os, sys
+from datetime import datetime, timezone
+cwd = os.getcwd()
+session_dir = os.path.join(cwd, ".pi-session")
+os.makedirs(session_dir, exist_ok=True)
+with open(os.path.join(cwd, "work.txt"), "a", encoding="utf-8") as f:
+    f.write("part-1\\n")
+now = datetime.now(timezone.utc).isoformat()
+with open(os.path.join(session_dir, "interrupted.jsonl"), "a",
+          encoding="utf-8") as f:
+    f.write(json.dumps({"type": "session", "id": "sess-interrupted"}) + "\\n")
+    f.write(json.dumps({
+        "type": "message", "timestamp": now,
+        "message": {"role": "assistant", "content": [
+            {"type": "toolCall", "name": "bash",
+             "arguments": {"command": "echo part-1 >> work.txt"}}]},
+    }) + "\\n")
+    f.write(json.dumps({
+        "type": "message", "timestamp": now,
+        "message": {"role": "toolResult", "toolName": "bash",
+                    "isError": False},
+    }) + "\\n")
+sys.stderr.write("killed mid-run (simulated interruption)")
+sys.exit(3)
+"""
+
+# The restart: the new session receives the resume context in its
+# context argument. It CONTINUES the existing work: it commits the
+# uncommitted changes (never discards or rewrites them) and appends.
+FAKE_PI_CONTINUE = """#!/usr/bin/env python3
+import os, subprocess, sys
+args = sys.argv[1:]
+context = args[-1]
+cwd = os.getcwd()
+with open(os.path.join(cwd, "resume-context.txt"), "w",
+          encoding="utf-8") as handle:
+    handle.write(context)
+if "Resume context (Issue #219)" not in context:
+    sys.stderr.write("resume context missing from the new session")
+    sys.exit(9)
+if "work.txt" not in context or "sess-interrupted" not in context:
+    sys.stderr.write("resume context lost the existing work")
+    sys.exit(9)
+# Continue the existing work: commit what is there, then append.
+with open(os.path.join(cwd, "work.txt"), "a", encoding="utf-8") as f:
+    f.write("part-2\\n")
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", "continue the interrupted work"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+"""
+
+# The fresh-mode agent (used by the fail-fast test's EXPECTED fresh
+# run — which must never happen): if it ever runs, the test fails.
+FAKE_PI_FRESH = """#!/usr/bin/env python3
+import sys
+sys.stderr.write("a FRESH run started — the resume was lost")
+sys.exit(7)
+"""
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def clone(tmp_path: Path) -> Path:
+    """Local bare origin plus a clone with two commits on main."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True, text=True, check=True,
+    )
+    git(clone, "config", "user.email", "pilot@test.local")
+    git(clone, "config", "user.name", "Pilot")
+    (clone / "a.txt").write_text("a", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "first")
+    (clone / "b.txt").write_text("b", encoding="utf-8")
+    git(clone, "add", ".")
+    git(clone, "commit", "-m", "second")
+    git(clone, "push", "origin", "main")
+    return clone
+
+
+@pytest.fixture(autouse=True)
+def _reset_run_id(monkeypatch):
+    """Each test starts without a bound run id."""
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+
+
+def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
+    """Put a fake ``pi`` executable first on PATH for the runner's Popen."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake = bin_dir / "pi"
+    fake.write_text(script, encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+
+def install_fake_gh(monkeypatch, comments: list[str],
+                    labels: dict[int, list[str]]):
+    """Answer the runner's ``gh`` calls; track labels and comments.
+
+    ``gh pr list`` / ``gh pr create`` are stateful (Issue #186): no PR
+    exists until the Runner's ``pr create`` lands, and the created PR
+    carries the local HEAD plus the exact body the Runner passed.
+    Returns the fake handler (the defensive branches are driven
+    directly by a dedicated test).
+    """
+    comment_ids: list[int] = []
+    created_prs: list[dict] = []
+    real_run = runner.run_command
+
+    def fake_run(command, **kwargs):
+        if command[:1] == ["gh"]:
+            if command[1] == "issue":
+                if command[2] == "comment":
+                    comment_ids.append(len(comments) + 1)
+                    comments.append(command[-1])
+                    return ""
+                if command[2] == "edit":
+                    number = int(command[3])
+                    current = labels.setdefault(number, [])
+                    if "--add-label" in command:
+                        label = command[command.index("--add-label") + 1]
+                        if label not in current:
+                            current.append(label)
+                    if "--remove-label" in command:
+                        label = command[command.index("--remove-label") + 1]
+                        if label in current:
+                            current.remove(label)
+                    return ""
+                if command[2] == "list":
+                    if "label:ai-in-progress" in " ".join(command):
+                        return json.dumps([
+                            {"number": number}
+                            for number in labels
+                            if "ai-in-progress" in labels[number]
+                        ])
+                    return "[]"
+            if command[1] == "api":
+                if "--method" in command:
+                    method = command[command.index("--method") + 1]
+                    body = command[command.index("--field") + 1][
+                        len("body="):]
+                    if method == "POST":
+                        comment_id = len(comments) + 1
+                        comment_ids.append(comment_id)
+                        comments.append(body)
+                        return json.dumps(
+                            {"id": comment_id, "body": body},
+                        )
+                    if method == "PATCH":
+                        comment_id = int(command[2].rsplit("/", 1)[1])
+                        index = comment_ids.index(comment_id)
+                        comments[index] = body
+                        return ""
+                return json.dumps([
+                    {"id": comment_id, "body": body}
+                    for comment_id, body in zip(comment_ids, comments)
+                ])
+            if command[1] == "pr":
+                if command[2] == "list":
+                    head = command[command.index("--head") + 1]
+                    return json.dumps(
+                        [pr for pr in created_prs
+                         if pr["headRefName"] == head]
+                    )
+                if command[2] == "create":
+                    base = command[command.index("--base") + 1]
+                    branch = command[command.index("--head") + 1]
+                    title = command[command.index("--title") + 1]
+                    body = command[command.index("--body") + 1]
+                    head = real_run(
+                        ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
+                    )
+                    created_prs.append({
+                        "url": PR_URL,
+                        "baseRefName": base,
+                        "headRefName": branch,
+                        "headRefOid": head,
+                        "headRepository": {"name": "repo"},
+                        "headRepositoryOwner": {"login": "owner"},
+                        "body": body,
+                        "title": title,
+                    })
+                    return PR_URL
+                raise AssertionError(f"unexpected gh pr command: {command}")
+            raise AssertionError(f"unexpected gh command: {command}")
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    return fake_run
+
+
+def write_prompt(tmp_path: Path) -> Path:
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text(
+        "You are the delivery agent.\n"
+        "- Delivery base branch: `{{BASE_BRANCH}}`\n"
+        "- Delivery base SHA: `{{BASE_SHA}}`\n"
+        "- Run id: `{{RUN_ID}}`\n",
+        encoding="utf-8",
+    )
+    return prompt
+
+
+def config_for(clone: Path, tmp_path: Path, source_repo: str) -> dict:
+    return {
+        "repo_dir": clone,
+        "prompt": write_prompt(tmp_path),
+        "base_branch": "main",
+        "source_repos": [source_repo],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+    }
+
+
+def issue() -> dict:
+    return {
+        "number": ISSUE_NUMBER, "title": "E2E", "body": "body",
+        "labels": [],
+    }
+
+
+def worktree_for(clone: Path, source_repo: str, run_id: str) -> Path:
+    return (
+        clone / ".worktrees"
+        / f"muyan-pilot-{source_repo.replace('/', '-')}"
+        f"-issue-{ISSUE_NUMBER}-{run_id}"
+    )
+
+
+def run_first_attempt(monkeypatch, tmp_path: Path, clone: Path,
+                      comments: list[str], labels: dict[int, list[str]],
+                      source_repo: str) -> Path:
+    """The interrupted first attempt: claim label left behind (the
+    failure path never ran — the runner was killed), uncommitted work
+    and a session file in the worktree.
+
+    The restart gets the REAL `edit_issue` again (the kill simulation
+    is over): the resumed attempt's label transitions reach GitHub.
+    """
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_INTERRUPTED)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    real_edit_issue = runner.edit_issue
+
+    def claiming_edit(number, **kwargs):
+        # Only the claim edit reaches GitHub before the kill; the
+        # failure path's label transition never happens.
+        if kwargs.get("add") == "ai-in-progress" \
+                and kwargs.get("remove") is None:
+            real_edit_issue(number, **kwargs)
+
+    monkeypatch.setattr(runner, "edit_issue", claiming_edit)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.process_issue(issue(), config_for(clone, tmp_path,
+                                                 source_repo),
+                             source_repo)
+    # The runner is back: label transitions work again.
+    monkeypatch.setattr(runner, "edit_issue", real_edit_issue)
+    worktree = worktree_for(clone, source_repo, "a1b2c3d4")
+    assert worktree.is_dir()
+    assert "ai-in-progress" in labels[ISSUE_NUMBER]
+    return worktree
+
+
+def test_e2e_restart_continues_on_the_uncommitted_work(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """AC1/AC3: the interrupted run's uncommitted changes + session
+    progress become the new session's starting point — the same run,
+    branch and worktree continue; the `resume_continue` line is
+    logged."""
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {ISSUE_NUMBER: ["ai-ready"]}
+    worktree = run_first_attempt(
+        monkeypatch, tmp_path, clone, comments, labels, REPO,
+    )
+    # The interruption left uncommitted work and a session file.
+    assert (worktree / "work.txt").read_text() == "part-1\n"
+    assert (worktree / ".pi-session" / "interrupted.jsonl").is_file()
+    assert git(worktree, "status", "--porcelain") != ""
+
+    # ---- Restart: the healthy runner resumes the same run.
+    caplog.set_level("INFO")
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_CONTINUE)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    pr_url = runner.process_issue(
+        issue(), config_for(clone, tmp_path, REPO), REPO,
+    )
+
+    # The SAME run continues: no second worktree, same branch.
+    assert pr_url == PR_URL
+    assert runner.current_run_id() == "a1b2c3d4"
+    assert not worktree_for(clone, REPO, "b2c3d4e5").exists()
+    assert git(
+        worktree, "branch", "--show-current",
+    ) == f"muyan-pilot/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-a1b2c3d4"
+
+    # The new session RECEIVED the resume context (the existing work),
+    # and the agent continued it: the committed work.txt carries BOTH
+    # parts — part-1 (the interrupted work, never discarded) and
+    # part-2 (the continuation).
+    context = (worktree / "resume-context.txt").read_text()
+    assert "Resume context (Issue #219)" in context
+    assert "work.txt" in context
+    assert "sess-interrupted" in context
+    committed = git(worktree, "show", "HEAD:work.txt")
+    assert committed == "part-1\npart-2"
+
+    # The structured resume line (auditable, Issue #219).
+    lines = [m for m in caplog.messages if "resume_continue" in m]
+    assert len(lines) == 1
+    assert f"worktree={worktree}" in lines[0]
+    assert "changed_files=" in lines[0]
+    assert "reused_runs=1" in lines[0]
+    assert "previous_session=sess-interrupted" in lines[0]
+
+    # The delivery finished: the in-progress label is gone.
+    assert "ai-in-progress" not in labels[ISSUE_NUMBER]
+    assert "ai-pr-opened" in labels[ISSUE_NUMBER]
+
+
+def test_e2e_repo_rename_finds_the_old_worktree_by_issue_and_name(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """AC2: the repo was renamed (slug `xqliu-orbi` ->
+    `orbi-build-orbi`): the old worktree is found by issue number +
+    repo NAME and the SAME run/branch/worktree continues — no second
+    run/branch/worktree is created."""
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {ISSUE_NUMBER: ["ai-ready"]}
+    worktree = run_first_attempt(
+        monkeypatch, tmp_path, clone, comments, labels, RENAME_OLD,
+    )
+    assert worktree.name == (
+        f"muyan-pilot-{RENAME_OLD.replace('/', '-')}"
+        f"-issue-{ISSUE_NUMBER}-a1b2c3d4"
+    )
+
+    # ---- Restart AFTER the rename: the configured source repo is the
+    # NEW slug; the old worktree must still be found and continued.
+    caplog.set_level("INFO")
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_CONTINUE)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    pr_url = runner.process_issue(
+        issue(), config_for(clone, tmp_path, RENAME_NEW), RENAME_NEW,
+    )
+
+    # The SAME worktree (old slug) continues; no second worktree under
+    # the new slug.
+    assert pr_url == PR_URL
+    assert runner.current_run_id() == "a1b2c3d4"
+    assert worktree.is_dir()
+    assert not worktree_for(clone, RENAME_NEW, "a1b2c3d4").exists()
+    assert not worktree_for(clone, RENAME_NEW, "b2c3d4e5").exists()
+    # The branch keeps its original (old-slug) name: the same branch
+    # continues, never a second one.
+    assert git(
+        worktree, "branch", "--show-current",
+    ) == f"muyan-pilot/{RENAME_OLD.replace('/', '-')}-issue-{ISSUE_NUMBER}-a1b2c3d4"
+    # The continued work landed on the ORIGINAL branch.
+    committed = git(worktree, "show", "HEAD:work.txt")
+    assert committed == "part-1\npart-2"
+    # The resume was logged.
+    assert [m for m in caplog.messages if "resume_continue" in m]
+
+
+def test_e2e_missing_run_state_fails_fast_without_a_fresh_run(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """AC4: the interrupted worktree exists but its run state file is
+    gone — the same run cannot be verified. The attempt fails fast
+    (the Issue goes `ai-blocked` with the reason); a fresh run is
+    never started."""
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {ISSUE_NUMBER: ["ai-ready"]}
+    worktree = run_first_attempt(
+        monkeypatch, tmp_path, clone, comments, labels, REPO,
+    )
+    # The state file is lost (e.g. a partial cleanup).
+    state = worktree / ".muyan-pilot" / "run-state.json"
+    assert state.is_file()
+    state.unlink()
+
+    # ---- Restart: the fresh-mode fake pi must NEVER run.
+    caplog.set_level("INFO")
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FRESH)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    with pytest.raises(RuntimeError, match="run state"):
+        runner.process_issue(
+            issue(), config_for(clone, tmp_path, REPO), REPO,
+        )
+    # The terminal state is `ai-blocked` (the claim label removed).
+    assert labels[ISSUE_NUMBER] == ["ai-ready", "ai-blocked"]
+    # The failure comment carries the reason and the run marker.
+    failed = [
+        body for body in comments
+        if "Muyan Pilot failed" in body
+        and "cannot continue the interrupted run" in body
+    ]
+    assert len(failed) == 1
+    assert "run state" in failed[0]
+    assert "<!-- muyan-pilot:run=" in failed[0]
+    # No fresh run was started: the existing work is untouched.
+    assert (worktree / "work.txt").read_text() == "part-1\n"
+    assert git(worktree, "status", "--porcelain") != ""
+    assert "resume_continue_failed" in caplog.text
+    assert "resume_continue " not in caplog.text
+
+
+def test_e2e_corrupt_run_state_fails_fast_without_a_fresh_run(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """AC4: a corrupt run state file is a delivery failure, never a
+    guess — the same fail-fast path as the missing file."""
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {ISSUE_NUMBER: ["ai-ready"]}
+    worktree = run_first_attempt(
+        monkeypatch, tmp_path, clone, comments, labels, REPO,
+    )
+    state = worktree / ".muyan-pilot" / "run-state.json"
+    state.write_text("corrupt", encoding="utf-8")
+
+    caplog.set_level("INFO")
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FRESH)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    with pytest.raises(RuntimeError, match="run state"):
+        runner.process_issue(
+            issue(), config_for(clone, tmp_path, REPO), REPO,
+        )
+    assert labels[ISSUE_NUMBER] == ["ai-ready", "ai-blocked"]
+    failed = [
+        body for body in comments
+        if "Muyan Pilot failed" in body
+        and "cannot continue the interrupted run" in body
+    ]
+    assert len(failed) == 1
+    assert "corrupt" in failed[0]
+    # The existing work is untouched (no fresh redo).
+    assert (worktree / "work.txt").read_text() == "part-1\n"
+
+
+def test_git_helper_fails_fast_on_nonzero_exit(tmp_path):
+    """A git failure is a test failure with the exact reason."""
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git(tmp_path, "rev-parse", "refs/heads/does-not-exist")
+
+
+def test_fake_gh_handler_answers_the_unreached_transitions(
+    tmp_path, monkeypatch,
+):
+    """The fake gh's defensive branches — a remove-only label edit, a
+    remove of a label that is not there, a non-resume issue list, a
+    plain comment GET, an unexpected subcommand — are driven directly:
+    the delivery flow itself never issues them."""
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {
+        ISSUE_NUMBER: ["ai-ready", "ai-in-progress"],
+    }
+    fake = install_fake_gh(monkeypatch, comments, labels)
+
+    # A remove-only label edit (the `--add-label`-absent branch).
+    fake(["gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
+          "--remove-label", "ai-in-progress"])
+    assert labels[ISSUE_NUMBER] == ["ai-ready"]
+    # Removing a label that is not there is a no-op (the `label in
+    # current`-false branch).
+    fake(["gh", "issue", "edit", str(ISSUE_NUMBER), "--repo", REPO,
+          "--remove-label", "ai-in-progress"])
+    assert labels[ISSUE_NUMBER] == ["ai-ready"]
+    # A non-resume issue list (no `label:ai-in-progress` in the
+    # search) answers the empty array.
+    assert fake(["gh", "issue", "list", "--repo", REPO,
+                 "--state", "open", "--search", "label:ai-ready",
+                 "--json", "number"]) == "[]"
+    # A POSTed comment gets an id; a plain GET lists the tracked
+    # comments.
+    posted = fake(["gh", "api", "repos/owner/repo/issues/219/comments",
+                   "--method", "POST", "--field", "body=scene"])
+    assert json.loads(posted) == {"id": 1, "body": "scene"}
+    get = fake(["gh", "api", "repos/owner/repo/issues/219/comments"])
+    assert json.loads(get) == [
+        {"id": 1, "body": "scene"},
+    ]
+    # An unexpected `gh pr` subcommand and an unexpected `gh`
+    # subcommand fail fast (the fake is a contract, not a sink).
+    with pytest.raises(AssertionError, match="unexpected gh pr"):
+        fake(["gh", "pr", "view", "219"])
+    with pytest.raises(AssertionError, match="unexpected gh command"):
+        fake(["gh", "release", "list"])
+    # A `gh issue` subcommand the flow never issues falls through the
+    # comment/edit/list handlers and fails fast.
+    with pytest.raises(AssertionError, match="unexpected gh command"):
+        fake(["gh", "issue", "view", str(ISSUE_NUMBER)])
+    # A `gh api` method that is neither POST nor PATCH falls through
+    # to the plain GET answer.
+    get = fake(["gh", "api", "repos/owner/repo/issues/219/comments",
+                "--method", "DELETE", "--field", "body=x"])
+    assert json.loads(get) == [
+        {"id": 1, "body": "scene"},
+    ]


### PR DESCRIPTION
<!-- muyan-pilot:run=1cc9fa91 -->

Fixes #219

core: 中断后继续既有工作，而不是 fresh 重做 (run_id=1cc9fa91)
