### PR TITLE
根治 dirty-worktree 门禁：orbi 自有契约产物源头迁出交付树（不再逐个补 .gitignore）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ each section points at the owning page instead of restating it.
 - External APIs, CLI flags and HTTP paths are asserted against official docs or one real call.
 - Blocking commands (Issue #95): any shell command that can block (running tests, generator/polling verification, network waits, interactive tools) is wrapped in `timeout <seconds> ...`; a timeout is the signal that the path needs a fix, never ignorable noise.
 - Testing an unbounded-loop function (`while True` poller) requires a termination guard (monkeypatched `time.sleep` raising on the Nth call, an injected iteration cap, or pytest-timeout): the red phase must fail fast and never hang.
-- Test exit codes (Issue #180): a pipeline exits with the exit code of the last command, so `pytest ... | tail` exits 0 even when pytest fails — never pipe a test, build or smoke command through `tail`, `head`, `grep` or any other filter that drops the exit code; redirect to a file and keep the real exit code (`set -o pipefail`, or `> test.log 2>&1; echo "exit=$?"`); `test.log` carries the real pytest output, never a self-declared "tests passed".
-- Coverage gate (Issue #234), tiered: the whole repository keeps line >= 95% and branch >= 95% (checked separately, never a merged single percentage); the Python lines and branches changed in the current PR keep 100% line/branch; the core state machines and critical failure paths (model_wait/idle recovery, Issue/label lifecycle, Git/PR/merge gate, config validation, deployment failure paths) keep 100% line/branch through their existing tests. Code below 95% is only allowed for non-core, clearly explainable legacy/defensive branches and must stay locatable in the coverage report — no unjustified `# pragma: no cover`. Full policy: `docs/testing.mdx` (EN) / `docs/zh/testing.mdx` (ZH):
+- Test exit codes (Issue #180): a pipeline exits with the exit code of the last command, so `pytest ... | tail` exits 0 even when pytest fails — never pipe a test, build or smoke command through `tail`, `head`, `grep` or any other filter that drops the exit code; redirect to a file and keep the real exit code (`set -o pipefail`, or `> .orbi/test.log 2>&1; echo "exit=$?"`); `.orbi/test.log` carries the real pytest output, never a self-declared "tests passed".
+- Run artifacts live in the excluded run dir (Issue #302): plan, test log and coverage data go to `.orbi/` (`.orbi/plan.md`, `.orbi/test.log`) — never at the worktree root, so the dirty-worktree gate never sees an orbi-produced artifact and a broken/renamed `.gitignore` weakens nothing (the Runner pins them in the local exclude).
+- Coverage gate (Issue #234), tiered: the whole repository keeps line >= 95% and branch >= 95% (checked separately, never a merged single percentage); the Python lines and branches changed in the current PR keep 100% line/branch; the core state machines and critical failure paths (model_wait/idle recovery, Issue/label lifecycle, Git/PR/merge gate, config validation, deployment failure paths) keep 100% line/branch through their existing tests. Code below 95% is only allowed for non-core, clearly explainable legacy/defensive branches and must stay locatable in the coverage report — no unjustified `# pragma: no cover`. Full policy: `docs/testing.mdx` (EN) / `docs/zh/testing.mdx` (ZH). The coverage data file lives in the excluded run dir — the worktree root never carries a coverage artifact:
 
   ```bash
-  /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-  /usr/bin/python3 -m coverage report --show-missing
-  /usr/bin/python3 coverage_gate.py
-  /usr/bin/python3 diff_coverage_gate.py origin/main
+  COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+  COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing
+  COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 coverage_gate.py .orbi/.coverage
+  COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 diff_coverage_gate.py origin/main
   ```
 
 ## UI work

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -21,13 +21,17 @@ entry guards and one defensive `except` guard in a test).
 ## Local contract commands
 
 Run them from the repository root (production interpreter
-`/usr/bin/python3`, Python 3.14):
+`/usr/bin/python3`, Python 3.14). `COVERAGE_FILE` (the official
+coverage.py environment variable) points the coverage data into the
+excluded run dir `.orbi/` (Issue #302): the worktree root never
+receives a coverage artifact, so the dirty-worktree gate never trips
+over one:
 
 ```bash
-/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-/usr/bin/python3 -m coverage report --show-missing
-/usr/bin/python3 coverage_gate.py
-/usr/bin/python3 diff_coverage_gate.py origin/main
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 coverage_gate.py .orbi/.coverage
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 diff_coverage_gate.py origin/main
 ```
 
 The report shows both real numbers (line and branch) per file. The two

--- a/docs/zh/testing.mdx
+++ b/docs/zh/testing.mdx
@@ -19,13 +19,16 @@ GitHub 远端运行。
 
 ## 本地契约命令
 
-从仓库根目录运行（生产解释器 `/usr/bin/python3`，Python 3.14）：
+从仓库根目录运行（生产解释器 `/usr/bin/python3`，Python 3.14）。`COVERAGE_FILE`
+（coverage.py 官方环境变量）把覆盖率数据指到已排除的运行目录 `.orbi/`
+（Issue #302）：worktree 根不会出现任何覆盖率产物，dirty-worktree 门禁
+也就不会被它绊住：
 
 ```bash
-/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-/usr/bin/python3 -m coverage report --show-missing
-/usr/bin/python3 coverage_gate.py
-/usr/bin/python3 diff_coverage_gate.py origin/main
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 coverage_gate.py .orbi/.coverage
+COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 diff_coverage_gate.py origin/main
 ```
 
 报告逐文件给出两个真实数字（行和分支）。两个门禁脚本才是门禁，不是

--- a/prompt.md
+++ b/prompt.md
@@ -26,8 +26,11 @@ another id (no `trace_id`, no new UUID) for this run.
   body; the runner rejects a delivery whose PR body is missing it.
 - Every Issue or PR comment you post (progress, review, fix, final) must
   contain the same marker and the visible field `run_id={{RUN_ID}}`.
-- Keep all run artifacts (plan, test, verify, review report) inside the task
-  worktree, whose path already carries `{{RUN_ID}}`.
+- Keep all run artifacts (plan, test, verify, review report) inside the
+  task worktree's excluded run dir `.orbi/` (`.orbi/plan.md`,
+  `.orbi/test.log` — never at the worktree root: a run artifact must
+  never reach the dirty-worktree gate, Issue #302); the worktree path
+  itself already carries `{{RUN_ID}}`.
 
 Read only what the task needs, in this priority order (Issue #180): the
 GitHub Issue (body and comments), the target repository's `AGENTS.md`,
@@ -91,15 +94,15 @@ Hard rules for test evidence (Issue #180):
   test, build or smoke command through `tail`, `head`, `grep` or any
   other filter that drops the exit code.
 - When the output is too long to display, keep the full output AND the
-  real exit code: redirect to a file (`pytest ... > test.log 2>&1;`
-  `echo "exit=$?" >> test.log`) and then `tail` the file, or run the
-  pipeline with `set -o pipefail`. The pytest exit code — not the
+  real exit code: redirect to a file (`pytest ... > .orbi/test.log 2>&1;`
+  `echo "exit=$?" >> .orbi/test.log`) and then `tail` the file, or run
+  the pipeline with `set -o pipefail`. The pytest exit code — not the
   pipeline's — is the result.
-- `test.log` must contain the real pytest output (the summary line, e.g.
-  `156 passed in 4.43s` or `1 failed, 155 passed in 4.43s`), never a
-  self-declared "tests passed": the Runner reads `test.log` for the
-  `tests passed/failed` milestone and the progress comment, and it must
-  stay consistent with CI.
+- `.orbi/test.log` must contain the real pytest output (the summary
+  line, e.g. `156 passed in 4.43s` or `1 failed, 155 passed in 4.43s`),
+  never a self-declared "tests passed": the Runner reads `.orbi/test.log`
+  for the `tests passed/failed` milestone and the progress comment, and
+  it must stay consistent with CI.
 - A failed run must be fixed before the delivery is committed: a
   delivery whose last test result in `test.log` is a failure is not a
   delivery.
@@ -107,7 +110,7 @@ Hard rules for test evidence (Issue #180):
 Context recovery after compaction (Issue #180):
 
 When the session context is compacted, recover from the run artifacts —
-read `plan.md`, `test.log`, the run's progress comment (the hidden run
+read `.orbi/plan.md`, `.orbi/test.log`, the run's progress comment (the hidden run
 marker) and, for a resumed delivery, the review findings comments — and
 continue from there. Do not re-scan the whole repository and do not
 re-read every context file: the artifacts carry the current plan, the
@@ -127,10 +130,10 @@ and the real test suite, not by reviewing yourself.
 Work through this exact loop:
 
 1. Read the GitHub Issue and inspect the relevant repository under the configured workspace root. The runner supplies the source repository and its context.
-2. Write `plan.md` with the goal, inspected context, repository decision, tasks, and verification commands.
+2. Write `.orbi/plan.md` with the goal, inspected context, repository decision, tasks, and verification commands.
 3. Implement the smallest complete change.
 4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts.
-5. Run the real project tests/build/smoke checks and record the commands and results in `test.log` inside the task worktree (the automatic `tests passed/failed` milestone and the progress comment's tests field read that file).
+5. Run the real project tests/build/smoke checks and record the commands and results in `.orbi/test.log` inside the task worktree (the automatic `tests passed/failed` milestone and the progress comment's tests field read that file).
 6. Verify the result yourself.
 7. Commit the change on the task branch. Your job ends at the committed delivery: you do not fetch the base, push, or create the PR. The Runner then completes the deterministic closeout (Issue #186): it re-fetches the base under the shared base-sync lock, absorbs a base advance with a plain merge, pushes the task branch, and opens exactly one PR for this Issue whose body contains the run marker and `Fixes #{{ISSUE_NUMBER}}` (it may be on the first line) so GitHub natively closes the source Issue when the PR merges into the default branch. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.
 

--- a/prompt_review.md
+++ b/prompt_review.md
@@ -35,7 +35,8 @@ pointless compactions of long sessions.
 ## Context recovery after compaction (Issue #180)
 
 When the session context is compacted, recover from the run artifacts —
-read the worktree's `plan.md` and `test.log`, the review findings
+read the worktree's `.orbi/plan.md` and `.orbi/test.log` (the excluded
+run dir, Issue #302), the review findings
 comments of this run (the Issue and PR comments carrying the run marker)
 and the run's progress comment — and continue from there. Do not
 re-scan the whole repository and do not re-read every context file: the
@@ -94,12 +95,12 @@ the exit code of the last command, so `pytest ... | tail` exits 0 even
 when pytest fails and the failure is disguised as a shell success. Never
 pipe a test, build or smoke command through `tail`, `head`, `grep` or
 any other filter that drops the exit code — redirect to a file
-(`pytest ... > test.log 2>&1;` `echo "exit=$?" >> test.log`) and then
-`tail` the file, or run the pipeline with `set -o pipefail`. `test.log`
-must contain the real pytest output (the summary line), never a
-self-declared "tests passed": the Runner reads it for the progress
-comment and the `tests passed/failed` milestone, and it must stay
-consistent with CI.
+(`pytest ... > .orbi/test.log 2>&1;` `echo "exit=$?" >> .orbi/test.log`)
+and then `tail` the file, or run the pipeline with `set -o pipefail`.
+`.orbi/test.log` (the excluded run dir, Issue #302) must contain the
+real pytest output (the summary line), never a self-declared "tests
+passed": the Runner reads it for the progress comment and the `tests
+passed/failed` milestone, and it must stay consistent with CI.
 
 1. CI first: when the PR has CI failures, read the CI failure logs
    BEFORE running any local test — `gh pr checks {{PR_NUMBER}}` (the

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4525,6 +4525,11 @@ def run_pi(issue: dict, worktree: Path, config: dict, source_repo: str,
     # local exclude BEFORE Pi starts (covers create, resume and
     # implement) — the tracked .gitignore is the agent's to rename.
     apply_runner_runtime_excludes(worktree)
+    # Issue #302: the run artifact dir exists BEFORE the session starts,
+    # so the contract commands write `.orbi/plan.md`, `.orbi/test.log`
+    # and the coverage artifacts without a mkdir step (a shell redirect
+    # into a missing directory fails the command outright).
+    (worktree / ".orbi").mkdir(exist_ok=True)
     started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt"].read_text(encoding="utf-8"),
@@ -4786,7 +4791,26 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
 # never depends on the task branch's content. The #246 rename converged the
 # legacy state dir onto `.orbi/`, so the migration window is closed and a
 # single pattern covers it.
-RUNNER_RUNTIME_EXCLUDES = (".orbi/", ".pi-session/")
+#
+# Issue #302 extends the set with the ORBI CONTRACT ARTIFACTS: the pi-loop
+# plugin state (#215) and the per-run plan/test/verify artifacts the
+# Runner's own prompt tells the agent to write (pre-#302 at the worktree
+# root, now under the excluded `.orbi/` run dir). The four historical
+# dirty-gate incidents (#215/#235/#256/#301) were all orbi-owned artifacts
+# blocking a finished delivery — the exemption is now the Runner's runtime
+# behavior, not a hand-maintained tracked blacklist. Excludes hide only
+# untracked paths, so a modified tracked file or a committed artifact
+# still fails the gate; coverage command artifacts are NOT in this set —
+# the contract commands write them into the excluded `.orbi/` run dir and
+# the tracked `.gitignore` stays as the fallback layer.
+RUNNER_RUNTIME_EXCLUDES = (
+    ".orbi/",
+    ".pi-session/",
+    ".pi/",
+    "plan.md",
+    "test.log",
+    "verify.md",
+)
 
 
 def runner_runtime_exclude_path(worktree: Path) -> Path:
@@ -5431,6 +5455,9 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     # Issue #256: the review/fix session gets the SAME local-exclude
     # preflight as the implementer (one idempotent helper, Pi 前).
     apply_runner_runtime_excludes(worktree)
+    # Issue #302: same run-dir guarantee as the implementer — the
+    # review session reads/writes the same `.orbi/` artifacts.
+    (worktree / ".orbi").mkdir(exist_ok=True)
     started = time.monotonic()
     system_prompt = render_prompt(
         config["prompt_review"].read_text(encoding="utf-8"),
@@ -6316,7 +6343,9 @@ def _is_no_result(line: str) -> bool:
 
 
 def read_test_result(worktree: Path) -> str | None:
-    """Summarize the worktree's `test.log`, or None when it does not exist.
+    """Summarize the worktree's `.orbi/test.log`, or None when it does
+    not exist (Issue #302: the contract test command writes the log
+    into the excluded run dir, never at the worktree root).
 
     Prefers the pytest summary line (`1 failed, 155 passed in 4.43s`):
     the LAST one with an outcome when the log holds several runs (TDD
@@ -6331,7 +6360,7 @@ def read_test_result(worktree: Path) -> str | None:
     and posting `tests passed` for it is a false notification (review
     round 3, PR #42).
     """
-    path = worktree / "test.log"
+    path = worktree / ".orbi" / "test.log"
     if not path.is_file():
         return None
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -6422,8 +6451,9 @@ def _progress_body(state: dict, *, outcome: str | None = None) -> str:
 
 
 def _publish_plan_milestone(publisher: ProgressPublisher, worktree: Path) -> None:
-    """Post the `plan ready` milestone once the worktree has a plan.md."""
-    if (worktree / "plan.md").is_file():
+    """Post the `plan ready` milestone once the worktree has the plan
+    artifact (Issue #302: `.orbi/plan.md`, the excluded run dir)."""
+    if (worktree / ".orbi" / "plan.md").is_file():
         publisher.milestone("plan ready")
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14454,6 +14454,9 @@ def test_run_pi_applies_runner_runtime_excludes_before_pi(monkeypatch, tmp_path)
         "owner/repo",
     )
     assert applied == [tmp_path]
+    # Issue #302: the run artifact dir exists before the session — the
+    # contract commands write `.orbi/plan.md` / `.orbi/test.log` into it.
+    assert (tmp_path / ".orbi").is_dir()
 
 
 def test_run_review_applies_runner_runtime_excludes_before_pi(
@@ -14479,6 +14482,9 @@ def test_run_review_applies_runner_runtime_excludes_before_pi(
         "owner/repo", 4, "branch", 1,
     )
     assert applied == [tmp_path]
+    # Issue #302: the review session reads/writes the same .orbi/ run
+    # artifacts — the run dir exists here too.
+    assert (tmp_path / ".orbi").is_dir()
 
 
 def test_deliver_pr_repairs_runner_runtime_leftovers(monkeypatch, tmp_path,
@@ -14593,6 +14599,18 @@ def test_runner_runtime_only_accepts_quoted_runner_paths():
     # are plain ASCII, so the unquoted match is exact.
     assert runner._is_runner_runtime_only('?? ".orbi/"\n')
     assert runner._is_runner_runtime_only('?? ".pi-session/"\n')
+    # Issue #302: the orbi contract artifact set (pi-loop state, per-run
+    # plan/test/verify artifacts) is runner-owned too — a porcelain entry
+    # carrying only them must keep the repair path open, never the fail
+    # fast.
+    assert runner._is_runner_runtime_only('?? ".pi/"\n')
+    assert runner._is_runner_runtime_only("?? plan.md\n")
+    assert runner._is_runner_runtime_only("?? test.log\n")
+    assert runner._is_runner_runtime_only("?? verify.md\n")
+    # An agent-owned leftover is NEVER runner-owned, mixed or alone.
+    assert runner._is_runner_runtime_only("?? notes.md\n") is False
+    assert runner._is_runner_runtime_only("?? unexpected.py\n") is False
+    assert runner._is_runner_runtime_only("?? plan.md\n?? notes.md\n") is False
 
 
 def test_exclude_path_for_a_plain_checkout_uses_its_own_git_dir(tmp_path):
@@ -14635,3 +14653,68 @@ def test_apply_runner_runtime_excludes_creates_a_missing_exclude_file(
     runner.apply_runner_runtime_excludes(wt)
     lines = exclude.read_text(encoding="utf-8").splitlines()
     assert lines == list(runner.RUNNER_RUNTIME_EXCLUDES)
+
+
+def test_runtime_excludes_exempt_the_orbi_contract_artifacts(tmp_path):
+    """Issue #302 acceptance: the four historical dirty-gate scenes are
+    exempted by the RUNTIME local exclude alone — with NO tracked
+    .gitignore at all (the #246 renamed/broken .gitignore scene), every
+    orbi-owned artifact is invisible to `git status --porcelain` while
+    real agent leftovers still fail the gate. No new .gitignore entry
+    is needed for any of them."""
+    repo, wt = _make_linked_worktree(tmp_path)
+    # The tracked .gitignore is gone entirely: the exemption must not
+    # depend on a file a task can legally rename or break.
+    assert not (wt / ".gitignore").exists()
+    runner.apply_runner_runtime_excludes(wt)
+    # Scene #215: pi-loop state written at session shutdown.
+    (wt / ".pi").mkdir()
+    (wt / ".pi" / "loops.json").write_text("{}\n", encoding="utf-8")
+    # Scene #256: runner runtime state (the brand dir and the pi
+    # session dir).
+    (wt / ".orbi").mkdir()
+    (wt / ".orbi" / "run-state.json").write_text("{}\n", encoding="utf-8")
+    (wt / ".pi-session").mkdir()
+    (wt / ".pi-session" / "s.jsonl").write_text("{}\n", encoding="utf-8")
+    # The per-run contract artifacts (the pre-#302 prompt wrote them at
+    # the worktree root) and the coverage gate output in the run dir.
+    for name in ("plan.md", "test.log", "verify.md"):
+        (wt / name).write_text("artifact\n", encoding="utf-8")
+    (wt / ".orbi" / "coverage.json").write_text(
+        '{"totals": {}}\n', encoding="utf-8",
+    )
+    (wt / ".orbi" / "test.log").write_text("156 passed\n", encoding="utf-8")
+    assert subprocess.run(
+        ["git", "status", "--porcelain"], cwd=wt,
+        capture_output=True, text=True, check=True,
+    ).stdout == ""
+    # The gate is NOT weakened: real agent leftovers are still reported.
+    (wt / "unexpected.py").write_text("x = 1\n", encoding="utf-8")
+    (wt / "notes.md").write_text("notes\n", encoding="utf-8")
+    lines = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=wt,
+        capture_output=True, text=True, check=True,
+    ).stdout.splitlines()
+    assert "?? unexpected.py" in lines
+    assert "?? notes.md" in lines
+
+
+def test_runtime_excludes_never_hide_a_modified_tracked_file(tmp_path):
+    # Issue #302 reverse verification: the runtime exclude only ever
+    # hides UNTRACKED orbi artifacts — a modified tracked source file is
+    # never exempted (excludes cannot hide tracked changes), so the
+    # delivery gate still fails fast on it.
+    repo, wt = _make_linked_worktree(tmp_path)
+    tracked = wt / "src.py"
+    tracked.write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(wt), "add", "src.py"], check=True)
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "src"], check=True,
+    )
+    runner.apply_runner_runtime_excludes(wt)
+    tracked.write_text("x = 2\n", encoding="utf-8")
+    (wt / "plan.md").write_text("artifact\n", encoding="utf-8")
+    assert subprocess.run(
+        ["git", "status", "--porcelain"], cwd=wt,
+        capture_output=True, text=True, check=True,
+    ).stdout == " M src.py\n"

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -71,6 +71,9 @@ def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
     def fake_create_worktree(*args, **kwargs):
         path = tmp_path / "wt"
         path.mkdir(parents=True, exist_ok=True)
+        # Issue #302: the real run_pi creates the .orbi/ run dir before
+        # the session; the fake worktree mirrors that guarantee.
+        (path / ".orbi").mkdir(exist_ok=True)
         return path
 
     monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
@@ -105,12 +108,21 @@ def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
 # --- helpers ------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _orbi_run_dir(tmp_path):
+    """Issue #302: the runner creates the excluded `.orbi/` run dir
+    before every Pi session; the milestone readers expect the run
+    artifacts there. Stand-in for the real preflight (run_pi is mocked
+    in the wiring tests)."""
+    (tmp_path / ".orbi").mkdir(exist_ok=True)
+
+
 def test_read_test_result_returns_none_without_test_log(tmp_path):
     assert runner.read_test_result(tmp_path) is None
 
 
 def test_read_test_result_returns_matching_summary_line(tmp_path):
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "collected 202 items\n156 passed in 4.43s\n",
         encoding="utf-8",
     )
@@ -118,12 +130,12 @@ def test_read_test_result_returns_matching_summary_line(tmp_path):
 
 
 def test_read_test_result_falls_back_to_last_line(tmp_path):
-    (tmp_path / "test.log").write_text("hello\nworld\n", encoding="utf-8")
+    (tmp_path / ".orbi" / "test.log").write_text("hello\nworld\n", encoding="utf-8")
     assert runner.read_test_result(tmp_path) == "world"
 
 
 def test_read_test_result_returns_none_for_blank_log(tmp_path):
-    (tmp_path / "test.log").write_text("   \n", encoding="utf-8")
+    (tmp_path / ".orbi" / "test.log").write_text("   \n", encoding="utf-8")
     assert runner.read_test_result(tmp_path) is None
 
 
@@ -132,7 +144,7 @@ def test_read_test_result_skips_failures_section_header(tmp_path):
     line, not the `=== FAILURES ===` section header (review round 2, PR
     #42): the old code returned the first `=` line, so a failed run
     posted `tests passed: === FAILURES ===`."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "============================= test session starts "
         "=============================\n"
         "platform linux -- Python 3.12.3, pytest-9.0.3\n"
@@ -161,7 +173,7 @@ def test_read_test_result_skips_failures_section_header(tmp_path):
 def test_read_test_result_prefers_last_summary_of_a_multi_run_log(tmp_path):
     """A log holding several runs (TDD red, then green) reports the most
     recent run: the last pytest summary line."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "1 failed, 155 passed in 4.43s\n"
         "--- second run ---\n"
         "156 passed in 4.43s\n",
@@ -176,7 +188,7 @@ def test_read_test_result_falls_back_to_failed_line_without_summary(
     """A truncated log with a FAILURES section but no summary line must
     not report the section header: the first `FAILED` line is the
     failure evidence."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "=================================== FAILURES "
         "==================================\n"
         "FAILED tests/test_b.py::test_b_fails - assert 1 == 2\n",
@@ -189,7 +201,7 @@ def test_read_test_result_falls_back_to_failed_line_without_summary(
 def test_read_test_result_unwraps_padded_summary_line(tmp_path):
     """Some runners wrap the final summary in `=` padding; the reported
     line is the bare summary, never the padding."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "========================= 1 failed, 155 passed in 4.43s "
         "=========================\n",
         encoding="utf-8",
@@ -203,7 +215,7 @@ def test_read_test_result_is_none_when_the_log_holds_only_headers(
     """A log holding nothing but section headers carries no result info:
     reporting the header itself is the bug this fix removes (review
     round 2, PR #42)."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "==================== FAILURES ====================\n",
         encoding="utf-8",
     )
@@ -214,7 +226,7 @@ def test_read_test_result_is_none_when_no_tests_ran(tmp_path):
     """A pytest run that collected no tests verified nothing: reporting
     it as a pass is a false mobile notification (review round 3, PR
     #42)."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "collected 0 items\nno tests ran in 0.01s\n",
         encoding="utf-8",
     )
@@ -224,7 +236,7 @@ def test_read_test_result_is_none_when_no_tests_ran(tmp_path):
 def test_read_test_result_is_none_when_no_tests_collected(tmp_path):
     """The collect-only variant of the no-tests message is no result
     either."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "no tests collected in 0.00s\n", encoding="utf-8",
     )
     assert runner.read_test_result(tmp_path) is None
@@ -233,14 +245,14 @@ def test_read_test_result_is_none_when_no_tests_collected(tmp_path):
 def test_read_test_result_is_none_for_deselected_only_summary(tmp_path):
     """A summary whose counts carry no outcome (`N deselected`) is no
     result either (review round 3, PR #42)."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "3 deselected in 0.02s\n", encoding="utf-8",
     )
     assert runner.read_test_result(tmp_path) is None
 
 
 def test_read_test_result_is_none_for_skipped_only_summary(tmp_path):
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "2 skipped in 0.01s\n", encoding="utf-8",
     )
     assert runner.read_test_result(tmp_path) is None
@@ -249,7 +261,7 @@ def test_read_test_result_is_none_for_skipped_only_summary(tmp_path):
 def test_read_test_result_prefers_last_run_with_an_outcome(tmp_path):
     """A multi-run log whose LAST run collected no tests reports the
     last run that actually collected tests (review round 3, PR #42)."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "1 failed, 1 passed in 0.03s\n"
         "--- second run (empty selection) ---\n"
         "no tests ran in 0.01s\n",
@@ -261,7 +273,7 @@ def test_read_test_result_prefers_last_run_with_an_outcome(tmp_path):
 def test_read_test_result_reports_error_summary(tmp_path):
     """A collection error IS an outcome (pytest exits non-zero): it is
     reported, so the milestone check can post `tests failed`."""
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "1 error in 0.01s\n", encoding="utf-8",
     )
     assert runner.read_test_result(tmp_path) == "1 error in 0.01s"
@@ -330,7 +342,7 @@ def test_publish_plan_milestone_posts_only_when_plan_exists(tmp_path):
     publisher.milestone = Mock(side_effect=lambda text: posted.append(text))
     runner._publish_plan_milestone(publisher, tmp_path)
     assert posted == []
-    (tmp_path / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (tmp_path / ".orbi" / "plan.md").write_text("# Plan\n", encoding="utf-8")
     runner._publish_plan_milestone(publisher, tmp_path)
     assert posted == ["plan ready"]
 
@@ -342,13 +354,13 @@ def test_publish_test_milestone_posts_passed_or_failed(tmp_path):
     # No test.log: nothing is posted.
     runner._publish_test_milestone(publisher, tmp_path)
     assert posted == []
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "156 passed in 4.43s\n", encoding="utf-8",
     )
     runner._publish_test_milestone(publisher, tmp_path)
     assert posted == ["tests passed: 156 passed in 4.43s"]
     posted.clear()
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "1 failed, 155 passed in 4.43s\n", encoding="utf-8",
     )
     runner._publish_test_milestone(publisher, tmp_path)
@@ -364,7 +376,7 @@ def test_publish_test_milestone_detects_failure_case_insensitively(
     posted = []
     publisher = Mock()
     publisher.milestone = Mock(side_effect=lambda text: posted.append(text))
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "FAILED tests/test_b.py::test_b_fails - assert 1 == 2\n",
         encoding="utf-8",
     )
@@ -382,14 +394,14 @@ def test_publish_test_milestone_posts_nothing_when_no_tests_ran(
     posted = []
     publisher = Mock()
     publisher.milestone = Mock(side_effect=lambda text: posted.append(text))
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "collected 0 items\nno tests ran in 0.01s\n",
         encoding="utf-8",
     )
     runner._publish_test_milestone(publisher, tmp_path)
     assert posted == []
     posted.clear()
-    (tmp_path / "test.log").write_text(
+    (tmp_path / ".orbi" / "test.log").write_text(
         "3 deselected in 0.02s\n", encoding="utf-8",
     )
     runner._publish_test_milestone(publisher, tmp_path)
@@ -583,7 +595,7 @@ def test_process_issue_finishes_progress_comment_with_delivery_summary(
     patch_process_deps(monkeypatch, tmp_path)
 
     def fake_run_pi(*args, **kwargs):
-        (tmp_path / "wt" / "test.log").write_text(
+        (tmp_path / "wt" / ".orbi" / "test.log").write_text(
             "156 passed in 4.43s\n", encoding="utf-8",
         )
         return "done"
@@ -686,7 +698,7 @@ def test_process_issue_posts_plan_ready_milestone_when_plan_written(
     patch_process_deps(monkeypatch, tmp_path)
     # The fake pi session writes plan.md into the worktree.
     def fake_run_pi(*args, **kwargs):
-        (tmp_path / "wt" / "plan.md").write_text(
+        (tmp_path / "wt" / ".orbi" / "plan.md").write_text(
             "# Plan\n\n## Goal\n\nship it\n", encoding="utf-8",
         )
         return "done"
@@ -711,7 +723,7 @@ def test_process_issue_posts_tests_passed_milestone_when_test_log_ok(
     patch_process_deps(monkeypatch, tmp_path)
 
     def fake_run_pi(*args, **kwargs):
-        (tmp_path / "wt" / "test.log").write_text(
+        (tmp_path / "wt" / ".orbi" / "test.log").write_text(
             "156 passed in 4.43s\n", encoding="utf-8",
         )
         return "done"
@@ -734,7 +746,7 @@ def test_process_issue_posts_tests_failed_milestone_when_test_log_fails(
     patch_process_deps(monkeypatch, tmp_path)
 
     def fake_run_pi(*args, **kwargs):
-        (tmp_path / "wt" / "test.log").write_text(
+        (tmp_path / "wt" / ".orbi" / "test.log").write_text(
             "1 failed, 155 passed in 4.43s\n", encoding="utf-8",
         )
         return "done"
@@ -1153,8 +1165,9 @@ def test_process_issue_plan_test_milestone_failures_do_not_fail_delivery(
     # plan.md and a passing test.log so both milestones would post.
     worktree = tmp_path / "wt"
     worktree.mkdir(parents=True, exist_ok=True)
-    (worktree / "plan.md").write_text("# Plan\n", encoding="utf-8")
-    (worktree / "test.log").write_text(
+    (worktree / ".orbi").mkdir(exist_ok=True)
+    (worktree / ".orbi" / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (worktree / ".orbi" / "test.log").write_text(
         "5 passed in 1.0s\n", encoding="utf-8",
     )
 

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -271,9 +271,10 @@ def test_prompt_review_md_narrows_the_context_reads():
 COMPACT_RECOVERY_ITEMS = (
     # The protocol names itself.
     ("compact-section", "context recovery after compaction"),
-    # The recovery reads the run artifacts, not the repository.
-    ("compact-plan", "plan.md"),
-    ("compact-test-log", "test.log"),
+    # The recovery reads the run artifacts, not the repository — in the
+    # excluded run dir (Issue #302), never at the worktree root.
+    ("compact-plan", ".orbi/plan.md"),
+    ("compact-test-log", ".orbi/test.log"),
     ("compact-progress", "progress comment"),
     # The implementer recovers its own plan; the reviewer recovers the
     # findings of the run.
@@ -317,7 +318,7 @@ EXIT_CODE_ITEMS = (
     ("exit-pipe-head", "head"),
     ("exit-pipe-grep", "grep"),
     # Truncation keeps the full output AND the real exit code.
-    ("exit-redirect-file", "> test.log 2>&1"),
+    ("exit-redirect-file", "> .orbi/test.log 2>&1"),
     ("exit-record-code", "exit=$?"),
     ("exit-pipefail", "set -o pipefail"),
     # test.log carries the real pytest output, never a self-declared
@@ -430,4 +431,52 @@ def test_agents_md_tdd_section_keeps_the_blocking_command_rule():
     missing = _missing(section, AGENTS_TDD_ITEMS)
     assert not missing, (
         f"AGENTS.md TDD section is missing the blocking-command rule: {missing}"
+    )
+
+
+# --- Issue #302: the orbi contract artifacts live in the excluded run dir -----
+
+# The four dirty-gate incidents (#215/#235/#256/#301) were all orbi-owned
+# artifacts landing at the worktree root. The prompts and the AGENTS.md
+# TDD section now route every contract artifact into the excluded
+# `.orbi/` run dir; the wording is locked here so it cannot drift back
+# to the worktree root.
+RUN_DIR_ITEMS = (
+    ("run-dir-plan", ".orbi/plan.md"),
+    ("run-dir-test-log", ".orbi/test.log"),
+    ("run-dir-never-root", "never at the worktree root"),
+)
+
+
+def test_prompt_md_routes_the_run_artifacts_into_the_run_dir():
+    missing = _missing(_text(PROMPT), RUN_DIR_ITEMS)
+    assert not missing, (
+        f"prompt.md is missing the .orbi/ run-dir contract (Issue #302): "
+        f"{missing}"
+    )
+
+
+def test_prompt_review_md_reads_the_run_artifacts_from_the_run_dir():
+    text = _text(PROMPT_REVIEW)
+    missing = _missing(text, RUN_DIR_ITEMS[:2])
+    assert not missing, (
+        f"prompt_review.md is missing the .orbi/ run-dir contract "
+        f"(Issue #302): {missing}"
+    )
+
+
+def test_agents_md_tdd_section_keeps_the_run_dir_coverage_commands():
+    text = _text(CONTRACT)
+    tdd = text.split("## tdd and coverage", 1)
+    assert len(tdd) == 2, "AGENTS.md is missing the TDD section"
+    section = tdd[1].split("## ui work", 1)[0]
+    missing = _missing(section, (
+        # The official COVERAGE_FILE env var points the data file into
+        # the run dir; the global gate takes the data file by argv.
+        ("tdd-coverage-file", "coverage_file=.orbi/.coverage"),
+        ("tdd-gate-data-file", "coverage_gate.py .orbi/.coverage"),
+    ))
+    assert not missing, (
+        f"AGENTS.md TDD section is missing the run-dir coverage commands "
+        f"(Issue #302): {missing}"
     )

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -4,7 +4,9 @@ Real git (local bare origin + clone) plus a fake ``pi`` executable that
 behaves like the delivery agent in both modes:
 
 - implement mode (``Run id:`` in the system prompt): writes the
-  run-scoped plan artifact and commits — the first delivery (Issue
+  run-scoped plan artifact (`.orbi/plan.md`, Issue #302 — the run dir
+  the Runner creates and excludes before the session starts) and
+  commits a real tracked source file — the first delivery (Issue
   #186: the agent stops at the committed delivery; the Runner pushes
   the task branch and opens the PR);
 - review mode (system prompt without the run id): Issue #82 — the
@@ -59,10 +61,12 @@ if match is None:
     )
     if merge.returncode != 0:
         # Conflict: resolve it in this session (never auto-resolved by
-        # the runner).
-        with open(os.path.join(cwd, "plan.md"), "w",
+        # the runner). The carrier is the tracked source file the fake
+        # pi really delivers (Issue #302: the plan artifact left the
+        # tracked surface — it lives in the excluded .orbi/ run dir).
+        with open(os.path.join(cwd, "impl.py"), "w",
                   encoding="utf-8") as handle:
-            handle.write("# Plan\\n\\nmerged main\\n")
+            handle.write("# impl\\n\\nmerged main\\n")
         subprocess.run(["git", "add", "."], cwd=cwd, check=True,
                        capture_output=True)
         subprocess.run(["git", "commit", "--no-edit"], cwd=cwd,
@@ -78,11 +82,17 @@ plan = (
     f"<!-- orbi:run={run_id} -->\\n"
     f"# Plan\\n\\nrun_id={run_id}\\n"
 )
-with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+# The plan artifact lives in the Runner-created .orbi/ run dir (Issue
+# #302): excluded from the delivery tree, never committed. The delivery
+# itself is a real tracked source file.
+with open(os.path.join(cwd, ".orbi", "plan.md"), "w",
+          encoding="utf-8") as handle:
     handle.write(plan)
+with open(os.path.join(cwd, "impl.py"), "w", encoding="utf-8") as handle:
+    handle.write("# impl\\n\\nagent delivery\\n")
 for command in (
     ["git", "add", "."],
-    ["git", "commit", "-m", f"plan for run {run_id}"],
+    ["git", "commit", "-m", f"delivery for run {run_id}"],
 ):
     subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 """
@@ -449,9 +459,12 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     assert f"Orbi opened PR: {PR_URL}" in opened
     assert f"run_id={run_id}" in opened
 
-    # ---- origin/main advances and edits the SAME file (plan.md).
-    (clone / "plan.md").write_text(
-        "main edited plan.md after the PR was opened\n", encoding="utf-8",
+    # ---- origin/main advances and edits the SAME tracked source file
+    #      the delivery carries (impl.py — Issue #302: the conflict
+    #      carrier is real tracked code, never the excluded plan
+    #      artifact).
+    (clone / "impl.py").write_text(
+        "main edited impl.py after the PR was opened\n", encoding="utf-8",
     )
     git(clone, "add", ".")
     git(clone, "commit", "-m", "main advances with a conflicting edit")
@@ -511,7 +524,9 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     assert git(worktree, "branch", "--show-current") == branch
     # The conflict was resolved by the review session, not
     # auto-resolved.
-    assert "merged main" in (worktree / "plan.md").read_text(encoding="utf-8")
+    assert "merged main" in (worktree / "impl.py").read_text(
+        encoding="utf-8",
+    )
 
     # The SAME PR updated: exactly one open PR for the head branch, and
     # its head is the new local HEAD (pushed by the review session).

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -32,7 +32,9 @@ PR_URL = "https://github.com/owner/repo/pull/41"
 
 # The fake pi behaves like the delivery agent: it extracts the run id from
 # the injected system prompt (exactly where the real runner puts it), writes
-# the plan artifact with the stable marker, then commits. It does NOT push
+# the plan artifact into the Runner-created .orbi/ run dir (Issue #302:
+# excluded from the delivery tree, never committed) with the stable marker,
+# then commits a real tracked source file. It does NOT push
 # and does NOT create the PR (Issue #186: the Runner owns the push and the
 # PR creation — the e2e proves the closeout lands without agent help).
 FAKE_PI = """#!/usr/bin/env python3
@@ -46,11 +48,14 @@ plan = (
     f"<!-- orbi:run={run_id} -->\\n"
     f"# Plan\\n\\nrun_id={run_id}\\n"
 )
-with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+with open(os.path.join(cwd, ".orbi", "plan.md"), "w",
+          encoding="utf-8") as handle:
     handle.write(plan)
+with open(os.path.join(cwd, "impl.py"), "w", encoding="utf-8") as handle:
+    handle.write("# impl\\n\\nagent delivery\\n")
 for command in (
     ["git", "add", "."],
-    ["git", "commit", "-m", f"plan for run {run_id}"],
+    ["git", "commit", "-m", f"delivery for run {run_id}"],
 ):
     subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 """
@@ -96,11 +101,14 @@ plan = (
     f"<!-- orbi:run={run_id} -->\\n"
     f"# Plan\\n\\nrun_id={run_id}\\n"
 )
-with open(os.path.join(cwd, "plan.md"), "w", encoding="utf-8") as handle:
+with open(os.path.join(cwd, ".orbi", "plan.md"), "w",
+          encoding="utf-8") as handle:
     handle.write(plan)
+with open(os.path.join(cwd, "impl.py"), "w", encoding="utf-8") as handle:
+    handle.write("# impl\\n\\nagent delivery\\n")
 for command in (
     ["git", "add", "."],
-    ["git", "commit", "-m", f"plan for run {run_id}"],
+    ["git", "commit", "-m", f"delivery for run {run_id}"],
 ):
     subprocess.run(command, cwd=cwd, check=True, capture_output=True)
 sys.stdout.write("done")
@@ -373,9 +381,10 @@ def test_e2e_one_run_id_carries_every_event_of_the_attempt(
         f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
     )
 
-    # 4. Run artifacts live inside the run-scoped worktree and carry the
-    #    marker; the Pi session dir is under the same run-scoped path.
-    plan = (worktree / "plan.md").read_text(encoding="utf-8")
+    # 4. Run artifacts live inside the run-scoped worktree (in the
+    #    excluded .orbi/ run dir, Issue #302) and carry the marker; the
+    #    Pi session dir is under the same run-scoped path.
+    plan = (worktree / ".orbi" / "plan.md").read_text(encoding="utf-8")
     assert f"<!-- orbi:run={run_id} -->" in plan
     assert (worktree / ".pi-session").is_dir()
 
@@ -399,8 +408,12 @@ def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
     assert first.is_dir() and second.is_dir()
 
     # The old scene is preserved and still queryable by the old run id.
-    assert "a1b2c3d4" in (first / "plan.md").read_text(encoding="utf-8")
-    assert "b2c3d4e5" in (second / "plan.md").read_text(encoding="utf-8")
+    assert "a1b2c3d4" in (first / ".orbi" / "plan.md").read_text(
+        encoding="utf-8",
+    )
+    assert "b2c3d4e5" in (second / ".orbi" / "plan.md").read_text(
+        encoding="utf-8",
+    )
 
     # Comments are not confused: each attempt carries exactly its own
     # id (six comments per attempt: started Pi, progress, started


### PR DESCRIPTION
<!-- orbi:run=18cc3f31 -->

Fixes #302

根治 dirty-worktree 门禁：orbi 自有契约产物源头迁出交付树（不再逐个补 .gitignore） (run_id=18cc3f31)
