### PR TITLE
P0 部署阻塞：品牌改名（#246/#261）后本机 systemd 部署陷入死循环，orbi 生产队列已暂停

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -261,13 +261,13 @@ EOF
 chmod 600 .orbi/env
 ```
 
-The committed unit template already carries
-`EnvironmentFile=-%h/Documents/orbi/orbi/.orbi/env`
-(Issue #172) — if your clone lives elsewhere, point the **installed**
-unit's `EnvironmentFile` at **your** `.orbi/env` like the
-`WorkingDirectory` Note in step 8. A keyless local server needs no env
-file at all (the literal `"local"` placeholder above satisfies the
-shape check).
+The committed unit template carries
+`EnvironmentFile=-{{ORBI_REPO_DIR}}/.orbi/env` (Issue #172); the
+`{{ORBI_REPO_DIR}}` placeholder is substituted with your checkout path
+at install time (Issue #262), so the installed unit's `EnvironmentFile`
+points at **your** `.orbi/env` automatically — no manual edit. A
+keyless local server needs no env file at all (the literal `"local"`
+placeholder above satisfies the shape check).
 
 #### What the Runner validates (fail fast, before any slot or claim)
 
@@ -433,14 +433,13 @@ capacity and the enabled timer count are both `max_concurrency`, while the
 flock slots remain the final safety boundary.
 
 <Note>
-The committed unit templates reference the author's clone layout via
-`%h` specifiers (`%h/Documents/orbi/orbi`). If your clone lives
-elsewhere, install the CLI from **your** clone path (step 2) and edit
-the **installed** units in your user unit directory
-(`~/.config/systemd/user/`) to point `WorkingDirectory` and
-`ORBI_CONFIG` at **your** clone path, then
-`systemctl --user daemon-reload`. `ExecStart` is the installed
-`orbi` CLI and stays relative. The repo templates stay the single
-source of truth for everything else — see [Operations](/operations) on
-drift detection.
+The committed unit templates are machine-independent: they carry the
+`{{ORBI_REPO_DIR}}` placeholder instead of a hardcoded checkout path
+(Issue #262). `orbi install-units` (and `orbi setup`) substitute it
+with **your** deployment checkout's resolved path at install time, so
+a clone at ANY location deploys cleanly — no manual edit of the
+installed units. `ExecStart` is the installed `orbi` CLI and stays
+home-relative (`%h/.local/bin/orbi`). The repo templates stay the
+single source of truth for everything else — see [Operations](/operations)
+on drift detection.
 </Note>

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -240,12 +240,12 @@ EOF
 chmod 600 .orbi/env
 ```
 
-提交的 unit 模板已带
-`EnvironmentFile=-%h/Documents/orbi/orbi/.orbi/env`
-（Issue #172）——如果你的 clone 在别处，像第 8 步的
-`WorkingDirectory` Note 一样，把**已安装** unit 的 `EnvironmentFile`
-指向**你的** `.orbi/env`。无 key 的本地 server 完全不需要 env
-文件（上面的 `"local"` 字面量占位即可通过形状检查）。
+提交的 unit 模板带
+`EnvironmentFile=-{{ORBI_REPO_DIR}}/.orbi/env`（Issue #172）；
+`{{ORBI_REPO_DIR}}` 占位符在安装时被替换为你的 checkout 路径
+（Issue #262），所以已安装 unit 的 `EnvironmentFile` 自动指向
+**你的** `.orbi/env`——无需手工编辑。无 key 的本地 server 完全
+不需要 env 文件（上面的 `"local"` 字面量占位即可通过形状检查）。
 
 #### Runner 校验什么（fail fast，在任何 slot/claim 之前）
 
@@ -391,12 +391,11 @@ fast-forward 和每实例启动语义定义在[运维](/zh/operations)（Timers�
 `max_concurrency` 决定，flock slot 仍是最终安全边界。
 
 <Note>
