### PR TITLE
补齐『外部单仓库模式』文档：#330/#334 引入的 deploy_home 解耦需要覆盖安装/setup/配置/运维

### DIFF
--- a/.orbi.example.toml
+++ b/.orbi.example.toml
@@ -5,6 +5,18 @@ source_repos = [
 ]
 
 repo_dir = "."
+# Deployment home (Issue #330): the orbi SOURCE checkout — where the
+# editable CLI install comes from, where the systemd/ unit templates and
+# labels.toml live, and where the prompt defaults (prompt.md,
+# prompt_review.md) resolve when unset. Default: repo_dir — the
+# orbi-bootstrap deployment (repo_dir IS the orbi checkout) keeps its
+# exact behavior. Set it to the orbi checkout path when repo_dir points
+# at a foreign user repo X (external single-repo mode): orbi is then
+# installed ONCE from the orbi repo and delivers Issues of X. The
+# installed systemd unit reads its config from <deploy_home>/orbi.toml,
+# so the config file (and .orbi/env) must live in the deploy home.
+# Must be a non-empty string; a missing directory fails the start fast.
+# deploy_home = "/path/to/orbi"
 workspace_root = ".."
 prompt = "prompt.md"
 # Implementer prompt (default prompt.md). The Runner also runs an

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pi 在隔离 worktree 中完成开发、测试并创建 PR，再经过独立审�
 ```bash
 # 1. clone
 git clone https://github.com/orbi-build/orbi.git && cd orbi
-# 2. 安装 CLI（editable uv tool 安装，官方本地部署方式）
+# 2. 安装 CLI（editable uv tool 安装，从 orbi 仓库安装一次；两种部署模式共用）
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 # 3. 创建配置（仓库只提交 example，真实配置本地维护）
 cp .orbi.example.toml orbi.toml
@@ -45,6 +45,12 @@ orbi doctor --config orbi.toml
 完整前提（Python 3.14、Pi、git + gh、systemd、模型端点）与从 0 开始的 smoke
 walkthrough 见 [Getting started](docs/getting-started.mdx)；setup 的完整输出
 契约与失败现场见 [One-time setup](docs/setup.mdx)。
+
+两种部署模式（Issue #330）：**自举模式**（默认，`repo_dir` 就是 orbi
+checkout 自身）与**外部单仓库模式**（`deploy_home` 指向 orbi checkout、
+`repo_dir` 指向用户仓库 X——orbi 安装一次后指向任意用户仓库，X 里开
+`ai-ready` issue 即被开发）。配置差异见 [Getting started](docs/getting-started.mdx)
+的 External single-repo mode 一节。
 
 ## 它能做什么
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -218,9 +218,11 @@ skills = []
 context_files = []
 ```
 
-(`workspace_root` must contain `repo_dir` — the task worktrees land in
-`<workspace_root>/.worktrees/`; unset `prompt` / `prompt_review`
-resolve against `deploy_home`.)
+(Task worktrees land in `<repo_dir>/.worktrees/` — the delivery
+checkout — and `workspace_root` is the directory the implementer agent
+is told contains the repositories it may touch (the
+`{{WORKSPACE_ROOT}}` prompt placeholder); unset `prompt` /
+`prompt_review` resolve against `deploy_home`.)
 
 Everything else — steps 4–8 (model provider, `orbi setup`, the manual
 tick, the smoke walkthrough, the timers) — is unchanged: `orbi setup`

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -73,6 +73,17 @@ orbi --help
 `uv tool` keeps the CLI in an isolated tool environment; the executable
 lands in `~/.local/bin` (on the PATH of the systemd unit).
 
