### PR TITLE
增强 Runner 启动阶段可观测性：定位 starting 卡点

### DIFF
--- a/bootstrap_runner.py
+++ b/bootstrap_runner.py
@@ -3031,6 +3031,133 @@ def _log_heartbeat(activity: dict, *, issue_ref: str,
     )
 
 
+def _log_startup(event: str, *, issue_ref: str, role: str, activity: dict,
+                 elapsed: float, extra: str = "") -> None:
+    """Log one startup phase line (Issue #176).
+
+    Every startup phase (`process_spawned`, `session_created`,
+    `first_request_started`, `first_response_received`,
+    `startup_failed`) is one stable `key=value` line carrying the issue,
+    role, the provider/model Pi selected (`-` until the session's
+    `model_change` record says otherwise), the elapsed time since the
+    Pi process was spawned, and any extra fields of the phase (`pid=`,
+    `reason=`, `session_created=`, `first_request=`). No `run=` field
+    (Issue #57): the `[run_id]` prefix is the single run-id carrier.
+    Identifiers only — never a key, the prompt or model output.
+    """
+    LOGGER.info(
+        "%s issue=%s role=%s provider=%s model=%s elapsed=%s%s",
+        event, issue_ref, role, activity.get("provider") or "-",
+        activity.get("model") or "-", format_duration(elapsed),
+        f" {extra}" if extra else "",
+    )
+
+
+def _classify_startup_exit(stderr: str, returncode: int) -> str:
+    """The distinguishable `startup_failed` reason for an early Pi exit
+    (Issue #176).
+
+    The classification is evidence-based on Pi's own stderr (the
+    minimal correlation the Issue asks for): a provider authentication
+    failure (`401`/`403`, `unauthorized`, `forbidden`, `api key`) is
+    `auth_failure`; a network timeout (`timed out`, `timeout`,
+    `etimedout`, `econnrefused`, `econnreset`, `enotfound`) is
+    `network_timeout`; anything else is the raw exit code
+    (`pi_exit_<N>`). The stderr text itself is NOT echoed into the
+    reason — only the class — so no sensitive response content can
+    leak into the journal.
+    """
+    lowered = stderr.lower()
+    if ("401" in lowered or "403" in lowered or "unauthorized" in lowered
+            or "forbidden" in lowered or "api key" in lowered):
+        return "auth_failure"
+    if ("timed out" in lowered or "timeout" in lowered
+            or "etimedout" in lowered or "econnrefused" in lowered
+            or "econnreset" in lowered or "enotfound" in lowered):
+        return "network_timeout"
+    return f"pi_exit_{returncode}"
+
+
+def _log_provider_config_loaded(*, issue_ref: str, role: str, config: dict,
+                                elapsed: float) -> None:
+    """Log the `provider_config_loaded` startup line (Issue #176).
+
+    The provider file has been loaded and validated (at config load)
+    and materialized for this run — or resolved to Pi's own agent dir
+    when unconfigured. The provider/model fields are the configured
+    identifiers (the same non-sensitive values already on the redacted
+    command line, Issue #119) or `-` when Pi keeps its own defaults.
+    """
+    _log_startup(
+        "provider_config_loaded", issue_ref=issue_ref, role=role,
+        activity={"provider": config.get("pi_provider"),
+                  "model": config.get("pi_model")},
+        elapsed=elapsed,
+    )
+
+
+def _log_startup_failed(*, issue_ref: str, role: str, activity: dict,
+                        elapsed: float, returncode: int, stderr: str,
+                        timed_out: bool, model_wait_dead: bool,
+                        model_wait_swallowed: bool,
+                        idle_recovery_failed: bool) -> None:
+    """Log one `startup_failed` line (Issue #176): the run failed
+    BEFORE the first response, so the line says WHERE the startup was
+    stuck (`session_created=`, `first_request=`) plus the
+    distinguishable `reason=`. The existing `run_failed` scene line and
+    the raised exception are unchanged (fail-fast semantics preserved).
+    """
+    reason = _startup_failed_reason(
+        activity, returncode=returncode, stderr=stderr,
+        timed_out=timed_out, model_wait_dead=model_wait_dead,
+        model_wait_swallowed=model_wait_swallowed,
+        idle_recovery_failed=idle_recovery_failed,
+    )
+    _log_startup(
+        "startup_failed", issue_ref=issue_ref, role=role,
+        activity=activity, elapsed=elapsed,
+        extra=(
+            f"session_created="
+            f"{'true' if activity['session_file'] else 'false'} "
+            f"first_request="
+            f"{'true' if activity['first_request'] else 'false'} "
+            f"reason={reason}"
+        ),
+    )
+
+
+def _startup_failed_reason(activity: dict, *, returncode: int,
+                           stderr: str, timed_out: bool,
+                           model_wait_dead: bool,
+                           model_wait_swallowed: bool,
+                           idle_recovery_failed: bool) -> str:
+    """The `startup_failed` reason for a failure before the first
+    response (Issue #176): the kill-path class first, then the
+    root-cause evidence from Pi's stderr (`auth_failure` /
+    `network_timeout` — the missing session file is usually the
+    CONSEQUENCE of the auth/network failure, never the cause), then
+    WHERE the startup was stuck (`session_not_created` /
+    `no_first_request` / the raw early exit). `first_response_timeout`
+    is the frozen `model_wait` killed before any response (the hung
+    first request)."""
+    if idle_recovery_failed:
+        return "idle_recovery_stale"
+    if model_wait_swallowed:
+        return "model_wait_swallowed"
+    if model_wait_dead:
+        return "first_response_timeout"
+    if timed_out:
+        return "timeout"
+    classified = _classify_startup_exit(stderr, returncode)
+    if classified != f"pi_exit_{returncode}":
+        return classified
+    if not activity["session_file"]:
+        return "session_not_created"
+    if not activity["first_request"]:
+        return "no_first_request"
+    return classified
+
+
 def _pending_timeout_targets(targets: list[dict]) -> list[tuple[dict, float]]:
     """The pre-idle descendants still INSIDE an explicit `timeout`
     deadline (Issue #169): `[(target, deadline_epoch), ...]`.
@@ -3101,6 +3228,24 @@ def stream_pi(
     as the complete local record; the full prompt and Issue body are
     never logged.
 
+    Startup phases (Issue #176): `process_spawned` is logged right
+    after the spawn (with the pid); `session_created`,
+    `first_request_started` and `first_response_received` are logged
+    once each as the session JSONL crosses the milestones (the session
+    record, the first user message, the first assistant message) — each
+    line carries the provider/model Pi selected by that point and the
+    elapsed time since the spawn. The live lines' `phase` is the
+    startup sub-phase while the first response is outstanding
+    (`session_pending` / `request_pending`), so a run stuck at
+    `starting` is locatable to its startup phase from the journal and
+    the progress comment alone. A failure before the first response
+    additionally logs `startup_failed` with the distinguishable reason
+    (`session_not_created`, `no_first_request`, `auth_failure`,
+    `network_timeout`, `pi_exit_<N>`, `timeout`,
+    `first_response_timeout`, `model_wait_swallowed`,
+    `idle_recovery_stale`); the existing `run_failed` line and the
+    raised failure are unchanged (fail-fast semantics preserved).
+
     `progress` (Issue #18) is invoked on EVERY poll — an activity change
     or a heartbeat — with the current activity state, while the Pi
     process is still running: the caller renders the live GitHub
@@ -3165,6 +3310,15 @@ def stream_pi(
     # SIGTERM during this window must shut the child down, never
     # orphan it. Cleared again once the child is reaped (finally).
     set_active_pi(process)
+    # Startup phase (Issue #176): the process is spawned — the first
+    # sub-phase of `starting` is now observable (pid, elapsed since
+    # spawn). The run_start scene line below carries the same
+    # pre-session state (phase=session_pending); from here the live
+    # lines and the milestone lines carry the startup sub-phases.
+    _log_startup(
+        "process_spawned", issue_ref=issue_ref, role=role,
+        activity=initial, elapsed=0.0, extra=f"pid={process.pid}",
+    )
     LOGGER.info(
         "run_start %s",
         format_run_scene(
@@ -3178,6 +3332,12 @@ def stream_pi(
     activity = watcher.poll()
     timed_out = False
     model_wait_dead = False
+    # Startup milestones already reported (Issue #176): each flips once
+    # per session file (a resumed run creates a NEW file, and its
+    # first request/response are the new session's — the watcher
+    # resets the flags on the switch, so the lines fire again for the
+    # new session, exactly once each).
+    startup_seen = (False, False, False)
     # Swallowed-model-request probe state (Issue #233): the monotonic
     # moment the /slots probe first reported every slot idle while Pi was
     # in model_wait (None until then). Reset whenever a slot is processing,
@@ -3246,6 +3406,37 @@ def stream_pi(
                     else:
                         stderr_chunks.append(data)
             activity = watcher.poll()
+            # Startup milestones (Issue #176): one line per flip — the
+            # session file appeared, the first request went out, the
+            # first response arrived. Each carries the provider/model
+            # selected by that point and the elapsed time since spawn.
+            # A session switch resets the watcher flags, so a resumed
+            # invocation reports its NEW session's milestones once each.
+            seen = (
+                activity["session_file"] is not None,
+                activity["first_request"],
+                activity["first_response"],
+            )
+            if seen != startup_seen:
+                if seen[0] and not startup_seen[0]:
+                    _log_startup(
+                        "session_created", issue_ref=issue_ref,
+                        role=role, activity=activity,
+                        elapsed=time.monotonic() - start,
+                    )
+                if seen[1] and not startup_seen[1]:
+                    _log_startup(
+                        "first_request_started", issue_ref=issue_ref,
+                        role=role, activity=activity,
+                        elapsed=time.monotonic() - start,
+                    )
+                if seen[2] and not startup_seen[2]:
+                    _log_startup(
+                        "first_response_received", issue_ref=issue_ref,
+                        role=role, activity=activity,
+                        elapsed=time.monotonic() - start,
+                    )
+                startup_seen = seen
             visible = (
                 activity["phase"], activity["action"], activity["result"],
             )
@@ -3632,6 +3823,20 @@ def stream_pi(
         _drain_stream(process.stderr, stderr_chunks)
     stdout = _decode_chunks(stdout_chunks)
     stderr = _decode_chunks(stderr_chunks)
+    # Startup failure (Issue #176): a failure before the first response
+    # is a STARTUP failure — the line says where the startup was stuck
+    # with a distinguishable reason. After the first response the
+    # existing `run_failed` scene line alone describes the mid-run
+    # failure (no `startup_failed` line).
+    if not activity["first_response"]:
+        _log_startup_failed(
+            issue_ref=issue_ref, role=role, activity=activity,
+            elapsed=time.monotonic() - start,
+            returncode=process.returncode or 0, stderr=stderr,
+            timed_out=timed_out, model_wait_dead=model_wait_dead,
+            model_wait_swallowed=model_wait_swallowed,
+            idle_recovery_failed=idle_recovery_failed,
+        )
     if idle_recovery_failed:
         stale = format_duration(activity["stale_seconds"])
         LOGGER.error(
@@ -3725,6 +3930,7 @@ def is_ticket_only(issue: dict) -> bool:
 def run_ticket_agent(issue: dict, config: dict, source_repo: str,
                      *, progress: Callable[[dict], None] | None = None) -> str:
     """Generate one ticket-only deliverable without using Git state (#209)."""
+    started = time.monotonic()
     system_prompt = (
         "You are a ticket-only content agent. Produce the requested final "
         "content as your complete stdout response. Do not create or modify "
@@ -3746,6 +3952,14 @@ def run_ticket_agent(issue: dict, config: dict, source_repo: str,
             *_pi_model_args(config), "--print", "--session-dir", str(session_dir),
             "--system-prompt", system_prompt, context,
         ]
+        # Startup phase (Issue #176): the ticket-only session keeps Pi's
+        # own agent dir (no per-run materialization) — the provider
+        # config is still loaded and resolved before the spawn.
+        _log_provider_config_loaded(
+            issue_ref=issue_context(source_repo, int(issue["number"])),
+            role=ROLE_TICKET, config=config,
+            elapsed=time.monotonic() - started,
+        )
         return stream_pi(
             command, cwd=ticket_dir,
             log_command=[
@@ -3859,6 +4073,7 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     prompt template itself is untouched; absent -> the exact
     pre-#219 context.
     """
+    started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
         {
@@ -3902,6 +4117,15 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     # only the #119 provider/model/thinking identifiers). Unconfigured
     # -> the stream_pi call keeps its exact pre-#157 shape.
     agent_dir = prepare_pi_agent_dir(worktree, config)
+    # Startup phase (Issue #176): the provider config is loaded and
+    # materialized for this run (or resolved to Pi's own agent dir when
+    # unconfigured) — the first startup line, before the process is
+    # spawned.
+    _log_provider_config_loaded(
+        issue_ref=issue_context(source_repo, int(issue["number"])),
+        role=ROLE_IMPLEMENT, config=config,
+        elapsed=time.monotonic() - started,
+    )
     extra = {}
     if agent_dir is not None:
         extra["pi_env"] = {"PI_CODING_AGENT_DIR": str(agent_dir)}
@@ -4613,6 +4837,7 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     Issue #41: one run_id end to end, the roles are steps of the same
     run).
     """
+    started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt_review"].read_text(encoding="utf-8"),
         {
@@ -4647,6 +4872,13 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     # Issue #157: the review session uses the SAME provider config as
     # the implementer (one materialized dir per worktree, re-used).
     agent_dir = prepare_pi_agent_dir(worktree, config)
+    # Startup phase (Issue #176): the review session's provider config
+    # is loaded and materialized too (same line shape, role=review).
+    _log_provider_config_loaded(
+        issue_ref=issue_context(source_repo, issue),
+        role=ROLE_REVIEW, config=config,
+        elapsed=time.monotonic() - started,
+    )
     extra = {}
     if agent_dir is not None:
         extra["pi_env"] = {"PI_CODING_AGENT_DIR": str(agent_dir)}

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -96,7 +96,41 @@ Stable `key=value` lines you will see:
 - `run_start` / `run_end` — the full scene (branch, worktree, session
   file) at start, and the result (PR URL, commit) at the end;
 - `activity` / `heartbeat` / `model_wait` / `resumed` — live Pi activity
-  while a session runs (phase, last action, elapsed, idle);
+  while a session runs (phase, last action, elapsed, idle). The
+  `phase` is the startup sub-phase while the first response is
+  outstanding: `session_pending` (Pi is spawned but has not created its
+  session file yet) and `request_pending` (the session exists, the
+  first response has not arrived); after the first response the
+  tool-based phase (`test`, `pr`, `bash`, …) applies as before;
+- `process_spawned` / `provider_config_loaded` / `session_created` /
+  `first_request_started` / `first_response_received` — the startup
+  phase lines (Issue #176): one line per phase, in order, each
+  carrying issue, role, the provider/model Pi selected (`-` until the
+  session's `model_change` record says otherwise), and the elapsed
+  time since the spawn (`process_spawned` additionally carries the
+  pid). `provider_config_loaded` is logged by the Runner before the
+  spawn (the provider file is loaded and materialized, or Pi's own
+  agent dir when unconfigured); the other four are logged by the
+  streamer as the session JSONL crosses each milestone (the session
+  record, the first user message — the first request goes out — and
+  the first assistant message — the first response arrives). A run
+  stuck at `starting` is locatable to its startup phase from these
+  lines plus the progress comment's `phase` alone; only identifiers
+  are logged — never a key, the prompt or model output;
+- `startup_failed` — one line when the run fails BEFORE the first
+  response (Issue #176): it says WHERE the startup was stuck
+  (`session_created=true|false`, `first_request=true|false`) plus the
+  distinguishable `reason=` — `session_not_created` (Pi exited before
+  creating its session file), `no_first_request` (session exists, no
+  first request), `auth_failure` / `network_timeout` (classified from
+  Pi's stderr — the class only, never the text), `pi_exit_<N>` (the
+  early exit code), `timeout` (the run deadline),
+  `first_response_timeout` (a frozen `model_wait` killed before any
+  response — the hung first request), `model_wait_swallowed` and
+  `idle_recovery_stale` (the existing kill paths). The existing
+  `run_failed` scene line and the raised failure are unchanged —
+  `startup_failed` is the extra observability, not a new failure
+  path;
 - `resume_continue` — one INFO when a resumed run continues the
   interrupted work (Issue #219): the worktree's run state file
   (`.muyan-pilot/run-state.json`) verified the SAME run (issue number

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -82,7 +82,32 @@ journalctl --user -u muyan-pilot@1.service -u muyan-pilot@2.service | grep e0738
 - `run_start` / `run_end` — 开始时的完整现场（branch、worktree、
   session 文件），结束时的结果（PR URL、commit）；
 - `activity` / `heartbeat` / `model_wait` / `resumed` — session 运行
-  期间的实时 Pi 活动（phase、最近动作、elapsed、idle）；
+  期间的实时 Pi 活动（phase、最近动作、elapsed、idle）。首个响应到达
+  前 `phase` 是启动子阶段：`session_pending`（Pi 已启动但还没创建
+  session 文件）和 `request_pending`（session 已存在、首个响应还没
+  到）；首个响应到达后按原规则用工具 phase（`test`、`pr`、`bash`…）；
+- `process_spawned` / `provider_config_loaded` / `session_created` /
+  `first_request_started` / `first_response_received` — 启动阶段行
+  （Issue #176）：每个阶段一行、按顺序，每行带 issue、role、Pi 实际
+  选择的 provider/model（session 的 `model_change` 记录出现前为
+  `-`）、距 spawn 的 elapsed（`process_spawned` 另带 pid）。
+  `provider_config_loaded` 由 Runner 在 spawn 前记录（provider 文件已
+  加载并物化；未配置时用 Pi 自己的 agent dir）；其余四行由 streamer
+  在 session JSONL 跨过每个里程碑时记录（session 记录、第一条 user
+  消息——首个请求发出——第一条 assistant 消息——首个响应到达）。卡在
+  `starting` 的 run 只靠这些行加 progress 评论的 `phase` 就能定位到
+  启动阶段；只记录标识符——从不记录 key、prompt 或模型输出；
+- `startup_failed` — run 在首个响应之前失败时的一行（Issue #176）：
+  说明启动卡在哪（`session_created=true|false`、
+  `first_request=true|false`）加可区分的 `reason=`——
+  `session_not_created`（Pi 退出前没创建 session 文件）、
+  `no_first_request`（session 存在但没有首个请求）、`auth_failure` /
+  `network_timeout`（从 Pi 的 stderr 分类——只记类别、从不记文本）、
+  `pi_exit_<N>`（提前退出码）、`timeout`（run deadline）、
+  `first_response_timeout`（冻结的 `model_wait` 在响应前被杀——挂死的
+  首个请求）、`model_wait_swallowed` 和 `idle_recovery_stale`
+  （既有 kill 路径）。既有的 `run_failed` 现场行和抛出的失败不变——
+  `startup_failed` 是额外的可观测性，不是新的失败路径；
 - `resume_continue` — 恢复的 run 继续中断的工作（Issue #219）时的一次
   INFO：worktree 的 run state 文件（`.muyan-pilot/run-state.json`）
   验证了同一个 run（issue 编号 + 仓库名——仓库改名后 slug 变了也能

--- a/pi_activity.py
+++ b/pi_activity.py
@@ -173,6 +173,17 @@ class SessionWatcher:
         self.start_time = now()
         self._offset = 0
         self._last_activity_epoch: float | None = None
+        # Startup milestones (Issue #176): the provider/model Pi ACTUALLY
+        # selected (from the session's `model_change` record, written
+        # right after the session record), the first request (the first
+        # user message record — Pi writes it when the first request goes
+        # out) and the first response (the first assistant message
+        # record). Identifiers only: the prompt and model output are
+        # never summarized here.
+        self.provider: str | None = None
+        self.model: str | None = None
+        self.first_request = False
+        self.first_response = False
 
     def poll(self) -> dict:
         """Read new session records; return the current activity state."""
@@ -215,6 +226,13 @@ class SessionWatcher:
         self.start_time = self._now()
         self._offset = 0
         self._last_activity_epoch = None
+        # The startup milestones belong to the session that is followed
+        # (Issue #176): a resumed invocation's first request/response are
+        # the NEW session's, never the previous one's.
+        self.provider = None
+        self.model = None
+        self.first_request = False
+        self.first_response = False
 
     def state(self, changed: bool = False) -> dict:
         """Return the activity state as a plain dict (no file access)."""
@@ -224,12 +242,25 @@ class SessionWatcher:
         else:
             stale = now - self.start_time
         in_model_wait = self.last_role == "toolResult"
+        # Startup sub-phase (Issue #176): the generic `starting` splits
+        # into `session_pending` (no session file yet — Pi is spawned
+        # but has not created its session) and `request_pending` (the
+        # session exists but the first response has not arrived). After
+        # the first response the tool-based phase applies as before.
+        if self.phase:
+            phase = self.phase
+        elif self.session_file is None:
+            phase = "session_pending"
+        elif not self.first_response:
+            phase = "request_pending"
+        else:
+            phase = "starting"
         return {
             "session_id": self.session_id,
             "session_file": str(self.session_file) if self.session_file
             else None,
             "events": self.events,
-            "phase": self.phase or "starting",
+            "phase": phase,
             "last_activity": self.last_activity,
             "action": self.action,
             "result": self.result,
@@ -241,6 +272,13 @@ class SessionWatcher:
             "model_wait": in_model_wait,
             "changed": changed,
             "stale_seconds": max(0.0, stale),
+            # Startup milestones (Issue #176): the selected provider/model
+            # (None until the `model_change` record is read) and the
+            # first request/response observed in the session file.
+            "provider": self.provider,
+            "model": self.model,
+            "first_request": self.first_request,
+            "first_response": self.first_response,
         }
 
     def _apply(self, record: dict) -> None:
@@ -251,6 +289,17 @@ class SessionWatcher:
             if isinstance(session_id, str) and session_id:
                 self.session_id = session_id
             return
+        if record_type == "model_change":
+            # The provider/model Pi actually selected (Issue #176): the
+            # identifiers are non-sensitive and visible on every startup
+            # line; a missing/invalid field stays unselected (None).
+            provider = record.get("provider")
+            if isinstance(provider, str) and provider:
+                self.provider = provider
+            model = record.get("modelId")
+            if isinstance(model, str) and model:
+                self.model = model
+            return
         if record_type != "message":
             return
         message = record.get("message")
@@ -259,8 +308,14 @@ class SessionWatcher:
         role = message.get("role")
         if role == "assistant":
             self._apply_assistant(message)
+            # The first response from the model arrived (Issue #176).
+            self.first_response = True
         elif role == "toolResult":
             self._apply_tool_result(message)
+        elif role == "user":
+            # The first request to the model went out (Issue #176): the
+            # milestone only — the prompt content is never summarized.
+            self.first_request = True
         self.last_role = role
         timestamp = record.get("timestamp")
         if isinstance(timestamp, str) and timestamp:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3018,6 +3018,111 @@ def test_run_pi_renders_base_sync_lock_into_prompt(monkeypatch, tmp_path):
     )
 
 
+def test_run_pi_logs_provider_config_loaded_with_selection(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #176: run_pi logs `provider_config_loaded` with the
+    configured provider/model identifiers (the same non-sensitive
+    values as the redacted command line) before Pi is spawned."""
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "done")
+    issue = {"number": 4, "title": "t", "body": "b"}
+    config = {
+        "prompt": prompt_path,
+        "repo_dir": tmp_path / "checkout",
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "run1",
+        "pi_provider": "local-qwen",
+        "pi_model": "qwen3.8:27b",
+    }
+    with caplog.at_level("INFO"):
+        runner.run_pi(
+            issue, tmp_path, config, "owner/repo",
+            branch="muyan-pilot/owner-repo-issue-4-run1",
+        )
+    lines = [line for line in caplog.text.splitlines()
+             if " provider_config_loaded " in line]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "issue=owner/repo#4" in line
+    assert "role=implement" in line
+    assert "provider=local-qwen" in line
+    assert "model=qwen3.8:27b" in line
+    assert "elapsed=" in line
+
+
+def test_run_pi_logs_provider_config_loaded_unconfigured(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #176: without a configured provider/model the line still
+    fires (Pi keeps its own agent dir) with `-` placeholders."""
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "done")
+    issue = {"number": 4, "title": "t", "body": "b"}
+    config = {
+        "prompt": prompt_path,
+        "repo_dir": tmp_path / "checkout",
+        "source_repos": ["owner/repo"],
+        "workspace_root": tmp_path,
+        "context_files": [],
+        "skills": [],
+        "base_branch": "main",
+        "base_sha": "abc123def456",
+        "run_id": "run1",
+    }
+    with caplog.at_level("INFO"):
+        runner.run_pi(
+            issue, tmp_path, config, "owner/repo", branch="b",
+        )
+    lines = [line for line in caplog.text.splitlines()
+             if " provider_config_loaded " in line]
+    assert len(lines) == 1
+    assert "provider=-" in lines[0]
+    assert "model=-" in lines[0]
+    assert "role=implement" in lines[0]
+
+
+def test_run_review_logs_provider_config_loaded_with_review_role(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #176: the review session logs the same line with
+    role=review (one run_id, the roles are steps of the same run)."""
+    prompt_path = tmp_path / "prompt_review.md"
+    prompt_path.write_text("REVIEW", encoding="utf-8")
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "ok")
+    with caplog.at_level("INFO"):
+        runner.run_review(
+            tmp_path,
+            {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+             "head_oid": "h1", "head_ref": "h"},
+            {
+                "prompt_review": prompt_path,
+                "repo_dir": tmp_path / "checkout",
+                "source_repos": ["owner/repo"],
+                "base_branch": "main",
+                "run_id": "a1b2c3d4",
+                "skills": [],
+                "pi_provider": "local-qwen",
+                "pi_model": "qwen3.8:27b",
+            },
+            "owner/repo", 4, "branch", 1,
+        )
+    lines = [line for line in caplog.text.splitlines()
+             if " provider_config_loaded " in line]
+    assert len(lines) == 1
+    assert "role=review" in lines[0]
+    assert "issue=owner/repo#4" in lines[0]
+    assert "provider=local-qwen" in lines[0]
+    assert "model=qwen3.8:27b" in lines[0]
+
+
 def test_run_review_renders_base_sync_lock_into_prompt(monkeypatch, tmp_path):
     # Issue #171: the review prompt carries the SAME lock path (the
     # review session's base merge fetch must not race the shared ref).
@@ -4595,7 +4700,10 @@ def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
     # record they are '-' (the full entry reappears on run_failed).
     assert "session=-" in start
     assert "session_file=-" in start
-    assert "phase=starting" in start
+    # Issue #176: the scene at start shows the startup sub-phase — no
+    # session file yet, so `session_pending` (not the generic
+    # `starting`).
+    assert "phase=session_pending" in start
     # The user message (full prompt / Issue body) never reaches the journal.
     assert "SECRET ISSUE BODY" not in caplog.text
 
@@ -4643,10 +4751,12 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     lines = caplog.text.splitlines()
     activities = [line for line in lines if " activity " in line]
     heartbeats = [line for line in lines if " heartbeat " in line]
-    # The visible fields change once (starting -> test): exactly one
-    # activity line; unchanged polls must not repeat it (Issue #40).
-    assert len(activities) == 1
-    line = activities[0]
+    # Issue #176: the visible fields change twice (request_pending ->
+    # test): the startup sub-phase line, then the tool-call line;
+    # unchanged polls must not repeat them (Issue #40).
+    assert len(activities) == 2
+    assert "phase=request_pending" in activities[0]
+    line = activities[1]
     # No redundant `run=` field on the high-frequency lines (Issue #57);
     # the `[run_id]` prefix is the run-id carrier (bound-run tests and
     # the e2e suite cover the prefix itself).
@@ -4667,7 +4777,8 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     for line in heartbeats:
         assert "run=run1" not in line
         assert "role=implement" in line
-        assert "phase=starting" in line or "phase=test" in line
+        assert ("phase=request_pending" in line
+                or "phase=test" in line)
         assert "elapsed=" in line
         assert "idle=" in line
         assert "branch=" not in line
@@ -4819,12 +4930,15 @@ def test_stream_pi_activity_keeps_action_after_tool_result(tmp_path, caplog):
         )
     lines = caplog.text.splitlines()
     activities = [line for line in lines if " activity " in line]
-    # One activity line for the tool call, one for the result=ok update;
-    # the action (the real command) is preserved on both.
-    assert len(activities) == 2
-    assert all('action="bash pytest tests/"' in line for line in activities)
-    assert "result=-" in activities[0]
-    assert "result=ok" in activities[1]
+    # Issue #176: one activity line for the startup sub-phase, one for
+    # the tool call, one for the result=ok update; the action (the real
+    # command) is preserved on the tool lines.
+    assert len(activities) == 3
+    assert "phase=request_pending" in activities[0]
+    assert all('action="bash pytest tests/"' in line
+               for line in activities[1:])
+    assert "result=-" in activities[1]
+    assert "result=ok" in activities[2]
     assert "tool_result" not in caplog.text
 
 
@@ -4844,9 +4958,10 @@ def test_stream_pi_heartbeat_interval_is_stable(tmp_path, caplog):
     activities = [line for line in lines if " activity " in line]
     assert activities == []
     # ~1s of idleness at a 0.1s interval: several heartbeats, one per poll.
+    # Issue #176: with no session file the sub-phase is session_pending.
     assert len(heartbeats) >= 4
     for line in heartbeats:
-        assert "phase=starting" in line
+        assert "phase=session_pending" in line
         assert "session=-" not in line  # session fields are not repeated
 
 
@@ -4938,6 +5053,9 @@ def test_stream_pi_heartbeats_when_session_is_idle(tmp_path, caplog):
 
 
 def test_stream_pi_heartbeats_when_no_session_file_appears(tmp_path, caplog):
+    # Issue #176: with no session file the startup sub-phase is
+    # `session_pending` (Pi is spawned but has not created its session
+    # yet) — the generic `starting` is gone from the live lines.
     command = make_fake_pi(tmp_path, session_records=[], sleep=1.0)
     with caplog.at_level("INFO"):
         runner.stream_pi(
@@ -4948,7 +5066,321 @@ def test_stream_pi_heartbeats_when_no_session_file_appears(tmp_path, caplog):
     heartbeats = [line for line in caplog.text.splitlines()
                   if " heartbeat " in line]
     assert len(heartbeats) >= 1
-    assert all("phase=starting" in line for line in heartbeats)
+    assert all("phase=session_pending" in line for line in heartbeats)
+
+
+# ------------------------------------ startup phases (Issue #176)
+
+def startup_records():
+    """A full healthy startup: session, the model Pi selected, the first
+    request (user message) and the first response (assistant message)."""
+    return [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+        (0.05, {"type": "model_change", "id": "m1",
+                "timestamp": fresh_timestamp(),
+                "provider": "local-qwen", "modelId": "qwen3.8:27b"}),
+        (0.1, {"type": "message", "id": "u1",
+               "timestamp": fresh_timestamp(),
+               "message": {"role": "user", "content": [
+                   {"type": "text", "text": "SECRET ISSUE BODY"}]}}),
+        (0.2, {"type": "message", "id": "a1",
+               "timestamp": fresh_timestamp(1),
+               "message": {"role": "assistant", "content": [
+                   {"type": "toolCall", "id": "t1", "name": "bash",
+                    "arguments": {"command": "pytest tests/"}}]}}),
+    ]
+
+
+def test_stream_pi_logs_process_spawned_after_popen(tmp_path, caplog):
+    """`process_spawned` is logged exactly once, right after the Pi
+    process is spawned, and carries the pid (Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=startup_records(), stdout="ok",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = [line for line in caplog.text.splitlines()
+             if " process_spawned " in line]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "issue=xqliu/muyan-pilot#24" in line
+    assert "role=implement" in line
+    # Before the session file exists the selection is unknown.
+    assert "provider=-" in line
+    assert "model=-" in line
+    assert "elapsed=" in line
+    # The pid is a real integer and the raw prompt never reaches the log.
+    pid = int(line.split("pid=")[1].split()[0])
+    assert pid > 0
+    assert "SECRET ISSUE BODY" not in caplog.text
+
+
+def test_stream_pi_logs_startup_milestones_in_order(tmp_path, caplog):
+    """A healthy startup logs `session_created`, `first_request_started`
+    and `first_response_received` exactly once each, in order, and the
+    lines carry the provider/model Pi actually selected (Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=startup_records(), stdout="ok",
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    created = [line for line in lines if " session_created " in line]
+    requested = [line for line in lines if " first_request_started " in line]
+    responded = [line for line in lines if " first_response_received " in line]
+    assert len(created) == 1
+    assert len(requested) == 1
+    assert len(responded) == 1
+    # The milestones appear in the order the session records arrive.
+    assert (lines.index(created[0]) < lines.index(requested[0])
+            < lines.index(responded[0]))
+    # The real selection (from the session's model_change record) is
+    # visible on the request/response lines.
+    assert "provider=local-qwen" in requested[0]
+    assert "model=qwen3.8:27b" in requested[0]
+    assert "provider=local-qwen" in responded[0]
+    assert "model=qwen3.8:27b" in responded[0]
+    for line in (created[0], requested[0], responded[0]):
+        assert "issue=xqliu/muyan-pilot#24" in line
+        assert "role=implement" in line
+        assert "elapsed=" in line
+
+
+def test_stream_pi_activity_lines_show_startup_sub_phase(tmp_path, caplog):
+    """The live activity/heartbeat lines show the startup sub-phase
+    instead of the generic `starting` (Issue #176): `session_pending`
+    until the session file exists, `request_pending` until the first
+    response, then the tool-based phase. The records are delayed so
+    each sub-phase is visible for at least one poll."""
+    records = [
+        (0.3, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+        (0.45, {"type": "model_change", "id": "m1",
+                "timestamp": fresh_timestamp(),
+                "provider": "local-qwen", "modelId": "qwen3.8:27b"}),
+        (0.6, {"type": "message", "id": "u1",
+               "timestamp": fresh_timestamp(),
+               "message": {"role": "user", "content": [
+                   {"type": "text", "text": "SECRET ISSUE BODY"}]}}),
+        (0.9, {"type": "message", "id": "a1",
+               "timestamp": fresh_timestamp(1),
+               "message": {"role": "assistant", "content": [
+                   {"type": "toolCall", "id": "t1", "name": "bash",
+                    "arguments": {"command": "pytest tests/"}}]}}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stdout="ok",
+        sleep=0.3,
+    )
+    with caplog.at_level("INFO"):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.1,
+            run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+            branch="b",
+        )
+    lines = caplog.text.splitlines()
+    live = [line for line in lines
+            if " activity " in line or " heartbeat " in line]
+    assert any("phase=session_pending" in line for line in live)
+    assert any("phase=request_pending" in line for line in live)
+    # After the first response the tool-based phase applies as before.
+    assert any("phase=test" in line for line in live)
+
+
+def test_stream_pi_startup_failed_without_session_file(tmp_path, caplog):
+    """Pi exits before creating its session file: `startup_failed`
+    carries `reason=session_not_created` (and the existing `run_failed`
+    line is unchanged, Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=[], stdout="", stderr="boom", exit_code=3,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    lines = [line for line in caplog.text.splitlines()
+             if " startup_failed " in line]
+    assert len(lines) == 1
+    line = lines[0]
+    assert "reason=session_not_created" in line
+    assert "session_created=false" in line
+    assert "first_request=false" in line
+    assert "issue=xqliu/muyan-pilot#24" in line
+    assert "role=implement" in line
+    assert "elapsed=" in line
+    # The existing fail-fast scene line is unchanged.
+    failed = [line for line in caplog.text.splitlines()
+              if " run_failed " in line]
+    assert len(failed) == 1
+    assert "reason=pi_exit_3" in failed[0]
+
+
+def test_stream_pi_startup_failed_without_first_request(tmp_path, caplog):
+    """The session file exists but Pi never sent its first request:
+    `reason=no_first_request` (Issue #176)."""
+    records = [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stderr="boom", exit_code=1,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    lines = [line for line in caplog.text.splitlines()
+             if " startup_failed " in line]
+    assert len(lines) == 1
+    assert "reason=no_first_request" in lines[0]
+    assert "session_created=true" in lines[0]
+    assert "first_request=false" in lines[0]
+
+
+def test_stream_pi_startup_failed_early_exit_after_first_request(
+        tmp_path, caplog,
+):
+    """The first request went out but Pi exited early without a first
+    response (unclassifiable stderr): `reason=pi_exit_<N>` with the
+    stuck-point fields (Issue #176)."""
+    records = [
+        (0.0, {"type": "session", "id": "sess-1",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+        (0.1, {"type": "message", "id": "u1",
+               "timestamp": fresh_timestamp(),
+               "message": {"role": "user", "content": [
+                   {"type": "text", "text": "SECRET ISSUE BODY"}]}}),
+    ]
+    command = make_fake_pi(
+        tmp_path, session_records=records, stderr="boom", exit_code=1,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    lines = [line for line in caplog.text.splitlines()
+             if " startup_failed " in line]
+    assert len(lines) == 1
+    assert "reason=pi_exit_1" in lines[0]
+    assert "session_created=true" in lines[0]
+    assert "first_request=true" in lines[0]
+    # The prompt never reaches the journal.
+    assert "SECRET ISSUE BODY" not in caplog.text
+
+
+def test_startup_failed_reason_maps_hung_first_request_to_timeout():
+    """A frozen model_wait killed before the first response is the
+    first-response timeout (Issue #176): the request was in flight and
+    the response never arrived."""
+    activity = {
+        "session_file": "/w/.pi-session/s.jsonl",
+        "first_request": True,
+        "first_response": False,
+    }
+    assert runner._startup_failed_reason(
+        activity, returncode=0, stderr="",
+        timed_out=False, model_wait_dead=True,
+        model_wait_swallowed=False, idle_recovery_failed=False,
+    ) == "first_response_timeout"
+    assert runner._startup_failed_reason(
+        activity, returncode=0, stderr="",
+        timed_out=False, model_wait_dead=False,
+        model_wait_swallowed=True, idle_recovery_failed=False,
+    ) == "model_wait_swallowed"
+    # The other failure classes keep their own reasons.
+    assert runner._startup_failed_reason(
+        activity, returncode=0, stderr="",
+        timed_out=True, model_wait_dead=False,
+        model_wait_swallowed=False, idle_recovery_failed=False,
+    ) == "timeout"
+    assert runner._startup_failed_reason(
+        activity, returncode=0, stderr="",
+        timed_out=False, model_wait_dead=False,
+        model_wait_swallowed=False, idle_recovery_failed=True,
+    ) == "idle_recovery_stale"
+
+
+def test_stream_pi_startup_failed_auth_failure(tmp_path, caplog):
+    """A provider authentication failure in Pi's stderr is classified as
+    `reason=auth_failure` (Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=[], stderr="Error: 401 Unauthorized",
+        exit_code=1,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    lines = [line for line in caplog.text.splitlines()
+             if " startup_failed " in line]
+    assert len(lines) == 1
+    assert "reason=auth_failure" in lines[0]
+    assert "session_created=false" in lines[0]
+
+
+def test_stream_pi_startup_failed_network_timeout(tmp_path, caplog):
+    """A network timeout in Pi's stderr is classified as
+    `reason=network_timeout` (Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=[],
+        stderr='Error: connect ETIMEDOUT (request timed out)',
+        exit_code=1,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    lines = [line for line in caplog.text.splitlines()
+             if " startup_failed " in line]
+    assert len(lines) == 1
+    assert "reason=network_timeout" in lines[0]
+
+
+def test_stream_pi_no_startup_failed_after_first_response(tmp_path, caplog):
+    """A failure AFTER the first response is a mid-run failure, not a
+    startup failure: no `startup_failed` line (Issue #176)."""
+    command = make_fake_pi(
+        tmp_path, session_records=startup_records(),
+        stderr="boom", exit_code=1,
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(subprocess.CalledProcessError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.1,
+                run_id="run1", issue=24, source_repo="xqliu/muyan-pilot",
+                branch="b",
+            )
+    assert not any(" startup_failed " in line
+                   for line in caplog.text.splitlines())
+    # The existing run_failed scene line still carries the reason.
+    failed = [line for line in caplog.text.splitlines()
+              if " run_failed " in line]
+    assert len(failed) == 1
+    assert "reason=pi_exit_1" in failed[0]
 
 
 def test_stream_pi_model_wait_then_resumed_no_warning_spam(
@@ -5071,7 +5503,9 @@ def test_stream_pi_logs_idle_warning_once_when_session_stalls(
     assert "run=run1" not in idle
     assert "issue=xqliu/muyan-pilot#24" in idle
     assert "role=implement" in idle
-    assert "phase=starting" in idle
+    # Issue #176: no session file was ever created, so the sub-phase is
+    # session_pending (the stall is visible with its stuck point).
+    assert "phase=session_pending" in idle
     assert "stale_seconds=" in idle
     # The warning is a WARNING (visible in journalctl without -p info).
     assert any(
@@ -5208,6 +5642,9 @@ def test_stream_pi_drains_pipe_data_written_after_exit(
             self._out_writer = os.fdopen(self._out_w, "wb")
             self._err_writer = os.fdopen(self._err_w, "wb")
             self.returncode = 0
+            # A real Popen always carries the child pid (the
+            # process_spawned line, Issue #176, logs it).
+            self.pid = os.getpid()
 
         def poll(self):
             return self.returncode
@@ -6609,8 +7046,11 @@ def test_stream_pi_invokes_progress_callback_while_child_is_running(
     # ...and it saw the activity change (starting -> test) live, before
     # the child exited: the tool call is visible in an early snapshot,
     # not only in a final state.
+    # Issue #176: the first live snapshot shows the startup sub-phase
+    # (request_pending: the session exists, the first response has not
+    # arrived yet), not the generic `starting`.
     phases = [entry["phase"] for entry in seen]
-    assert phases[0] == "starting"
+    assert phases[0] == "request_pending"
     assert "test" in phases
     assert phases.index("test") < len(phases) - 1
     test_entries = [entry for entry in seen if entry["phase"] == "test"]
@@ -10840,6 +11280,53 @@ def test_run_ticket_agent_uses_a_temporary_session_without_git(monkeypatch, tmp_
     assert kwargs["role"] == runner.ROLE_TICKET
     assert str(tmp_path) not in command[command.index("--session-dir") + 1]
     assert Path(command[command.index("--session-dir") + 1]).parent == kwargs["cwd"]
+
+
+def test_run_ticket_agent_logs_provider_config_loaded(monkeypatch, tmp_path, caplog):
+    """Issue #176: the ticket-only session logs the provider config
+    line too (role=ticket) — every Pi session has the same startup
+    sequence."""
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "copy")
+    with caplog.at_level("INFO"):
+        runner.run_ticket_agent(
+            {"number": 99, "title": "Launch thread", "body": "Write copy"},
+            {"repo_dir": tmp_path, "run_id": "a1b2c3d4", "skills": [],
+             "pi_provider": "local-qwen", "pi_model": "qwen3.8:27b",
+             "pi_thinking": None},
+            "o/r",
+        )
+    lines = [line for line in caplog.text.splitlines()
+             if " provider_config_loaded " in line]
+    assert len(lines) == 1
+    assert "role=ticket" in lines[0]
+    assert "issue=o/r#99" in lines[0]
+    assert "provider=local-qwen" in lines[0]
+    assert "model=qwen3.8:27b" in lines[0]
+
+
+def test_progress_state_passes_startup_sub_phase_to_comment(tmp_path):
+    """Issue #176: the progress comment's `phase` carries the watcher's
+    startup sub-phase (session_pending / request_pending) instead of
+    the generic `starting` while the first response is outstanding."""
+    for sub_phase in ("session_pending", "request_pending"):
+        state = runner._progress_state(
+            issue=176, title="t", run_id="a1b2c3d4", role="implement",
+            branch="b", worktree=tmp_path, started=time.monotonic(),
+            pr_url=None, review_round=0, priority="normal",
+            activity={"phase": sub_phase, "last_activity": None,
+                      "action": None, "session_id": None},
+        )
+        assert state["phase"] == sub_phase
+    # The tool-based phase passes through unchanged once the first
+    # response arrived.
+    state = runner._progress_state(
+        issue=176, title="t", run_id="a1b2c3d4", role="implement",
+        branch="b", worktree=tmp_path, started=time.monotonic(),
+        pr_url=None, review_round=0, priority="normal",
+        activity={"phase": "test", "last_activity": None,
+                  "action": "bash pytest tests/", "session_id": "s1"},
+    )
+    assert state["phase"] == "test"
 
 
 def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch):

--- a/tests/test_muyan_pilot.py
+++ b/tests/test_muyan_pilot.py
@@ -961,7 +961,10 @@ def test_status_report_includes_live_lines_for_current_issue(monkeypatch, tmp_pa
         "slot_dir": tmp_path / ".muyan-pilot" / "slots",
     })
     assert "current: #3 now u3" in report
-    assert "    live: phase=starting last_activity=- action=- result=-" in report
+    # Issue #176: the session file exists but no first response has
+    # arrived, so the live line shows the request_pending sub-phase.
+    assert ("    live: phase=request_pending last_activity=- action=- "
+            "result=-") in report
     assert f"    session: {session_dir / 's.jsonl'}" in report
     assert f"    worktree: {worktree}" in report
     assert "ready: -" in report

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -3,7 +3,10 @@
 The session JSONL is append-only: `session` / `model_change` /
 `thinking_level_change` / `message` records. Only assistant and toolResult
 messages are agent activity; user messages carry the full prompt and Issue
-body and must never be summarized.
+body and must never be summarized. The watcher also tracks the startup
+milestones (Issue #176): the selected provider/model (`model_change`
+record), the first request (first user message) and the first response
+(first assistant message).
 """
 import json
 import os
@@ -511,9 +514,10 @@ def test_watcher_known_files_switches_to_newer_file_and_resets_state(
     assert state["session_file"] == str(second)
     assert state["session_id"] == "sess-second"
     # The state was reset: the old file's events/phase/action/result are
-    # gone...
+    # gone... (Issue #176: the new session exists but has no first
+    # response yet, so the sub-phase is request_pending)
     assert state["events"] == 1
-    assert state["phase"] == "starting"
+    assert state["phase"] == "request_pending"
     assert state["action"] is None
     assert state["result"] is None
     assert state["last_activity"] is None
@@ -585,7 +589,8 @@ def test_watcher_stale_seconds_from_start_without_activity(tmp_path):
     watcher.start_time = 1_000_000.0
     state = watcher.poll()
     assert state["stale_seconds"] == pytest.approx(50.0)
-    assert state["phase"] == "starting"
+    # Issue #176: no session file yet -> the session_pending sub-phase.
+    assert state["phase"] == "session_pending"
     assert state["action"] is None
     assert state["result"] is None
 
@@ -630,6 +635,116 @@ def test_watcher_state_no_model_wait_after_tool_call(tmp_path):
 def test_watcher_state_no_model_wait_without_session(tmp_path):
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     assert watcher.poll()["model_wait"] is False
+
+
+# --------------------------------------- startup milestones (Issue #176)
+
+def test_watcher_state_tracks_selected_provider_and_model(tmp_path):
+    """The `model_change` record carries the provider/model Pi ACTUALLY
+    selected (written right after the session record): the identifiers are
+    non-sensitive and must be visible on the state (Issue #176)."""
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {"type": "model_change", "id": "m1",
+         "timestamp": "2026-01-01T00:00:00Z",
+         "provider": "local-qwen", "modelId": "qwen3.8:27b"},
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["provider"] == "local-qwen"
+    assert state["model"] == "qwen3.8:27b"
+
+
+def test_watcher_state_model_change_without_fields_stays_unselected(tmp_path):
+    # A model_change record without usable provider/modelId fields must
+    # not fabricate a selection (the fields stay None, not empty).
+    session = tmp_path / "s.jsonl"
+    write_records(session, [
+        SESSION_RECORD,
+        {"type": "model_change", "id": "m1",
+         "timestamp": "2026-01-01T00:00:00Z",
+         "provider": 7, "modelId": ""},
+    ])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["provider"] is None
+    assert state["model"] is None
+
+
+def test_watcher_state_first_request_on_first_user_message(tmp_path):
+    """The first user message record is written when the first request to
+    the model goes out: `first_request` flips on it, and the prompt
+    content itself is NEVER summarized (Issue #176)."""
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    assert watcher.poll()["first_request"] is False
+    with session.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(USER_RECORD) + "\n")
+    state = watcher.poll()
+    assert state["first_request"] is True
+    # The user message is a milestone, not an activity: no action.
+    assert state["action"] is None
+    assert "SECRET ISSUE BODY" not in json.dumps(state)
+
+
+def test_watcher_state_first_response_on_first_assistant_message(tmp_path):
+    """The first assistant message record is the first response from the
+    model: `first_response` flips on it (Issue #176)."""
+    session = tmp_path / "s.jsonl"
+    write_records(session, [SESSION_RECORD, USER_RECORD])
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["first_request"] is True
+    assert state["first_response"] is False
+    with session.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(ASSISTANT_TEXT) + "\n")
+    state = watcher.poll()
+    assert state["first_response"] is True
+
+
+def test_watcher_state_milestones_absent_before_any_session(tmp_path):
+    watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
+    state = watcher.poll()
+    assert state["provider"] is None
+    assert state["model"] is None
+    assert state["first_request"] is False
+    assert state["first_response"] is False
+
+
+def test_watcher_switch_resets_startup_milestones(tmp_path):
+    """Switching to a newer session file resets the startup milestones
+    with the rest of the tracked state (a resumed invocation's first
+    request/response are the NEW session's, Issue #176)."""
+    first = tmp_path / "first.jsonl"
+    write_records(first, [
+        SESSION_RECORD,
+        {"type": "model_change", "id": "m1",
+         "timestamp": "2026-01-01T00:00:00Z",
+         "provider": "p1", "modelId": "m1"},
+        USER_RECORD,
+        ASSISTANT_TEXT,
+    ])
+    watcher = pi_activity.SessionWatcher(
+        tmp_path, now=lambda: 1_000_000.0, known_files=set(),
+    )
+    state = watcher.poll()
+    assert state["provider"] == "p1"
+    assert state["model"] == "m1"
+    assert state["first_request"] is True
+    assert state["first_response"] is True
+    second = tmp_path / "second.jsonl"
+    write_records(second, [{
+        "type": "session", "id": "sess-second",
+        "timestamp": "2026-01-01T02:00:00Z", "cwd": "/w",
+    }])
+    state = watcher.poll()
+    assert state["session_id"] == "sess-second"
+    assert state["provider"] is None
+    assert state["model"] is None
+    assert state["first_request"] is False
+    assert state["first_response"] is False
 
 
 def test_watcher_switch_reset_clears_model_wait(tmp_path):
@@ -683,18 +798,29 @@ def test_watcher_ignores_records_without_message_object(tmp_path):
     session = tmp_path / "s.jsonl"
     write_records(session, [
         SESSION_RECORD,
+        # A real Pi record type the watcher does not track (Issue #176):
+        # it must be ignored, not treated as a message.
+        {"type": "thinking_level_change", "id": "t1",
+         "timestamp": "2026-01-01T00:00:01Z", "thinkingLevel": "medium"},
         {"type": "message", "id": "x1", "timestamp": "2026-01-01T00:00:02Z"},
         {"type": "message", "id": "x2", "timestamp": "2026-01-01T00:00:03Z",
          "message": "not a dict"},
         {"type": "message", "id": "x3", "timestamp": "2026-01-01T00:00:04Z",
          "message": {"role": "user", "content": "plain string"}},
+        # A message with a role the watcher does not track: no milestone.
+        {"type": "message", "id": "x4", "timestamp": "2026-01-01T00:00:05Z",
+         "message": {"role": "system", "content": "note"}},
     ])
     watcher = pi_activity.SessionWatcher(tmp_path, now=lambda: 1_000_000.0)
     state = watcher.poll()
-    assert state["events"] == 4
+    assert state["events"] == 6
     assert state["action"] is None
     assert state["result"] is None
-    assert state["phase"] == "starting"
+    # Issue #176: the user record (even with malformed content) is the
+    # first-request milestone; the session exists, no first response.
+    assert state["first_request"] is True
+    assert state["first_response"] is False
+    assert state["phase"] == "request_pending"
 
 
 def test_watcher_handles_malformed_tool_call_items(tmp_path):

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -62,6 +62,50 @@ sys.stderr.write("pi exploded")
 sys.exit(3)
 """
 
+# The startup-scene fake pi (Issue #176): like FAKE_PI it plans and
+# commits, but it ALSO writes a full session JSONL (session, the model
+# Pi selected, the first request, the first response) with fresh
+# timestamps — the real record order of Pi 0.84.3 — so the runner's
+# startup milestones fire on the real Runner path.
+FAKE_PI_STARTUP = """#!/usr/bin/env python3
+import json, os, re, subprocess, sys
+from datetime import datetime, timezone
+args = sys.argv[1:]
+prompt = args[args.index("--system-prompt") + 1]
+run_id = re.search(r"Run id: `([0-9a-f]{8})`", prompt).group(1)
+cwd = os.getcwd()
+session_dir = os.path.join(cwd, ".pi-session")
+os.makedirs(session_dir, exist_ok=True)
+now = datetime.now(timezone.utc).isoformat()
+records = [
+    {"type": "session", "id": f"e2e-{run_id}", "timestamp": now,
+     "cwd": cwd},
+    {"type": "model_change", "id": "m1", "timestamp": now,
+     "provider": "local-qwen", "modelId": "qwen3.8:27b"},
+    {"type": "message", "id": "u1", "timestamp": now,
+     "message": {"role": "user",
+                 "content": [{"type": "text", "text": "prompt"}]}},
+    {"type": "message", "id": "a1", "timestamp": now,
+     "message": {"role": "assistant",
+                 "content": [{"type": "text", "text": "done"}]}},
+]
+with open(os.path.join(session_dir, "s.jsonl"), "a", encoding="utf-8") as handle:
+    for record in records:
+        handle.write(json.dumps(record) + "\\n")
+plan = (
+    f"<!-- muyan-pilot:run={run_id} -->\\n"
+    f"# Plan\\n\\nrun_id={run_id}\\n"
+)
+with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+    handle.write(plan)
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", f"plan for run {run_id}"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+sys.stdout.write("done")
+"""
+
 
 def git(repo: Path, *args: str) -> str:
     result = subprocess.run(
@@ -489,6 +533,54 @@ def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
     # The delivery finished: the in-progress label is gone.
     assert "ai-in-progress" not in labels[ISSUE_NUMBER]
     assert "ai-pr-opened" in labels[ISSUE_NUMBER]
+
+
+def test_e2e_startup_sequence_visible_in_journal(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """Issue #176: a run stuck at `starting` must be locatable to its
+    startup sub-phase from the journal alone. The REAL Runner path
+    (process_issue -> run_pi -> stream_pi) logs the full startup
+    sequence in order — every line carrying the run id — and a healthy
+    run never logs `startup_failed`."""
+    comments: list[str] = []
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_STARTUP)
+    install_fake_gh(monkeypatch, comments)
+    caplog.set_level("INFO")
+
+    pr_url = runner.process_issue(issue(), config_for(clone, tmp_path), REPO)
+    assert pr_url == PR_URL
+    run_id = runner.current_run_id()
+
+    lines = [m for m in caplog.messages if m.startswith(f"[{run_id}]")]
+    kinds = (
+        "provider_config_loaded", "process_spawned", "run_start",
+        "session_created", "first_request_started",
+        "first_response_received",
+    )
+    positions = {}
+    for kind in kinds:
+        matches = [i for i, m in enumerate(lines) if f" {kind} " in m]
+        assert len(matches) == 1, f"{kind}: {matches}"
+        positions[kind] = matches[0]
+    # The sequence is strictly ordered: the provider config is resolved
+    # before the spawn, the session milestones follow the scene line.
+    assert (positions["provider_config_loaded"]
+            < positions["process_spawned"]
+            < positions["run_start"]
+            < positions["session_created"]
+            < positions["first_request_started"]
+            < positions["first_response_received"])
+    # The real selection (the session's model_change record) is visible
+    # on the milestone lines.
+    requested = lines[positions["first_request_started"]]
+    responded = lines[positions["first_response_received"]]
+    assert "provider=local-qwen" in requested
+    assert "model=qwen3.8:27b" in requested
+    assert "provider=local-qwen" in responded
+    assert "model=qwen3.8:27b" in responded
+    # A healthy startup never reports a startup failure.
+    assert not any(" startup_failed " in m for m in lines)
 
 
 def test_fake_gh_tracks_labels_for_the_resume_scan(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- muyan-pilot:run=af947988 -->

Fixes #176

增强 Runner 启动阶段可观测性：定位 starting 卡点 (run_id=af947988)
