### PR TITLE
Runner: model_wait 回收后未处理 RuntimeError 使 service 失败并阻塞任务

### DIFF
--- a/src/muyan_pilot/runner.py
+++ b/src/muyan_pilot/runner.py
@@ -252,6 +252,22 @@ TRUSTED_COMMENT_ASSOCIATIONS = frozenset({
 })
 
 
+class ModelWaitDeadError(RuntimeError):
+    """The hung-model-request recovery (Issue #218/#228) killed the Pi
+    session: the model request is HUNG (the model service process is alive
+    but the request never completes, the session JSONL froze in
+    `model_wait` past `model_wait_dead_seconds`).
+
+    This is a CLASSIFIED, AI-recoverable delivery failure (Issue #227):
+    the worktree keeps the interrupted work and the run state file is
+    intact, so `process_issue` keeps the Issue `ai-in-progress` and the
+    next tick's in-flight restart scan resumes the SAME run (same run id,
+    branch, worktree, progress comment). It is never `ai-blocked` and
+    never an unclassified top-level exception: the recovery stays
+    fail-fast (Pi killed, the slot released by the tick ending) but its
+    terminal outcome goes through the recoverable delivery path."""
+
+
 class UnrecoverableDeliveryError(RuntimeError):
     """A delivery failure that is an EXTERNAL precondition the AI cannot
     safely judge or fix (Issue #50).
@@ -3881,7 +3897,10 @@ def stream_pi(
             ),
             stale,
         )
-        raise RuntimeError(
+        # Issue #227: the classified hung-model-request failure —
+        # `process_issue` keeps the Issue `ai-in-progress` (the next tick
+        # resumes the same run) instead of the terminal `ai-blocked`.
+        raise ModelWaitDeadError(
             f"Pi is stuck in model_wait with a frozen session for {stale}: "
             "the model request is hung (the model service process is "
             "alive but the request never completes); Pi was killed "
@@ -6230,6 +6249,46 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
             ),
         )
         return pr_url
+    except ModelWaitDeadError as exc:
+        # Issue #227: the hung-model-request recovery is a CLASSIFIED,
+        # AI-recoverable failure — NOT the terminal `ai-blocked`. The
+        # worktree keeps the interrupted work and the run state file is
+        # intact, so the Issue keeps `ai-in-progress`: the next tick's
+        # in-flight restart scan (`pick_in_progress_issue`) resumes the
+        # SAME run (same run id, branch, worktree, progress comment).
+        # The recovery stays fail-fast (Pi was killed, the tick ends
+        # cleanly below, the slot is released by `main`'s `finally`);
+        # only the label outcome changes — never `ai-blocked`.
+        LOGGER.exception("issue=%s model_wait_dead_recovered", number)
+        detail = _failure_detail(exc)
+        body = (
+            f"{run_marker(run_id)}\n"
+            f"Muyan Pilot model_wait recovered: {detail}; the run is "
+            "recoverable — the Issue stays ai-in-progress and the next "
+            f"tick resumes the same run ({run_info})"
+        )
+        # The scene comment is the main delivery record (not a bypass):
+        # a failure here propagates to the generic handler below, which
+        # still ends the tick cleanly (the recovery label outcome — keep
+        # `ai-in-progress`, never `ai-blocked` — is already the contract).
+        comment_issue(number, repo=source_repo, body=body)
+        _safe_publish(
+            run_id=run_id, issue=number, source_repo=source_repo,
+            role=ROLE_IMPLEMENT,
+            action=lambda: publisher.finish(_progress_body(_progress_state(
+                issue=number, title=title, run_id=run_id,
+                role=ROLE_IMPLEMENT, branch=branch,
+                worktree=worktree, started=started,
+                pr_url=None, review_round=0, priority=priority,
+            ), outcome=(
+                "**Muyan Pilot model_wait recovered**\n\n"
+                f"failure: {detail}\n"
+                "next step: nothing — the Issue stays ai-in-progress "
+                "and the next tick resumes the same run (same run id, "
+                "branch, worktree)"
+            ))),
+        )
+        return None
     except Exception as exc:
         LOGGER.exception("issue=%s failed", number)
         scene = ""

--- a/src/muyan_pilot/runner.py
+++ b/src/muyan_pilot/runner.py
@@ -6267,11 +6267,19 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
             "recoverable — the Issue stays ai-in-progress and the next "
             f"tick resumes the same run ({run_info})"
         )
-        # The scene comment is the main delivery record (not a bypass):
-        # a failure here propagates to the generic handler below, which
-        # still ends the tick cleanly (the recovery label outcome — keep
-        # `ai-in-progress`, never `ai-blocked` — is already the contract).
-        comment_issue(number, repo=source_repo, body=body)
+        # The recovery comment is the delivery record, but the resume
+        # does not parse it (the run state file, the worktree and the
+        # `ai-in-progress` label carry the resume —
+        # `worktree_resume_scene`): a failure here must only log.
+        # Falling through to the generic handler below would mark the
+        # Issue `ai-blocked` — exactly the unrecoverable state Issue
+        # #227 forbids for this recovery.
+        try:
+            comment_issue(number, repo=source_repo, body=body)
+        except Exception:
+            LOGGER.exception(
+                "issue=%s model_wait_recovered_comment_failed", number,
+            )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_IMPLEMENT,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4126,22 +4126,20 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
     assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked[0]
 
 
-def test_process_issue_model_wait_dead_failure_marks_blocked(
+def test_process_issue_model_wait_dead_failure_stays_in_progress(
     monkeypatch, tmp_path,
 ):
-    """Issue #218 acceptance: the hung-model-request failure of the
+    """Issue #227 acceptance: the hung-model-request failure of the
     implementer session (the model service process is alive but the
     request never completes, the session JSONL froze in model_wait,
-    stream_pi killed Pi and raised) flows through the NORMAL failure
-    path: the Issue is marked `ai-blocked` (removing
-    `ai-in-progress`), the `Muyan Pilot failed` comment carries the
-    hung-model-request reason and the run marker (the scene stays in
-    the Issue), and `process_issue` returns `None` so the tick ends
-    cleanly and the slot is released by `main`'s `finally` (Issue
-    #239: the handled failure never re-raises to crash the service). The
-    next tick resumes the SAME run (the restart-resume scan reuses the
-    newest worktree's run id) or claims the next ready Issue. No
-    special handling, no fallback."""
+    stream_pi killed Pi and raised the classified `ModelWaitDeadError`)
+    is RECOVERABLE: the Issue keeps `ai-in-progress` (never `ai-blocked`),
+    the `Muyan Pilot model_wait recovered` comment carries the
+    hung-model-request reason and the run marker, and `process_issue`
+    returns `None` so the tick ends cleanly and the slot is released by
+    `main`'s `finally`. The next tick's in-flight restart scan resumes
+    the SAME run (same run id, branch, worktree, progress comment). No
+    terminal label, no fallback."""
     calls = []
     monkeypatch.setattr(
         runner, "edit_issue",
@@ -4154,7 +4152,7 @@ def test_process_issue_model_wait_dead_failure_marks_blocked(
     monkeypatch.setattr(
         runner, "create_worktree", Mock(return_value=tmp_path),
     )
-    model_wait_dead = RuntimeError(
+    model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m: "
         "the model request is hung (the model service process is alive "
         "but the request never completes); Pi was killed (Issue #218)"
@@ -4179,41 +4177,43 @@ def test_process_issue_model_wait_dead_failure_marks_blocked(
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    # The failure is terminal: `process_issue` returns `None` (no PR) and
-    # does NOT re-raise — the service must not crash on it (Issue #239).
+    # The failure is recoverable: `process_issue` returns `None` (no PR)
+    # and does NOT re-raise — the service must not crash on it (Issue
+    # #239), and the Issue must NOT be marked `ai-blocked` (Issue #227).
     assert runner.process_issue(
         {"number": 218, "title": "Model wait dead", "body": ""},
         {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
          "base_branch": "main"},
         "xqliu/muyan-pilot",
     ) is None
-    # The failure happened BEFORE the opened-PR transition: the
-    # terminal state removes the claim label (the edit calls are the
-    # dict entries; the `gh issue comment` traffic is tuple entries).
+    # The Issue keeps `ai-in-progress`: the ONLY label edit is the claim
+    # at the start — no `ai-blocked`, no removal of `ai-in-progress`
+    # (the edit calls are the dict entries; the `gh issue comment`
+    # traffic is tuple entries).
     edits = [entry for entry in calls if isinstance(entry, dict)]
     assert edits == [
         {"repo": "xqliu/muyan-pilot", "add": "ai-in-progress"},
-        {"repo": "xqliu/muyan-pilot", "add": "ai-blocked",
-         "remove": "ai-in-progress"},
     ]
     comment_bodies = [
         entry[2]["body"] for entry in calls
         if isinstance(entry, tuple) and entry[0] == "comment"
     ]
-    failure = [
+    recovered = [
         body for body in comment_bodies
-        if "Muyan Pilot failed:" in body
+        if "Muyan Pilot model_wait recovered:" in body
     ]
-    assert len(failure) == 1
+    assert len(recovered) == 1
     # The hung-model-request reason and the run marker stay in the
     # Issue.
-    assert "the model request is hung" in failure[0]
-    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in failure[0]
-    # The blocked milestone notification carries the same scene.
-    blocked = [body for body in posted if "Muyan Pilot: blocked" in body]
-    assert blocked
-    assert "the model request is hung" in blocked[0]
-    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in blocked[0]
+    assert "the model request is hung" in recovered[0]
+    assert "<!-- muyan-pilot:run=a1b2c3d4 -->" in recovered[0]
+    # The resumable scene is explicit: the Issue stays ai-in-progress
+    # and the next tick resumes the same run.
+    assert "stays ai-in-progress" in recovered[0]
+    # No terminal failure comment was posted.
+    assert not any(
+        "Muyan Pilot failed:" in body for body in comment_bodies
+    )
 
 
 def test_process_issue_idle_recovery_failure_marks_blocked(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4216,6 +4216,81 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
     )
 
 
+def test_process_issue_model_wait_dead_comment_failure_stays_in_progress(
+    monkeypatch, tmp_path,
+):
+    """Issue #227: the recovery scene comment is the delivery record,
+    but the resume does not parse it (the run state file, the worktree
+    and the `ai-in-progress` label carry the resume —
+    `worktree_resume_scene`): a failure of the comment must only log.
+    Falling through to the generic failure handler would mark the
+    Issue `ai-blocked` — exactly the unrecoverable state Issue #227
+    forbids for the model_wait recovery."""
+    calls = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    )
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(
+        runner, "create_worktree", Mock(return_value=tmp_path),
+    )
+    model_wait_dead = runner.ModelWaitDeadError(
+        "Pi is stuck in model_wait with a frozen session for 10m: "
+        "the model request is hung (the model service process is alive "
+        "but the request never completes); Pi was killed (Issue #218)"
+    )
+
+    def dead_run_pi(*args, **kwargs):
+        raise model_wait_dead
+
+    monkeypatch.setattr(runner, "run_pi", dead_run_pi)
+    monkeypatch.setattr(
+        runner, "activity_snapshot", lambda session_dir: None,
+    )
+    posted = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "list"]:
+            # Restart-resume scan (Issue #18): fresh claim, no label.
+            return "[]"
+        if (command[:3] == ["gh", "issue", "comment"]
+                and "model_wait recovered" in command[-1]):
+            raise RuntimeError(
+                "gh issue comment failed: API rate limit exceeded",
+            )
+        calls.append(("comment", (), {"body": command[-1]}))
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.process_issue(
+        {"number": 218, "title": "Model wait dead", "body": ""},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/muyan-pilot",
+    ) is None
+    # The Issue keeps `ai-in-progress`: the ONLY label edit is the claim
+    # at the start — the failed recovery comment must NOT fall through
+    # to the generic handler's terminal `ai-blocked` (Issue #227).
+    edits = [entry for entry in calls if isinstance(entry, dict)]
+    assert edits == [
+        {"repo": "xqliu/muyan-pilot", "add": "ai-in-progress"},
+    ]
+    # No terminal failure comment was posted.
+    comment_bodies = [
+        entry[2]["body"] for entry in calls
+        if isinstance(entry, tuple) and entry[0] == "comment"
+    ]
+    assert not any(
+        "Muyan Pilot failed:" in body for body in comment_bodies
+    )
+
+
 def test_process_issue_idle_recovery_failure_marks_blocked(
     monkeypatch, tmp_path,
 ):


### PR DESCRIPTION
<!-- muyan-pilot:run=1e289aae -->

Fixes #227

Runner: model_wait 回收后未处理 RuntimeError 使 service 失败并阻塞任务 (run_id=1e289aae)
