### PR TITLE
Bug：隔离 Runner 自有运行状态，避免 .muyan-pilot/ 被误判为 agent 未提交变更

### DIFF
--- a/src/muyan_pilot/runner.py
+++ b/src/muyan_pilot/runner.py
@@ -32,6 +32,7 @@ import math
 import os
 import re
 import select
+import shutil
 import signal
 import subprocess
 import tempfile
@@ -4093,6 +4094,10 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     prompt template itself is untouched; absent -> the exact
     pre-#219 context.
     """
+    # Issue #256: pin the Runner-owned runtime paths in the worktree's
+    # local exclude BEFORE Pi starts (covers create, resume and
+    # implement) — the tracked .gitignore is the agent's to rename.
+    apply_runner_runtime_excludes(worktree)
     started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
@@ -4344,6 +4349,123 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     return url
 
 
+# Runner-owned runtime paths inside a task worktree (Issue #256): created
+# by the parent Runner and the Pi session machinery, never by the agent's
+# delivery. The task branch's tracked `.gitignore` must NOT be the thing
+# that keeps them out of the delivery commit boundary — a task may legally
+# rename that file (the #246 brand-rename scene, run `b879a88c`), so the
+# Runner pins its own runtime paths in the worktree's LOCAL git exclude
+# (`.git/info/exclude`): git metadata that never enters an agent commit and
+# never depends on the task branch's content. The migration window keeps
+# BOTH the legacy state dir (`.muyan-pilot/`) and the renamed one
+# (`.orbi/`) excluded until the old runner/unit can no longer write the
+# legacy path.
+RUNNER_RUNTIME_EXCLUDES = (".muyan-pilot/", ".orbi/", ".pi-session/")
+
+
+def runner_runtime_exclude_path(worktree: Path) -> Path:
+    """The task worktree's local git exclude file (`.git/info/exclude`).
+
+    A linked worktree's `.git` is a pointer file (`gitdir: <path>`); the
+    exclude must live in THAT worktree-specific gitdir, so each task
+    worktree gets its own exclude file. The main checkout and the user's
+    global excludes are never touched.
+    """
+    git_entry = worktree / ".git"
+    if git_entry.is_file():
+        for line in git_entry.read_text(encoding="utf-8").splitlines():
+            if line.startswith("gitdir:"):
+                git_dir = Path(line.split(":", 1)[1].strip())
+                return git_dir / "info" / "exclude"
+        raise ValueError(
+            f"worktree .git pointer {git_entry} has no gitdir entry"
+        )
+    return git_entry / "info" / "exclude"
+
+
+def apply_runner_runtime_excludes(worktree: Path) -> None:
+    """Idempotently pin the Runner-owned runtime paths in the worktree's
+    local git exclude (Issue #256).
+
+    Existing exclude content (including user-written patterns) is
+    preserved verbatim; a pattern already present is never written twice.
+    Called before every Pi launch (implement, resume, review) and before
+    the delivery commit-boundary check. A directory without a `.git`
+    entry (unit-test tmp dirs) is a no-op: the delivery commit boundary
+    still fails fast on a real corrupted scene.
+    """
+    git_entry = worktree / ".git"
+    if not git_entry.exists():
+        LOGGER.debug(
+            "runner_runtime_exclude_skipped worktree=%s (no .git entry)",
+            worktree,
+        )
+        return
+    exclude_path = runner_runtime_exclude_path(worktree)
+    existing = ""
+    if exclude_path.is_file():
+        existing = exclude_path.read_text(encoding="utf-8")
+    present = {line.strip() for line in existing.splitlines()}
+    missing = [p for p in RUNNER_RUNTIME_EXCLUDES if p not in present]
+    if not missing:
+        return
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = "\n" if existing and not existing.endswith("\n") else ""
+    exclude_path.write_text(
+        existing + prefix + "\n".join(missing) + "\n", encoding="utf-8",
+    )
+
+
+def _is_runner_runtime_only(status: str) -> bool:
+    """True when EVERY non-empty porcelain entry is a Runner-owned runtime
+    path (Issue #256): the delivery repair may then continue; any
+    agent-owned entry keeps the `delivery_uncommitted_changes` fail fast."""
+    entries = [line for line in status.splitlines() if line.strip()]
+    if not entries:
+        return False
+    for line in entries:
+        path = line[3:].strip()
+        if path.startswith('"') and path.endswith('"'):
+            # Porcelain quotes paths with special characters; the runner
+            # paths are plain ASCII, so an unquoted match is exact.
+            path = path[1:-1]
+        if not any(
+            path == pattern.strip("/") or path.startswith(pattern)
+            for pattern in RUNNER_RUNTIME_EXCLUDES
+        ):
+            return False
+    return True
+
+
+def cleanup_task_worktree(worktree: Path, repo_dir: Path, *, run_id: str,
+                          issue: int) -> None:
+    """Remove a terminally failed task's worktree and Runner state
+    (Issue #256).
+
+    Called ONLY on the terminal `ai-blocked` outcome AFTER the Issue
+    evidence (journal line + `Muyan Pilot failed` comment) is recorded.
+    A retry generates a NEW run id and a NEW worktree, so the terminal
+    scene is never needed again; the recoverable `ai-fix-needed` /
+    model_wait paths keep the worktree for the same-run resume and must
+    never call this. A cleanup failure is logged as
+    `worktree_cleanup_failed` — never swallowed, never re-raised (the
+    tick already handled the delivery failure).
+    """
+    try:
+        if worktree.is_dir():
+            shutil.rmtree(worktree)
+        run_command(["git", "worktree", "prune"], cwd=repo_dir)
+        LOGGER.info(
+            "worktree_cleaned issue=%s run_id=%s worktree=%s",
+            issue, run_id, worktree,
+        )
+    except Exception as exc:
+        LOGGER.exception(
+            "worktree_cleanup_failed issue=%s run_id=%s worktree=%s: %s",
+            issue, run_id, worktree, exc,
+        )
+
+
 def deliver_pr(worktree: Path, branch: str, base_branch: str,
                base_sha: str, run_id: str, *, issue: int,
                issue_title: str, repo_dir: Path) -> str:
@@ -4377,11 +4499,24 @@ def deliver_pr(worktree: Path, branch: str, base_branch: str,
         raise RuntimeError(
             f"Pi changed branch: expected={branch} actual={current_branch}"
         )
-    # Commit boundary (Issue #186): the Agent's delivery is the
-    # committed worktree state. Uncommitted changes stay uncommitted —
-    # the Runner never commits them and never expands the Agent's
-    # commit boundary; a dirty worktree is a delivery failure.
+    # Commit boundary (Issue #186 + #256): the Agent's delivery is the
+    # committed worktree state. The Runner-owned runtime paths are
+    # pinned in the worktree's LOCAL exclude BEFORE the check, so a task
+    # that renamed the tracked .gitignore (the #246 scene) cannot make
+    # the Runner's own state look like agent leftovers.
+    apply_runner_runtime_excludes(worktree)
     dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    if dirty and _is_runner_runtime_only(dirty):
+        # Only Runner-owned runtime paths remain (the exclude write raced
+        # or the path appeared after it): re-write the exclude and
+        # re-check. The repair is deterministic — no git add, no
+        # deletion, no arbitrary whitelisting.
+        apply_runner_runtime_excludes(worktree)
+        LOGGER.info(
+            "runner_runtime_exclude_repaired branch=%s status=%s",
+            branch, " ".join(dirty.splitlines()),
+        )
+        dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
     if dirty:
         LOGGER.error(
             "delivery_uncommitted_changes branch=%s status=%s",
@@ -4857,6 +4992,9 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     Issue #41: one run_id end to end, the roles are steps of the same
     run).
     """
+    # Issue #256: the review/fix session gets the SAME local-exclude
+    # preflight as the implementer (one idempotent helper, Pi 前).
+    apply_runner_runtime_excludes(worktree)
     started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt_review"].read_text(encoding="utf-8"),
@@ -6318,6 +6456,12 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
                 )
             except Exception:
                 LOGGER.exception("issue=%s activity scene failed", number)
+        # Issue #256: the terminal worktree cleanup is gated on the
+        # `ai-blocked` transition ACTUALLY reaching GitHub — a simulated
+        # kill (the failure path's label edit never lands) leaves the
+        # Issue recoverable (ai-in-progress), so the scene must be kept
+        # for the same-run resume.
+        blocked_transition_done = False
         try:
             # The claim label is removed on every failure; when the
             # delivery already made the opened-PR transition (the
@@ -6331,6 +6475,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
                     PR_OPENED_LABEL if pr_opened else IN_PROGRESS_LABEL
                 ),
             )
