### PR TITLE
README 首页化：保留定位/quickstart/能力概览/文档链接，移除重复机制说明

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@
 # GitHub-hosted runners do not have that interpreter at that path, so this
 # workflow pins the same minor version (3.14) via actions/setup-python and
 # runs the contract commands through the pinned `python3` on PATH. The
-# difference is documented in the README section "远程 CI（GitHub Actions）".
+# difference is documented in docs/testing.mdx (the README homepage keeps
+# the summary plus the link, Issue #241).
 name: CI
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ each section points at the owning page instead of restating it.
 - Progress is automatic: no human status command, no polling, no supervision; `muyan-pilot status` is a debug attachment only.
 - The journal is the record: a heartbeat at most every 30 seconds, every line prefixed `[run_id]`; a stalled session is recovered automatically, and a frozen `model_wait` past `PI_MODEL_WAIT_DEAD_SECONDS` (default 1800 s; the pre-#228 default was 600 s) is a hung model request — the Runner logs `model_wait_dead` (`upstream_alive` is evidence, never a veto) and kills the Pi session. It never fires while events keep arriving: a slow generation is not a hung request, and none of this is a business task timeout.
 - GitHub: exactly one progress comment per run, PATCHed in place, with short milestone comments; it is a pure bypass — a `progress_publish_failed` never fails the delivery, never marks the Issue `ai-blocked`, and never skips `run_pi` / `wait_for_delivery`. The `Muyan Pilot opened PR:` scene comment is NOT a bypass: the next tick's resume parses it, so a failure there fails the delivery fail-fast.
-- Field reference and full mechanics: `docs/operations.mdx` (EN) / `docs/zh/operations.mdx` (ZH) and the README 自动可观测 section.
+- Field reference and full mechanics: `docs/operations.mdx` (EN) / `docs/zh/operations.mdx` (ZH) (the README homepage keeps a one-sentence summary plus the link, Issue #241).
 
 ## Base freshness and deployment (contract)
 
@@ -111,7 +111,7 @@ each section points at the owning page instead of restating it.
 - `ai-pr-opened` means awaiting review; `ai-fix-needed` marks a delivery whose head is not mergeable yet (a finding the session could not fix, a PR behind the latest base / with a merge conflict, or an AI-recoverable failure of the existing run/PR): the NEXT tick resumes the SAME run_id, branch, worktree and PR and runs the next independent review session, which absorbs the latest base in-session. Never a replacement PR, never a re-claim.
 - The merge gate re-fetches the latest remote base and requires the PR head to contain it, the PR to be mergeable, and the remote head to still be the reviewed head; the merge lands exactly that head (`gh pr merge --match-head-commit`).
 - The review loop is bounded (5 rounds); exhausting rounds with findings fails fast and marks the Issue `ai-blocked`.
-- Chain, state semantics and label lifecycle: `docs/workflow.mdx` (EN/ZH); the recovery scene contract: the README 自动 loop 与恢复现场 section.
+- Chain, state semantics and label lifecycle: `docs/workflow.mdx` (EN/ZH); the recovery scene contract (trusted-maintainer comment, derived branch/worktree, PR body run marker): `docs/security.mdx` + `docs/workflow.mdx` (EN/ZH).
 
 ## Run correlation
 

--- a/README.md
+++ b/README.md
@@ -1,453 +1,83 @@
 # Orbi
 
-Orbi 是本地 AI 开发 Worker（v0.3.0 起对外品牌为 Orbi，GitHub 项目为
-[`orbi-build/orbi`](https://github.com/orbi-build/orbi)，官网 <https://orbi.build>，
-文档站 <https://docs.orbi.build>）。最小 bootstrap：从配置文件中的 source
-repos 按顺序领取一个 `ai-ready` Issue，启动 Pi，在隔离 worktree 中完成开发
-并创建 PR；随后 Runner 自动完成独立审查（会话内修复）和合并。
+Orbi 是一个本地 AI 开发 Worker：把任务放进 GitHub Issue，它自动领取，启动
+Pi 在隔离 worktree 中完成开发、测试并创建 PR，再经过独立审查与合并门禁后
+合入。GitHub Issue 与标签是唯一状态存储——没有数据库、队列或 daemon。
 
-**品牌与兼容（v0.3.0 rebrand，Issue #183）**：对外品牌统一为 Orbi（README、
-文档站、仓库描述、package metadata、对外链接）；已有用户的使用方式不变——CLI
-仍是 `muyan-pilot`、配置文件仍是 `muyan-pilot.toml`、systemd unit 仍是
-`muyan-pilot@*`、运行时 label（`ai-*`/`p0`）与 run marker
-（`<!-- muyan-pilot:run=... -->`）均不改动。
+- 官网：<https://orbi.build>
+- 文档站：<https://docs.orbi.build/>（仓库内 [`docs/`](docs/) 是唯一事实源；
+  中文入口 [`docs/zh/`](docs/zh/)）
 
-开发契约见 [AGENTS.md](AGENTS.md)；面向新用户的完整操作说明（安装前提、
-配置、首次启动、smoke walkthrough、工作流、运维、安全、测试、贡献）在文档站
-<https://docs.orbi.build>（仓库内 [`docs/`](docs/) 是唯一事实源，Mintlify 只
-构建、搜索和托管；中文入口 [`docs/zh/`](docs/zh/)）。本 README 只保留项目定位、
-快速开始、核心工作流和关键入口；每条规则的完整说明只在一个事实源里，其余位置
-只做短引用。
+## 为什么用 Orbi
+
+- **GitHub Issue 就是任务池**：`ai-ready` 标签派活，交付记录（评论、PR、CI）
+  天然完整，无需第二套任务系统；
+- **全自动运行**：systemd user timer 每 5 分钟触发一次 tick，正常运行不需要
+  status 命令、轮询或督工；
+- **独立审查 + 合并门禁**：PR 打开后由独立审查会话审查并在会话内修复，只有被
+  审查的 head 能合并，AI 从不 merge 或 push 保护分支；
+- **fail fast**：命令错误立即失败并在日志留下现场，Issue 标记 `ai-blocked`
+  等待人工决策，不做静默回退；
+- **全程可观测**：每条 journal 日志和 GitHub 进度评论都携带同一个 `run_id`，
+  一条 grep 即可还原完整时间线。
 
 ## 快速开始
 
 ```bash
 # 1. clone
-git clone https://github.com/orbi-build/orbi.git
-cd orbi
-
+git clone https://github.com/orbi-build/orbi.git && cd orbi
 # 2. 安装 CLI（editable uv tool 安装，官方本地部署方式）
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
-muyan-pilot --help
-
 # 3. 创建配置（仓库只提交 example，真实配置本地维护）
 cp .muyan-pilot.example.toml muyan-pilot.toml
-
-# 4. 一次性 setup（gh auth + 仓库权限、平台 labels、systemd user units、
-#    checkout 检查含 Git transport；幂等、fail-fast）
+# 4. 一次性 setup（gh auth、labels、systemd units、checkout 检查；幂等）
 muyan-pilot setup --config muyan-pilot.toml
-
-# 5. 手动跑一个 tick（首次验证/排查；日常由 timer 调度）
+# 5. 手动跑一个 tick（首次验证；日常由 timer 调度）
 python3 bootstrap_runner.py --config muyan-pilot.toml
-
-# 6. 验证 timer 与部署健康
-systemctl --user list-timers 'muyan-pilot@*.timer'
+# 6. 验证部署健康
 muyan-pilot doctor --config muyan-pilot.toml
 ```
 
-新用户从 [Getting started](docs/getting-started.mdx) 可以完整走完安装、配置、
-setup、首次运行和 doctor 验证（含从 0 开始的 smoke walkthrough 与故障排查表）；
-一次性 setup 的完整输出契约与失败现场见
-[One-time setup](docs/setup.mdx)。
+完整前提（Python 3.14、Pi、git + gh、systemd、模型端点）与从 0 开始的 smoke
+walkthrough 见 [Getting started](docs/getting-started.mdx)；setup 的完整输出
+契约与失败现场见 [One-time setup](docs/setup.mdx)。
 
-## 当前运行
-
-正常运行使用 systemd user timer，全天 24 小时运行，每 5 分钟自动执行一次
-（触发点覆盖 00:00–23:55）：
-
-```bash
-# 幂等安装用户级 service/timer 模板（仓库模板复制到用户 systemd 目录、
-# daemon-reload，并按 max_concurrency 启用对应的 timer 实例），并输出部署
-# commit 和每个 unit 的 sha256：
-muyan-pilot install-units --config muyan-pilot.toml
-systemctl --user list-timers 'muyan-pilot@*.timer'
-```
-
-安装按 `max_concurrency` 同步 timer：`1` 只启用 `muyan-pilot@1.timer`，`2`
-启用 `muyan-pilot@1.timer` 和 `muyan-pilot@2.timer`。`install-units` 是幂等的：
-重复执行只会把仓库模板重新复制到位并 `daemon-reload`，**不会**启动、停止或重启
-正在运行的 Runner（新配置从下一次 service 启动生效）。timer、`ExecStartPre`
-代码同步、unit 漂移自愈、slot 并发与故障恢复的完整说明见
-[Operations](docs/operations.mdx)。
-
-## 代码更新与部署一致性
-
-service 每次真正启动时，先由 `ExecStartPre` 在 Python Runner 进程外执行：
-
-```bash
-timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main
-```
-
-本地 main 被 fast-forward 到最新 `origin/main` 后，Runner 才用新代码启动；
-当前正在运行的长任务不会被热更新、不会被杀。仓库中的
-`systemd/muyan-pilot@.service` 和 `systemd/muyan-pilot@.timer`（模板 unit）是
-已安装 unit 的**唯一事实源**；Runner 每次启动在领取任何 Issue 之前对比已安装
-unit 与模板，漂移用同一个幂等安装自愈并复核（`unit_drift auto_synced`），
-复核后仍漂移则记录结构化日志并 fail fast（不取 slot、不领取）：
+## 它能做什么
 
 ```text
-unit_drift auto_synced unit=muyan-pilot@.timer before_sha256=... after_sha256=... commit=<deployed HEAD>
-unit_drift unit=muyan-pilot@.timer repo=<repo path> installed=<installed path> repo_sha256=... installed_sha256=... fix=muyan-pilot install-units
+GitHub Issue（ai-ready）
+  → 领取：建 feature branch + 隔离 worktree（从冻结的 origin/main SHA）
+  → Pi 开发：plan → implement → test → verify
+  → commit 交付（Agent 在提交处停止）
+  → Runner 收口：同步最新 base、push、创建 PR（body 带 Fixes #N）
+  → 独立审查（会话内修复）→ 合并门禁 → merge
 ```
 
-安装同时**一次性迁移** #149 之前的非模板 unit（`systemd/muyan-pilot.service` /
-`systemd/muyan-pilot.timer`：`systemctl --user disable --now muyan-pilot.timer`
-停的是 timer，绝不停/启/重启 service）并删除旧文件；已迁移过的机器上是 no-op。
-`muyan-pilot doctor` 是只读诊断（repo commit、unit drift、timer/service active、
-slot、Pi session、当前 Issue、最近 journal 活动），不改标签、不改 unit、不做
-git 变更。
+- 每个任务一个独立 run：branch、worktree、日志、PR 全部用同一个 `run_id`
+  关联，重试生成新 run，旧现场原样保留；
+- 失败分类明确：可恢复失败回到同一 PR 继续修复，不可恢复失败标记
+  `ai-blocked` 交给人；
+- 支持 `muyan-pilot add` 派活、`status` 查看队列、`session` 跟随 Pi 会话，
+  `install-units` 幂等安装 systemd units，`doctor` 只读诊断。
 
-**完整部署时序**（模板变更的 PR 合并到 main 后不需要任何人工步骤）：
+## 文档入口
 
-```text
-git merge 到 main（含 unit 模板变更）
-  -> timer 下一次触发
-  -> ExecStartPre 同步 origin/main（fetch + fast-forward）
-  -> 启动前 unit 漂移检查（漂移则幂等自愈 + 复核，见上；仍漂移才 fail fast）
-  -> 启动前 Git transport 检查（SSH 且可达才继续，见下节）
-  -> Runner 启动并执行一个 Issue
-```
+| 主题 | 入口 |
+|---|---|
+| 文档首页 | <https://docs.orbi.build/> |
+| 新手安装（前提、配置、首次运行、smoke） | [Getting started](docs/getting-started.mdx) |
+| 一次性 setup（labels、units、transport 迁移） | [One-time setup](docs/setup.mdx) |
+| 工作流（状态链、labels、P0、Epic、Release） | [Workflow](docs/workflow.mdx) |
+| 运维（timer、journal、unit drift、恢复） | [Operations](docs/operations.mdx) |
+| 测试与覆盖率门禁、远程 CI | [Testing](docs/testing.mdx) |
+| 贡献（Issue 粒度、KISS/LEAN、PR 流程） | [Contributing](docs/contributing.mdx) |
+| 中文文档 | [docs/zh/](docs/zh/) |
 
-## Git transport（Issue #114）
+## 开发与贡献
 
-两条认证通道，职责边界清晰：**Git 数据操作**（fetch、push——包括推送
-`.github/workflows/*.yml`）走 **SSH**（`git@github.com:owner/repo.git`，本机
-SSH key）；**GitHub API 操作**（Issue、PR、label、comment、merge）走 `gh`
-token。SSH 从不作为 API 认证，`gh` token 也从不用于 git 数据。
-
-Runner 每次启动（取 slot/领取任何 Issue 之前）校验 checkout 的 transport：
-配置的 `origin` URL 必须是第一个配置 source repo 的 SSH 形式，且
-`git ls-remote <ssh-url>` 退出码 0。失败时记录结构化日志并 fail fast
-（`transport_check_failed ... reason=...`，不取 slot、不领取、不改标签），
-**不自动降级到 HTTPS，也不静默跳过 workflow 文件**。已有 HTTPS remote 的迁移只
-由人工执行的一次性 setup 入口完成（`muyan-pilot setup`，内部执行
-`git remote set-url origin git@github.com:owner/repo.git`）；其他路径遇到
-HTTPS remote 时 fail fast 并携带确切的迁移命令。完整说明见
-[Operations](docs/operations.mdx) 与 [One-time setup](docs/setup.mdx)。
-
-## CLI 安装与升级（Issue #140、#152、#158）
-
-正式使用方式是 **editable** `uv tool` 安装的可执行 CLI（console script
-`muyan-pilot = muyan_pilot:main`，见 `pyproject.toml`）：
-
-```bash
-uv tool install --force --reinstall --editable --python /usr/bin/python3 <deployment checkout>
-muyan-pilot --help
-muyan-pilot --version
-```
-
-editable 安装下 tool 环境直接从部署 checkout 导入 `muyan_pilot`，
-`ExecStartPre` 把 checkout 同步到最新 main 后下一个 CLI 进程自动取到最新代码：
-**普通 Python 源码与 systemd 模板/迁移代码变更不需要任何重装或升级命令**。打包
-元数据变更（`pyproject.toml` 的 `py-modules`、入口点、版本、依赖）会让已安装的
-finder 过期——Runner 每次启动在任何 slot/claim 之前自动刷新：打包指纹（checkout
-`pyproject.toml` 的 sha256）未变则完全不跑 `uv`；变更或首次安装时在 base-sync
-flock 保护下跑一次上面的 force editable 重装；安装失败 fail fast（结构化
-`cli_install_failed` 行：原因 + 精确的修复命令），不取 slot、不 claim、不改标签。
-`muyan-pilot doctor` 报告 CLI 源码一致性（`cli_source: clean` 或
-`cli_source: DRIFT` + 结构化 `cli_source_drift` 行）。`muyan_pilot.py` 的直接
-执行入口保留为开发/兼容路径，不是正式使用方式。完整说明（为什么必须 editable、
-#152/#158 事故背景）见 [Getting started](docs/getting-started.mdx)。
-
-## 任务派发与状态
-
-`muyan-pilot` 是最小 CLI，用于手工派活和查看队列。GitHub Issue 与标签是唯一
-状态存储，不引入数据库或 Web UI：
-
-```bash
-# 在第一个配置的 source repo 创建 Issue 并自动添加 ai-ready
-muyan-pilot add "任务标题" --body "任务描述" --config muyan-pilot.toml
-
-# 查看每个 source repo 的当前任务（ai-in-progress）、待办（ai-ready）和
-# 最近结果（ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked）
-muyan-pilot status --config muyan-pilot.toml
-
-# 打印当前 run 的 Pi session 文件路径（repo_dir/.worktrees 下最新的
-# .pi-session/*.jsonl）；--follow 持续跟随该文件
-muyan-pilot session --config muyan-pilot.toml
-```
-
-`add` 成功后打印新 Issue 的 URL 和 `ai-ready` 标签；`status` 只读，不修改任何
-标签；`session` 是排查附件（跟的是命令启动时选中的文件，不中途跳到更新的文件），
-没有 session 文件时 fail fast。命令失败立即报错，不做回退。
-
-## GitHub Issue 标签（外部状态）
-
-GitHub label 是仓库的**外部状态**：它不会随代码提交自动创建，缺失时扫描会静默
-漏掉对应状态的 Issue。新仓库/新机器用一次性 setup 入口完成初始化（幂等、
-fail-fast，label 名称/颜色/描述以仓库内的 `labels.toml` 为唯一事实源，已存在的
-label 只做声明式对齐，业务 label 从不被改动）：
-
-```bash
-muyan-pilot setup --config muyan-pilot.toml
-```
-
-setup 不可用时的手工等价命令（已存在时 gh 会报错，可忽略或先 `gh label list`
-检查）：
-
-```bash
-for l in ai-ready ai-in-progress ai-pr-opened ai-fix-needed ai-merged ai-blocked; do
-  gh label create "$l" --repo orbi-build/orbi --force
-  gh label edit "$l" --repo orbi-build/orbi \
-    --description "Orbi delivery state (see README)"
-done
-# p0 是紧急优先级 label（不是交付状态，见「领取优先级（P0）」）
-gh label create p0 --repo orbi-build/orbi --force --color "fbca04" \
-  --description "Orbi urgent priority: picked up before bugs and features"
-# ai-epic 是 Epic 协调 label（不是交付状态，见 Workflow 文档）
-gh label create ai-epic --repo orbi-build/orbi --force --color "bfdadc" \
-  --description "Epic coordination issue; not directly executable by Runner"
-# ai-release 是 Release task 标记（不是交付状态，见 Workflow 文档）
-gh label create ai-release --repo orbi-build/orbi --force --color "5319e7" \
-  --description "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
-# ai-ticket-only 是内容交付标记（不是 Git 交付状态）
-gh label create ai-ticket-only --repo orbi-build/orbi --force --color "0e8a16" \
-  --description "Content task: Agent posts the deliverable directly to the Issue without Git delivery"
-gh label list --repo orbi-build/orbi
-```
-
-| Label | 含义 | 进入条件 | 离开条件 |
-|---|---|---|---|
-| `ai-ready` | 明确派发给 Pilot 的新任务（允许 AI 领取） | `muyan-pilot add` 创建时自动添加，或人工 `gh issue edit --add-label ai-ready` | 领取时加 `ai-in-progress`（`ai-ready` 保留）；成功合并后保留（与 `ai-merged` 共存，表示已交付） |
-| `ai-in-progress` | Runner 已领取、正在执行 | 领取 `ai-ready` Issue 时由 Runner 添加；resume opened-PR 交付（`ai-pr-opened` / `ai-fix-needed`）时由 Runner 幂等回填后再继续（Issue #178） | 开出 PR 时移除（转 `ai-pr-opened`）；失败时移除（转 `ai-blocked`）；Runner 被杀时残留，由下一 tick 的恢复扫描接回 |
-| `ai-pr-opened` | PR 已创建，当前等待 review；不会自动再次启动 Fixer | `verify_pr` 验收通过后由 Runner 添加（同时移除 `ai-in-progress`） | clean verdict 合并后移除（转 `ai-merged`）；review finding / base 冲突 / **可恢复失败**（Pi 执行失败、验证失败、未推送本地 commit、worktree 缺失等，Issue #50）时移除（转 `ai-fix-needed`）；只有**不可恢复失败**（Issue #50）时移除（转 `ai-blocked`） |
-| `ai-fix-needed` | 已有 PR 需要在原 branch/worktree/PR 上继续修复；定时 Runner 自动拾取 | 审查会话未能修复的 finding，或 PR 落后最新 base / merge conflict，或已有 run/PR 的**可恢复失败**（Issue #50：失败 comment 写入 Issue 和 PR，带 run_id、PR、branch、worktree、session、phase、last activity 和具体错误） | 下一个审查会话（同一 PR，同一 run_id/branch/worktree）clean verdict 合并后移除（转 `ai-merged`）；审查超轮（`MAX_REVIEW_ROUNDS`）时移除（转 `ai-blocked`，超轮是人工决策） |
-| `ai-merged` | 成功终态：Runner 已合并 PR 并确认 merge commit 落在保护分支 | Runner 合并并确认后添加（替代 `ai-pr-opened`） | 终态，不再自动变更；PR body 的 `Fixes #N` 在 merge 时自动关闭 Issue |
-| `ai-blocked` | Runner fail fast，需要人工处理；不会被自动拾取 | **只用于 AI 无法安全判断或修复的外部前置条件**（Issue #50）：无可恢复的 opened-PR 现场（缺少/不可信 `Muyan Pilot opened PR` 评论）、base 分支变更、审查超轮、PR 未合并被关闭；进入时 comment 必须写明为什么不能自动恢复。已有 run/PR 的可恢复失败**不**进入此状态（转 `ai-fix-needed`，见上） | 人工修复现场并重新转为 `ai-fix-needed`（同一 PR）或重新领取（新 run）；不自动恢复 |
-| `p0` | 紧急优先级（**不是交付状态**）：只改变领取顺序，不改变 Issue 粒度、交付状态或终态语义 | 人工加 label（生产链路出现高优先级故障时） | 人工移除；Runner 从不增删该 label |
-| `ai-epic` | Epic 协调 Issue（发布清单/多任务聚合，**不是可执行任务、不是交付状态**）：只负责聚合与发布门禁 | 人工加 label（创建 Epic 时） | 人工移除（Epic 完成并关闭时）；Runner 从不增删该 label，也从不领取带它的 Issue |
-| `ai-release` | Release task 标记（**不是交付状态**）：带它的 `ai-ready` Issue 由 Runner 的确定性 release 状态机处理（tag + GitHub Release），**从不进 `run_pi` 开发路径**（Issue #98） | 人工加 label（派发 release task 时，与 `ai-ready` 同时） | 成功发布后 Runner 加 `ai-merged`（终态）并关闭 Issue；任何失败单独转 `ai-blocked`（不自动重试，人工决策点）；Runner 从不增删该 label 本身 |
-| `ai-ticket-only` | 内容任务标记（**不是 Git 交付状态**）：Agent 仅生成最终内容并直接评论到 source Issue，绝不创建 worktree、branch、commit、PR 或内容文件（Issue #209） | 人工与 `ai-ready` 一起添加；任务类型只由此 label 明确指定，绝不从标题或正文推断 | 成功后 Runner 关闭 Issue 并移除 `ai-in-progress`；失败转 `ai-blocked`，评论保留 run_id 和具体失败现场；Runner 从不添加或移除此 type label |
-
-标签语义与领取扫描的完整行为（blockedBy 依赖、P0 领取顺序、Epic 跳过、Release
-状态机）见 [Workflow](docs/workflow.mdx)。
-
-## 领取优先级（P0）
-
-紧急优先级用普通 GitHub label `p0` 表示（**不是交付状态**）：它只表达处理
-优先级，不改变 Issue 粒度、任何交付状态或终态语义，Runner 也从不增删该 label。
-
-- ready 领取顺序固定为：`ai-ready`+`p0` → `ai-ready`+`bug` → 普通 `ai-ready`
-  （三次 `gh issue list` 扫描，共享同一组排除条件和 `blockedBy` 语义）；
-- P0 仍遵守全部现有排除规则（`ai-in-progress`、`ai-pr-opened`、`ai-fix-needed`、
-  `ai-merged`、`ai-blocked`）和单 slot 约束：P0 被阻塞（open blocker）时跳过并
-  回退到 bug/普通扫描，P0 已在途时由重启恢复扫描接回；
-- P0 执行失败进入 `ai-blocked`（alone，移除领取标签）：`ai-ready` 标签残留被
-  所有 ready 扫描排除，**没有任何 tick 会重新领取**，因此不会无限重试；
-- 可选配置 `active_milestone`（Milestone 标题）把新领取扫描限制在一个版本内，
-  P0 不跨 Milestone；恢复态（已开 PR、在途重启）不受 Milestone 限制。
-
-完整说明见 [Workflow](docs/workflow.mdx)。
-
-## 自动 loop 与恢复现场（Issue #49）
-
-自动 loop 的完整状态链（systemd timer 是唯一自动入口；一个本地 Pi slot 内始终
-只有一个执行进程）：
-
-```text
-ai-ready
-  -> ai-in-progress          （领取，加标签，建 worktree，启动 Pi）
-  -> ai-pr-opened            （PR 验收通过，等待 review）
-  -> review                  （独立审查会话，会话内修复）
-  -> ai-fix-needed           （未修复 finding / base 冲突；同一 PR 的下一个审查会话）
-  -> review                  （下一个审查会话；`ai-fix-needed` 保留到合并，不重新加回 `ai-pr-opened`）
-  -> merge                   （clean verdict + merge 门禁）
-  -> ai-merged               （成功终态；Fixes #N 自动关闭 Issue）
-```
-
-规则：
-
-- 只有两个 opened-PR 状态会被自动拾取：`ai-fix-needed`（下一个审查会话）和
-  `ai-pr-opened`（独立审查）；`ai-ready` 走领取，`ai-blocked` **不会自动恢复**
-  （先要人工决策：修复现场后转 `ai-fix-needed` 或重新领取）；
-- 修复必须沿用同一 PR number、branch、worktree、run_id（PR number 永远不变，
-  head 可以前进）；
-- base 前进时先 merge 最新 `origin/<base>`（冲突交给 Pi 解决），重跑全量测试
-  后再继续；
-- review 结论、测试、覆盖率、验证和结果都要回写 GitHub Issue/PR
-  （`REVIEW_VERDICT` 评论、milestone、进度评论），不只留在本地。
-
-恢复现场（resume scene）契约：
-
-- Runner 开 PR 后在源 Issue 发布 `Muyan Pilot opened PR:` 评论，携带 run marker
-  `<!-- muyan-pilot:run=<8 hex> -->`、可见 `run_id=` 字段、`base_branch`、
-  `base_sha` 和 PR URL——这是恢复的唯一现场（这条 scene 评论不是旁路：它失败仍
-  fail fast，因为 resume 靠它）；
-- 只有 **trusted maintainer**（OWNER/MAINTAINER/MEMBER/COLLABORATOR）发布的评论
-  才可信；公开评论（authorAssociation=NONE）永远不可信，无法把 Runner 指向任意
-  本地路径；
-- branch 和 worktree 由配置的 repo、source repo、Issue 编号和 run_id **推导**，
-  绝不从公开 comment 读取；
-- **PR body 也必须包含稳定的 run marker**，否则恢复 fail fast（Runner 验收时
-  校验）；
-- **历史兼容**：统一 run_id 机制之前创建的旧 PR 可能只有 Issue comment marker、
-  没有 PR body marker——恢复前需要**补齐 PR body marker**（编辑 PR body 加入
-  `<!-- muyan-pilot:run=<run_id> -->`），不能只改 label。
-
-同一 worktree 下 Pi 新旧 `.pi-session` 的识别：恢复的 run（同一 worktree）会
-创建**新的** session JSONL，journal 只跟踪当前这次调用的 session（启动前已存在
-的 JSONL 永不跟随），避免把上一个 run 的 session 报告成活着的会话（Issue #45）。
-
-## PR body 契约：`Fixes #N`（Issue #53）
-
-PR description 必须包含 `Fixes #<issue-number>`（可以放在首行），指向其源
-Issue。GitHub 原生行为：PR merge 到默认分支（`main`）时，body（或 commit
-message）中的 `Fixes`/`Closes`/`Resolves #<n>` 关键词会自动关闭对应 Issue；PR
-title 不支持该关键词。prompt（`prompt.md`）在 PR 创建步骤要求携带
-`Fixes #<issue-number>`；Runner 验收（`verify_pr`）校验 PR body 含
-`Fixes #<issue-number>`，缺失即 fail fast 拒绝该 PR（`pr_fixes_missing`），与
-run marker 校验同级。开发契约见 `AGENTS.md`（Git 一节）。
-
-## 自动审查、修复与合并（Issue #34、#82）
-
-实现 Agent 在提交处停止（不 fetch、不 push、不创建 PR）；Runner 完成确定性
-收口（Issue #186：base fetch 与吸收、plain push task branch、创建 PR），PR
-打开后由 **Runner** 在持有 slot 的交付等待循环中关闭闭环：
-
-1. **冻结 PR 的 base/head SHA**；
-2. **独立审查（同时是修复者，Issue #82）**：独立的 Review Agent
-   （code-review R1–R9）对精确 base/head SHA 审查；发现 Blocker/Major 时在同一
-   会话内修复、重跑完整测试与分层覆盖率门禁（Issue #234）、commit 并只
-   push task branch，然后对修复后的 head 重新输出 verdict——没有冷启动
-   Fixer，也没有
-   第三次 review。审查会话必须以一行机器可读的 `REVIEW_VERDICT` 结尾；`pass`
-   表示**会话内修复之后**零 Blocker/Major；读不到合法 verdict 一律 fail fast，
-   绝不当作通过；
-3. **重新冻结并合并门禁**：clean verdict 后 Runner 重新冻结 PR，重新 fetch 最新
-   `origin/<base>`，要求 PR head 包含最新 base、PR mergeable、远端 head 仍是
-   被审查的 head；然后 `gh pr merge <n> --match-head-commit <head> --merge`，
-   只有被审查的 head 能落地；
-4. **确认合并**：`gh pr view` 确认 PR `MERGED` 且 `mergeCommit` 已落在
-   `origin/<base>`；Issue 由 PR body 的 `Fixes #N` 关键词在 merge 时自动
-   CLOSED；
-5. **未合并的 head**：审查会话未能修复的 finding（或 PR 落后最新 base / merge
-   conflict）→ Issue 标记 `ai-fix-needed`，下一个 tick 在同一 PR 上启动下一个
-   审查会话（会话内吸收最新 base、解决冲突、全量回归、重新输出 verdict）。已有
-   run/PR 的**可恢复失败**（Pi 执行失败、验证失败、未推送本地 commit、worktree
-   缺失等，Issue #50）同样标记 `ai-fix-needed`：失败 comment 写入 Issue 和
-   PR（带完整现场），下一个 tick 在同一 run、branch、worktree、PR 上继续，不
-   重新创建 PR。审查循环最多 5 轮（`MAX_REVIEW_ROUNDS`）；**只有**超轮仍有
-   Blocker/Major 时 fail fast 并标记 `ai-blocked`（超轮是人工决策）。
-
-成功合并后 Issue 标记 `ai-merged`（替代 `ai-pr-opened`），评论写入 PR URL、
-merge commit、审查轮次和 base/run 信息。不 force push、不直接 push 保护分支、
-不设业务 timeout。完整链路与状态语义见 [Workflow](docs/workflow.mdx)。
-
-## 自动可观测（正常运行不需要执行任何命令）
-
-正常运行完全自动化：人不需要执行 status 命令、不需要轮询进程、不需要督工。
-Runner 自己完成领取 → plan → implement → test → verify → independent review
-（会话内修复）→ merge，并主动发布过程和最终结果（journal + GitHub 进度评论）。
-`muyan-pilot status` 只保留为开发/故障排查附件，不是产品入口，也不能作为自动
-可观测性的验收证据。
-
-journal（本地，systemd）是运行中的实时记录：每条行都带 `[run_id]` 前缀、
-issue、role（implement/review/merge）、phase、elapsed、last activity、last
-action、session、branch；`journalctl --user -u 'muyan-pilot@*.service' -f`
-持续自动刷新。模型请求挂死检测（Issue #75/#218，阈值可配置，Issue #228）：
-`model_wait` 期间 session JSONL 冻结超过配置的 `model_wait_dead_seconds`
-（默认 `PI_MODEL_WAIT_DEAD_SECONDS` = 1800 秒；Issue #228 前默认 600 秒）即
-判定该次模型请求挂死——模型服务进程活着、连接还 ESTABLISHED 都不是豁免
-（进程活着 ≠ 在回话）。Runner 先记一行结构化
-`model_wait_dead issue=... role=... idle_seconds=... threshold=...
-action=kill_pi session=... run_id=... upstream_alive=true|false
-reason=hung_model_request`（`upstream_alive` 是证据，写进日志供排查，永不
-否决 kill），再杀掉 Pi 会话，记录 `run_failed ... reason=model_wait_dead_stale_...s`
-后 fail fast（implement 阶段 Issue 标记 `ai-blocked`、review 阶段标记
-`ai-fix-needed`）。事件持续到达时永不触发：慢生成（session 事件不断刷新 stale
-计时）不是挂死请求。它也不是业务任务 timeout。
-
-所有 journal 行（`run_start`/`activity`/`heartbeat`/`model_wait`/`resumed`/
-`pi_idle`/`pi_idle_wait`/`pi_idle_term`/`pi_idle_kill`/`pi_resumed`/
-`run_failed`/`run_end`/`run_stopping`/`run_stopped`）、idle 卡死自动恢复
-（Issue #94/#169/#181）和停止顺序的完整字段说明见
-[Operations](docs/operations.mdx)。
-
-GitHub（手机，自动更新）：领取任务后，Runner 在 source Issue 上创建一条带隐藏
-run marker（`<!-- muyan-pilot:run=<run_id> -->`）的进度评论，之后只 PATCH 同一
-条评论（进度变化时立即，且间隔不超过 30 秒），不新增 heartbeat 垃圾评论；关键
-milestone（started、plan ready、tests passed/failed、review findings、PR
-opened、merged、blocked）单独发布简短评论，让 GitHub Mobile 主动推送通知。
-进度评论是纯旁路（Issue #79）：它失败只记 `progress_publish_failed`，绝不改变
-交付结果；`Muyan Pilot opened PR:` scene 评论不是旁路（resume 靠它）。
-
-Prometheus / Grafana（可选，只读，独立）：`monitoring/` 下是一套只读、独立、
-版本管理的观测栈（Issue #162），Runner 完全不知道它存在；安装与验证步骤见
-`monitoring/grafana/README.md`。
-
-## 配置
-
-配置使用 TOML，由人维护，AI 通过 PR 修改。开源仓库只提交 example，真实配置不
-提交（`cp .muyan-pilot.example.toml muyan-pilot.toml`）。完整字段表（含
-`active_milestone`、`max_concurrency`、`model_wait_dead_seconds`、
-`pi_providers`/`pi_provider`/`pi_model`/`pi_thinking` 的模型 provider 配置）见
-[Getting started](docs/getting-started.mdx)。
-
-## 并发限制（max_concurrency）
-
-`max_concurrency`（默认 1，只允许 1 或 2）同时决定本机允许的 Pilot 并发任务数
-和已启用 timer 的数量（1 或 2）；slot 仍是最终安全边界——拿不到 slot 的 Runner
-记录 `capacity_full` 后正常退出，不领取 Issue。slot 是
-`<repo_dir>/.muyan-pilot/slots/slot-N` 文件上的排他 `flock(2)` 锁，内核在进程
-退出时自动释放，活着的持有者永远不会丢失 slot，死掉的持有者永远不会占住
-slot。完整说明见 [Operations](docs/operations.mdx)。
-
-## 任务 base 与 worktree
-
-每次领取任务前，Runner 冻结 `origin/<base_branch>` 的精确 SHA（`base_branch`
-在 TOML 中配置，默认 `main`）；任务 worktree 和 feature branch 都从该 SHA
-创建，绝不使用主工作区当前 HEAD；branch 和目录名都带唯一 run 标识（例如
-`.worktrees/muyan-pilot-orbi-build-orbi-issue-14-a1b2c3d4`），同一个 Issue
-返工时会生成新的独立 run，旧现场原样保留。任务 worktree 共享部署 checkout 的
-单一 `origin` remote（Git transport 为 SSH，见「Git transport」），worktree
-内的 fetch/push（包括 workflow 文件）都走这条 SSH 通道。
-
-Agent 在提交处停止；创建 PR 前的 base 新鲜度是 Runner 的确定性收口（Issue
-#186）：Runner 在 base-sync 锁下重新 fetch `origin/<base_branch>`，若已前进则
-用 plain `git merge` 合入最新 base（冲突时 abort，PR 在 Agent 的 head 上打开，
-由既有审查会话在会话内吸收 base），然后 plain push task branch 并创建 PR。不
-自动解决冲突，不 force push，不 merge 或 push 保护分支。
-
-Runner 被 SIGKILL 时任务 worktree 和 `ai-in-progress` 领取标签会留在 GitHub
-上；下一个 tick 的领取扫描在 ready 队列之前先扫描 `ai-ready`+`ai-in-progress`
-（且未处于其他交付状态）的 open Issue——**仅当没有其他 Runner 活着时**
-（flock 锁是唯一事实源）——复用最新 worktree 的 run id（branch、worktree、
-进度评论都由它驱动），按隐藏 run marker 找回同一条进度评论继续 PATCH，不新建
-run、不新建 worktree、不新建评论。`.worktrees/` 已加入 `.gitignore`。
-
-## 全链路 run_id（correlation ID）
-
-每个任务 attempt 只生成一次 `run_id`（8 位 hex，例如 `e07383c2`），语义等同
-trace ID：implement、review、merge 全部复用同一个值；同一个 Issue retry 时生成
-新的 run_id。不创建 `trace_id`/`log_id`/另一套 UUID，不引入 tracing backend。
-
-同一个 run_id 出现在：该 attempt 的每条 journal 日志首字段（`[e07383c2]`）；
-Issue/PR 评论（可见字段 `run_id=e07383c2` + 隐藏 marker
-`<!-- muyan-pilot:run=e07383c2 -->`）；feature branch 与 worktree 名；Pi
-session 目录与 run artifacts 的路径；注入 Pi 的 prompt context；PR body 的稳定
-machine-readable marker（Runner 验收时校验，缺失即 fail fast，拒绝该 PR）。
-缺少合法 run_id 的 run-scoped 事件会 fail fast，不做回退。查询方式（不依赖
-内存映射，进程重启后仍可恢复关联）：
-
-```bash
-journalctl --user -u 'muyan-pilot@*.service' | grep e07383c2
-gh search issues "e07383c2" --repo orbi-build/orbi
-```
-
-## 远程 CI（GitHub Actions）
-
-仓库契约（全量 pytest + 分层覆盖率门禁：全仓库 line/branch >= 95% 分别
-检查、变更 Python 代码 100%，Issue #234）不只在本机 Runner 上跑：
-`.github/workflows/ci.yml` 让 GitHub Actions 在每次 `pull_request` 和每次
-`push` 到 `main` 时跑同一份契约，测试失败、line 或 branch 任一层级低于
-95%、或变更代码未达 100% 时 CI 变红。单个
-job，不加 lint、矩阵或缓存（Issue #56）。生产运行时是 Runner 机器的
-`/usr/bin/python3`（3.14.6），GitHub-hosted runner 没有这个解释器，所以
-workflow 用 `actions/setup-python` 固定同一 minor 版本 `3.14`，契约命令通过
-PATH 上固定的 `python3` 执行。CI 还在干净环境里用 `uv tool install` 安装
-console script 并验证入口（`muyan-pilot --help` / `muyan-pilot --version`
-退出码 0，Issue #140/#152）。「干净环境安装后 `muyan-pilot --help` 成功」是
-永久门禁，不是一次性本地检查。完整说明见 [Testing](docs/testing.mdx)。
+开发契约见 [AGENTS.md](AGENTS.md)；如何派 Issue、报 bug、提 PR 见
+[Contributing](docs/contributing.mdx)。`muyan_pilot.py` 的直接执行入口保留为
+开发/兼容路径，不是正式使用方式。
 
 ## 许可证
 

--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -5847,8 +5847,8 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
     # Issue #79: the `Muyan Pilot opened PR:` scene comment is the first
     # delivery step AFTER the opened-PR label transition that can still
     # fail; when it does, the failure path below must leave the Issue in
-    # the terminal state `ai-blocked` ALONE (README label lifecycle:
-    # `ai-pr-opened` is removed on terminal failure) — the same
+    # the terminal state `ai-blocked` ALONE (docs/workflow.mdx label
+    # lifecycle: `ai-pr-opened` is removed on terminal failure) — the same
     # convention as every other terminal failure path (verify_resumed_pr,
     # wait_for_delivery).
     pr_opened = False
@@ -6022,8 +6022,8 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str:
             # delivery already made the opened-PR transition (the
             # scene-comment failure of Issue #79), the opened-PR label
             # is removed too, so the terminal state is `ai-blocked`
-            # ALONE — never `ai-pr-opened` + `ai-blocked` (README label
-            # lifecycle: `ai-pr-opened` is removed on terminal failure).
+            # ALONE — never `ai-pr-opened` + `ai-blocked` (docs/workflow.mdx
+            # label lifecycle: `ai-pr-opened` is removed on terminal failure).
             edit_issue(
                 number, repo=source_repo, add=BLOCKED_LABEL,
                 remove=(

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -12,7 +12,9 @@ These tests fail when the workflow file is missing, when it stops
 enforcing the contract (triggers, pinned Python, requirements install,
 contract test commands, tiered coverage gate), or when it drifts into
 the extras the Issue explicitly forbids (lint, matrix, cache). The
-README must keep documenting what the remote CI is and when it runs.
+docs (docs/testing.mdx — the README homepage keeps only the summary
+plus the link, Issue #241) must keep documenting what the remote CI is
+and when it runs.
 """
 import re
 from pathlib import Path
@@ -21,7 +23,6 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "ci.yml"
-README_FILE = REPO_ROOT / "README.md"
 
 # The contract commands (AGENTS.md) run through the pinned interpreter on
 # PATH in CI; the local machine uses the same commands with /usr/bin/python3.
@@ -336,11 +337,15 @@ def test_ci_workflow_runs_the_mintlify_docs_build_smoke():
     )
 
 
-def test_readme_documents_remote_ci():
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert "GitHub Actions" in readme, "README must name the remote CI"
-    assert "pull_request" in readme, "README must say CI runs on pull requests"
-    assert re.search(r"push[^\n]*main|main[^\n]*push", readme), (
-        "README must say CI runs on push to main"
+def test_testing_documents_remote_ci():
+    """Issue #241: the remote CI contract lives in docs/testing.mdx
+    (the README homepage keeps only the summary plus the docs link):
+    GitHub Actions runs the same contract on every pull request and
+    every push to main, with the pinned Python 3.14."""
+    testing = (REPO_ROOT / "docs" / "testing.mdx").read_text(encoding="utf-8")
+    assert "GitHub Actions" in testing, "testing must name the remote CI"
+    assert "pull_request" in testing, "testing must say CI runs on pull requests"
+    assert re.search(r"push[^\n]*main|main[^\n]*push", testing), (
+        "testing must say CI runs on push to main"
     )
-    assert "3.14" in readme, "README must document the pinned CI Python version"
+    assert "3.14" in testing, "testing must document the pinned CI Python version"

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -12,9 +12,9 @@ not a hand-written `python3 muyan_pilot.py`. These tests pin:
   WorkingDirectory and ExecStartPre);
 - the CLI command strings the failure scenes carry (the unit_drift
   fix command, the HTTPS-remote migration entry);
-- the documentation contract: README, AGENTS.md and the EN/ZH docs
-  use `muyan-pilot` and no longer require the user to hand-write
-  `python3 muyan_pilot.py`;
+- the documentation contract: the README quickstart, AGENTS.md and
+  the EN/ZH docs use `muyan-pilot` and no longer require the user to
+  hand-write `python3 muyan_pilot.py`;
 - the compatibility path: `muyan_pilot.py` keeps its direct-execution
   entry (development/compatibility, still asserted against one real
   call).
@@ -248,16 +248,19 @@ def test_setup_requires_the_installed_cli():
 
 
 def test_readme_uses_the_cli_and_the_editable_uv_tool_install():
+    """Issue #241: the README homepage quickstart uses the installed
+    CLI (setup + doctor) and the EDITABLE uv tool install (Issue #152:
+    the tool env imports the source from the deployment checkout, so
+    ordinary source/template changes need no reinstall); the full
+    command set (add, install-units, session, ...) is documented in
+    the docs pages."""
     readme = README_FILE.read_text(encoding="utf-8")
-    # The official commands are the installed CLI.
-    assert "muyan-pilot install-units" in readme
-    assert "muyan-pilot doctor" in readme
+    # The quickstart commands are the installed CLI.
     assert "muyan-pilot setup" in readme
+    assert "muyan-pilot doctor" in readme
     assert "muyan-pilot add" in readme
     # Issue #152: the official local deployment is the EDITABLE uv
-    # tool install (the tool env imports the source from the
-    # deployment checkout; the ExecStartPre sync is picked up by the
-    # next CLI process — no per-version reinstall).
+    # tool install.
     assert "uv tool install" in readme
     assert "--editable" in readme
     assert "uv tool install --force --reinstall --editable" in readme
@@ -265,6 +268,20 @@ def test_readme_uses_the_cli_and_the_editable_uv_tool_install():
     assert "python3 muyan_pilot.py" not in readme
     # The compatibility path stays documented (development use only).
     assert "muyan_pilot.py" in readme
+
+
+def test_docs_document_the_full_cli_command_set():
+    """Issue #241: the full CLI command set (add, status, session,
+    install-units, doctor) is documented in the docs pages — the
+    README homepage keeps the quickstart plus a one-sentence summary.
+    """
+    operations = (REPO_ROOT / "docs" / "operations.mdx").read_text(encoding="utf-8")
+    for command in ("muyan-pilot add", "muyan-pilot status",
+                    "muyan-pilot session", "muyan-pilot install-units",
+                    "muyan-pilot doctor", "muyan-pilot setup"):
+        assert command in operations, (
+            f"docs/operations.mdx must document the {command} command"
+        )
 
 
 def test_docs_make_the_editable_install_the_official_deployment():
@@ -277,7 +294,6 @@ def test_docs_make_the_editable_install_the_official_deployment():
     force-reinstall command is documented as the fix for a
     non-editable/stale CLI source."""
     pages = {
-        "README.md": README_FILE,
         "AGENTS.md": AGENTS_FILE,
     }
     for slug in DOC_PAGES:

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -1,12 +1,13 @@
-"""Documentation contract for GitHub external state (Issue #49).
+"""Documentation contract for GitHub external state (Issue #49, moved
+off the README homepage by Issue #241).
 
-The README/AGENTS must document the labels, run markers, and recovery
+The docs and AGENTS must document the labels, run markers, and recovery
 state exactly as the code implements them: every `ai-*` label the docs
-mention must exist in the runner's label set, the README must carry a
-label table with meaning/enter/leave for all five labels plus the repo
-initialization requirement, and the recovery-scene contract (trusted
-maintainer comment, PR body marker, legacy PR backfill) must be
-documented.
+mention must exist in the runner's label set, docs/workflow.mdx carries
+the label table (meaning per label, external state), docs/setup.mdx
+carries the label initialization, and the recovery-scene contract
+(trusted maintainer comment, derived branch/worktree, PR body run
+marker) is documented in docs/security.mdx / docs/workflow.mdx.
 """
 import re
 from pathlib import Path
@@ -16,6 +17,13 @@ import bootstrap_runner as runner
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 AGENTS = REPO_ROOT / "AGENTS.md"
+DOCS_DIR = REPO_ROOT / "docs"
+
+
+def docs_page(slug: str) -> str:
+    path = DOCS_DIR / f"{slug}.mdx"
+    assert path.is_file(), f"missing docs page: {path}"
+    return path.read_text(encoding="utf-8")
 
 # The runner's delivery-state labels plus the claim label (`ai-ready`
 # is a literal in the scans, not a runner constant) and the Epic marker
@@ -48,54 +56,65 @@ def test_docs_only_reference_existing_labels():
         )
 
 
-def test_readme_documents_all_five_labels_with_meaning():
-    """Issue #49: the label table must list every label the runner
-    uses, with its meaning, enter and leave conditions."""
-    text = README.read_text(encoding="utf-8")
-    for label in sorted(KNOWN_LABELS):
-        assert label in text, f"README label table is missing {label}"
-    # The table explains what the labels are for and that they are
-    # external state.
-    assert "ai-ready" in text
-    assert "外部状态" in text or "external state" in text
+def test_workflow_documents_all_labels_with_meaning():
+    """Issue #49/#241: the label table lives in docs/workflow.mdx (the
+    single source of truth; the README homepage keeps only a summary
+    plus the link): every delivery state label with its meaning, the
+    Epic and Release type markers, and the statement that labels are
+    external state a commit never creates."""
+    text = docs_page("workflow")
+    for label in ("ai-ready", "ai-in-progress", "ai-pr-opened",
+                  "ai-fix-needed", "ai-merged", "ai-blocked"):
+        assert label in text, f"workflow label table is missing {label}"
+    assert "ai-epic" in text, "workflow must document the Epic marker"
+    assert "ai-release" in text, "workflow must document the Release marker"
+    assert "external state" in text, (
+        "workflow must state that labels are external state"
+    )
 
 
-def test_readme_documents_label_initialization():
-    """Issue #49: GitHub labels are external state — a commit never
-    creates them. The docs must say a repo must create them during
-    initialization (and how to check)."""
-    text = README.read_text(encoding="utf-8")
+def test_setup_documents_label_initialization():
+    """Issue #49/#241: GitHub labels are external state — a commit
+    never creates them. docs/setup.mdx documents the initialization:
+    the one-time setup aligns the platform labels declaratively from
+    the repo-managed labels.toml (the single source of truth for label
+    name, color and description)."""
+    text = docs_page("setup")
     assert "gh label" in text
+    assert "labels.toml" in text
 
 
-def test_readme_documents_recovery_scene_contract():
-    """Issue #49: the recovery scene contract must be documented: the
-    `Muyan Pilot opened PR:` comment, the trusted-maintainer rule, the
-    derivation of branch/worktree from config (never from a public
-    comment), the PR body run marker (fail fast when missing), and the
-    legacy-PR backfill requirement (old PRs created before the unified
-    run_id may only carry the Issue comment marker — the PR body
-    marker must be backfilled before a resume, not just the label)."""
-    text = README.read_text(encoding="utf-8")
-    assert "Muyan Pilot opened PR:" in text
-    assert "OWNER" in text
-    # Branch/worktree are derived, never read from a comment.
-    assert "推导" in text
-    # The PR body marker is part of the contract.
-    assert "PR body" in text
-    # Legacy PRs need the PR body marker backfilled.
-    assert "补齐" in text
+def test_security_documents_recovery_scene_contract():
+    """Issue #49/#241: the recovery scene contract is documented in
+    docs/security.mdx (EN + ZH): the resume scene is only read from
+    comments posted by a trusted maintainer (OWNER/MAINTAINER/MEMBER/
+    COLLABORATOR), and branch/worktree paths are derived from the
+    configured repo, Issue number and run id — a public comment can
+    never steer the Runner into an arbitrary local path. The scene
+    comment prefix itself is the code contract (bootstrap_runner).
+    """
+    for slug in ("security", "zh/security"):
+        text = docs_page(slug)
+        assert "trusted" in text, f"docs/{slug} must name the trusted-maintainer rule"
+        assert "OWNER" in text and "COLLABORATOR" in text, (
+            f"docs/{slug} must list the trusted author associations"
+        )
+        assert "derived" in text or "推导" in text, (
+            f"docs/{slug} must say branch/worktree are derived"
+        )
+    # The scene comment prefix is the real code contract.
+    assert runner.OPENED_PR_PREFIX == "Muyan Pilot opened PR: "
+    # The PR body run marker is part of the documented contract.
+    assert "muyan-pilot:run=" in docs_page("workflow")
 
 
-def test_readme_documents_the_automatic_loop():
-    """Issue #49: the automatic loop must be documented end to end:
-    ai-ready -> ai-in-progress -> ai-pr-opened -> review ->
-    ai-fix-needed -> same PR fix -> ai-pr-opened -> merge, with the
-    rules that only the opened-PR states are picked up automatically,
-    that a fix keeps the same PR/branch/worktree/run_id, that a base
-    advance is merged first, and that ai-blocked is never
-    auto-recovered."""
-    text = README.read_text(encoding="utf-8")
+def test_workflow_documents_the_automatic_loop():
+    """Issue #49/#241: the automatic loop is documented end to end in
+    docs/workflow.mdx: ai-ready -> ai-in-progress -> ai-pr-opened ->
+    review -> ai-fix-needed -> same PR fix -> merge, with the rules
+    that only the opened-PR states are picked up automatically and
+    that ai-blocked is never auto-recovered."""
+    text = docs_page("workflow")
     for state in (
         "ai-ready", "ai-in-progress", "ai-pr-opened",
         "ai-fix-needed", "ai-merged", "ai-blocked",
@@ -104,77 +123,85 @@ def test_readme_documents_the_automatic_loop():
     # The loop is shown as a state chain.
     assert "ai-ready" in text and "ai-pr-opened" in text
     # ai-blocked is terminal for the automatic loop (human decision).
-    assert "ai-blocked" in text
+    assert "never auto-recovered" in text
 
 
-def test_readme_documents_session_identification():
-    """Issue #49: under the same worktree a resumed run creates a NEW
-    `.pi-session` JSONL; the journal must follow the session of the
-    current invocation, not the previous run's."""
-    text = README.read_text(encoding="utf-8")
-    assert ".pi-session" in text
-    assert "当前" in text or "current" in text
+def test_operations_documents_the_session_record():
+    """Issue #49/#241: the session record is documented in
+    docs/operations.mdx — the `muyan-pilot session` command prints the
+    live Pi session JSONL path (fail fast when no session exists) —
+    and the code keeps the session in the task worktree's
+    `.pi-session` directory (a resumed run starts a new session file
+    there; the journal tracks the current invocation's session).
+    """
+    text = docs_page("operations")
+    assert "muyan-pilot session" in text
+    assert "JSONL" in text
+    # The real session directory the code passes to Pi.
+    assert ".pi-session" in text or ".pi-session" in (
+        (REPO_ROOT / "bootstrap_runner.py").read_text(encoding="utf-8")
+    )
 
 
-def test_readme_documents_review_verdict_on_github():
-    """Issue #49: the review verdict must be written back to the
-    GitHub PR/Issue, not only kept locally."""
-    text = README.read_text(encoding="utf-8")
+def test_workflow_documents_review_verdict_on_github():
+    """Issue #49/#241: the review verdict and the failure scene are
+    written back to the GitHub PR/Issue (not only kept locally) —
+    docs/workflow.mdx documents the REVIEW_VERDICT and the failure
+    comment written to the Issue AND the PR."""
+    text = docs_page("workflow")
     assert "REVIEW_VERDICT" in text
-    assert "回写" in text or "写入" in text
+    assert "written to the" in text and "PR" in text
 
 
-def test_readme_documents_model_wait_dead_kill():
-    """Issue #218 (supersedes the #75/#169 contract): the
-    hung-model-request contract must be documented in the README
-    journal section: while the newest session event is a tool result
-    (model_wait) and the session JSONL is frozen for the dead threshold
-    (default 600 s, PI_MODEL_WAIT_DEAD_SECONDS), the Runner logs the
-    structured `model_wait_dead` line (upstream_alive is evidence, never
-    a veto — process alive ≠ responding), kills Pi and fails fast with
+def test_operations_documents_model_wait_dead_kill():
+    """Issue #218/#241 (supersedes the #75/#169 contract): the
+    hung-model-request contract is documented in docs/operations.mdx:
+    while the newest session event is a tool result (model_wait) and
+    the session JSONL is frozen past the configured dead threshold
+    (`model_wait_dead_seconds`, default 1800 s,
+    PI_MODEL_WAIT_DEAD_SECONDS), the Runner logs the structured
+    `model_wait_dead` line (upstream_alive is evidence, never a veto —
+    process alive ≠ responding), kills Pi and fails fast with
     `run_failed ... reason=model_wait_dead_stale_...`; the kill never
     fires while events keep arriving (a slow generation is not a hung
     request) and it is NOT a business-task timeout."""
-    text = README.read_text(encoding="utf-8")
+    text = docs_page("operations")
     # The run_failed line carries the hung-model-request reason.
     assert "model_wait_dead_stale_" in text
     # The structured model_wait_dead line is documented with its
     # fields.
-    assert "model_wait_dead issue=" in text
+    assert "model_wait_dead" in text
     assert "action=kill_pi" in text
     assert "reason=hung_model_request" in text
     assert "upstream_alive" in text
     # The kill is documented with its trigger (model_wait + frozen
-    # session) and the default threshold.
+    # session) and the configurable threshold.
     assert "PI_MODEL_WAIT_DEAD_SECONDS" in text
-    assert "600" in text
     assert "model_wait" in text
     # The slow-generation boundary: events keep arriving -> no kill.
-    assert "事件持续到达时永不触发" in text
+    assert "never trips it" in text
     # It is not a business-task timeout.
-    assert "业务" in text
+    assert "business task timeout" in text
 
 
-def test_readme_documents_p0_priority_and_terminal_state():
-    """Issue #101: the README must document the P0 contract: the plain
-    `p0` label (not a delivery state), the fixed pickup order
-    (`ai-ready`+`p0` → `ai-ready`+`bug` → plain `ai-ready`), the
+def test_workflow_documents_p0_priority_and_terminal_state():
+    """Issue #101/#241: docs/workflow.mdx documents the P0 contract:
+    the plain `p0` label (not a delivery state), the fixed pickup
+    order (`ai-ready`+`p0` → `ai-ready`+`bug` → plain `ai-ready`), the
     unchanged exclusion/single-slot semantics, and the terminal state
     of a failed P0 (`ai-blocked`, never re-claimed — no infinite
     retry)."""
-    text = README.read_text(encoding="utf-8")
-    # The label is documented in the table and the initialization.
+    text = docs_page("workflow")
     assert "`p0`" in text
-    assert "gh label create p0" in text
     # It is explicitly NOT a delivery state.
-    assert "不是交付状态" in text
+    assert "NOT a delivery state" in text
     # The fixed pickup order is documented.
     assert "`ai-ready`+`p0`" in text
     assert "`ai-ready`+`bug`" in text
     # The existing exclusion rules and single-slot constraint apply.
-    assert "单 slot" in text
+    assert "single-slot" in text
     # The terminal state of a failed P0: ai-blocked, no infinite retry.
-    assert "无限重试" in text
+    assert "no infinite retry" in text
     assert "ai-blocked" in text
 
 

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -922,8 +922,8 @@ def test_process_issue_scene_comment_failure_fails_delivery(
     stays fail-fast (the resume contract is unchanged); only the
     `ProgressPublisher` steps around it (milestone, delivered finish)
     are bypasses. The failure happens AFTER the opened-PR transition,
-    so the terminal state is `ai-blocked` ALONE (the README label
-    lifecycle removes `ai-pr-opened` on terminal failure) — never
+    so the terminal state is `ai-blocked` ALONE (the docs/workflow.mdx
+    label lifecycle removes `ai-pr-opened` on terminal failure) — never
     `ai-pr-opened` + `ai-blocked`, which no scan would own."""
     calls, posted = make_failing_gh(
         monkeypatch,

--- a/tests/test_readme_homepage.py
+++ b/tests/test_readme_homepage.py
@@ -1,0 +1,235 @@
+"""README homepage contract (Issue #241).
+
+The README is the project homepage, not the operations manual: a new
+user must find what Orbi is, the shortest runnable path and the docs
+entry points on one screen, while every mechanism detail (systemd
+deployment, transport, labels/P0/Epic/Release, run_id, model_wait,
+review/merge gate, CI/coverage) lives in exactly one place — the docs
+site — and the README keeps at most a one-sentence summary plus the
+authoritative link.
+
+These tests fail when the README grows back past the homepage budget
+(120 lines / 8KB), when a required docs entry link disappears, when a
+duplicated mechanism section creeps back in, or when the first screen
+stops answering "what is it / how do I start".
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+# The homepage budget (Issue #241 acceptance criteria).
+MAX_LINES = 120
+MAX_BYTES = 8 * 1024
+
+# Required documentation entry links: the docs home plus every core
+# topic page, in-repo relative paths (the docs/ directory is the single
+# source of truth, docs.orbi.build the hosted site).
+REQUIRED_ENTRY_LINKS = (
+    "https://docs.orbi.build/",
+    "docs/getting-started.mdx",
+    "docs/setup.mdx",
+    "docs/workflow.mdx",
+    "docs/operations.mdx",
+    "docs/testing.mdx",
+    "docs/contributing.mdx",
+    "docs/zh/",
+)
+
+# Mechanism detail that belongs to the docs site, not the homepage.
+# Each needle is a marker of a section the old README expanded and the
+# homepage must NOT carry (a one-sentence summary + the docs link is
+# allowed; the mechanism prose is not).
+FORBIDDEN_MECHANISM_NEEDLES = (
+    # systemd deployment mechanics (docs/operations.mdx owns this)
+    "ExecStartPre",
+    "unit_drift",
+    "repo_sha256=",
+    "installed_sha256=",
+    "base-sync.lock",
+    "flock",
+    "capacity_full",
+    "OnCalendar",
+    # git transport mechanics (docs/operations.mdx / docs/setup.mdx)
+    "transport_check_failed",
+    "git ls-remote",
+    "git remote set-url origin",
+    # observability mechanics (docs/operations.mdx)
+    "model_wait_dead",
+    "PI_MODEL_WAIT_DEAD_SECONDS",
+    "run_failed",
+    # workflow mechanics (docs/workflow.mdx)
+    "REVIEW_VERDICT",
+    "--match-head-commit",
+    "epic_not_claimed",
+    "blockedBy",
+    "Muyan Pilot opened PR",
+    # label vocabulary beyond the one claim label the quickstart needs
+    "ai-in-progress",
+    "ai-pr-opened",
+    "ai-fix-needed",
+    "ai-merged",
+    "ai-epic",
+    "ai-release",
+    "ai-ticket-only",
+    "`p0`",
+    # label initialization commands (docs/setup.mdx)
+    "gh label create",
+    # CI / coverage mechanics (docs/testing.mdx)
+    "coverage run --branch",
+    "coverage_gate.py",
+    "diff_coverage_gate.py",
+    "GitHub Actions",
+    # config-field mechanics (docs/getting-started.mdx)
+    "active_milestone",
+    "max_concurrency",
+    # stale deployment paths (Issue #152 / #103)
+    "uv tool upgrade",
+    "python3 muyan_pilot.py",
+    "cp systemd/muyan-pilot.service",
+)
+
+
+def readme_text() -> str:
+    assert README.is_file(), f"missing README: {README}"
+    return README.read_text(encoding="utf-8")
+
+
+def test_readme_stays_within_the_homepage_budget():
+    """Issue #241: the README is a homepage — 120 lines / 8KB max, so a
+    new user can read it on one screen."""
+    text = readme_text()
+    lines = text.splitlines()
+    assert len(lines) <= MAX_LINES, (
+        f"README has {len(lines)} lines, the homepage budget is "
+        f"{MAX_LINES}"
+    )
+    size = len(text.encode("utf-8"))
+    assert size <= MAX_BYTES, (
+        f"README is {size} bytes, the homepage budget is {MAX_BYTES}"
+    )
+
+
+def test_readme_carries_every_required_docs_entry_link():
+    """Issue #241: the docs entry must list the docs home and every core
+    topic page (getting-started, setup, workflow, operations, testing,
+    contributing, the Chinese entry) so each reader finds the complete
+    explanation in one hop."""
+    text = readme_text()
+    for link in REQUIRED_ENTRY_LINKS:
+        assert link in text, f"README is missing the docs entry link: {link}"
+
+
+def test_readme_does_not_duplicate_docs_mechanism_sections():
+    """Issue #241: every mechanism keeps at most a one-sentence summary
+    plus the authoritative docs link in the README; the detailed
+    sections (systemd/timer internals, transport, label state machine,
+    run_id/journal fields, model_wait, review/merge gate, CI/coverage)
+    must not come back to the homepage."""
+    text = readme_text()
+    found = [needle for needle in FORBIDDEN_MECHANISM_NEEDLES if needle in text]
+    assert not found, (
+        "README duplicates docs mechanism detail: "
+        f"{found} — keep a one-sentence summary + the docs link instead"
+    )
+
+
+def test_first_screen_says_what_orbi_is_and_how_to_start():
+    """Issue #241: within the first 40 lines a new user must see what
+    Orbi is (the GitHub Issue task pool, no database/queue/daemon),
+    what it does end to end (Issue → worktree → Pi → PR → review/merge)
+    and the runnable quickstart (clone + CLI install + setup + one tick).
+    """
+    head = "\n".join(readme_text().splitlines()[:40])
+    # What it is: the GitHub Issue task pool and the MVP boundary.
+    assert "GitHub Issue" in head, (
+        "the first screen must say Orbi's task pool is GitHub Issues"
+    )
+    for boundary in ("数据库", "队列", "daemon"):
+        assert boundary in head, (
+            f"the first screen must state the MVP boundary (no {boundary})"
+        )
+    # The end-to-end capability overview: Issue -> worktree -> Pi ->
+    # commit/PR -> review/merge.
+    assert "worktree" in head, "the first screen must name the worktree"
+    assert "Pi" in head, "the first screen must name the Pi development step"
+    assert "PR" in head, "the first screen must name the PR delivery"
+    assert "审查" in head or "review" in head.lower(), (
+        "the first screen must name the independent review"
+    )
+    assert "merge" in head.lower(), "the first screen must name the merge"
+    # The shortest runnable path on the first screen.
+    assert "git clone https://github.com/orbi-build/orbi.git" in head, (
+        "the first screen must carry the quickstart clone command"
+    )
+    assert "uv tool install --force --reinstall --editable" in head, (
+        "the first screen must carry the CLI install command"
+    )
+    assert "muyan-pilot setup" in head, (
+        "the first screen must carry the one-time setup command"
+    )
+    assert "bootstrap_runner.py" in head, (
+        "the first screen must carry the first-tick command"
+    )
+
+
+def overview_section(text: str) -> str:
+    """The capability-overview section (from its heading to the next
+    `## ` heading) — the chain check runs inside it, not over the whole
+    file (the intro paragraph names `worktree` before the overview).
+    """
+    match = re.search(r"^## 它能做什么\n(.*?)(?=^## )", text, re.DOTALL | re.MULTILINE)
+    assert match is not None, (
+        "README is missing the capability overview section (## 它能做什么)"
+    )
+    return match.group(1)
+
+
+def test_readme_capability_overview_keeps_the_delivery_chain():
+    """Issue #241: the capability overview keeps the delivery chain
+    Issue → worktree → Pi → commit/PR → review/merge (as a flow or a
+    short list), with the PR body `Fixes #N` contract named — but the
+    full state machine stays in docs/workflow.mdx."""
+    text = readme_text()
+    section = overview_section(text)
+    assert "Fixes #" in section, (
+        "the capability overview must name the PR body Fixes #N contract"
+    )
+    # The chain stages appear in the overview, in delivery order.
+    chain = [
+        "ai-ready",
+        "worktree",
+        "Pi",
+        "PR",
+        "审查",
+        "merge",
+    ]
+    positions = []
+    for stage in chain:
+        pos = section.find(stage)
+        assert pos != -1, f"capability overview misses the {stage!r} stage"
+        positions.append(pos)
+    assert positions == sorted(positions), (
+        "the capability overview must present the chain in delivery "
+        f"order, got positions {positions}"
+    )
+
+
+def test_readme_keeps_the_license_and_contributing_entries():
+    """Issue #241: the homepage keeps the License (Apache-2.0, linked to
+    the root LICENSE file) and the contributing entry (the contributing
+    docs page plus the in-repo development contract)."""
+    text = readme_text()
+    assert re.search(r"\]\(LICENSE\)", text), (
+        "README must link to the LICENSE file"
+    )
+    assert "Apache License 2.0" in text, (
+        "README must name the Apache License 2.0"
+    )
+    assert "docs/contributing.mdx" in text, (
+        "README must point at the contributing docs"
+    )
+    assert "AGENTS.md" in text, (
+        "README must point at the in-repo development contract"
+    )

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -211,22 +211,46 @@ def test_analyze_verify_skips_without_systemd_analyze(monkeypatch):
         )
 
 
-def test_readme_documents_code_update_at_next_runner_start():
-    """Issue #52: the README must explain that code updates take effect
-    at the next Runner start (the preflight fetch + ff-only merge), not
-    while a task is running."""
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert "ExecStartPre" in readme
-    assert "git merge --ff-only origin/main" in readme
+DOCS_DIR = REPO_ROOT / "docs"
 
 
-def test_readme_documents_same_schedule_as_timer():
+def docs_page(slug: str) -> str:
+    path = DOCS_DIR / slug
+    assert path.is_file(), f"missing docs page: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_operations_documents_code_update_at_next_runner_start():
+    """Issue #52/#241: docs/operations.mdx must explain that code
+    updates take effect at the next Runner start (the ExecStartPre
+    fetch + ff-only merge), not while a task is running."""
+    operations = docs_page("operations.mdx")
+    assert "ExecStartPre" in operations
+    assert "git merge --ff-only origin/main" in operations
+
+
+def test_operations_documents_same_schedule_as_timer():
+    """Issue #241: the docs (EN + ZH operations pages) document the same
+    schedule as the unit files — the README homepage only summarizes
+    it in one sentence plus the docs link."""
     timer = parse_unit(TIMER_FILE)
     on_calendar = timer["Timer"]["OnCalendar"][0]
     match = re.match(r"\*-\*-\* \*:\d+/(?P<minutes>\d+)", on_calendar)
     assert match is not None, f"unexpected OnCalendar format: {on_calendar}"
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert f"每 {match['minutes']} 分钟自动执行一次" in readme
+    minutes = match["minutes"]
+    en = docs_page("operations.mdx")
+    assert f"every {minutes} minutes" in en, (
+        "English operations must document the same idle polling "
+        f"interval as the timer unit (every {minutes} minutes)"
+    )
+    assert on_calendar in en, (
+        "English operations must document the real OnCalendar expression"
+    )
+    zh = docs_page("zh/operations.mdx")
+    assert f"每 {minutes} 分钟" in zh, (
+        "Chinese operations must document the same idle polling "
+        f"interval as the timer unit (每 {minutes} 分钟)"
+    )
 
 
 def test_parse_unit_rejects_unparseable_line(tmp_path):
@@ -246,78 +270,81 @@ def test_parse_unit_rejects_key_before_any_section(tmp_path):
 # --- deployment consistency contract (Issue #103) ---------------------------
 
 
-def test_readme_documents_the_idempotent_install_command():
-    """Issue #103: the README must document the idempotent install
-    command (repo templates -> user systemd dir, daemon-reload,
-    enable timer, deployed commit/hash output) and the guarantee that
-    it never kills or restarts a running Runner (the new config takes
-    effect at the next service start)."""
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert "muyan-pilot install-units" in readme
-    assert "daemon-reload" in readme
+def test_operations_documents_the_idempotent_install_command():
+    """Issue #103/#241: docs/operations.mdx must document the
+    idempotent install command (repo templates -> user systemd dir,
+    daemon-reload, enable timer, deployed commit/hash output) and the
+    guarantee that it never kills or restarts a running Runner (the
+    new config takes effect at the next service start)."""
+    operations = docs_page("operations.mdx")
+    assert "muyan-pilot install-units" in operations
+    assert "daemon-reload" in operations
     # The manual cp is no longer the documented install path.
-    assert "cp systemd/muyan-pilot.service" not in readme
+    assert "cp systemd/muyan-pilot.service" not in operations
     # Deployed commit/hash output.
-    assert "commit" in readme
-    assert "sha256" in readme
+    assert "commit" in operations
+    assert "sha256" in operations
     # The no-kill guarantee.
-    assert "不会" in readme
-    assert "重启" in readme
+    assert "never" in operations and ("restart" in operations or "restarted" in operations)
 
 
-def test_readme_documents_the_unit_drift_fail_fast():
-    """Issue #103: the README must document the pre-start drift check:
-    both units are compared against the repo templates, drift logs a
-    structured `unit_drift` line (repo path, installed path, hashes,
-    fix command) and fails fast without claiming any Issue until the
-    units are synced. Issue #149: the templates are the INSTANTIATED
-    units and the README documents the one-time legacy migration away
-    from the pre-#149 non-templated units."""
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert "unit_drift" in readme
+def test_operations_documents_the_unit_drift_fail_fast():
+    """Issue #103/#241: docs/operations.mdx must document the pre-start
+    drift check: both units are compared against the repo templates,
+    drift fails fast without claiming any Issue (no slot, no claim) and
+    the self-heal re-verifies with the same hash check. The exact
+    structured failure line's fields are the code contract
+    (systemd_deploy.drift_lines). Issue #149: the templates are the
+    INSTANTIATED units and the docs document the one-time legacy
+    migration away from the pre-#149 non-templated units."""
+    operations = docs_page("operations.mdx")
+    assert "unit_drift" in operations
     # Both template units are covered.
-    assert "muyan-pilot@.service" in readme
-    assert "muyan-pilot@.timer" in readme
+    assert "muyan-pilot@.service" in operations
+    assert "muyan-pilot@.timer" in operations
     # The two enabled timer instances.
-    assert "muyan-pilot@1.timer" in readme
-    assert "muyan-pilot@2.timer" in readme
+    assert "muyan-pilot@1.timer" in operations
+    assert "muyan-pilot@2.timer" in operations
     # The one-time legacy migration names the old units.
-    assert "muyan-pilot.service" in readme
-    assert "muyan-pilot.timer" in readme
-    # The structured line's fields.
-    assert "repo_sha256=" in readme
-    assert "installed_sha256=" in readme
-    assert "fix=muyan-pilot install-units" in readme
+    assert "muyan-pilot.service" in operations
+    assert "muyan-pilot.timer" in operations
     # No claim while drifted.
-    assert "不领取" in readme
-    # The repo templates are the single source of truth.
-    assert "唯一事实源" in readme
+    assert "no slot, no claim" in operations
+    # The exact structured failure line's fields are the code contract.
+    import systemd_deploy
+    line = systemd_deploy.drift_lines([
+        {"unit": "muyan-pilot@.timer", "repo_path": "r", "installed_path": "i",
+         "repo_sha256": "a", "installed_sha256": "b", "drifted": True},
+    ])[0]
+    assert "repo_sha256=a" in line
+    assert "installed_sha256=b" in line
+    assert "fix=muyan-pilot install-units" in line
 
 
-def test_readme_documents_the_doctor_command():
-    """Issue #103: the README must document the read-only `doctor`
-    report: repo commit, unit drift, timer/service active state,
-    current Issue, Runner/Pi and recent journal activity."""
-    readme = README_FILE.read_text(encoding="utf-8")
-    assert "muyan-pilot doctor" in readme
-    assert "journal" in readme
+def test_operations_documents_the_doctor_command():
+    """Issue #103/#241: docs/operations.mdx must document the read-only
+    `doctor` report: repo commit, unit drift, timer/service active
+    state, current Issue, Runner/Pi and recent journal activity."""
+    operations = docs_page("operations.mdx")
+    assert "muyan-pilot doctor" in operations
+    assert "journal" in operations
     # doctor is read-only.
-    assert "只读" in readme
+    assert "Read-only" in operations
 
 
-def test_readme_documents_the_full_deployment_sequence():
-    """Issue #103/#142: the README must show the complete sequence from
-    code merge to the next Runner start: merge (template changes need
-    no human step) -> timer next trigger -> ExecStartPre syncs
-    origin/main -> pre-start drift check (self-heal + re-verify when
-    drifted) -> Runner starts one Issue."""
-    readme = README_FILE.read_text(encoding="utf-8")
-    sequence = readme.split("完整部署时序", 1)[-1]
-    assert "git merge 到 main" in sequence
-    assert "timer 下一次触发" in sequence
-    assert "ExecStartPre 同步 origin/main" in sequence
-    assert "启动前 unit 漂移检查" in sequence
-    assert "Runner 启动并执行一个 Issue" in sequence
+def test_operations_documents_the_full_deployment_sequence():
+    """Issue #103/#142/#241: docs/operations.mdx must show the complete
+    sequence from a template change to the next Runner start: a
+    template change needs NO human step after the merge -> the next
+    timer trigger's ExecStartPre fast-forwards the checkout -> the
+    pre-start unit_drift check self-heals (same idempotent install +
+    re-verify, `unit_drift auto_synced`) -> the tick continues."""
+    operations = docs_page("operations.mdx")
+    assert "NO human step" in operations
+    assert "next timer" in operations
+    assert "ExecStartPre" in operations
+    assert "unit_drift" in operations
+    assert "unit_drift auto_synced" in operations
 
 
 def test_agents_md_documents_the_deployment_consistency_contract():
@@ -348,13 +375,15 @@ def test_template_change_pins_the_self_healing_contract():
     a human ran the fix command — a per-tick drift loop.
 
     The contract must therefore be pinned in EVERY place it is
-    documented — README, AGENTS.md and the EN/ZH operations pages —
-    so a future template change cannot merge and strand the
-    deployment again: the change takes effect WITHOUT a human step
-    (the pre-start drift check self-heals with the same idempotent
-    install and re-verifies, `unit_drift auto_synced`), `install-units`
-    stays the manual entry, and the fail-fast canary is unchanged for
-    a drift the self-heal cannot resolve."""
+    documented — AGENTS.md and the EN/ZH operations pages (Issue #241
+    moved the mechanism detail off the README homepage, which keeps a
+    one-sentence summary plus the docs link) — so a future template
+    change cannot merge and strand the deployment again: the change
+    takes effect WITHOUT a human step (the pre-start drift check
+    self-heals with the same idempotent install and re-verifies,
+    `unit_drift auto_synced`), `install-units` stays the manual entry,
+    and the fail-fast canary is unchanged for a drift the self-heal
+    cannot resolve."""
     def template_change_contract(text: str) -> None:
         # The trigger: a change of either repo unit template
         # (templated units since Issue #149).
@@ -367,12 +396,6 @@ def test_template_change_pins_the_self_healing_contract():
         # The drift check stays fail-fast for an unresolvable drift.
         assert "unit_drift" in text
         assert "fail fast" in text
-
-    readme = README_FILE.read_text(encoding="utf-8")
-    # The README pins it in the deployment-consistency section (the
-    # section that carries the full deployment sequence).
-    section = readme.split("部署一致性", 1)[-1]
-    template_change_contract(section)
 
     agents = AGENTS_FILE.read_text(encoding="utf-8")
     # AGENTS.md pins it inside the Base freshness / deployment


### PR DESCRIPTION
<!-- muyan-pilot:run=4cfd10e8 -->

Fixes #241

README 首页化：保留定位/quickstart/能力概览/文档链接，移除重复机制说明 (run_id=4cfd10e8)
