### PR TITLE
orbi setup validates the provider key against the process env only, ignoring .orbi/env — the documented step 4→5 flow fails verbatim

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -464,6 +464,47 @@ def _config_path(value: str, base: Path) -> Path:
     return (path if path.is_absolute() else base / path).resolve()
 
 
+def _load_deploy_env_file(deploy_home: Path) -> None:
+    """Merge `<deploy_home>/.orbi/env` into the process environment (Issue #348).
+
+    The documented env-file-first flow (getting-started step 4) writes the
+    provider key to this gitignored file, and the installed unit loads it
+    via `EnvironmentFile` at service start — the CLI process does not, so
+    `orbi setup` and friends must read it themselves or the documented
+    step 4 -> 5 flow fails verbatim. Plain systemd EnvironmentFile syntax:
+    `KEY=VALUE` lines, optional `export ` prefix, matching single/double
+    quotes stripped, blank lines and `#` comments skipped. A variable
+    already exported in the shell wins (`setdefault`): the shell export is
+    the documented override for manual ticks. A missing file is a no-op
+    (a keyless local server needs no env file at all); a line without `=`
+    is a misconfiguration and fails fast.
+    """
+    env_file = deploy_home / ".orbi" / "env"
+    if not env_file.is_file():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped[len("export "):]
+        if "=" not in stripped:
+            raise ValueError(
+                f"malformed line in env file {env_file}: {stripped!r} "
+                "(expected KEY=VALUE)"
+            )
+        name, value = stripped.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in ('"', "'")
+        ):
+            value = value[1:-1]
+        os.environ.setdefault(name, value)
+
+
 def load_config(path: Path) -> dict:
     """Load the human-maintained TOML config and resolve its paths."""
     base = path.resolve().parent
@@ -532,15 +573,6 @@ def load_config(path: Path) -> dict:
     # Pi's own `models.json` shape; `orbi.toml` only selects the
     # provider/model/thinking used at runtime. Absent key -> None (Pi
     # keeps using its own agent dir, the exact pre-#157 behavior).
-    pi_providers = _optional_pi_string(data, "pi_providers")
-    pi_providers_path = (
-        _config_path(pi_providers, base) if pi_providers is not None
-        else None
-    )
-    pi_providers_data = (
-        _load_pi_providers(pi_providers_path, pi_provider, pi_model)
-        if pi_providers_path is not None else None
-    )
     repo_dir = _config_path(data.get("repo_dir", "."), base)
     # Deployment home (Issue #330): the orbi source checkout — the editable
     # CLI install source, the systemd/ unit templates, labels.toml and the
@@ -558,6 +590,29 @@ def load_config(path: Path) -> dict:
         _config_path(deploy_home_raw, base)
         if deploy_home_raw is not None
         else repo_dir
+    )
+    # The deploy-home env file (Issue #348): step 4 of getting-started
+    # writes the provider key to `<deploy_home>/.orbi/env` and the
+    # installed unit loads it via `EnvironmentFile` at service start —
+    # the CLI process does not. Load it here so `orbi setup` (and every
+    # other CLI entry) validates the key exactly like the unit would.
+    _load_deploy_env_file(deploy_home)
+    # Optional Pi provider file (Issue #157): the provider metadata
+    # (baseUrl / api / apiKey / models) lives in a separate JSON file in
+    # Pi's own `models.json` shape; `orbi.toml` only selects the
+    # provider/model/thinking used at runtime. Absent key -> None (Pi
+    # keeps using its own agent dir, the exact pre-#157 behavior).
+    pi_providers = _optional_pi_string(data, "pi_providers")
+    pi_providers_path = (
+        _config_path(pi_providers, base) if pi_providers is not None
+        else None
+    )
+    pi_providers_data = (
+        _load_pi_providers(
+            pi_providers_path, pi_provider, pi_model,
+            deploy_home / ".orbi" / "env",
+        )
+        if pi_providers_path is not None else None
     )
     return {
         "source_repos": source_repos,
@@ -767,7 +822,7 @@ def _model_wait_dead_seconds(data: dict) -> float:
 
 
 def _load_pi_providers(path: Path, pi_provider: str | None,
-                       pi_model: str | None) -> dict:
+                       pi_model: str | None, env_file: Path) -> dict:
     """Load and validate the Pi provider file (Issue #157).
 
     The file uses Pi's own `models.json` shape (`{"providers": {id:
@@ -843,7 +898,7 @@ def _load_pi_providers(path: Path, pi_provider: str | None,
         # Only the SELECTED provider's key must resolve: an unselected
         # provider with a missing key just stays unavailable in Pi
         # (verified against real Pi 0.84.3), it never breaks the run.
-        _check_pi_provider_api_key(path, pi_provider, entry)
+        _check_pi_provider_api_key(path, pi_provider, entry, env_file)
         if pi_model is not None:
             model_ids = [
                 model["id"] for model in entry.get("models", [])
@@ -857,7 +912,7 @@ def _load_pi_providers(path: Path, pi_provider: str | None,
 
 
 def _check_pi_provider_api_key(path: Path, provider_id: str,
-                               entry: dict) -> None:
+                               entry: dict, env_file: Path) -> None:
     """Fail fast when an `apiKey` env-var reference is unresolved.
 
     Pi's value-resolution syntax (`docs/models.md`): `$VAR` or
