### PR TITLE
orbi setup crashes with a raw traceback when reporting the disabled surplus timer instance (systemctl is-enabled exit 1)

### DIFF
--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -472,8 +472,14 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     ])
     instances = {}
     for instance in systemd_deploy.TIMER_INSTANCES:
+        try:
+            enabled = unit_is_enabled(run_command, instance)
+        except subprocess.CalledProcessError as exc:
+            raise SetupError(
+                f"systemctl is-enabled failed for {instance}: {exc}"
+            ) from exc
         instances[instance] = {
-            "enabled": unit_is_enabled(run_command, instance),
+            "enabled": enabled,
             "active": run_command([
                 "systemctl", "--user", "show", "-p", "ActiveState",
                 "--value", instance,

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import shutil
 import tomllib
 from pathlib import Path
@@ -426,6 +427,24 @@ def timer_next_trigger(list_timers_output: str, unit_name: str) -> str:
     return "-"
 
 
+def unit_is_enabled(run_command, instance: str) -> bool:
+    """Whether the systemd unit is enabled.
+
+    ``systemctl --user is-enabled`` exits non-zero with the state word on
+    stdout (``disabled``, ``masked``, ...) for a unit that is NOT enabled —
+    that non-zero exit is documented systemd behavior, not a command
+    failure (Issue #339). A genuine systemctl failure (no user bus: empty
+    stdout, error on stderr) re-raises so setup fails fast.
+    """
+    try:
+        state = run_command(["systemctl", "--user", "is-enabled", instance])
+    except subprocess.CalledProcessError as exc:
+        state = (exc.stdout or "").strip()
+        if state not in ("disabled", "masked", "static", "indirect"):
+            raise
+    return state == "enabled"
+
+
 def install_units_step(repo_dir: Path, installed_dir: Path | None,
                        *, max_concurrency: int = len(systemd_deploy.TIMER_INSTANCES),
                        run_command) -> dict:
@@ -454,9 +473,7 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     instances = {}
     for instance in systemd_deploy.TIMER_INSTANCES:
         instances[instance] = {
-            "enabled": run_command([
-                "systemctl", "--user", "is-enabled", instance,
-            ]) == "enabled",
+            "enabled": unit_is_enabled(run_command, instance),
             "active": run_command([
                 "systemctl", "--user", "show", "-p", "ActiveState",
                 "--value", instance,

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -179,8 +179,15 @@ def fake_run_factory(state: dict):
             return ""
         if head[:3] == ["systemctl", "--user", "is-enabled"]:
             unit = command[-1]
-            return state.get(
+            value = state.get(
                 f"is_enabled:{unit}", state.get("is_enabled", "enabled"),
+            )
+            if value == "enabled":
+                return value
+            # Real systemctl: a not-enabled unit exits 1 with the state
+            # word on stdout (Issue #339).
+            raise subprocess.CalledProcessError(
+                1, command, output=value,
             )
         if head[:3] == ["systemctl", "--user", "list-timers"]:
             return state.get(
@@ -589,6 +596,69 @@ def test_install_units_step_reports_the_disabled_surplus_timer(tmp_path):
     assert [
         "systemctl", "--user", "disable", "--now", "orbi@2.timer",
     ] in calls
+
+
+def test_install_units_step_treats_is_enabled_exit_1_disabled_as_not_enabled(
+    tmp_path,
+):
+    """Regression (Issue #339): ``is-enabled`` exits 1 with stdout
+    ``disabled`` for the surplus instance — that is the expected state,
+    not a command failure; setup must report ``enabled=False`` instead of
+    dying with a traceback."""
+    state = {}
+    fake_run, calls = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", max_concurrency=1, run_command=fake_run,
+    )
+    instances = result["timer"]["instances"]
+    assert instances["orbi@1.timer"]["enabled"] is True
+    assert instances["orbi@2.timer"]["enabled"] is False
+    assert [
+        "systemctl", "--user", "disable", "--now", "orbi@2.timer",
+    ] in calls
+
+
+def test_install_units_step_is_enabled_exit_1_masked_is_not_enabled(tmp_path):
+    state = {}
+    fake_run, _ = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+
+    def masked(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "is-enabled"]:
+            raise subprocess.CalledProcessError(
+                1, command, output="masked",
+            )
+        return fake_run(command, **kwargs)
+
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", run_command=masked,
+    )
+    for instance in systemd_deploy.TIMER_INSTANCES:
+        assert result["timer"]["instances"][instance]["enabled"] is False
+
+
+def test_install_units_step_fails_fast_on_a_genuine_is_enabled_failure(
+    tmp_path,
+):
+    """A genuine systemctl failure (no user bus: exit 1, empty stdout)
+    must still fail fast, not be swallowed as "not enabled"."""
+    state = {}
+    fake_run, _ = fake_run_factory(state)
+    repo = make_repo(tmp_path)
+
+    def failing(command, **kwargs):
+        if command[:3] == ["systemctl", "--user", "is-enabled"]:
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr="Failed to connect to bus: No such file or directory",
+            )
+        return fake_run(command, **kwargs)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        pilot_setup.install_units_step(
+            repo, tmp_path / "units", run_command=failing,
+        )
 
 
 def test_install_units_step_reports_a_missing_next_trigger(tmp_path):

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -642,7 +642,8 @@ def test_install_units_step_fails_fast_on_a_genuine_is_enabled_failure(
     tmp_path,
 ):
     """A genuine systemctl failure (no user bus: exit 1, empty stdout)
-    must still fail fast, not be swallowed as "not enabled"."""
+    must still fail fast with a structured SetupError (never a raw
+    traceback — the #339 scene), not be swallowed as "not enabled"."""
     state = {}
     fake_run, _ = fake_run_factory(state)
     repo = make_repo(tmp_path)
@@ -655,10 +656,13 @@ def test_install_units_step_fails_fast_on_a_genuine_is_enabled_failure(
             )
         return fake_run(command, **kwargs)
 
-    with pytest.raises(subprocess.CalledProcessError):
+    with pytest.raises(
+        pilot_setup.SetupError, match="is-enabled failed for orbi@1.timer",
+    ) as excinfo:
         pilot_setup.install_units_step(
             repo, tmp_path / "units", run_command=failing,
         )
+    assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
 
 def test_install_units_step_reports_a_missing_next_trigger(tmp_path):


### PR DESCRIPTION
<!-- orbi:run=77d01f26 -->

Fixes #339

orbi setup crashes with a raw traceback when reporting the disabled surplus timer instance (systemctl is-enabled exit 1) (run_id=77d01f26)