+            blocked_transition_done = True
             detail = _failure_detail(exc)
             body = (
                 f"{run_marker(run_id)}\n"
@@ -6374,6 +6519,20 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
                 )
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)
+        else:
+            # Issue #256: the terminal evidence is recorded (journal +
+            # `Muyan Pilot failed` comment) and the Issue is genuinely
+            # `ai-blocked` — the scene is never needed again (a retry
+            # gets a new run id and worktree), so clean it up. The
+            # recoverable paths (ModelWaitDeadError, ai-fix-needed) and
+            # the simulated-kill scene (blocked transition never landed)
+            # never reach this branch — the worktree is kept for the
+            # same-run resume.
+            if worktree is not None and blocked_transition_done:
+                cleanup_task_worktree(
+                    worktree, config["repo_dir"], run_id=run_id,
+                    issue=number,
+                )
         # Issue #239: the failure is terminal — the Issue is `ai-blocked`
         # and the `Muyan Pilot failed` comment is posted above. Returning
         # `None` ends the tick cleanly: `main` skips the delivery wait

--- a/src/muyan_pilot/runner.py
+++ b/src/muyan_pilot/runner.py
@@ -4366,17 +4366,23 @@ RUNNER_RUNTIME_EXCLUDES = (".muyan-pilot/", ".orbi/", ".pi-session/")
 def runner_runtime_exclude_path(worktree: Path) -> Path:
     """The task worktree's local git exclude file (`.git/info/exclude`).
 
-    A linked worktree's `.git` is a pointer file (`gitdir: <path>`); the
-    exclude must live in THAT worktree-specific gitdir, so each task
-    worktree gets its own exclude file. The main checkout and the user's
-    global excludes are never touched.
+    A linked worktree's `.git` is a pointer file (`gitdir: <path>`) that
+    resolves to `<common-gitdir>/worktrees/<name>`. Git applies the
+    exclude file of the COMMON gitdir to every worktree of the repo (the
+    worktree-specific gitdir carries no exclude of its own — verified
+    against real git), so the exclude is written to
+    `<common-gitdir>/info/exclude`. That is repository-local metadata:
+    it never enters an agent commit and never touches the user's global
+    excludes (`core.excludesFile`).
     """
     git_entry = worktree / ".git"
     if git_entry.is_file():
         for line in git_entry.read_text(encoding="utf-8").splitlines():
             if line.startswith("gitdir:"):
                 git_dir = Path(line.split(":", 1)[1].strip())
