### PR TITLE
启动门禁把 repo_dir 当 orbi 可编辑安装源：让『单仓库 X（≠orbi）』作为交付仓库需解耦 CLI 自更新与 checkout

### DIFF
--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -345,8 +345,11 @@ def install_units_command(config: dict, installed_dir: Path | None) -> str:
     HEAD — the commit the installed templates came from) and the
     installed sha256 of each unit (Issue #103).
     """
+    # Issue #330: the unit templates live in the deployment home (they
+    # render the home path into {{ORBI_REPO_DIR}}), never in the delivery
+    # checkout.
     result = systemd_deploy.install_units(
-        config["repo_dir"], installed_dir,
+        config["deploy_home"], installed_dir,
         max_concurrency=config["max_concurrency"], run_command=run_command,
     )
     lines = [
@@ -399,7 +402,9 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
         )
     except git_transport.TransportError as exc:
         lines.append(f"transport: FAILED {exc}")
-    status = systemd_deploy.unit_status(repo_dir, installed_dir)
+    # Issue #330: unit drift is compared against the deployment home's
+    # templates (the same comparison the pre-start check uses).
+    status = systemd_deploy.unit_status(config["deploy_home"], installed_dir)
     drifted = [entry for entry in status if entry["drifted"]]
     if drifted:
         lines.append("unit_drift: DRIFT")
@@ -427,7 +432,9 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
     # with the editable reinstall, never with
     # `orbi install-units` alone). Read-only: the report stays
     # readable and the rest of the health report is still produced.
-    source = cli_source.cli_source(repo_dir)
+    # Issue #330: the editable CLI source is expected in the deployment
+    # home, not the delivery checkout.
+    source = cli_source.cli_source(config["deploy_home"])
     line = cli_source.drift_line(source)
     if line is None:
         lines.append(f"cli_source: clean source={source['actual']}")

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -601,14 +601,18 @@ def run_setup(config: dict, installed_dir: Path | None, *,
                 )
         targets = list(repos)
     repo_dir = config["repo_dir"]
-    defs = load_label_defs(repo_dir / LABELS_FILE)
+    # Issue #330: labels.toml, the CLI editable install and the unit
+    # templates live in the deployment home; the delivery checkout
+    # (repo_dir) may be a foreign repo without any of them.
+    deploy_home = config["deploy_home"]
+    defs = load_label_defs(deploy_home / LABELS_FILE)
     check_commands(run_command)
     # Issue #152: the CLI source step precedes every other step — the
     # running CLI must import from the deployment checkout, otherwise
     # the unit migration below (and the pre-start self-heal it
     # repairs) could never run the new code (the #152 deadlock).
     cli = install_cli_step(
-        repo_dir, cli_source.module_file(), run_command=run_command,
+        deploy_home, cli_source.module_file(), run_command=run_command,
     )
     check_auth(run_command)
     repo_results = []
@@ -620,7 +624,8 @@ def run_setup(config: dict, installed_dir: Path | None, *,
             "labels": {"aligned": labels["aligned"], "total": labels["total"]},
         })
     units = install_units_step(
-        repo_dir, installed_dir, max_concurrency=config["max_concurrency"],
+        deploy_home, installed_dir,
+        max_concurrency=config["max_concurrency"],
         run_command=run_command,
     )
     checkout = check_checkout(

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -541,13 +541,42 @@ def load_config(path: Path) -> dict:
         if pi_providers_path is not None else None
     )
     repo_dir = _config_path(data.get("repo_dir", "."), base)
+    # Deployment home (Issue #330): the orbi source checkout — the editable
+    # CLI install source, the systemd/ unit templates, labels.toml and the
+    # prompt defaults. Absent -> repo_dir (the orbi-bootstrap deployment,
+    # home == delivery checkout, keeps its exact behavior). Present -> must
+    # be a non-empty string, resolved like every other config path; the
+    # delivery checkout (repo_dir) is then decoupled from the CLI
+    # self-update and the startup gates act on the home only.
+    deploy_home_raw = data.get("deploy_home")
+    if deploy_home_raw is not None and (
+        not isinstance(deploy_home_raw, str) or not deploy_home_raw
+    ):
+        raise ValueError("deploy_home must be a non-empty string")
+    deploy_home = (
+        _config_path(deploy_home_raw, base)
+        if deploy_home_raw is not None
+        else repo_dir
+    )
     return {
         "source_repos": source_repos,
         "repo_dir": repo_dir,
+        "deploy_home": deploy_home,
         "workspace_root": _config_path(data.get("workspace_root", ".."), base),
-        "prompt": _config_path(data.get("prompt", "prompt.md"), base),
+        # Issue #330: when deploy_home is EXPLICIT the prompt defaults
+        # live in the deployment home (the delivery checkout may be a
+        # foreign repo without them); an explicit prompt path still
+        # resolves against the config file dir. deploy_home absent ->
+        # the original config-file-dir resolution (bootstrap unchanged).
+        "prompt": _config_path(
+            data.get("prompt", "prompt.md"),
+            base if "prompt" in data
+            else (deploy_home if deploy_home_raw is not None else base),
+        ),
         "prompt_review": _config_path(
-            data.get("prompt_review", "prompt_review.md"), base,
+            data.get("prompt_review", "prompt_review.md"),
+            base if "prompt_review" in data
+            else (deploy_home if deploy_home_raw is not None else base),
         ),
         "skills": [_config_path(item, base) for item in data.get("skills", [])],
         "context_files": [
@@ -1123,6 +1152,11 @@ def render_prompt(template: str, values: dict[str, str]) -> str:
 def validate_config(config: dict) -> None:
     if not config["repo_dir"].is_dir():
         raise FileNotFoundError(config["repo_dir"])
+    # Issue #330: the deployment home (CLI install source, unit templates,
+    # labels.toml, prompt defaults) must exist too — a missing home fails
+    # the start fast, like a missing delivery checkout.
+    if not config["deploy_home"].is_dir():
+        raise FileNotFoundError(config["deploy_home"])
     for path in [
         config["prompt"], config["prompt_review"],
         *config["skills"], *config["context_files"],
@@ -7763,8 +7797,11 @@ def main(argv: list[str] | None = None) -> int:
     # lives in THIS module (see the NOTE at the top): a separate new
     # module would not be importable in the stale-finder tool env, and
     # the refresh that repairs the finder could never run.
+    # Issue #330: the CLI self-update acts on the deployment home, never
+    # on the delivery checkout (repo_dir may be a foreign repo X without
+    # any orbi packaging input).
     refresh_cli_install(
-        config["repo_dir"], run_command=run_command,
+        config["deploy_home"], run_command=run_command,
     )
     # Deployment consistency (Issue #103, #142): BEFORE any slot or
     # claim the installed systemd units must match the repo templates
@@ -7777,10 +7814,11 @@ def main(argv: list[str] | None = None) -> int:
     # structured `unit_drift` line per unit and fails fast: this
     # start takes no slot, claims no Issue and changes no label.
     try:
-        check_unit_drift(config["repo_dir"])
+        check_unit_drift(config["deploy_home"])
     except UnitDriftError:
         sync_drifted_units(
-            config["repo_dir"], max_concurrency=config["max_concurrency"],
+            config["deploy_home"],
+            max_concurrency=config["max_concurrency"],
             run_command=run_command,
         )
     # Git transport preflight (Issue #114): BEFORE any slot or claim

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -70,6 +70,100 @@ def test_load_config_defaults_base_branch_to_main(tmp_path):
     assert config["base_branch"] == "main"
 
 
+def test_load_config_defaults_deploy_home_to_repo_dir(tmp_path):
+    """Issue #330: without deploy_home the deployment home IS the delivery
+    checkout — the orbi-bootstrap layout keeps its exact behavior."""
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["deploy_home"] == (tmp_path / "repo").resolve()
+
+
+def test_load_config_reads_explicit_deploy_home(tmp_path):
+    """Issue #330: an explicit deploy_home resolves like every other
+    config path (relative to the config file dir)."""
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n'
+        'deploy_home = "home"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["repo_dir"] == (tmp_path / "repo").resolve()
+    assert config["deploy_home"] == (tmp_path / "home").resolve()
+
+
+def test_load_config_rejects_an_empty_deploy_home(tmp_path):
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\ndeploy_home = ""\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="deploy_home must be a non-empty string",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_rejects_a_non_string_deploy_home(tmp_path):
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\ndeploy_home = 7\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="deploy_home must be a non-empty string",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_prompt_defaults_resolve_from_deploy_home(tmp_path):
+    """Issue #330: with deploy_home set and no explicit prompt, the prompt
+    defaults live in the deployment home — never in the delivery checkout."""
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n'
+        'deploy_home = "home"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["prompt"] == (tmp_path / "home" / "prompt.md").resolve()
+    assert config["prompt_review"] == (
+        tmp_path / "home" / "prompt_review.md"
+    ).resolve()
+
+
+def test_load_config_explicit_prompt_resolves_from_config_dir(tmp_path):
+    """Issue #330: an explicit prompt path keeps resolving against the
+    config file dir even when deploy_home is set."""
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n'
+        'deploy_home = "home"\nprompt = "my-prompt.md"\n',
+        encoding="utf-8",
+    )
+    config = runner.load_config(config_path)
+    assert config["prompt"] == (tmp_path / "my-prompt.md").resolve()
+
+
+def test_validate_config_requires_the_deploy_home_dir(tmp_path):
+    """Issue #330: a missing deployment home fails the start fast, like a
+    missing delivery checkout."""
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "repo"\n'
+        'deploy_home = "missing-home"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "repo").mkdir()
+    config = runner.load_config(config_path)
+    with pytest.raises(FileNotFoundError):
+        runner.validate_config(config)
+
+
 def test_load_config_repair_issue_creation_is_opt_in(tmp_path):
     config_path = tmp_path / "orbi.toml"
     config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
@@ -609,6 +703,7 @@ def test_validate_config_accepts_existing_files(tmp_path):
         path.write_text("ok", encoding="utf-8")
     runner.validate_config({
         "repo_dir": tmp_path,
+        "deploy_home": tmp_path,
         "prompt": prompt,
         "prompt_review": prompt_review,
         "skills": [skill],
@@ -622,6 +717,7 @@ def test_validate_config_requires_review_prompt(tmp_path):
     with pytest.raises(FileNotFoundError, match="prompt_review.md"):
         runner.validate_config({
             "repo_dir": tmp_path,
+            "deploy_home": tmp_path,
             "prompt": prompt,
             "prompt_review": tmp_path / "prompt_review.md",
             "skills": [],
@@ -633,6 +729,7 @@ def test_validate_config_fails_before_issue_claim_when_path_missing(tmp_path):
     with pytest.raises(FileNotFoundError, match="missing.md"):
         runner.validate_config({
             "repo_dir": tmp_path,
+            "deploy_home": tmp_path,
             "prompt": tmp_path / "missing.md",
             "prompt_review": tmp_path / "prompt_review.md",
             "skills": [],
@@ -644,6 +741,7 @@ def test_validate_config_rejects_missing_repo_dir(tmp_path):
     with pytest.raises(FileNotFoundError, match="missing-repo"):
         runner.validate_config({
             "repo_dir": tmp_path / "missing-repo",
+            "deploy_home": tmp_path,
             "prompt": tmp_path / "prompt.md",
             "skills": [],
             "context_files": [],
@@ -680,6 +778,8 @@ def _base_config(tmp_path: Path) -> dict:
         path.write_text("ok", encoding="utf-8")
     return {
         "repo_dir": tmp_path,
+        # Issue #330: the bootstrap deployment — home == delivery checkout.
+        "deploy_home": tmp_path,
         "prompt": prompt,
         "prompt_review": prompt_review,
         "skills": [],
@@ -8394,6 +8494,88 @@ def test_main_cli_install_refresh_runs_before_slot_and_claim(
     # ...and the tick proceeded to the normal claim flow (slot taken
     # after the refresh).
     assert (tmp_path / ".orbi" / "slots" / "slot-1").exists()
+
+
+def test_main_cli_refresh_uses_deploy_home_not_repo_dir(
+    monkeypatch, tmp_path,
+):
+    """Issue #330: with deploy_home set the CLI self-update acts on the
+    deployment home — the delivery checkout (repo_dir) is never treated
+    as the orbi editable-install source."""
+    seen: dict = {}
+
+    def fake_refresh(repo_dir, *, run_command, lock_timeout_seconds=300.0):
+        seen["repo_dir"] = Path(repo_dir)
+        return "unchanged"
+
+    monkeypatch.setattr(runner, "refresh_cli_install", fake_refresh)
+    monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
+    monkeypatch.setattr(
+        runner, "check_transport",
+        lambda *a, **k: {
+            "remote": "origin", "protocol": "ssh",
+            "url": "git@github.com:owner/repo.git",
+            "expected": "git@github.com:owner/repo.git",
+            "migrated": False, "ssh_reachable": True,
+        },
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    for name in ("prompt.md", "prompt_review.md"):
+        (home / name).write_text("prompt", encoding="utf-8")
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "."\n'
+        'deploy_home = "home"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+    )
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen["repo_dir"] == home
+
+
+def test_main_unit_drift_check_uses_deploy_home(
+    monkeypatch, tmp_path,
+):
+    """Issue #330: the pre-start unit drift check and its self-heal act on
+    the deployment home's templates, never the delivery checkout."""
+    seen: list[Path] = []
+
+    def fake_check(repo_dir, *args, **kwargs):
+        seen.append(Path(repo_dir))
+
+    monkeypatch.setattr(runner, "check_unit_drift", fake_check)
+    monkeypatch.setattr(
+        runner, "refresh_cli_install", lambda *a, **k: "unchanged",
+    )
+    monkeypatch.setattr(
+        runner, "check_transport",
+        lambda *a, **k: {
+            "remote": "origin", "protocol": "ssh",
+            "url": "git@github.com:owner/repo.git",
+            "expected": "git@github.com:owner/repo.git",
+            "migrated": False, "ssh_reachable": True,
+        },
+    )
+    home = tmp_path / "home"
+    home.mkdir()
+    for name in ("prompt.md", "prompt_review.md"):
+        (home / name).write_text("prompt", encoding="utf-8")
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nrepo_dir = "."\n'
+        'deploy_home = "home"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda repos, slot_dir, max_concurrency, active_milestone=None: None,
+    )
+    assert runner.main(["--config", str(config)]) == 0
+    assert seen == [home]
 
 
 def test_main_cli_install_failure_fails_fast_before_slot_and_claim(

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1175,6 +1175,74 @@ def test_install_units_command_reports_commit_and_hashes(monkeypatch,
         in lines
 
 
+def test_install_units_command_uses_deploy_home(monkeypatch, tmp_path):
+    """Issue #330: `orbi install-units` deploys the unit templates from
+    the deployment home — the delivery checkout (repo_dir) may be a
+    foreign repo without a systemd/ directory."""
+    from orbi import systemd_deploy
+
+    config, _ = _deploy_world(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    config["deploy_home"] = home
+    installed = tmp_path / "elsewhere"
+    captured = {}
+
+    def fake_install(repo_dir, installed_dir, *, max_concurrency, run_command):
+        captured["repo_dir"] = Path(repo_dir)
+        return {
+            "commit": "0123456789abcdef0123456789abcdef01234567",
+            "installed_dir": installed_dir,
+            "units": {
+                name: {"installed_path": installed_dir / name,
+                       "sha256": f"hash-{name}"}
+                for name in systemd_deploy.UNIT_NAMES
+            },
+        }
+
+    monkeypatch.setattr(systemd_deploy, "install_units", fake_install)
+    orbi.install_units_command(config, installed)
+    assert captured["repo_dir"] == home
+    assert captured["repo_dir"] != config["repo_dir"]
+
+
+def test_doctor_report_routes_home_checks_to_deploy_home(
+    monkeypatch, tmp_path,
+):
+    """Issue #330: `orbi doctor` compares unit drift and the editable CLI
+    source against the deployment home's templates and checkout — never
+    the delivery checkout (which may be a foreign repo)."""
+    from orbi import cli_source, systemd_deploy
+
+    config, installed = _deploy_world(tmp_path, drift=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    config["deploy_home"] = home
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
+    seen = {}
+
+    def spy_unit_status(repo_dir, installed_dir):
+        seen["units"] = Path(repo_dir)
+        return []
+
+    def spy_cli_source(expected_repo_dir):
+        seen["cli"] = Path(expected_repo_dir)
+        return {"actual": str(home)}
+
+    monkeypatch.setattr(
+        systemd_deploy, "unit_status", spy_unit_status,
+    )
+    monkeypatch.setattr(cli_source, "cli_source", spy_cli_source)
+    monkeypatch.setattr(cli_source, "drift_line", lambda source: None)
+    report = orbi.doctor_report(config, installed)
+    assert seen["units"] == home
+    assert seen["cli"] == home
+    assert home != config["repo_dir"]
+    assert "unit_drift: clean" in report.splitlines()
+    assert f"cli_source: clean source={home}" in report.splitlines()
+
+
 def test_main_install_units_prints_report_and_returns_zero(
     monkeypatch, tmp_path, capsys,
 ):

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1099,6 +1099,8 @@ def _deploy_world(tmp_path, drift: bool = False) -> tuple[dict, Path]:
     config = {
         "source_repos": ["xqliu/orbi"],
         "repo_dir": repo,
+        # Issue #330: the bootstrap deployment — home == delivery checkout.
+        "deploy_home": repo,
         "base_branch": "main",
         "max_concurrency": 1,
         "slot_dir": repo / ".orbi" / "slots",

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -1511,3 +1511,58 @@ def test_run_setup_rejects_an_empty_repo_list(tmp_path):
             repos=[],
             run_command=lambda command, **kwargs: "",
         )
+
+
+def test_run_setup_routes_home_files_to_deploy_home(tmp_path, monkeypatch):
+    """Issue #330: with deploy_home set, labels.toml, the CLI editable
+    install and the unit templates come from the deployment home; the
+    delivery checkout (repo_dir) is only the transport-checked repo."""
+    repo, installed, state = make_run_state(tmp_path)
+    fake_run, calls = fake_run_factory(state)
+    home = tmp_path / "home"
+    home.mkdir()
+    config = runner.load_config(make_config(tmp_path, repo))
+    config["deploy_home"] = home
+
+    seen: dict = {}
+
+    def spy_load(path):
+        seen["labels"] = Path(path)
+        return [dict(entry) for entry in VALID_DEFS]
+
+    def spy_cli(repo_dir, module_file, *, run_command):
+        seen["cli"] = Path(repo_dir)
+        return {"action": "verified", "source": str(repo_dir)}
+
+    def spy_units(repo_dir, installed_dir, *, max_concurrency, run_command):
+        seen["units"] = Path(repo_dir)
+        return {
+            "service": {
+                "installed": True,
+                "installed_path": str(installed_dir / "orbi@.service"),
+                "sha256": "deadbeef",
+            },
+            "timer": {"instances": {}},
+        }
+
+    def spy_checkout(repo_dir, base_branch, source_repos, *, run_command):
+        seen["checkout"] = Path(repo_dir)
+        return {
+            "remote": "origin", "branch": "main", "clean": True,
+            "base_fresh": True, "remote_url": "git@github.com:x/orbi.git",
+            "remote_protocol": "ssh", "migrated": False,
+            "ssh_reachable": True,
+        }
+
+    monkeypatch.setattr(pilot_setup, "load_label_defs", spy_load)
+    monkeypatch.setattr(pilot_setup, "install_cli_step", spy_cli)
+    monkeypatch.setattr(pilot_setup, "install_units_step", spy_units)
+    monkeypatch.setattr(pilot_setup, "check_checkout", spy_checkout)
+
+    result = pilot_setup.run_setup(config, installed, run_command=fake_run)
+    assert result["setup"] == "ok"
+    assert seen["labels"] == home / "labels.toml"
+    assert seen["cli"] == home
+    assert seen["units"] == home
+    # The delivery checkout stays the transport-checked repo.
+    assert seen["checkout"] == repo


### PR DESCRIPTION
<!-- orbi:run=51b13b14 -->

Fixes #330

启动门禁把 repo_dir 当 orbi 可编辑安装源：让『单仓库 X（≠orbi）』作为交付仓库需解耦 CLI 自更新与 checkout (run_id=51b13b14)