+**Two deployment modes** (Issue #330, PR #334): the install command is
+identical in both — orbi is always installed ONCE from the orbi clone —
+but the config differs. In the **bootstrap mode** (this page's default)
+`repo_dir` is the orbi checkout itself: the deployment home and the
+delivery checkout are one directory. In the **external single-repo
+mode**, `deploy_home` points at the orbi checkout and `repo_dir` points
+at a foreign user repo X, so orbi delivers Issues of X without ever
+being reinstalled from X. The config difference is in step 3 and in the
+[External single-repo mode](#external-single-repo-mode-deploy_home)
+section below.
+
 **Why `--editable` matters**: a non-editable install copies the source
 into the tool environment's site-packages. The service's `ExecStartPre`
 fast-forwards the checkout to the latest `main` before every start —
@@ -124,7 +135,8 @@ directory):
 | Field | Required | Default | Meaning |
 |---|---|---|---|
 | `source_repos` | yes | — | Ordered list of `owner/repo` task pools scanned each tick (e.g. your pilot repo first, then your backlog repo) |
-| `repo_dir` | no | `.` | The Runner checkout the service starts from (where the `src/orbi/` package lives) |
+| `repo_dir` | no | `.` | The delivery checkout: the repository whose Issues the Runner delivers. Task worktrees are created from its frozen `origin/<base_branch>` SHA, PRs open against it, and the slot locks live in `<repo_dir>/.orbi/slots/`. In bootstrap mode this is the orbi checkout itself; in the external single-repo mode (Issue #330) it is a foreign user repo X |
+| `deploy_home` | no | `repo_dir` | The orbi SOURCE checkout (Issue #330): the editable CLI install source (the self-update), the `systemd/` unit templates, `labels.toml`, and the prompt defaults (`prompt.md`, `prompt_review.md` when unset). Absent = `repo_dir` (bootstrap mode, unchanged). Set it to the orbi checkout when `repo_dir` is a foreign repo X. Must be a non-empty string; a missing directory fails the start fast |
 | `workspace_root` | no | `..` | Directory that contains the task worktrees and the repositories the agent may modify |
 | `prompt` | no | `prompt.md` | Implementer prompt template (placeholders like `{{SOURCE_REPO}}` are rendered by the Runner) |
 | `prompt_review` | no | `prompt_review.md` | Review prompt template for the independent post-PR review session |
@@ -159,6 +171,62 @@ max_concurrency = 1
 skills = []
 context_files = []
 ```
+
+### External single-repo mode (deploy_home)
+
+Issue #330 (PR #334) decoupled orbi's deployment home from the delivery
+checkout, so orbi can be installed ONCE from the orbi repository and
+then pointed at any user repository X: an `ai-ready` Issue opened in X
+is picked up, implemented in a worktree of X, and delivered as a PR
+against X.
+
+- **Bootstrap mode (default)**: `repo_dir` is the orbi checkout itself —
+  the deployment home and the delivery checkout are the same directory
+  (`deploy_home` absent, defaulting to `repo_dir`). Steps 1–8 of this
+  page describe exactly that mode.
+- **External single-repo mode**: `repo_dir` is the user repo X and
+  `deploy_home` is the orbi checkout. The two checkouts play different
+  roles:
+  - `deploy_home` (orbi checkout) — the CLI self-update source (the
+    editable `uv tool` install, the `ExecStartPre` fast-forward and the
+    CLI self-heal), the `systemd/` unit templates (the `{{ORBI_REPO_DIR}}`
+    placeholder renders THIS path), `labels.toml`, and the prompt
+    defaults;
+  - `repo_dir` (user repo X) — the delivery checkout: Issues are claimed
+    from X, task worktrees are created from X's frozen
+    `origin/<base_branch>`, PRs open against X, and the slot locks live
+    in `<repo_dir>/.orbi/slots/`.
+
+Install once (step 2 above, from the orbi clone), then put the config
+file in the deploy home — the installed systemd unit reads its config
+from `<deploy_home>/orbi.toml` (the `{{ORBI_REPO_DIR}}` placeholder
+renders the deploy home path), so `orbi.toml` and the optional
+`.orbi/env` live in the orbi checkout, not in X:
+
+```toml
+# <deploy_home>/orbi.toml — the orbi checkout, NOT the user repo X
+source_repos = [
+  "OWNER/USER-REPO-X",
+]
+
+repo_dir = "/path/to/user-repo-x"
+deploy_home = "/path/to/orbi"
+workspace_root = "/path/to"
+base_branch = "main"
+max_concurrency = 1
+skills = []
+context_files = []
+```
+
+(`workspace_root` must contain `repo_dir` — the task worktrees land in
+`<workspace_root>/.worktrees/`; unset `prompt` / `prompt_review`
+resolve against `deploy_home`.)
+
+Everything else — steps 4–8 (model provider, `orbi setup`, the manual
+tick, the smoke walkthrough, the timers) — is unchanged: `orbi setup`
+reads the labels, the CLI install and the unit templates from
+`deploy_home` and checks the delivery checkout `repo_dir` (see
+[One-time setup](/setup)).
 
 ## 4. Configure the model provider
 
@@ -443,10 +511,15 @@ flock slots remain the final safety boundary.
 The committed unit templates are machine-independent: they carry the
 `{{ORBI_REPO_DIR}}` placeholder instead of a hardcoded checkout path
 (Issue #262). `orbi install-units` (and `orbi setup`) substitute it
-with **your** deployment checkout's resolved path at install time, so
-a clone at ANY location deploys cleanly — no manual edit of the
-installed units. `ExecStart` is the installed `orbi` CLI and stays
-home-relative (`%h/.local/bin/orbi`). The repo templates stay the
-single source of truth for everything else — see [Operations](/operations)
-on drift detection.
+with the resolved path of the **deployment home** (`deploy_home`,
+defaulting to `repo_dir`) at install time, so a clone at ANY location
+deploys cleanly — no manual edit of the installed units. In the
+external single-repo mode (Issue #330) that means the unit's
+`WorkingDirectory`, `ORBI_CONFIG`, `EnvironmentFile`, the `ExecStartPre`
+fast-forward, the `base-sync.lock` and the CLI self-heal ALL act on the
+orbi source checkout — never on the delivery checkout X. `ExecStart` is
+the installed `orbi` CLI and stays home-relative
+(`%h/.local/bin/orbi`). The repo templates stay the single source of
+truth for everything else — see [Operations](/operations) on drift
+detection.
 </Note>

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -18,7 +18,7 @@ queued) and starts its OWN service instance
 Runner instances can run concurrently. Each tick's service instance:
 
 1. **Fast-forwards the code first** (`ExecStartPre`, outside the Python
-   process): `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`. The fetch disables automatic maintenance so it cannot detach a Git child beyond the preflight and shared-lock lifetime.
+   process): `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`. The checkout that is fast-forwarded is the **deployment home** — the `{{ORBI_REPO_DIR}}` placeholder renders the `deploy_home` path at install time (defaulting to `repo_dir`), so in the external single-repo mode (Issue #330) the fast-forward, the `base-sync.lock` and the CLI self-heal below all act on the orbi source checkout, never on the delivery checkout (user repo X). The fetch disables automatic maintenance so it cannot detach a Git child beyond the preflight and shared-lock lifetime.
    A dirty checkout, a failed fetch or a non-fast-forwardable state fails
    the preflight: the service does not start and the reason lands in the
    systemd journal (fail fast). A currently running long task is never
@@ -71,8 +71,12 @@ systemctl --user status 'orbi@*.service'
 
 The unit templates (`systemd/orbi@.service` and
 `systemd/orbi@.timer`) are deployment config, not ordinary code
-— but a template change needs NO human step after the merge. The next timer
-trigger's `ExecStartPre` fast-forwards the checkout, and the pre-start
+— but a template change needs NO human step after the merge. The templates
+live in the deployment home (`deploy_home`, defaulting to `repo_dir` —
+Issue #330), and the drift check compares the installed units against
+THOSE templates. The next timer
+trigger's `ExecStartPre` fast-forwards the deployment home checkout, and
+the pre-start
 `unit_drift` check self-heals: it runs the SAME idempotent install
 (copy both templates into the user unit directory, daemon-reload,
 enable or disable timer instances through `max_concurrency` — it never
@@ -229,8 +233,12 @@ sync, the reinstall-free source changes, the packaging-input refresh)
 is defined in [Getting started](/getting-started) step 2.
 `orbi doctor` reports the consistency (`cli_source: clean` or
 `cli_source: DRIFT` with the structured `cli_source_drift` line: actual
-import path, expected repo_dir, the exact editable reinstall command),
-and `orbi setup` verifies or reinstalls it. The checkout root
+import path, expected deploy_home, the exact editable reinstall command),
+and `orbi setup` verifies or reinstalls it. The expected source is the
+**deployment home** (`deploy_home`, defaulting to `repo_dir` — Issue
+#330): in the external single-repo mode a clean `cli_source` means the
+editable install imports from the orbi checkout, even though the
+delivery checkout is a foreign repo X. The checkout root
 carries no `orbi.py`: a flat file named like the package would
 shadow the installed package for every process with the checkout root
 on sys.path. The direct-execution entry `python3 -m orbi.cli`

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -31,14 +31,18 @@ non-zero exit code.
 2. **CLI editable install** (Issue #152) — the official local
    deployment is the EDITABLE `uv tool` install (the why — the
    `ExecStartPre` checkout sync — is defined in [Getting
-   started](/getting-started) step 2). When the running process
-   already imports from the configured `repo_dir` the step verifies it
-   (no uv call, `cli=verified`); otherwise it runs the exact force
-   editable reinstall (`uv tool install --force --reinstall --editable
-   --python /usr/bin/python3 <repo_dir>`, `cli=installed`). A failing
-   install fails fast — no unit install, no half-initialized state. The
-   step never touches a running Runner process (the new source is
-   loaded by the next CLI start).
+   started](/getting-started) step 2). The install acts on the
+   **deployment home** (`deploy_home`, defaulting to `repo_dir` —
+   Issue #330): when the running process already imports from the
+   configured `deploy_home` the step verifies it (no uv call,
+   `cli=verified`); otherwise it runs the exact force editable
+   reinstall (`uv tool install --force --reinstall --editable
+   --python /usr/bin/python3 <deploy_home>`, `cli=installed`). In the
+   external single-repo mode the CLI is NEVER (re)installed from the
+   delivery checkout — `repo_dir` may be a foreign repo X without any
+   orbi packaging input. A failing install fails fast — no unit install,
+   no half-initialized state. The step never touches a running Runner
+   process (the new source is loaded by the next CLI start).
 3. **Auth** — `gh auth status` (logged in with a usable token).
 4. **Per target repository** (every configured `source_repos` entry by
    default; exactly one with `--repo OWNER/REPO`):
@@ -46,20 +50,27 @@ non-zero exit code.
      (`gh repo view` → `viewerPermission` must be `WRITE`, `MAINTAIN`
      or `ADMIN`);
    - the eight platform labels are aligned **declaratively** from the
-     repo-managed `labels.toml` (repo root) — the single source of
-     truth for label name, color and description: a missing label is
-     created, a drifted label is updated, nothing is deleted, and
-     business labels (`bug`, `enhancement`, ...) are never touched.
-5. **Systemd units** — the repo templates
-   (`systemd/orbi@.service`, `systemd/orbi@.timer`) are
-   installed idempotently into the user unit directory (the same
+     deployment home's `labels.toml` (`<deploy_home>/labels.toml`,
+     Issue #330) — the single source of truth for label name, color and
+     description: a missing label is created, a drifted label is
+     updated, nothing is deleted, and business labels (`bug`,
+     `enhancement`, ...) are never touched. In the external single-repo
+     mode the labels come from the orbi checkout, never from the
+     delivery checkout X.
+5. **Systemd units** — the deployment home's templates
+   (`<deploy_home>/systemd/orbi@.service`,
+   `<deploy_home>/systemd/orbi@.timer`; in bootstrap mode the orbi
+   checkout, Issue #330) are installed idempotently into the user unit
+   directory (the same
    install `install-units` performs: copy, migrate the pre-#149
    non-templated units away once, `daemon-reload`, then enables `@1` for
    `max_concurrency = 1` or `@1` and `@2` for `2` (and disables surplus
    timers) — the service is never started, stopped or restarted), then each timer
    instance's enabled/active state and next trigger time are reported.
-6. **Checkout + git transport** — check of the configured `repo_dir`:
-   the `origin` remote's **transport** (Issue #114): git data
+6. **Checkout + git transport** — check of the configured delivery
+   checkout `repo_dir` (the orbi checkout in bootstrap mode, the user
+   repo X in the external single-repo mode): the `origin` remote's
+   **transport** (Issue #114): git data
    operations (fetch, push — including `.github/workflows/*.yml`) must
    go over SSH (`git@github.com:owner/repo.git`), so an existing
    HTTPS `origin` is migrated here with the plain
@@ -85,6 +96,26 @@ non-zero exit code.
 
 Setup never creates business Issues, never claims a task, never starts
 Pi, and never modifies a protected branch.
+
+## External single-repo mode (deploy_home)
+
+In the external single-repo mode (Issue #330, PR #334) the config
+separates the two checkouts: `deploy_home` is the orbi source checkout
+and `repo_dir` is the user repo X. Setup routes accordingly — steps 2
+(CLI editable install), 4 (`labels.toml`) and 5 (unit templates) act on
+`deploy_home`, while step 6 (checkout + git transport) checks
+`repo_dir`: X's `origin` must be SSH for the first configured source
+repo, X's worktree must be clean, and X's base freshness is reported.
+Note that in external mode the timer's `ExecStartPre` fast-forward acts
+on the deploy home (the orbi checkout), not on X — X is only read from
+when the Runner creates task worktrees. `deploy_home` absent means bootstrap mode: everything acts on
+`repo_dir` exactly as before.
+
+One practical consequence: the installed systemd unit reads its config
+from `<deploy_home>/orbi.toml` (the `{{ORBI_REPO_DIR}}` placeholder
+renders the deploy home path), so in external mode `orbi.toml` and the
+optional `.orbi/env` live in the orbi checkout — run setup with
+`--config <deploy_home>/orbi.toml`.
 
 ## Options
 

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -190,9 +190,10 @@ skills = []
 context_files = []
 ```
 
-（`workspace_root` 必须包含 `repo_dir`——任务 worktree 落在
-`<workspace_root>/.worktrees/`；未设置的 `prompt` / `prompt_review`
-相对 `deploy_home` 解析。）
+（任务 worktree 落在交付 checkout 的 `<repo_dir>/.worktrees/`；
+`workspace_root` 是告诉实现者 agent「可修改仓库所在目录」的路径
+（`{{WORKSPACE_ROOT}}` prompt 占位符）；未设置的 `prompt` /
+`prompt_review` 相对 `deploy_home` 解析。）
 
 其余一切——第 4–8 步（模型 provider、`orbi setup`、手工 tick、smoke
 walkthrough、timers）——不变：`orbi setup` 从 `deploy_home` 读标签、

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -66,6 +66,14 @@ orbi --help
 `uv tool` 把 CLI 装进隔离的 tool 环境，可执行文件落在 `~/.local/bin`
 （systemd unit 的 PATH 已包含该目录）。
 
+**两种部署模式**（Issue #330，PR #334）：安装命令两者完全相同——orbi
+永远从 orbi clone **安装一次**——区别在配置。**自举模式**（本页默认）：
+`repo_dir` 就是 orbi checkout 自身，部署 home 和交付 checkout 是同一
+个目录。**外部单仓库模式**：`deploy_home` 指向 orbi checkout，
+`repo_dir` 指向外部用户仓库 X——orbi 安装一次后指向 X，X 里开
+`ai-ready` issue 即被开发，且绝不会从 X 重装 CLI。配置差异见第 3 步
+和下面的「外部单仓库模式（deploy_home）」一节。
+
 **为什么必须 `--editable`**：非 editable 安装会把源码复制进 tool
 环境的 site-packages；service 的 `ExecStartPre` 每次启动前把 checkout
 快进到最新 `main`——源码被复制后 CLI 仍在执行旧副本（启动死锁：
@@ -106,7 +114,8 @@ cp .orbi.example.toml orbi.toml
 | 字段 | 必填 | 默认 | 含义 |
 |---|---|---|---|
 | `source_repos` | 是 | — | 每个 tick 按顺序扫描的 `owner/repo` 任务池列表（例如先你的 pilot 仓库，再你的 backlog 仓库） |
-| `repo_dir` | 否 | `.` | service 启动的 Runner checkout（`src/orbi/` package 所在目录） |
+| `repo_dir` | 否 | `.` | 交付 checkout：Runner 交付 Issue 的仓库。任务 worktree 从它冻结的 `origin/<base_branch>` SHA 创建，PR 对它打开，slot 锁在 `<repo_dir>/.orbi/slots/`。自举模式下它就是 orbi checkout 自身；外部单仓库模式（Issue #330）下是外部用户仓库 X |
+| `deploy_home` | 否 | `repo_dir` | orbi **源码** checkout（Issue #330）：editable CLI 安装来源（自更新）、`systemd/` unit 模板、`labels.toml`、prompt 默认（`prompt.md`、`prompt_review.md` 未设置时）。缺省 = `repo_dir`（自举模式，行为不变）。`repo_dir` 是外部仓库 X 时把它设为 orbi checkout。必须是非空字符串；目录不存在会启动 fail fast |
 | `workspace_root` | 否 | `..` | 包含任务 worktree 和 agent 可修改仓库的目录 |
 | `prompt` | 否 | `prompt.md` | 实现者 prompt 模板（`{{SOURCE_REPO}}` 等占位符由 Runner 渲染） |
 | `prompt_review` | 否 | `prompt_review.md` | PR 后独立审查 session 的 review prompt 模板 |
@@ -141,6 +150,54 @@ max_concurrency = 1
 skills = []
 context_files = []
 ```
+
+### 外部单仓库模式（deploy_home）
+
+Issue #330（PR #334）把 orbi 的部署 home 与交付 checkout 解耦：orbi
+从 orbi 仓库**安装一次**后，可以指向任意用户仓库 X——在 X 里开
+`ai-ready` Issue，会被领取、在 X 的 worktree 里实现、对 X 开 PR。
+
+- **自举模式（默认）**：`repo_dir` 就是 orbi checkout 自身——部署 home
+  和交付 checkout 是同一个目录（`deploy_home` 缺省，取 `repo_dir`）。
+  本页第 1–8 步描述的就是这个模式。
+- **外部单仓库模式**：`repo_dir` 是用户仓库 X，`deploy_home` 是 orbi
+  checkout。两个 checkout 各司其职：
+  - `deploy_home`（orbi checkout）——CLI 自更新来源（editable `uv tool`
+    安装、`ExecStartPre` fast-forward 与 CLI 自愈）、`systemd/` unit
+    模板（`{{ORBI_REPO_DIR}}` 占位符渲染的是**这个**路径）、
+    `labels.toml`、prompt 默认；
+  - `repo_dir`（用户仓库 X）——交付 checkout：Issue 从 X 领取，任务
+    worktree 从 X 冻结的 `origin/<base_branch>` 创建，PR 对 X 打开，
+    slot 锁在 `<repo_dir>/.orbi/slots/`。
+
+先安装一次（上面第 2 步，从 orbi clone），然后把配置文件放进部署 home
+——已安装 systemd unit 从 `<deploy_home>/orbi.toml` 读配置
+（`{{ORBI_REPO_DIR}}` 占位符渲染的是 deploy home 路径），所以
+`orbi.toml` 和可选的 `.orbi/env` 放在 orbi checkout，而不是 X：
+
+```toml
+# <deploy_home>/orbi.toml — orbi checkout，不是用户仓库 X
+source_repos = [
+  "OWNER/USER-REPO-X",
+]
+
+repo_dir = "/path/to/user-repo-x"
+deploy_home = "/path/to/orbi"
+workspace_root = "/path/to"
+base_branch = "main"
+max_concurrency = 1
+skills = []
+context_files = []
+```
+
+（`workspace_root` 必须包含 `repo_dir`——任务 worktree 落在
+`<workspace_root>/.worktrees/`；未设置的 `prompt` / `prompt_review`
+相对 `deploy_home` 解析。）
+
+其余一切——第 4–8 步（模型 provider、`orbi setup`、手工 tick、smoke
+walkthrough、timers）——不变：`orbi setup` 从 `deploy_home` 读标签、
+CLI 安装和 unit 模板，检查交付 checkout `repo_dir`（见[一次性
+setup](/zh/setup)）。
 
 ## 4. 配置模型 provider
 
@@ -398,9 +455,12 @@ fast-forward 和每实例启动语义定义在[运维](/zh/operations)（Timers�
 <Note>
 提交的 unit 模板与机器无关：它们携带 `{{ORBI_REPO_DIR}}` 占位符
 而不是硬编码的 checkout 路径（Issue #262）。`orbi install-units`
-（以及 `orbi setup`）在安装时用**你的**部署 checkout 的解析后
-路径替换它，因此任何位置的 clone 都能干净部署——无需手工编辑
-已安装的 units。`ExecStart` 是已安装的 `orbi` CLI，保持 home 相对
-（`%h/.local/bin/orbi`）。仓库模板仍是其余一切的唯一事实源——
-漂移检测见[运维](/zh/operations)。
+（以及 `orbi setup`）在安装时用**部署 home**（`deploy_home`，缺省
+`repo_dir`）的解析后路径替换它，因此任何位置的 clone 都能干净部署
+——无需手工编辑已安装的 units。外部单仓库模式（Issue #330）下，unit
+的 `WorkingDirectory`、`ORBI_CONFIG`、`EnvironmentFile`、`ExecStartPre`
+fast-forward、`base-sync.lock` 和 CLI 自愈**全部**作用于 orbi 源码
+checkout，绝不作用于交付 checkout X。`ExecStart` 是已安装的 `orbi`
+CLI，保持 home 相对（`%h/.local/bin/orbi`）。仓库模板仍是其余一切的
+唯一事实源——漂移检测见[运维](/zh/operations)。
 </Note>

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -15,7 +15,7 @@ service 实例（`orbi@1.timer` → `orbi@1.service`，
 两个独立的 Runner 实例。每个 tick 的 service 实例：
 
 1. **先 fast-forward 代码**（`ExecStartPre`，在 Python 进程外）：
-   `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`。fetch 禁用自动维护，避免 Git 子进程脱离 preflight 和共享锁的生命周期。checkout
+   `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`。被 fast-forward 的 checkout 是**部署 home**——`{{ORBI_REPO_DIR}}` 占位符在安装时渲染的是 `deploy_home` 路径（缺省 `repo_dir`），所以外部单仓库模式（Issue #330）下 fast-forward、`base-sync.lock` 和下面的 CLI 自愈全部作用于 orbi 源码 checkout，绝不作用于交付 checkout（用户仓库 X）。fetch 禁用自动维护，避免 Git 子进程脱离 preflight 和共享锁的生命周期。checkout
    不干净、fetch 失败或无法 fast-forward 时 preflight 失败：service 不
    启动，原因写入 systemd journal（fail fast）。正在运行的长任务从不被
    热更新或杀掉——一个 service 实例 active 时 systemd 忽略对**该实例**
@@ -59,7 +59,10 @@ systemctl --user status 'orbi@*.service'
 ## Unit 模板变更后（Issue #131、#142）
 
 unit 模板（`systemd/orbi@.service` 和 `systemd/orbi@.timer`）
-是部署配置，不是普通代码——但模板变更合并后**不需要任何人工步骤**。下一次 timer 触发时 `ExecStartPre` 同步 checkout，启动前
+是部署配置，不是普通代码——但模板变更合并后**不需要任何人工步骤**。模板
+位于部署 home（`deploy_home`，缺省 `repo_dir`——Issue #330），漂移检查
+对比的是**这些**模板与已安装 unit。下一次 timer 触发时 `ExecStartPre`
+同步部署 home checkout，启动前
 `unit_drift` 检查自动自愈：用同一个幂等安装（把两个模板复制到用户
 unit 目录、daemon-reload、按 `max_concurrency` enable 或 disable timer
 实例——从不启动、停止或重启运行中的 Runner）、再用同一个哈希检查复核，tick 继续，每个 unit
@@ -176,8 +179,10 @@ idle 告警和模型请求挂死 kill 是日志/健康阈值——它们不是�
 免重装的源码变更、打包输入刷新）定义在[快速开始](/zh/getting-started)
 第 2 步。`orbi doctor` 报告一致性（`cli_source: clean` 或
 `cli_source: DRIFT` + 结构化 `cli_source_drift` 行：实际导入路径、
-期望 repo_dir、精确的 editable 重装命令），`orbi setup` 校验或
-重装。checkout 根目录**没有** `orbi.py`（与 package 同名的 flat
+期望 deploy_home、精确的 editable 重装命令），`orbi setup` 校验或
+重装。期望来源是**部署 home**（`deploy_home`，缺省 `repo_dir`——Issue
+#330）：外部单仓库模式下 `cli_source` clean 表示 editable 安装从 orbi
+checkout 导入，即使交付 checkout 是外部仓库 X。checkout 根目录**没有** `orbi.py`（与 package 同名的 flat
 文件会遮蔽已安装 package）；直接执行入口 `python3 -m orbi.cli`
 运行与 console script 完全相同的代码，保留为开发/兼容路径。
 

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -26,29 +26,38 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    错误失败）。
 2. **CLI editable 安装**（Issue #152）——官方本地部署是 **editable**
    `uv tool` 安装（为什么——`ExecStartPre` checkout 同步——定义在
-   [快速开始](/zh/getting-started) 第 2 步）。运行进程已经从配置的
-   `repo_dir` 导入时只校验（不调 uv，`cli=verified`）；否则执行精确的
-   force editable 重装（`uv tool install --force --reinstall --editable
-   --python /usr/bin/python3 <repo_dir>`，`cli=installed`）。安装失败
-   fail fast——不装 unit、不半初始化。该步骤从不碰运行中的 Runner 进程
-   （新源码由下一个 CLI 启动加载）。
+   [快速开始](/zh/getting-started) 第 2 步）。安装作用于**部署 home**
+   （`deploy_home`，缺省 `repo_dir`——Issue #330）：运行进程已经从配置
+   的 `deploy_home` 导入时只校验（不调 uv，`cli=verified`）；否则执行
+   精确的 force editable 重装（`uv tool install --force --reinstall
+   --editable --python /usr/bin/python3 <deploy_home>`，`cli=installed`）。
+   外部单仓库模式下**绝不**从交付 checkout 重装 CLI——`repo_dir` 可能是
+   没有任何 orbi 打包输入的外部仓库 X。安装失败 fail fast——不装 unit、
+   不半初始化。该步骤从不碰运行中的 Runner 进程（新源码由下一个 CLI
+   启动加载）。
 3. **认证** — `gh auth status`（已登录且 token 可用）。
 4. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
    OWNER/REPO` 时恰好一个）：
    - 仓库存在且 viewer 有写权限（`gh repo view` → `viewerPermission`
      必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）；
-   - 八个平台标签从仓库根目录的 `labels.toml` **声明式**对齐——标签
+   - 八个平台标签从部署 home 的 `labels.toml`
+     （`<deploy_home>/labels.toml`，Issue #330）**声明式**对齐——标签
      名/颜色/描述的唯一事实源：缺的创建、漂移的更新、从不删除，业务
-     标签（`bug`、`enhancement`、...）从不被碰。
-5. **Systemd units** — 仓库模板（`systemd/orbi@.service`、
-   `systemd/orbi@.timer`）幂等安装到 user unit 目录（与
+     标签（`bug`、`enhancement`、...）从不被碰。外部单仓库模式下标签
+     来自 orbi checkout，绝不来自交付 checkout X。
+5. **Systemd units** — 部署 home 的模板（
+   `<deploy_home>/systemd/orbi@.service`、
+   `<deploy_home>/systemd/orbi@.timer`；自举模式下即 orbi checkout，
+   Issue #330）幂等安装到 user unit 目录（与
    `install-units` 相同的安装：复制、一次性迁移 #149 之前的非模板
    unit、`daemon-reload`、按 `max_concurrency` 启用 `@1`（值为 `1`）或
    `@1`/`@2`（值为 `2`），并停掉多余 timer——从不启动、停止或重启
    service），然后报告每个 timer 实例的 enabled/active 状态和
    下次触发时间。
-6. **Checkout + git transport** — 检查配置的 `repo_dir`：`origin`
-   remote 的**传输协议**（Issue #114）：git 数据操作（fetch、push——
+6. **Checkout + git transport** — 检查配置的交付 checkout `repo_dir`
+   （自举模式下是 orbi checkout，外部单仓库模式下是用户仓库 X）：
+   `origin` remote 的**传输协议**（Issue #114）：git 数据操作
+   （fetch、push——
    包括 `.github/workflows/*.yml`）必须走 SSH
    （`git@github.com:owner/repo.git`），所以已有的 HTTPS `origin` 在这里
    用普通的 `git remote set-url origin git@github.com:owner/repo.git`
@@ -68,6 +77,23 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
    缺失或不健康只是输出里的 warning，从不阻塞核心 GitHub/Orbi setup。
 
 setup 从不创建业务 Issue、从不领取任务、从不启动 Pi、从不修改保护分支。
+
+## 外部单仓库模式（deploy_home）
+
+外部单仓库模式（Issue #330，PR #334）下，配置把两个 checkout 分开：
+`deploy_home` 是 orbi 源码 checkout，`repo_dir` 是用户仓库 X。setup
+按此路由——第 2 步（CLI editable 安装）、第 4 步（`labels.toml`）和第
+5 步（unit 模板）作用于 `deploy_home`，第 6 步（checkout + git
+transport）检查 `repo_dir`：X 的 `origin` 必须是第一个配置的 source
+repo 的 SSH，X 的 worktree 必须干净，X 的 base 新鲜度只报告。注意
+外部模式下 timer 的 `ExecStartPre` fast-forward 作用于部署 home（orbi
+checkout）而不是 X——X 只在 Runner 创建任务 worktree 时被读取。
+`deploy_home` 缺省即自举模式：一切照旧作用于 `repo_dir`。
+
+一个实际后果：已安装 systemd unit 从 `<deploy_home>/orbi.toml` 读配置
+（`{{ORBI_REPO_DIR}}` 占位符渲染的是 deploy home 路径），所以外部模式
+下 `orbi.toml` 和可选的 `.orbi/env` 放在 orbi checkout——用
+`--config <deploy_home>/orbi.toml` 运行 setup。
 
 ## 选项
 

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -57,6 +57,10 @@ LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")
 KNOWN_CONFIG_FIELDS = frozenset({
     "source_repos",
     "repo_dir",
+    # Issue #330 (PR #334): the deployment home — the orbi source checkout
+    # (CLI install source, unit templates, labels.toml, prompt defaults);
+    # default = repo_dir (bootstrap mode unchanged).
+    "deploy_home",
     "workspace_root",
     "prompt",
     "prompt_review",
@@ -207,6 +211,23 @@ def test_chinese_getting_started_documents_prerequisites_and_smoke():
         "journalctl --user -u orbi@1.service -u "
         "orbi@2.service" in text
     ), "smoke must show the real journal command (both service instances)"
+
+
+def test_chinese_getting_started_documents_the_external_single_repo_mode():
+    """Issue #335 (docs for Issue #330 / PR #334): the Chinese
+    getting-started carries the same external single-repo mode facts as
+    the English page — the deploy_home field, its default (= repo_dir),
+    and the two-checkout relationship."""
+    text = zh_page_text("getting-started")
+    assert "deploy_home" in text, (
+        "Chinese getting-started must document the deploy_home config field"
+    )
+    assert "repo_dir" in text, (
+        "Chinese getting-started must keep documenting repo_dir"
+    )
+    assert "Issue #330" in text, (
+        "the external mode must cite its source issue (#330)"
+    )
 
 
 def test_chinese_getting_started_documents_the_model_provider_configuration():

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -228,6 +228,10 @@ def test_chinese_getting_started_documents_the_external_single_repo_mode():
     assert "Issue #330" in text, (
         "the external mode must cite its source issue (#330)"
     )
+    assert "<repo_dir>/.worktrees/" in text, (
+        "Chinese getting-started must document the task worktree "
+        "location in the delivery checkout like the English page"
+    )
 
 
 def test_chinese_getting_started_documents_the_model_provider_configuration():

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -313,6 +313,10 @@ def test_docs_getting_started_documents_the_external_single_repo_mode():
     assert "deploy_home" in example, (
         ".orbi.example.toml must carry the deploy_home field"
     )
+    assert "<repo_dir>/.worktrees/" in text, (
+        "task worktrees must be documented as landing in the delivery "
+        "checkout's .worktrees (worktree_path), never in workspace_root"
+    )
 
 
 def test_docs_getting_started_documents_the_model_provider_configuration():

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -62,6 +62,10 @@ LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")
 KNOWN_CONFIG_FIELDS = frozenset({
     "source_repos",
     "repo_dir",
+    # Issue #330 (PR #334): the deployment home — the orbi source checkout
+    # (CLI install source, unit templates, labels.toml, prompt defaults);
+    # default = repo_dir (bootstrap mode unchanged).
+    "deploy_home",
     "workspace_root",
     "prompt",
     "prompt_review",
@@ -286,6 +290,28 @@ def test_docs_config_field_table_matches_the_implementation():
     missing = example_fields - documented
     assert not missing, (
         f"docs field table misses fields of the committed example: {sorted(missing)}"
+    )
+
+
+def test_docs_getting_started_documents_the_external_single_repo_mode():
+    """Issue #335 (docs for Issue #330 / PR #334): the external
+    single-repo mode must be documented next to the bootstrap
+    deployment — the deploy_home field, its default (= repo_dir,
+    bootstrap unchanged), and the two-checkout relationship (deploy
+    home = orbi source checkout, repo_dir = delivery checkout X)."""
+    text = page_text("getting-started")
+    assert "deploy_home" in text, (
+        "getting-started must document the deploy_home config field"
+    )
+    assert "repo_dir" in text, (
+        "getting-started must keep documenting repo_dir"
+    )
+    assert "Issue #330" in text, (
+        "the external mode must cite its source issue (#330)"
+    )
+    example = EXAMPLE_CONFIG.read_text(encoding="utf-8")
+    assert "deploy_home" in example, (
+        ".orbi.example.toml must carry the deploy_home field"
     )
 
 


### PR DESCRIPTION
<!-- orbi:run=67aa55f1 -->

Fixes #335

补齐『外部单仓库模式』文档：#330/#334 引入的 deploy_home 解耦需要覆盖安装/setup/配置/运维 (run_id=67aa55f1)