-提交的 unit 模板通过 `%h` 占位符引用作者的 clone 布局
-（`%h/Documents/orbi/orbi`）。如果你的 clone 在别处，从**你**
-的 clone 路径安装 CLI（第 2 步），并编辑你 user unit 目录
-（`~/.config/systemd/user/`）里**已安装**的 units，把
-`WorkingDirectory` 和 `ORBI_CONFIG` 指向**你的** clone 路径，
-然后 `systemctl --user daemon-reload`。`ExecStart` 是已安装的
-`orbi` CLI，保持相对名。仓库模板仍是其余一切的唯一事实源——
+提交的 unit 模板与机器无关：它们携带 `{{ORBI_REPO_DIR}}` 占位符
+而不是硬编码的 checkout 路径（Issue #262）。`orbi install-units`
+（以及 `orbi setup`）在安装时用**你的**部署 checkout 的解析后
+路径替换它，因此任何位置的 clone 都能干净部署——无需手工编辑
+已安装的 units。`ExecStart` 是已安装的 `orbi` CLI，保持 home 相对
+（`%h/.local/bin/orbi`）。仓库模板仍是其余一切的唯一事实源——
 漂移检测见[运维](/zh/operations)。
 </Note>

--- a/src/orbi/systemd_deploy.py
+++ b/src/orbi/systemd_deploy.py
@@ -49,6 +49,26 @@ SERVICE_INSTANCES = (
 LEGACY_TIMER_UNIT = "orbi.timer"
 LEGACY_UNIT_NAMES = ("orbi.service", "orbi.timer")
 
+# Issue #262: the unit templates are machine-independent. The single
+# machine-specific value (the deployment checkout path) is carried as
+# this placeholder and substituted at install time with the checkout's
+# resolved absolute path — the templates no longer hardcode
+# ``%h/Documents/orbi/orbi``, so a checkout at ANY path deploys cleanly.
+REPO_DIR_PLACEHOLDER = "{{ORBI_REPO_DIR}}"
+
+# Issue #262: the pre-#246 renamed units. The brand rename (#246/#261)
+# changed the unit names from ``muyan-pilot@*`` to ``orbi@*``; a machine
+# deployed before the rename still carries the OLD installed units, whose
+# ExecStartPre self-heal probes ``muyan-pilot --version`` and reinstalls
+# from the (now ``orbi``) checkout — a guaranteed probe → reinstall →
+# probe dead loop. install_units migrates them away once.
+RENAMED_TEMPLATE_UNITS = (
+    "muyan-pilot@.service", "muyan-pilot@.timer",
+)
+RENAMED_TIMER_INSTANCES = (
+    "muyan-pilot@1.timer", "muyan-pilot@2.timer",
+)
+
 # The idempotent install command that repairs any drift (carried on
 # every unit_drift line as the fix command). Issue #140: the official
 # entry is the installed `orbi` CLI (the uv-tool console
@@ -87,6 +107,20 @@ def sha256_hex(path: Path) -> str:
     return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
 
+def render_unit_template(template_text: str, repo_dir: Path) -> str:
+    """Substitute the deployment checkout path into a unit template.
+
+    The repo templates are machine-independent: the single
+    machine-specific value (the deployment checkout path) is carried as
+    the ``{{ORBI_REPO_DIR}}`` placeholder and replaced here with the
+    checkout's resolved absolute path. A template without the placeholder
+    is returned unchanged.
+    """
+    return template_text.replace(
+        REPO_DIR_PLACEHOLDER, str(Path(repo_dir).resolve()),
+    )
+
+
 def unit_status(repo_dir: Path, installed_dir: Path) -> list[dict]:
     """Compare the installed units against the repo templates.
 
@@ -101,7 +135,19 @@ def unit_status(repo_dir: Path, installed_dir: Path) -> list[dict]:
     for name in UNIT_NAMES:
         repo_path = repo_unit_dir(repo_dir) / name
         installed_path = installed_dir / name
-        repo_sha = sha256_hex(repo_path) if repo_path.is_file() else None
+        if repo_path.is_file():
+            # Issue #262: the installed unit is the RENDERED template
+            # (the checkout path substituted), so the drift check must
+            # compare against the rendered form — otherwise a clean
+            # install would always look drifted.
+            rendered = render_unit_template(
+                repo_path.read_text(encoding="utf-8"), repo_dir,
+            )
+            repo_sha = hashlib.sha256(
+                rendered.encode("utf-8"),
+            ).hexdigest()
+        else:
+            repo_sha = None
         installed_sha = (
             sha256_hex(installed_path) if installed_path.is_file() else None
         )
@@ -260,6 +306,38 @@ def migrate_legacy_units(installed_dir: Path, *, run_command) -> bool:
     return True
 
 
+def migrate_renamed_units(installed_dir: Path, *, run_command) -> bool:
+    """One-time migration away from the pre-#246 renamed units (#262).
+
+    The brand rename (#246/#261) changed the unit names from
+    ``muyan-pilot@*`` to ``orbi@*``, but a machine deployed before the
+    rename still carries the OLD installed units. Their ``ExecStartPre``
+    self-heal probes ``muyan-pilot --version`` and, on failure, reinstalls
+    from the checkout — but the checkout's package is now ``orbi``, so the
+    reinstall produces ``orbi``, never ``muyan-pilot``: a guaranteed probe
+    → reinstall → probe dead loop, one crash per timer tick. This
+    migration breaks the loop: it disables the old timer instances (TIMER
+    stops — the service is never started/stopped/restarted, so a running
+    Runner keeps running) and removes the old unit files, so the old
+    schedule cannot keep firing. One-time and idempotent: no old timer
+    file → no-op (a fresh or already-migrated machine). A failing step
+    propagates unchanged (fail fast).
+    """
+    if not (installed_dir / "muyan-pilot@.timer").is_file():
+        return False
+    for instance in RENAMED_TIMER_INSTANCES:
+        run_command(["systemctl", "--user", "disable", "--now", instance])
+    for name in RENAMED_TEMPLATE_UNITS:
+        legacy = installed_dir / name
+        if legacy.is_file():
+            legacy.unlink()
+    LOGGER.info(
+        "renamed_units_migrated installed_dir=%s removed=%s",
+        installed_dir, ",".join(RENAMED_TEMPLATE_UNITS),
+    )
+    return True
+
+
 def install_units(repo_dir: Path, installed_dir: Path | None = None,
                   *, max_concurrency: int = len(TIMER_INSTANCES),
                   run_command) -> dict:
@@ -294,10 +372,17 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
             )
     installed_dir.mkdir(parents=True, exist_ok=True)
     migrate_legacy_units(installed_dir, run_command=run_command)
+    migrate_renamed_units(installed_dir, run_command=run_command)
     for name in UNIT_NAMES:
-        (installed_dir / name).write_bytes(
-            (repo_unit_dir(repo_dir) / name).read_bytes(),
-        )
+        # Issue #262: render the template (substitute the deployment
+        # checkout path for the {{ORBI_REPO_DIR}} placeholder) so the
+        # installed unit points at THIS checkout regardless of where it
+        # lives. A template without the placeholder is written unchanged.
+        template_text = (
+            repo_unit_dir(repo_dir) / name
+        ).read_text(encoding="utf-8")
+        rendered = render_unit_template(template_text, repo_dir)
+        (installed_dir / name).write_bytes(rendered.encode("utf-8"))
     run_command(["systemctl", "--user", "daemon-reload"])
     for instance in TIMER_INSTANCES[:max_concurrency]:
         run_command(["systemctl", "--user", "enable", "--now", instance])

--- a/systemd/orbi@.service
+++ b/systemd/orbi@.service
@@ -5,16 +5,21 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Documents/orbi/orbi
+# Issue #262: the deployment checkout path is NOT hardcoded. The
+# {{ORBI_REPO_DIR}} placeholder is substituted at install time by
+# `orbi install-units` with the checkout's resolved absolute path, so a
+# checkout at ANY location deploys cleanly (the pre-#262 templates
+# hardcoded %h/Documents/orbi/orbi, which broke every other layout).
+WorkingDirectory={{ORBI_REPO_DIR}}
 Environment="PATH=%h/.npm-global/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
-Environment="ORBI_CONFIG=%h/Documents/orbi/orbi/orbi.toml"
+Environment="ORBI_CONFIG={{ORBI_REPO_DIR}}/orbi.toml"
 # Issue #172: the provider file may reference API keys as environment
 # variables (e.g. $GROQ_API_KEY). The user-local env file in the
 # gitignored state dir (next to base-sync.lock) carries them; the `-`
 # prefix keeps deployments without provider files working. The key
 # lives only in that local file — never in this template, the repo, or
 # the journal.
-EnvironmentFile=-%h/Documents/orbi/orbi/.orbi/env
+EnvironmentFile=-{{ORBI_REPO_DIR}}/.orbi/env
 # Deployment adapter only: disable systemd's default startup kill limit.
 TimeoutStartSec=infinity
 # Issue #52: before the Runner starts, fast-forward the local main
@@ -31,7 +36,7 @@ TimeoutStartSec=infinity
 # the SAME lock): the main worktree is never written concurrently.
 # Issue #191: disabling fetch's automatic maintenance prevents Git from
 # detaching a maintenance child beyond this preflight and flock lifetime.
-ExecStartPre=/usr/bin/timeout 90s /usr/bin/flock %h/Documents/orbi/orbi/.orbi/base-sync.lock -c 'git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main'
+ExecStartPre=/usr/bin/timeout 90s /usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock -c 'git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main'
 # Issue #248: self-heal the editable CLI install OUTSIDE Python. The #158
 # in-Runner refresh (runner.refresh_cli_install) is unreachable when the
 # console script cannot even `import orbi` (the #248 scene: the
@@ -46,7 +51,7 @@ ExecStartPre=/usr/bin/timeout 90s /usr/bin/flock %h/Documents/orbi/orbi/.orbi/ba
 # instances starting in the same tick never race the tool env), and the
 # timeout matches runner.UV_INSTALL_TIMEOUT_SECONDS: a failing reinstall
 # fails this preflight, the service does not start (fail fast), no fallback.
-ExecStartPre=/usr/bin/timeout 300s /usr/bin/flock %h/Documents/orbi/orbi/.orbi/base-sync.lock -c '%h/.local/bin/orbi --version >/dev/null 2>&1 || uv tool install --force --reinstall --editable --python /usr/bin/python3 %h/Documents/orbi/orbi'
+ExecStartPre=/usr/bin/timeout 300s /usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock -c '%h/.local/bin/orbi --version >/dev/null 2>&1 || uv tool install --force --reinstall --editable --python /usr/bin/python3 {{ORBI_REPO_DIR}}'
 # Issue #140: the Runner is the installed `orbi` CLI (the
 # uv-tool console script, `uv tool install` / `uv tool upgrade`; the
 # executable lands in the user bin dir `~/.local/bin`). The absolute

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -197,8 +197,11 @@ def test_service_keeps_working_directory_and_preflight():
     Issue #52 preflight are unchanged by the CLI switch."""
     service = parse_unit(SERVICE_FILE)
     section = service["Service"]
+    # Issue #262: the deployment checkout path is NOT hardcoded; the
+    # template carries the {{ORBI_REPO_DIR}} placeholder, substituted
+    # with the checkout's resolved path at install time.
     assert section["WorkingDirectory"] == [
-        "%h/Documents/orbi/orbi",
+        "{{ORBI_REPO_DIR}}",
     ]
     pre = section["ExecStartPre"][0]
     assert pre.startswith("/usr/bin/timeout 90s /usr/bin/flock ")
@@ -224,7 +227,7 @@ def test_service_preflight_self_heals_the_editable_cli():
     # The same timeout wrapper + shared lock as the git sync step.
     assert heal.startswith("/usr/bin/timeout 300s /usr/bin/flock ")
     assert (
-        "%h/Documents/orbi/orbi/.orbi/base-sync.lock"
+        "{{ORBI_REPO_DIR}}/.orbi/base-sync.lock"
         in heal
     )
     # The probe: the installed console script's `--version` succeeds iff
@@ -243,12 +246,13 @@ def test_service_preflight_self_heals_the_editable_cli():
     reinstall_part = heal_argv.split("||", 1)[1].strip()
     assert reinstall_part == (
         "uv tool install --force --reinstall --editable "
-        "--python /usr/bin/python3 %h/Documents/orbi/orbi"
+        "--python /usr/bin/python3 {{ORBI_REPO_DIR}}"
     )
     # The reinstall argv is the same as the Python-side source of truth
-    # (the path is the only difference: the template uses the %h
-    # specifier, the Python command the resolved repo_dir).
-    py_args = cli_source.reinstall_args(Path("%h/Documents/orbi/orbi"))
+    # (the path is the only difference: the template carries the
+    # {{ORBI_REPO_DIR}} placeholder, substituted at install time with
+    # the resolved repo_dir).
+    py_args = cli_source.reinstall_args(Path("{{ORBI_REPO_DIR}}"))
     assert reinstall_part == " ".join(py_args)
 
 
@@ -274,13 +278,26 @@ def test_service_template_passes_systemd_analyze_verify():
     resolves the unit's absolute ExecStart against a real executable
     on both — no skip needed (a missing executable is exactly the
     failure this check must catch, never skippable noise)."""
-    import os
     import subprocess
+    import tempfile
 
-    result = subprocess.run(
-        ["systemd-analyze", "--user", "verify", str(SERVICE_FILE)],
-        capture_output=True, text=True, timeout=60,
-    )
+    # Issue #262: the template carries the {{ORBI_REPO_DIR}} placeholder,
+    # so it is rendered with a real checkout path before verify — the raw
+    # template is a machine-independent source, not a runnable unit.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".service", delete=False,
+    ) as handle:
+        handle.write(systemd_deploy.render_unit_template(
+            SERVICE_FILE.read_text(encoding="utf-8"), REPO_ROOT,
+        ))
+        rendered_path = handle.name
+    try:
+        result = subprocess.run(
+            ["systemd-analyze", "--user", "verify", rendered_path],
+            capture_output=True, text=True, timeout=60,
+        )
+    finally:
+        Path(rendered_path).unlink(missing_ok=True)
     assert result.returncode == 0, (
         f"systemd-analyze verify failed rc={result.returncode} "
         f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 import pytest
 
+from orbi import systemd_deploy
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 REPO = "owner/repo"
 # Issue #168 src layout: the Runner is the package module
@@ -545,12 +547,18 @@ def write_config(
 _RUNNING: list[subprocess.Popen] = []
 
 
-def install_deployed_units(unit_dir: Path) -> None:
+def install_deployed_units(unit_dir: Path, repo_dir: Path) -> None:
     """Simulate the deployed machine: the repo templates installed as
-    the user units (the idempotent install the README documents)."""
+    the user units (the idempotent install the README documents). The
+    templates are rendered exactly as `orbi install-units` does — the
+    {{ORBI_REPO_DIR}} placeholder replaced with the checkout path — so
+    the pre-start drift check (which compares against the rendered
+    template) sees a clean deployment."""
     unit_dir.mkdir(parents=True, exist_ok=True)
     for name in ("orbi@.service", "orbi@.timer"):
-        shutil.copyfile(REPO_ROOT / "systemd" / name, unit_dir / name)
+        template = (REPO_ROOT / "systemd" / name).read_text(encoding="utf-8")
+        rendered = systemd_deploy.render_unit_template(template, repo_dir)
+        (unit_dir / name).write_bytes(rendered.encode("utf-8"))
 
 
 def start_runner(
@@ -570,7 +578,7 @@ def start_runner(
     # installed), or an explicit dir for the drift scenarios.
     if unit_dir is None:
         unit_dir = config_path.parent / "unit-dir"
-        install_deployed_units(unit_dir)
+        install_deployed_units(unit_dir, config_path.parent / "clone")
     env["ORBI_UNIT_DIR"] = str(unit_dir)
     env["PYTHONPATH"] = str(REPO_ROOT / "src")
     process = subprocess.Popen(
@@ -1437,7 +1445,7 @@ def test_unit_drift_auto_syncs_and_claims_without_human_intervention(
 
     # A drifted deployment: the installed timer carries one extra line.
     unit_dir = tmp_path / "drifted-units"
-    install_deployed_units(unit_dir)
+    install_deployed_units(unit_dir, clone)
     with (unit_dir / "orbi@.timer").open(
         "a", encoding="utf-8",
     ) as handle:
@@ -1512,7 +1520,7 @@ def test_unit_drift_unresolvable_blocks_the_start_without_claiming(
 
     # A drifted deployment: the installed timer carries one extra line.
     unit_dir = tmp_path / "unresolvable-units"
-    install_deployed_units(unit_dir)
+    install_deployed_units(unit_dir, clone)
     with (unit_dir / "orbi@.timer").open(
         "a", encoding="utf-8",
     ) as handle:

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -632,3 +632,207 @@ def test_sync_drifted_units_still_drifted_after_sync_fails_fast(
     assert "unit_drift unit=orbi@.timer" in caplog.text
     assert "fix=orbi install-units" in caplog.text
     assert "unit_drift auto_synced" not in caplog.text
+
+
+# --- Issue #262: template path placeholder + renamed-unit migration ----------
+
+
+def test_render_unit_template_substitutes_the_repo_dir(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    template = (
+        "[Service]\n"
+        "WorkingDirectory={{ORBI_REPO_DIR}}\n"
+        'ExecStartPre=flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock -c "x"\n'
+    )
+    rendered = systemd_deploy.render_unit_template(template, repo)
+    assert "{{ORBI_REPO_DIR}}" not in rendered
+    assert f"WorkingDirectory={repo}" in rendered
+    assert f"flock {repo}/.orbi/base-sync.lock" in rendered
+
+
+def test_render_unit_template_no_placeholder_is_unchanged(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    template = "WorkingDirectory=/fixed/path\n"
+    assert systemd_deploy.render_unit_template(template, repo) == template
+
+
+def test_install_units_writes_the_rendered_unit_with_the_real_path(tmp_path):
+    repo = tmp_path / "checkout"
+    (repo / "systemd").mkdir(parents=True)
+    (repo / "systemd" / "orbi@.service").write_text(
+        "[Service]\n"
+        "WorkingDirectory={{ORBI_REPO_DIR}}\n"
+        'Environment="ORBI_CONFIG={{ORBI_REPO_DIR}}/orbi.toml"\n'
+        "EnvironmentFile=-{{ORBI_REPO_DIR}}/.orbi/env\n"
+        'ExecStartPre=/usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock '
+        '-c \'git fetch\'\n'
+        'ExecStartPre=/usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock '
+        "-c '%h/.local/bin/orbi --version || uv tool install --force "
+        "--reinstall --editable --python /usr/bin/python3 "
+        "{{ORBI_REPO_DIR}}'\n"
+        "ExecStart=%h/.local/bin/orbi\n",
+        encoding="utf-8",
+    )
+    (repo / "systemd" / "orbi@.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
+    )
+    installed = tmp_path / "install"
+    systemd_deploy.install_units(
+        repo, installed, run_command=lambda command, **kwargs: "",
+    )
+    service = (installed / "orbi@.service").read_text(encoding="utf-8")
+    # No placeholder or hardcoded path survives; the real checkout path is
+    # substituted everywhere, while the home-relative bits stay %h.
+    assert "{{ORBI_REPO_DIR}}" not in service
+    assert "%h/Documents/orbi/orbi" not in service
+    assert f"WorkingDirectory={repo}" in service
+    assert f'ORBI_CONFIG={repo}/orbi.toml' in service
+    assert f"EnvironmentFile=-{repo}/.orbi/env" in service
+    assert f"flock {repo}/.orbi/base-sync.lock" in service
+    assert f"python3 {repo}'" in service
+    assert "ExecStart=%h/.local/bin/orbi" in service
+
+
+def test_unit_status_is_clean_when_installed_matches_the_rendered_template(
+    tmp_path,
+):
+    repo = tmp_path / "checkout"
+    (repo / "systemd").mkdir(parents=True)
+    (repo / "systemd" / "orbi@.service").write_text(
+        "WorkingDirectory={{ORBI_REPO_DIR}}\n", encoding="utf-8",
+    )
+    (repo / "systemd" / "orbi@.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
+    )
+    installed = tmp_path / "install"
+    systemd_deploy.install_units(
+        repo, installed, run_command=lambda command, **kwargs: "",
+    )
+    status = systemd_deploy.unit_status(repo, installed)
+    for entry in status:
+        assert entry["drifted"] is False
+        assert entry["missing"] is False
+        assert entry["repo_sha256"] == entry["installed_sha256"]
+
+
+def test_unit_status_drifts_when_installed_differs_from_the_rendered_template(
+    tmp_path,
+):
+    repo = tmp_path / "checkout"
+    (repo / "systemd").mkdir(parents=True)
+    (repo / "systemd" / "orbi@.service").write_text(
+        "WorkingDirectory={{ORBI_REPO_DIR}}\n", encoding="utf-8",
+    )
+    (repo / "systemd" / "orbi@.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
+    )
+    installed = tmp_path / "install"
+    systemd_deploy.install_units(
+        repo, installed, run_command=lambda command, **kwargs: "",
+    )
+    # Tamper the installed unit so it no longer matches the rendered
+    # template (e.g. a hand edit to a different path).
+    (installed / "orbi@.service").write_text(
+        "WorkingDirectory=/somewhere/else\n", encoding="utf-8",
+    )
+    status = systemd_deploy.unit_status(repo, installed)
+    service = [e for e in status if e["unit"] == "orbi@.service"][0]
+    assert service["drifted"] is True
+    assert service["repo_sha256"] != service["installed_sha256"]
+
+
+def test_migrate_renamed_units_disables_instances_and_removes_files(
+    tmp_path, caplog,
+):
+    installed = tmp_path / "install"
+    installed.mkdir()
+    (installed / "muyan-pilot@.service").write_text(
+        "[Service]\nExecStart=old\n", encoding="utf-8",
+    )
+    (installed / "muyan-pilot@.timer").write_text(
+        "[Timer]\nOnCalendar=old\n", encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return ""
+
+    with caplog.at_level("INFO"):
+        migrated = systemd_deploy.migrate_renamed_units(
+            installed, run_command=fake_run,
+        )
+    assert migrated is True
+    # Both old timer instances are stopped (TIMER stops — the service is
+    # never started/stopped/restarted).
+    for instance in ("muyan-pilot@1.timer", "muyan-pilot@2.timer"):
+        assert [
+            "systemctl", "--user", "disable", "--now", instance,
+        ] in calls
+    # The old unit files are removed.
+    assert not (installed / "muyan-pilot@.service").exists()
+    assert not (installed / "muyan-pilot@.timer").exists()
+    assert "renamed_units_migrated" in caplog.text
+
+
+def test_migrate_renamed_units_is_a_noop_without_the_old_files(tmp_path):
+    installed = tmp_path / "install"
+    installed.mkdir()
+    calls: list[list[str]] = []
+    assert systemd_deploy.migrate_renamed_units(
+        installed, run_command=lambda command, **kwargs:
+        calls.append(command) or "",
+    ) is False
+    assert calls == []
+
+
+def test_migrate_renamed_units_removes_only_the_files_that_exist(tmp_path):
+    installed = tmp_path / "install"
+    installed.mkdir()
+    (installed / "muyan-pilot@.timer").write_text(
+        "[Timer]\nOnCalendar=old\n", encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+    migrated = systemd_deploy.migrate_renamed_units(
+        installed, run_command=lambda command, **kwargs:
+        calls.append(command) or "",
+    )
+    assert migrated is True
+    assert not (installed / "muyan-pilot@.timer").exists()
+    assert not (installed / "muyan-pilot@.service").exists()
+
+
+def test_install_units_migrates_the_renamed_units_when_present(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = tmp_path / "install"
+    installed.mkdir()
+    (installed / "muyan-pilot@.service").write_text(
+        "[Service]\nExecStart=old\n", encoding="utf-8",
+    )
+    (installed / "muyan-pilot@.timer").write_text(
+        "[Timer]\nOnCalendar=old\n", encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "0123456789abcdef0123456789abcdef01234567"
+        return ""
+
+    systemd_deploy.install_units(repo, installed, run_command=fake_run)
+    for instance in ("muyan-pilot@1.timer", "muyan-pilot@2.timer"):
+        assert [
+            "systemctl", "--user", "disable", "--now", instance,
+        ] in calls
+    assert not (installed / "muyan-pilot@.service").exists()
+    assert not (installed / "muyan-pilot@.timer").exists()
+    # The new templates are installed and both new instances enabled.
+    for name in systemd_deploy.UNIT_NAMES:
+        assert (installed / name).is_file()
+    for instance in systemd_deploy.TIMER_INSTANCES:
+        assert [
+            "systemctl", "--user", "enable", "--now", instance,
+        ] in calls

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from orbi import systemd_deploy
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TIMER_FILE = REPO_ROOT / "systemd" / "orbi@.timer"
 SERVICE_FILE = REPO_ROOT / "systemd" / "orbi@.service"
@@ -126,7 +128,7 @@ def test_service_loads_optional_provider_env_file():
     service = parse_unit(SERVICE_FILE)
     section = service["Service"]
     assert section["EnvironmentFile"] == [
-        "-%h/Documents/orbi/orbi/.orbi/env"
+        "-{{ORBI_REPO_DIR}}/.orbi/env"
     ]
 
 
@@ -187,8 +189,14 @@ def test_templates_and_instances_pass_systemd_analyze_verify(
         pytest.skip("systemd-analyze not available on this machine")
     unit_dir = tmp_path / "systemd" / "user"
     unit_dir.mkdir(parents=True)
+    # Issue #262: the templates carry the {{ORBI_REPO_DIR}} placeholder;
+    # render them with a real checkout path (as `orbi install-units`
+    # does) before verify — the raw template is machine-independent and
+    # not a runnable unit.
     for name in ("orbi@.service", "orbi@.timer"):
-        shutil.copyfile(REPO_ROOT / "systemd" / name, unit_dir / name)
+        template = (REPO_ROOT / "systemd" / name).read_text(encoding="utf-8")
+        rendered = systemd_deploy.render_unit_template(template, REPO_ROOT)
+        (unit_dir / name).write_bytes(rendered.encode("utf-8"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     for name in ("orbi@.service", "orbi@.timer",
                  "orbi@1.service", "orbi@1.timer",


### PR DESCRIPTION
<!-- orbi:run=b2f8efb1 -->

Fixes #262

P0 部署阻塞：品牌改名（#246/#261）后本机 systemd 部署陷入死循环，orbi 生产队列已暂停 (run_id=b2f8efb1)
