### PR TITLE
Bug：发布后 active_milestone 不前进，Runner 静默空转且无法从日志区分

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -532,6 +532,9 @@ def load_config(path: Path) -> dict:
         ],
         "base_branch": base_branch,
         "active_milestone": active_milestone,
+        # Issue #270: the resolved config file path, so the release
+        # success path can write an advanced `active_milestone` back.
+        "config_path": path,
         "auto_repair_issues": auto_repair_issues,
         "max_concurrency": max_concurrency,
         "slot_dir": slot_dir_for(repo_dir),
@@ -1189,6 +1192,44 @@ def ready_searches(active_milestone: str | None = None) -> tuple[str, str, str]:
         f"label:ai-ready label:bug{scope} {READY_SCAN_EXCLUSIONS}",
         f"label:ai-ready{scope} {READY_SCAN_EXCLUSIONS}",
     )
+
+
+def check_active_milestone(repo: str, active_milestone: str) -> str:
+    """Return the state of the configured Milestone (Issue #270).
+
+    Lists the repo's Milestones with `state=all` (the default
+    `state=open` would hide already-closed ones) and matches the EXACT
+    title — never guessed, never fuzzy-matched:
+
+    - exactly one Milestone with that title -> its `state` (`"open"`
+      or `"closed"`);
+    - no Milestone with that exact title -> `"missing"`;
+    - several Milestones with that exact title -> fail fast (ambiguous,
+      the same rule as `close_release_milestone`).
+
+    A real `gh` failure propagates unchanged: a check that cannot be
+    made is a failed check, never a silent `no_ready_issue`.
+    """
+    raw = run_command([
+        "gh", "api", f"repos/{repo}/milestones?state=all", "--paginate",
+    ])
+    milestones = parse_issue_array(raw)
+    matches = [
+        m for m in milestones
+        if isinstance(m, dict) and m.get("title") == active_milestone
+    ]
+    if not matches:
+        return "missing"
+    if len(matches) > 1:
+        numbers = ", ".join(
+            f"#{m.get('number')}" for m in matches
+        )
+        raise RuntimeError(
+            f"active_milestone {active_milestone!r}: {len(matches)} "
+            f"Milestones share the exact title in {repo} — ambiguous, "
+            f"refusing to guess which one is active: {numbers}"
+        )
+    return str(matches[0].get("state"))
 
 
 def issue_priority(issue: dict) -> str:
@@ -1939,6 +1980,112 @@ def close_release_milestone(repo: str, version: str) -> str:
     )
 
 