-                return git_dir / "info" / "exclude"
+                # <common-gitdir>/worktrees/<name> -> <common-gitdir>
+                common_gitdir = git_dir.parent.parent
+                return common_gitdir / "info" / "exclude"
         raise ValueError(
             f"worktree .git pointer {git_entry} has no gitdir entry"
         )

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13544,3 +13544,30 @@ def test_runner_runtime_only_accepts_quoted_runner_paths():
     # are plain ASCII, so the unquoted match is exact.
     assert runner._is_runner_runtime_only('?? ".muyan-pilot/"\n')
     assert runner._is_runner_runtime_only('?? ".pi-session/"\n')
+
+
+def test_exclude_path_for_a_plain_checkout_uses_its_own_git_dir(tmp_path):
+    # A worktree whose `.git` is a DIRECTORY (a plain checkout, not a
+    # linked worktree): the exclude is its own `.git/info/exclude`.
+    wt = tmp_path / "checkout"
+    (wt / ".git").mkdir(parents=True)
+    exclude = runner.runner_runtime_exclude_path(wt)
+    assert exclude == wt / ".git" / "info" / "exclude"
+
+
+def test_runner_runtime_only_rejects_an_empty_status():
+    # An empty status is not "runner-only" — the repair must not fire on
+    # a clean worktree.
+    assert runner._is_runner_runtime_only("") is False
+    assert runner._is_runner_runtime_only("\n") is False
+
+
+def test_cleanup_task_worktree_prunes_without_a_scene(tmp_path):
+    # The worktree directory is already gone (a partial failure): the
+    # cleanup still prunes the git metadata and logs success.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    missing = tmp_path / "already-gone"
+    runner.cleanup_task_worktree(missing, repo, run_id="abc12345", issue=4)
+    assert not missing.exists()

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4017,6 +4017,9 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4090,6 +4093,9 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4173,6 +4179,9 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4336,6 +4345,9 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4717,6 +4729,9 @@ def test_process_issue_failure_without_session_still_carries_scene(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4753,6 +4768,9 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4798,6 +4816,9 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[:3] == ["git", "worktree", "prune"]:
+            # Issue #256 terminal cleanup — not a delivery comment.
+            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -13292,3 +13313,231 @@ def test_deliver_pr_verifies_the_pr_with_the_latest_base_check_skipped(
     # Exactly one fetch (the deliver fetch); nothing after the push.
     assert len(fetches) == 1
     assert fetches[0] < push
+
+
+# --- Issue #256: Runner-owned runtime state isolation ----------------------
+
+
+def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A real git repo plus one linked task worktree (the exact shape
+    `create_worktree` produces: `.git` is a pointer file)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "t@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "test"], check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "base"],
+        check=True,
+    )
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "-C", str(repo), "worktree", "add", "-b", "task",
+         str(wt), "HEAD"],
+        check=True,
+    )
+    return repo, wt
+
+
+def test_exclude_path_resolves_the_linked_worktree_gitdir(tmp_path):
+    repo, wt = _make_linked_worktree(tmp_path)
+    exclude = runner.runner_runtime_exclude_path(wt)
+    assert exclude.name == "exclude"
+    assert exclude.parts[-2] == "info"
+    # The linked worktree's exclude lives in the shared repo's gitdir,
+    # never in the worktree checkout itself.
+    assert exclude.is_relative_to(repo / ".git")
+    assert not exclude.is_relative_to(wt)
+
+
+def test_apply_runner_runtime_excludes_writes_all_patterns(tmp_path):
+    _, wt = _make_linked_worktree(tmp_path)
+    runner.apply_runner_runtime_excludes(wt)
+    lines = runner.runner_runtime_exclude_path(wt).read_text(
+        encoding="utf-8",
+    ).splitlines()
+    for pattern in runner.RUNNER_RUNTIME_EXCLUDES:
+        assert pattern in lines
+
+
+def test_apply_runner_runtime_excludes_is_idempotent(tmp_path):
+    _, wt = _make_linked_worktree(tmp_path)
+    runner.apply_runner_runtime_excludes(wt)
+    first = runner.runner_runtime_exclude_path(wt).read_text(encoding="utf-8")
+    runner.apply_runner_runtime_excludes(wt)
+    second = runner.runner_runtime_exclude_path(wt).read_text(encoding="utf-8")
+    assert first == second
+    lines = second.splitlines()
+    assert len(lines) == len(set(lines)), "patterns must not be duplicated"
+
+
+def test_apply_runner_runtime_excludes_preserves_user_content(tmp_path):
+    _, wt = _make_linked_worktree(tmp_path)
+    exclude = runner.runner_runtime_exclude_path(wt)
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    exclude.write_text("# my custom exclude\nsecrets-local/\n", encoding="utf-8")
+    runner.apply_runner_runtime_excludes(wt)
+    text = exclude.read_text(encoding="utf-8")
+    assert "# my custom exclude" in text
+    assert "secrets-local/" in text
+    assert ".muyan-pilot/" in text
+    assert ".pi-session/" in text
+
+
+def test_apply_runner_runtime_excludes_without_git_is_a_noop(tmp_path):
+    wt = tmp_path / "not-a-worktree"
+    wt.mkdir()
+    runner.apply_runner_runtime_excludes(wt)  # must not raise
+    assert not (wt / ".git").exists()
+    assert not list(wt.iterdir())
+
+
+def test_run_pi_applies_runner_runtime_excludes_before_pi(monkeypatch, tmp_path):
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("SYSTEM", encoding="utf-8")
+    applied: list[Path] = []
+    monkeypatch.setattr(
+        runner, "apply_runner_runtime_excludes",
+        lambda worktree: applied.append(worktree),
+    )
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "done")
+    config = {
+        "prompt": prompt_path, "repo_dir": tmp_path,
+        "source_repos": ["owner/repo"], "workspace_root": tmp_path,
+        "context_files": [], "skills": [], "base_branch": "main",
+        "base_sha": "abc123def456", "run_id": "run1",
+    }
+    runner.run_pi(
+        {"number": 5, "title": "t", "body": "b"}, tmp_path, config,
+        "owner/repo",
+    )
+    assert applied == [tmp_path]
+
+
+def test_run_review_applies_runner_runtime_excludes_before_pi(
+    monkeypatch, tmp_path,
+):
+    prompt_path = tmp_path / "prompt_review.md"
+    prompt_path.write_text("REVIEW", encoding="utf-8")
+    applied: list[Path] = []
+    monkeypatch.setattr(
+        runner, "apply_runner_runtime_excludes",
+        lambda worktree: applied.append(worktree),
+    )
+    monkeypatch.setattr(runner, "stream_pi", lambda command, **kwargs: "ok")
+    runner.run_review(
+        tmp_path,
+        {"number": 4, "url": "https://x/pull/4", "base_oid": "b1",
+         "head_oid": "h1", "head_ref": "h"},
+        {
+            "prompt_review": prompt_path, "repo_dir": tmp_path / "checkout",
+            "source_repos": ["owner/repo"], "base_branch": "main",
+            "run_id": "a1b2c3d4", "skills": [],
+        },
+        "owner/repo", 4, "branch", 1,
+    )
+    assert applied == [tmp_path]
+
+
+def test_deliver_pr_repairs_runner_runtime_leftovers(monkeypatch, tmp_path,
+                                                     caplog):
+    """The #246 scene: the task renamed the tracked .gitignore away from
+    `.muyan-pilot/`, but the parent Runner still created it. The delivery
+    applies the local exclude, repairs, logs
+    `runner_runtime_exclude_repaired`, and continues — no
+    `delivery_uncommitted_changes`."""
+    status_calls = {"n": 0}
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "status", "--porcelain"]:
+            status_calls["n"] += 1
+            # First check: the Runner's own state looks untracked. After
+            # the exclude repair the re-check is clean.
+            return "?? .muyan-pilot/\n" if status_calls["n"] == 1 else ""
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level(logging.INFO, logger="muyan_pilot.bootstrap"):
+        url = runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+    assert url == FAKE_PR_URL
+    assert "runner_runtime_exclude_repaired" in caplog.text
+    assert "delivery_uncommitted_changes" not in caplog.text
+    assert status_calls["n"] == 2
+
+
+def test_deliver_pr_repairs_the_renamed_state_dir_too(monkeypatch, tmp_path,
+                                                      caplog):
+    """Migration window: the renamed state dir `.orbi/` is Runner-owned
+    as well and must be repaired, not failed."""
+    status_calls = {"n": 0}
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "status", "--porcelain"]:
+            status_calls["n"] += 1
+            return "?? .orbi/\n" if status_calls["n"] == 1 else ""
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level(logging.INFO, logger="muyan_pilot.bootstrap"):
+        url = runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+    assert url == FAKE_PR_URL
+    assert "runner_runtime_exclude_repaired" in caplog.text
+
+
+def test_deliver_pr_still_fails_on_agent_leftovers_alongside_runner_state(
+    monkeypatch, tmp_path,
+):
+    """Runner state plus a REAL agent leftover: the repair must not mask
+    the agent's uncommitted code — `delivery_uncommitted_changes` stands."""
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return " M src/app.py\n?? .muyan-pilot/\n?? foo.py\n"
+        return fake_deliver_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="uncommitted changes"):
+        runner.deliver_pr(
+            tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
+            issue=4, issue_title="t", repo_dir=tmp_path,
+        )
+
+
+def test_cleanup_task_worktree_removes_the_scene_and_prunes(tmp_path):
+    repo, wt = _make_linked_worktree(tmp_path)
+    (wt / ".muyan-pilot").mkdir(parents=True)
+    (wt / ".pi-session").mkdir(parents=True)
+    runner.cleanup_task_worktree(wt, repo, run_id="abc12345", issue=4)
+    assert not wt.exists()
+    listing = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert str(wt) not in listing
+
+
+def test_cleanup_task_worktree_logs_failure_and_keeps_the_scene(
+    monkeypatch, tmp_path, caplog,
+):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(runner.shutil, "rmtree", boom)
+    with caplog.at_level(logging.ERROR, logger="muyan_pilot.bootstrap"):
+        runner.cleanup_task_worktree(wt, tmp_path, run_id="abc12345", issue=4)
+    assert "worktree_cleanup_failed" in caplog.text
+    assert wt.exists(), "a failed cleanup must never claim the scene is gone"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4017,9 +4017,6 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
-        if command[:3] == ["git", "worktree", "prune"]:
-            # Issue #256 terminal cleanup — not a delivery comment.
-            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4093,9 +4090,6 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
-        if command[:3] == ["git", "worktree", "prune"]:
-            # Issue #256 terminal cleanup — not a delivery comment.
-            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4179,9 +4173,6 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
-        if command[:3] == ["git", "worktree", "prune"]:
-            # Issue #256 terminal cleanup — not a delivery comment.
-            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -4345,9 +4336,6 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
-        if command[:3] == ["git", "worktree", "prune"]:
-            # Issue #256 terminal cleanup — not a delivery comment.
-            return ""
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -13541,3 +13529,18 @@ def test_cleanup_task_worktree_logs_failure_and_keeps_the_scene(
         runner.cleanup_task_worktree(wt, tmp_path, run_id="abc12345", issue=4)
     assert "worktree_cleanup_failed" in caplog.text
     assert wt.exists(), "a failed cleanup must never claim the scene is gone"
+
+
+def test_exclude_path_rejects_a_pointer_without_gitdir(tmp_path):
+    wt = tmp_path / "wt"
+    (wt / ".git").parent.mkdir(parents=True, exist_ok=True)
+    (wt / ".git").write_text("# not a real pointer\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="no gitdir entry"):
+        runner.runner_runtime_exclude_path(wt)
+
+
+def test_runner_runtime_only_accepts_quoted_runner_paths():
+    # Porcelain quotes paths with special characters; the runner paths
+    # are plain ASCII, so the unquoted match is exact.
+    assert runner._is_runner_runtime_only('?? ".muyan-pilot/"\n')
+    assert runner._is_runner_runtime_only('?? ".pi-session/"\n')

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13332,14 +13332,16 @@ def _make_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
     return repo, wt
 
 
-def test_exclude_path_resolves_the_linked_worktree_gitdir(tmp_path):
+def test_exclude_path_resolves_the_common_gitdir(tmp_path):
     repo, wt = _make_linked_worktree(tmp_path)
     exclude = runner.runner_runtime_exclude_path(wt)
     assert exclude.name == "exclude"
     assert exclude.parts[-2] == "info"
-    # The linked worktree's exclude lives in the shared repo's gitdir,
-    # never in the worktree checkout itself.
-    assert exclude.is_relative_to(repo / ".git")
+    # Git applies the exclude of the COMMON gitdir to every worktree of
+    # the repo (the worktree-specific gitdir carries none of its own):
+    # the exclude is the shared repo's `.git/info/exclude`, never inside
+    # the worktree checkout.
+    assert exclude == repo / ".git" / "info" / "exclude"
     assert not exclude.is_relative_to(wt)
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13582,7 +13582,9 @@ def test_apply_runner_runtime_excludes_creates_a_missing_exclude_file(
     # creates the file with exactly the runner-owned patterns.
     repo, wt = _make_linked_worktree(tmp_path)
     exclude = repo / ".git" / "info" / "exclude"
-    assert not exclude.exists()
+    # `git init` ships a default exclude file (comments only); remove it
+    # so this drives the file-creation branch.
+    exclude.unlink()
     runner.apply_runner_runtime_excludes(wt)
     lines = exclude.read_text(encoding="utf-8").splitlines()
     assert lines == list(runner.RUNNER_RUNTIME_EXCLUDES)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13573,3 +13573,16 @@ def test_cleanup_task_worktree_prunes_without_a_scene(tmp_path):
     missing = tmp_path / "already-gone"
     runner.cleanup_task_worktree(missing, repo, run_id="abc12345", issue=4)
     assert not missing.exists()
+
+
+def test_apply_runner_runtime_excludes_creates_a_missing_exclude_file(
+    tmp_path,
+):
+    # The common gitdir exists but has no info/exclude yet: the helper
+    # creates the file with exactly the runner-owned patterns.
+    repo, wt = _make_linked_worktree(tmp_path)
+    exclude = repo / ".git" / "info" / "exclude"
+    assert not exclude.exists()
+    runner.apply_runner_runtime_excludes(wt)
+    lines = exclude.read_text(encoding="utf-8").splitlines()
+    assert lines == list(runner.RUNNER_RUNTIME_EXCLUDES)

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -311,10 +311,15 @@ def run_first_attempt(monkeypatch, tmp_path: Path, clone: Path,
 
     def claiming_edit(number, **kwargs):
         # Only the claim edit reaches GitHub before the kill; the
-        # failure path's label transition never happens.
+        # failure path's label transition never happens. The blocked
+        # edit RAISING (Issue #256) is what keeps the Issue recoverable
+        # (ai-in-progress) — the terminal worktree cleanup is gated on
+        # the ai-blocked transition actually landing.
         if kwargs.get("add") == "ai-in-progress" \
                 and kwargs.get("remove") is None:
             real_edit_issue(number, **kwargs)
+            return
+        raise AssertionError("kill simulation: label edit must not land")
 
     monkeypatch.setattr(runner, "edit_issue", claiming_edit)
     # Issue #239: the failure path runs (the `claiming_edit` above

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -457,10 +457,11 @@ def test_e2e_failed_attempt_marks_blocked_with_same_run_id(
     for message in caplog.messages:
         assert message.startswith("[a1b2c3d4]"), message
 
-    # The run-scoped worktree (session scene) is preserved for inspection.
+    # Issue #256: the attempt is terminally `ai-blocked` — the scene is
+    # never needed again (a retry gets a new run id and worktree), so
+    # the run-scoped worktree is cleaned, not preserved.
     worktree = worktree_for(clone, "a1b2c3d4")
-    assert worktree.is_dir()
-    assert (worktree / ".pi-session").is_dir()
+    assert not worktree.is_dir()
 
 
 def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
@@ -486,10 +487,15 @@ def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
 
     def claiming_edit(number, **kwargs):
         # Only the claim edit reaches GitHub before the kill; the
-        # failure path's label removal never happens.
+        # failure path's label removal never happens. The blocked edit
+        # RAISING (Issue #256) is what keeps the Issue recoverable
+        # (ai-in-progress) — the terminal worktree cleanup is gated on
+        # the ai-blocked transition actually landing.
         if kwargs.get("add") == "ai-in-progress" \
                 and kwargs.get("remove") is None:
             real_edit_issue(number, **kwargs)
+            return
+        raise AssertionError("kill simulation: label edit must not land")
 
     monkeypatch.setattr(runner, "edit_issue", claiming_edit)
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")


### PR DESCRIPTION
<!-- muyan-pilot:run=c9904f3d -->

Fixes #256

Bug：隔离 Runner 自有运行状态，避免 .muyan-pilot/ 被误判为 agent 未提交变更 (run_id=c9904f3d)