@@ -865,7 +920,9 @@ def _check_pi_provider_api_key(path: Path, provider_id: str,
     variable leaves the value unresolved and Pi would only fail at
     request time. The Runner fails at config load instead (before any
     slot or claim). Only the variable NAME is reported — never a key
-    value.
+    value. The error names BOTH remedies (Issue #348): export the
+    variable in the shell, or add it to the deploy-home env file the
+    unit loads via `EnvironmentFile`.
     """
     api_key = entry.get("apiKey")
     if not isinstance(api_key, str) or not api_key:
@@ -877,7 +934,9 @@ def _check_pi_provider_api_key(path: Path, provider_id: str,
             raise ValueError(
                 f"API key for provider {provider_id!r} references "
                 f"missing environment variable {name} "
-                f"(pi_providers file {path})"
+                f"(pi_providers file {path}). Export {name} in your "
+                f"shell or add it to {env_file} (the unit's "
+                f"EnvironmentFile)."
             )
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -11391,6 +11391,127 @@ def test_load_config_pi_providers_braced_env_reference(tmp_path, monkeypatch):
     assert config["pi_providers_data"] == providers
 
 
+def test_load_config_api_key_from_deploy_env_file_ok(tmp_path, monkeypatch):
+    """Issue #348: the key lives in `<deploy_home>/.orbi/env` (step 4 of
+    getting-started) but is NOT exported in the shell — `load_config`
+    must read the env file and validate successfully."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    env_file = tmp_path / ".orbi" / "env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text("GROQ_API_KEY=file-key\n", encoding="utf-8")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"',
+    )
+    config = runner.load_config(config_path)
+    assert config["pi_providers_data"] == GROQ_PROVIDERS
+    # The variable must be visible to the process so the per-run Pi agent
+    # dir expansion (_expand_pi_api_key_refs) resolves it too.
+    assert os.environ.get("GROQ_API_KEY") == "file-key"
+
+
+def test_load_config_api_key_shell_export_wins_over_env_file(
+    tmp_path, monkeypatch,
+):
+    """A shell-exported value stays the documented override for manual
+    ticks: the env file never replaces an existing variable."""
+    monkeypatch.setenv("GROQ_API_KEY", "shell-key")
+    env_file = tmp_path / ".orbi" / "env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text("GROQ_API_KEY=file-key\n", encoding="utf-8")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"',
+    )
+    runner.load_config(config_path)
+    assert os.environ.get("GROQ_API_KEY") == "shell-key"
+
+
+def test_load_config_api_key_missing_everywhere_names_both_remedies(
+    tmp_path, monkeypatch,
+):
+    """Key absent from the shell AND from `.orbi/env`: the failure must
+    point at both fixes, not only name the missing variable."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"',
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"missing environment variable GROQ_API_KEY.*"
+        r"Export GROQ_API_KEY.*\.orbi/env",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_env_file_absent_missing_key_still_fails(
+    tmp_path, monkeypatch,
+):
+    """No `.orbi/env` at all: the pre-#348 behavior is unchanged."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"',
+    )
+    with pytest.raises(
+        ValueError, match="missing environment variable GROQ_API_KEY",
+    ):
+        runner.load_config(config_path)
+
+
+def test_load_config_env_file_follows_explicit_deploy_home(
+    tmp_path, monkeypatch,
+):
+    """The env file is read from `<deploy_home>/.orbi/env`, not the
+    delivery checkout (repo_dir) when deploy_home is explicit."""
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    home = tmp_path / "orbi-home"
+    home.mkdir()
+    env_file = home / ".orbi" / "env"
+    env_file.parent.mkdir()
+    env_file.write_text("GROQ_API_KEY=home-key\n", encoding="utf-8")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS, pi_provider='"groq"',
+        pi_model='"qwen/qwen3.8-27b"', deploy_home=f'"{home}"',
+    )
+    runner.load_config(config_path)
+    assert os.environ.get("GROQ_API_KEY") == "home-key"
+
+
+def test_load_deploy_env_file_parses_comments_quotes_and_export(
+    tmp_path, monkeypatch,
+):
+    """Plain systemd EnvironmentFile syntax: blank lines and `#` comments
+    are skipped; matching quotes are stripped; `export ` prefix is
+    accepted."""
+    env_file = tmp_path / ".orbi" / "env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text(
+        "# a comment\n"
+        "\n"
+        'QUOTED="double"\n'
+        "SINGLE='single'\n"
+        "export EXPORTED=yes\n"
+        "PLAIN=raw\n",
+        encoding="utf-8",
+    )
+    runner._load_deploy_env_file(tmp_path)
+    assert os.environ.get("QUOTED") == "double"
+    assert os.environ.get("SINGLE") == "single"
+    assert os.environ.get("EXPORTED") == "yes"
+    assert os.environ.get("PLAIN") == "raw"
+
+
+def test_load_deploy_env_file_malformed_line_fails_fast(tmp_path):
+    """A line without `=` is a misconfiguration — fail fast, no fallback."""
+    env_file = tmp_path / ".orbi" / "env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text("NOT_AN_ASSIGNMENT\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="NOT_AN_ASSIGNMENT"):
+        runner._load_deploy_env_file(tmp_path)
+
+
 def test_prepare_pi_agent_dir_user_models_json_without_providers_key(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
<!-- orbi:run=6dc795ca -->

Fixes #348

orbi setup validates the provider key against the process env only, ignoring .orbi/env — the documented step 4→5 flow fails verbatim (run_id=6dc795ca)