+SEMVER_MILESTONE_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_milestone_version(title: str) -> tuple[int, int, int] | None:
+    """Parse a `v<major>.<minor>.<patch>` Milestone title (Issue #270).
+
+    Returns the numeric triple used for semantic-version ordering, or
+    None when the title is not a plain semantic version — such titles
+    are never guessed at.
+    """
+    match = SEMVER_MILESTONE_RE.match(title)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def set_config_active_milestone(path: Path, value: str) -> None:
+    """Write `active_milestone = "<value>"` back into the TOML config.
+
+    Only the existing `active_milestone` line (double- or single-quoted)
+    is rewritten; every other byte of the file is untouched. A config
+    without that line is a misconfiguration — fail fast, never guess
+    where to write it.
+    """
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"""(?m)^active_milestone\s*=\s*['"][^'"]*['"]\s*$"""
+    )
+    if not pattern.search(text):
+        raise RuntimeError(
+            f"config {path}: no active_milestone line to update — "
+            "refusing to guess where to write it"
+        )
+    path.write_text(
+        pattern.sub(f'active_milestone = "{value}"', text, count=1),
+        encoding="utf-8",
+    )
+
+
+def advance_active_milestone(
+    config: dict, repo: str, released_version: str,
+) -> str | None:
+    """Advance the configured `active_milestone` past a release (Issue #270).
+
+    Called on the release success path right after the released
+    Milestone is closed. It acts only when the config's
+    `active_milestone` is EXACTLY the released version — an unset scope
+    (unscoped scans) or a different active Milestone is left untouched.
+
+    The next scope is the nearest OPEN Milestone strictly above the
+    released version in semantic-version order (`v0.3.0` < `v0.3.1` <
+    `v0.4.0`); non-semver titles are never guessed. The new value is
+    written back to the config file so the NEXT tick claims from the new
+    Milestone without a human config edit.
+
+    Returns the new value, or None when nothing was advanced. "No next
+    open Milestone" is logged explicitly (`active_milestone_advance_none`)
+    — never silent.
+    """
+    current = config.get("active_milestone")
+    if current is None or current != released_version:
+        return None
+    released = parse_milestone_version(released_version)
+    if released is None:
+        raise RuntimeError(
+            f"release {released_version!r}: the released version is not "
+            "a plain v<major>.<minor>.<patch> — refusing to guess the "
+            "next Milestone"
+        )
+    raw = run_command([
+        "gh", "api", f"repos/{repo}/milestones?state=open", "--paginate",
+    ])
+    milestones = parse_issue_array(raw)
+    candidates = []
+    for milestone in milestones:
+        if not isinstance(milestone, dict):
+            continue
+        title = milestone.get("title")
+        if not isinstance(title, str):
+            continue
+        version = parse_milestone_version(title)
+        if version is not None and version > released:
+            candidates.append((version, title))
+    if not candidates:
+        LOGGER.warning(
+            "active_milestone_advance_none repo=%s current=%s — no open "
+            "Milestone above %s; the claim scope stays %s until a human "
+            "updates it",
+            repo, current, released_version, current,
+        )
+        return None
+    _, next_title = min(candidates)
+    config_path = config.get("config_path")
+    if config_path is None:
+        raise RuntimeError(
+            f"release {released_version}: no config path available to "
+            "write the advanced active_milestone — refusing to guess"
+        )
+    set_config_active_milestone(Path(config_path), next_title)
+    LOGGER.info(
+        "active_milestone_advanced repo=%s from=%s to=%s config=%s",
+        repo, current, next_title, config_path,
+    )
+    return next_title
+
+
 def release_success_comment_body(run_id: str, run_info: str,
                                  release_url: str, tag: str,
                                  release_commit: str,
@@ -2031,7 +2178,12 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        (idempotent when already closed); fail fast — never a silent
        skip, never a different Milestone — when no Milestone carries
        that exact title or open Issues remain.
-    11. Any failure: `ai-blocked` ALONE (no automatic retry — a
+    11. Advance the configured `active_milestone` past the released
+       version (Issue #270): only when it is exactly the released
+       version, the nearest open Milestone above it is written back to
+       the config file; "no next open Milestone" is logged, never
+       silent.
+    12. Any failure: `ai-blocked` ALONE (no automatic retry — a
         release is a human decision point), the failure comment
         carries the run marker and the concrete reason, and the
         exception propagates so the tick fails fast.
@@ -2206,6 +2358,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         milestone_evidence = close_release_milestone(
             source_repo, tag,
         )
+        advance_active_milestone(config, source_repo, tag)
         comment_issue(
             number, repo=source_repo,
             body=release_success_comment_body(
@@ -2715,6 +2868,7 @@ def block_scene_failure(issue: dict, error: ValueError, repo: str,
 def pick_next_delivery(
     repos: list[str], slot_dir: Path, max_concurrency: int,
     active_milestone: str | None = None,
+    stale_repos: set[str] | None = None,
 ) -> tuple[str, dict, dict | None] | None:
     """Scan sources in order: resumable PRs, in-flight restarts, ready.
 
@@ -2732,6 +2886,11 @@ def pick_next_delivery(
     (`pick_issue`) — the resumable-PR and in-flight restart scans are
     resume states, and running an in-flight or opened-PR delivery to
     completion is never gated by a Milestone change.
+
+    Issue #270: `stale_repos` are repos whose configured Milestone is
+    closed or missing (validated by the tick loop before the call); their
+    fresh-claim scan is skipped — a closed Milestone with leftover open
+    Issues must never be claimed — while their resume scans still run.
     """
     for repo in repos:
         selected = pick_resumable_delivery(
@@ -2747,6 +2906,8 @@ def pick_next_delivery(
         if issue is not None:
             return repo, issue, None
     for repo in repos:
+        if stale_repos is not None and repo in stale_repos:
+            continue
         issue = pick_issue(repo, active_milestone)
         if issue is not None:
             return repo, issue, None
@@ -7232,12 +7393,35 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
     try:
+        # Issue #270: a stale `active_milestone` (closed or missing) must
+        # never masquerade as "no ready issue". Validate the fresh-claim
+        # scope BEFORE the claim scan; resumes are never gated by it (the
+        # resumable-PR and in-flight scans run inside pick_next_delivery
+        # regardless).
+        stale_repos: set[str] = set()
+        if config["active_milestone"] is not None:
+            for repo in config["source_repos"]:
+                state = check_active_milestone(
+                    repo, config["active_milestone"],
+                )
+                if state != "open":
+                    LOGGER.warning(
+                        "active_milestone_stale repo=%s current=%s "
+                        "state=%s",
+                        repo, config["active_milestone"], state,
+                    )
+                    stale_repos.add(repo)
         selected = pick_next_delivery(
             config["source_repos"], config["slot_dir"],
             config["max_concurrency"],
             config["active_milestone"],
+            stale_repos=stale_repos,
         )
         if selected is None:
+            if stale_repos:
+                # The active_milestone_stale warning above is the
+                # recorded reason — no indiscriminate no_ready_issue.
+                return 0
             LOGGER.info(
                 "source_repos=%s outcome=no_ready_issue",
                 config["source_repos"],

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13941,13 +13941,12 @@ def test_advance_active_milestone_logs_none_when_there_is_no_next(
 def test_advance_active_milestone_is_a_noop_when_scope_is_unset(
     monkeypatch,
 ):
-    def fake_run(command, **kwargs):
-        raise AssertionError("no milestone query expected")
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    calls = []
+    monkeypatch.setattr(runner, "run_command", calls.append)
     assert runner.advance_active_milestone(
         {"active_milestone": None, "config_path": None}, "o/r", "v0.3.0",
     ) is None
+    assert calls == []
 
 
 def test_advance_active_milestone_is_a_noop_when_active_differs(
@@ -13959,27 +13958,51 @@ def test_advance_active_milestone_is_a_noop_when_active_differs(
         encoding="utf-8",
     )
 
-    def fake_run(command, **kwargs):
-        raise AssertionError("no milestone query expected")
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    calls = []
+    monkeypatch.setattr(runner, "run_command", calls.append)
     config = {"active_milestone": "v0.3.1", "config_path": config_file}
     assert runner.advance_active_milestone(config, "o/r", "v0.3.0") is None
     assert 'active_milestone = "v0.3.1"' in config_file.read_text(
         encoding="utf-8"
     )
+    assert calls == []
 
 
 def test_advance_active_milestone_fails_fast_on_non_semver_release(
     monkeypatch,
 ):
-    def fake_run(command, **kwargs):
-        raise AssertionError("no milestone query expected")
-
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    calls = []
+    monkeypatch.setattr(runner, "run_command", calls.append)
     config = {"active_milestone": "v0.3.0-rc1", "config_path": None}
     with pytest.raises(RuntimeError, match="not a plain"):
         runner.advance_active_milestone(config, "o/r", "v0.3.0-rc1")
+    assert calls == []
+
+
+def test_advance_active_milestone_ignores_malformed_milestone_entries(
+    monkeypatch, tmp_path,
+):
+    """Issue #270: a non-dict entry or a non-string title in the
+    Milestone list is skipped, never guessed at."""
+    config_file = tmp_path / "orbi.toml"
+    config_file.write_text(
+        'source_repos = ["o/r"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+
+    def fake_run(command, **kwargs):
+        return json.dumps([
+            "not-a-dict",
+            {"number": 7, "title": None},
+            {"number": 8, "title": 42},
+            {"number": 2, "title": "v0.3.1", "state": "open"},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.0", "config_path": config_file}
+    assert runner.advance_active_milestone(config, "o/r", "v0.3.0") == (
+        "v0.3.1"
+    )
 
 
 def test_advance_active_milestone_fails_fast_without_config_path(monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4444,7 +4444,7 @@ def _write_prompts(tmp_path):
 def test_main_returns_zero_when_queue_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
@@ -4466,11 +4466,17 @@ def test_main_passes_configured_active_milestone_to_the_claim_scan(
     )
     seen = {}
 
-    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None,
+                  stale_repos=None):
         seen["milestone"] = active_milestone
         return None
 
     monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    # Issue #270: the tick validates the configured Milestone before the
+    # claim scan; stub it as open so no gh call is made.
+    monkeypatch.setattr(
+        runner, "check_active_milestone", lambda repo, title: "open",
+    )
     assert runner.main(["--config", str(config)]) == 0
     assert seen["milestone"] == "v0.2.0"
 
@@ -4485,7 +4491,7 @@ def test_main_passes_none_active_milestone_when_unconfigured(
     config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     seen = {}
 
-    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None):
         seen["milestone"] = active_milestone
         return None
 
@@ -4503,7 +4509,7 @@ def test_main_processes_one_issue(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\nprompt = \"prompt.md\"\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "xqliu/orbi", issue, None
         ),
     )
@@ -4536,7 +4542,7 @@ def test_main_ends_tick_when_process_issue_delivers_nothing(
     config.write_text("source_repos = [\"owner/repo\"]\nprompt = \"prompt.md\"\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, None
         ),
     )
@@ -4563,7 +4569,7 @@ def test_main_ticket_only_finishes_without_entering_pr_delivery_wait(
     config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, None
         ),
     )
@@ -4599,7 +4605,7 @@ def test_main_release_success_ends_tick_without_pr_delivery_wait(
     config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, None
         ),
     )
@@ -4641,7 +4647,7 @@ def test_main_routes_fix_needed_resume_to_delivery_wait(
     }
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, scene,
         ),
     )
@@ -4687,7 +4693,7 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
     }
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, scene,
         ),
     )
@@ -4717,7 +4723,7 @@ def test_main_accepts_repeated_source_repo(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"xqliu/orbi\", \"xqliu/muyan-ceo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             seen.append(repos) or (repos[0], issue, None)
         ),
     )
@@ -7887,7 +7893,7 @@ def test_main_holds_slot_while_processing_issue(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     seen = {}
 
-    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None):
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None):
         seen["occupancy"] = pilot_slots.slot_occupancy(
             tmp_path / ".orbi" / "slots", 1,
         )
@@ -7909,7 +7915,7 @@ def test_main_reacquires_slot_after_previous_release(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
 
     assert runner.main(["--config", str(config)]) == 0
@@ -8072,7 +8078,7 @@ def test_main_unit_drift_auto_syncs_and_proceeds_to_claim(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -8156,7 +8162,7 @@ def test_main_unit_drift_clean_proceeds_to_claim(monkeypatch, tmp_path,
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -8181,7 +8187,7 @@ def test_main_preflight_receives_the_configured_repo_dir(
     config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     assert runner.main(["--config", str(config)]) == 0
     assert seen == [tmp_path]
@@ -8260,7 +8266,7 @@ def test_main_transport_check_clean_proceeds_to_claim(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(config)]) == 0
@@ -8293,7 +8299,7 @@ def test_main_transport_preflight_receives_the_configured_args(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     assert runner.main(["--config", str(config)]) == 0
     assert seen["repo_dir"] == tmp_path
@@ -8328,7 +8334,7 @@ def test_main_cli_install_refresh_runs_before_slot_and_claim(
     )
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: None,
     )
     assert runner.main(["--config", str(config)]) == 0
     assert seen["repo_dir"] == tmp_path
@@ -9708,7 +9714,7 @@ def test_main_holds_slot_through_delivery_wait(monkeypatch, tmp_path):
     _write_prompts(tmp_path)
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, None
         ),
     )
@@ -11152,7 +11158,7 @@ def test_main_installs_the_stop_handler(monkeypatch, tmp_path):
     repo.mkdir()
     (repo / ".git").mkdir()
     monkeypatch.setattr(
-        runner, "pick_next_delivery", lambda *args: None,
+        runner, "pick_next_delivery", lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(runner, "acquire_slot", lambda *args: Mock(release=lambda: None))
     monkeypatch.setattr(runner, "refresh_cli_install", lambda *a, **k: "unchanged")
@@ -13623,3 +13629,399 @@ def test_apply_runner_runtime_excludes_creates_a_missing_exclude_file(
     runner.apply_runner_runtime_excludes(wt)
     lines = exclude.read_text(encoding="utf-8").splitlines()
     assert lines == list(runner.RUNNER_RUNTIME_EXCLUDES)
+
+
+# ---------------------------------------------------------------------------
+# Issue #270: active_milestone staleness — a distinguishable reason instead
+# of an indiscriminate no_ready_issue (B), and auto-advance after a release
+# closes its milestone (A).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_milestone_version_parses_semver_titles():
+    assert runner.parse_milestone_version("v0.3.0") == (0, 3, 0)
+    assert runner.parse_milestone_version("0.3.0") == (0, 3, 0)
+    assert runner.parse_milestone_version("v1.10.2") == (1, 10, 2)
+
+
+def test_parse_milestone_version_rejects_non_semver_titles():
+    assert runner.parse_milestone_version("latest") is None
+    assert runner.parse_milestone_version("v0.3") is None
+    assert runner.parse_milestone_version("v0.3.0-rc1") is None
+    assert runner.parse_milestone_version("") is None
+
+
+def test_check_active_milestone_returns_open_state(monkeypatch):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return json.dumps([
+            {"number": 5, "title": "v0.3.0", "state": "open",
+             "open_issues": 3},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.check_active_milestone("o/r", "v0.3.0") == "open"
+    assert commands == [["gh", "api", "repos/o/r/milestones?state=all",
+                         "--paginate"]]
+
+
+def test_check_active_milestone_returns_closed_state(monkeypatch):
+    def fake_run(command, **kwargs):
+        return json.dumps([
+            {"number": 5, "title": "v0.3.0", "state": "closed",
+             "open_issues": 0},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.check_active_milestone("o/r", "v0.3.0") == "closed"
+
+
+def test_check_active_milestone_returns_missing_for_unknown_title(
+    monkeypatch,
+):
+    def fake_run(command, **kwargs):
+        return json.dumps([
+            {"number": 5, "title": "v0.3.0", "state": "open",
+             "open_issues": 0},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.check_active_milestone("o/r", "v9.9.9") == "missing"
+
+
+def test_check_active_milestone_fails_fast_on_ambiguous_titles(monkeypatch):
+    def fake_run(command, **kwargs):
+        return json.dumps([
+            {"number": 5, "title": "v0.3.0", "state": "open"},
+            {"number": 6, "title": "v0.3.0", "state": "open"},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        runner.check_active_milestone("o/r", "v0.3.0")
+
+
+def test_check_active_milestone_propagates_gh_failure(monkeypatch):
+    def fake_run(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command, stderr="rate limit exceeded"
+        )
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.check_active_milestone("o/r", "v0.3.0")
+
+
+def test_pick_next_delivery_skips_ready_scan_for_stale_repos(monkeypatch):
+    """Issue #270: a repo whose active_milestone is closed/missing is
+    skipped by the fresh-claim scan — a closed Milestone with leftover
+    open Issues must never be claimed."""
+    picked = []
+
+    def fake_pick(repo, active_milestone=None):
+        picked.append(repo)
+        return {"number": 1, "title": "t", "body": "b"}
+
+    monkeypatch.setattr(runner, "pick_issue", fake_pick)
+    monkeypatch.setattr(runner, "pick_resumable_delivery", lambda *a: None)
+    monkeypatch.setattr(runner, "pick_in_progress_issue", lambda *a: None)
+    result = runner.pick_next_delivery(
+        ["o/stale", "o/fresh"], Path("/slots"), 1,
+        active_milestone="v0.3.0", stale_repos={"o/stale"},
+    )
+    assert result == ("o/fresh", {"number": 1, "title": "t", "body": "b"},
+                      None)
+    assert picked == ["o/fresh"]
+
+
+def test_pick_next_delivery_scans_every_repo_without_stale_repos(
+    monkeypatch,
+):
+    """Issue #270 compat: without `stale_repos` the ready scan is
+    byte-identical to the pre-#270 behavior."""
+    picked = []
+
+    def fake_pick(repo, active_milestone=None):
+        picked.append(repo)
+        return None
+
+    monkeypatch.setattr(runner, "pick_issue", fake_pick)
+    monkeypatch.setattr(runner, "pick_resumable_delivery", lambda *a: None)
+    monkeypatch.setattr(runner, "pick_in_progress_issue", lambda *a: None)
+    assert runner.pick_next_delivery(
+        ["o/a", "o/b"], Path("/slots"), 1, active_milestone="v0.3.0",
+    ) is None
+    assert picked == ["o/a", "o/b"]
+
+
+def test_main_stale_milestone_logs_reason_instead_of_no_ready_issue(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #270 regression: with a closed active_milestone the tick must
+    log `active_milestone_stale` and must NOT log the indiscriminate
+    `outcome=no_ready_issue`."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+    seen = {}
+
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None,
+                  stale_repos=None):
+        seen["stale"] = stale_repos
+        return None
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    monkeypatch.setattr(
+        runner, "check_active_milestone", lambda repo, title: "closed",
+    )
+    with caplog.at_level("WARNING"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert seen["stale"] == {"owner/repo"}
+    assert "active_milestone_stale" in caplog.text
+    assert "state=closed" in caplog.text
+    assert "outcome=no_ready_issue" not in caplog.text
+
+
+def test_main_missing_milestone_logs_reason_instead_of_no_ready_issue(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #270: a configured milestone that does not exist is reported
+    as `state=missing`, never as an ordinary empty queue."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v9.9.9"\n',
+        encoding="utf-8",
+    )
+
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None,
+                  stale_repos=None):
+        return None
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    monkeypatch.setattr(
+        runner, "check_active_milestone", lambda repo, title: "missing",
+    )
+    with caplog.at_level("WARNING"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert "active_milestone_stale" in caplog.text
+    assert "state=missing" in caplog.text
+    assert "outcome=no_ready_issue" not in caplog.text
+
+
+def test_main_valid_milestone_keeps_no_ready_issue_outcome(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #270: an open milestone with no ready issues keeps the exact
+    pre-change outcome — no stale warning, plain no_ready_issue."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+
+    def fake_pick(repos, slot_dir, max_concurrency, active_milestone=None,
+                  stale_repos=None):
+        assert stale_repos == set()
+        return None
+
+    monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    monkeypatch.setattr(
+        runner, "check_active_milestone", lambda repo, title: "open",
+    )
+    with caplog.at_level("INFO"):
+        assert runner.main(["--config", str(config)]) == 0
+    assert "outcome=no_ready_issue" in caplog.text
+    assert "active_milestone_stale" not in caplog.text
+
+
+def test_set_config_active_milestone_rewrites_only_the_milestone_line(
+    tmp_path,
+):
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\n'
+        'active_milestone = "v0.3.0"\n'
+        'base_branch = "main"\n',
+        encoding="utf-8",
+    )
+    runner.set_config_active_milestone(config, "v0.3.1")
+    text = config.read_text(encoding="utf-8")
+    assert 'active_milestone = "v0.3.1"' in text
+    assert 'active_milestone = "v0.3.0"' not in text
+    assert 'source_repos = ["owner/repo"]' in text
+    assert 'base_branch = "main"' in text
+
+
+def test_set_config_active_milestone_handles_single_quoted_line(tmp_path):
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        "source_repos = [\"owner/repo\"]\n"
+        "active_milestone = 'v0.3.0'\n",
+        encoding="utf-8",
+    )
+    runner.set_config_active_milestone(config, "v0.3.1")
+    assert 'active_milestone = "v0.3.1"' in config.read_text(encoding="utf-8")
+
+
+def test_set_config_active_milestone_fails_fast_without_the_line(tmp_path):
+    config = tmp_path / "orbi.toml"
+    config.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    with pytest.raises(RuntimeError, match="no active_milestone line"):
+        runner.set_config_active_milestone(config, "v0.3.1")
+    assert 'active_milestone' not in config.read_text(encoding="utf-8")
+
+
+def _open_milestones_payload() -> str:
+    return json.dumps([
+        {"number": 2, "title": "v0.3.1", "state": "open", "open_issues": 8},
+        {"number": 3, "title": "v0.4.0", "state": "open", "open_issues": 0},
+        {"number": 4, "title": "latest", "state": "open", "open_issues": 0},
+    ])
+
+
+def test_advance_active_milestone_moves_to_nearest_open_semver(
+    monkeypatch, tmp_path,
+):
+    config_file = tmp_path / "orbi.toml"
+    config_file.write_text(
+        'source_repos = ["o/r"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return _open_milestones_payload()
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.0", "config_path": config_file}
+    assert runner.advance_active_milestone(config, "o/r", "v0.3.0") == (
+        "v0.3.1"
+    )
+    assert commands == [["gh", "api", "repos/o/r/milestones?state=open",
+                         "--paginate"]]
+    assert 'active_milestone = "v0.3.1"' in config_file.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_advance_active_milestone_logs_none_when_there_is_no_next(
+    monkeypatch, tmp_path, caplog,
+):
+    config_file = tmp_path / "orbi.toml"
+    config_file.write_text(
+        'source_repos = ["o/r"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+
+    def fake_run(command, **kwargs):
+        return json.dumps([
+            {"number": 1, "title": "v0.2.0", "state": "open"},
+            {"number": 2, "title": "latest", "state": "open"},
+        ])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.0", "config_path": config_file}
+    assert runner.advance_active_milestone(config, "o/r", "v0.3.0") is None
+    # The config is untouched: the next tick's stale check keeps reporting
+    # the closed Milestone until a human acts.
+    assert 'active_milestone = "v0.3.0"' in config_file.read_text(
+        encoding="utf-8"
+    )
+    assert "active_milestone_advance_none" in caplog.text
+
+
+def test_advance_active_milestone_is_a_noop_when_scope_is_unset(
+    monkeypatch,
+):
+    def fake_run(command, **kwargs):
+        raise AssertionError("no milestone query expected")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.advance_active_milestone(
+        {"active_milestone": None, "config_path": None}, "o/r", "v0.3.0",
+    ) is None
+
+
+def test_advance_active_milestone_is_a_noop_when_active_differs(
+    monkeypatch, tmp_path,
+):
+    config_file = tmp_path / "orbi.toml"
+    config_file.write_text(
+        'source_repos = ["o/r"]\nactive_milestone = "v0.3.1"\n',
+        encoding="utf-8",
+    )
+
+    def fake_run(command, **kwargs):
+        raise AssertionError("no milestone query expected")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.1", "config_path": config_file}
+    assert runner.advance_active_milestone(config, "o/r", "v0.3.0") is None
+    assert 'active_milestone = "v0.3.1"' in config_file.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_advance_active_milestone_fails_fast_on_non_semver_release(
+    monkeypatch,
+):
+    def fake_run(command, **kwargs):
+        raise AssertionError("no milestone query expected")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.0-rc1", "config_path": None}
+    with pytest.raises(RuntimeError, match="not a plain"):
+        runner.advance_active_milestone(config, "o/r", "v0.3.0-rc1")
+
+
+def test_advance_active_milestone_fails_fast_without_config_path(monkeypatch):
+    def fake_run(command, **kwargs):
+        return _open_milestones_payload()
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    config = {"active_milestone": "v0.3.0", "config_path": None}
+    with pytest.raises(RuntimeError, match="no config path"):
+        runner.advance_active_milestone(config, "o/r", "v0.3.0")
+
+
+def test_process_release_advances_active_milestone_after_closing_it(
+    monkeypatch, tmp_path,
+):
+    """Issue #270 A: the release success path writes the next open
+    milestone into the config file, so the next tick claims from it
+    without a human config edit."""
+    make_release_process_env(monkeypatch)
+    config_file = tmp_path / "orbi.toml"
+    config_file.write_text(
+        'source_repos = ["o/r"]\nactive_milestone = "v0.3.0"\n',
+        encoding="utf-8",
+    )
+    real_run = runner.run_command
+
+    def run_with_open_milestones(command, **kwargs):
+        if command == ["gh", "api", "repos/o/r/milestones?state=open",
+                       "--paginate"]:
+            return json.dumps([
+                {"number": 6, "title": "v0.3.1", "state": "open",
+                 "open_issues": 8},
+            ])
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_command", run_with_open_milestones)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    config = {"repo_dir": Path("/r"), "base_branch": "main",
+              "active_milestone": "v0.3.0", "config_path": config_file}
+    runner.process_release(issue, config, "o/r")
+    assert 'active_milestone = "v0.3.1"' in config_file.read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -843,7 +843,7 @@ def test_main_resumes_resumable_delivery_before_claiming_new(monkeypatch, tmp_pa
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, scene
         ),
     )
@@ -884,7 +884,7 @@ def test_main_still_claims_new_issue_when_no_resumable(monkeypatch, tmp_path):
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
     monkeypatch.setattr(
         runner, "pick_next_delivery",
-        lambda repos, slot_dir, max_concurrency, active_milestone=None: (
+        lambda repos, slot_dir, max_concurrency, active_milestone=None, stale_repos=None: (
             "owner/repo", issue, None
         ),
     )


### PR DESCRIPTION
<!-- orbi:run=e5c50918 -->

Fixes #270

Bug：发布后 active_milestone 不前进，Runner 静默空转且无法从日志区分 (run_id=e5c50918)
