### PR TITLE
Health watchdog files Runner crash-loop alerts as ai-ready tasks in the delivery repo instead of routing orbi bugs to the orbi repo

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -568,6 +568,12 @@ def load_config(path: Path) -> dict:
     # pending checks on the release commit before failing with its own
     # timeout reason.
     release_ci_wait_seconds = _release_ci_wait_seconds(data)
+    # Runner-self health alert routing (Issue #345): the orbi repo that
+    # receives the watchdog's crash_loop / stale_pickup Issues. Absent ->
+    # None (the Runner derives the orbi repo from the deploy home's git
+    # origin); present -> must be a non-empty `owner/repo` string, used
+    # verbatim for fork/private deployments.
+    health_alert_repo = _optional_pi_string(data, "health_alert_repo")
     # Optional Pi provider file (Issue #157): the provider metadata
     # (baseUrl / api / apiKey / models) lives in a separate JSON file in
     # Pi's own `models.json` shape; `orbi.toml` only selects the
@@ -618,6 +624,7 @@ def load_config(path: Path) -> dict:
         "source_repos": source_repos,
         "repo_dir": repo_dir,
         "deploy_home": deploy_home,
+        "health_alert_repo": health_alert_repo,
         "workspace_root": _config_path(data.get("workspace_root", ".."), base),
         # Issue #330: when deploy_home is EXPLICIT the prompt defaults
         # live in the deployment home (the delivery checkout may be a

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -65,6 +65,20 @@ VOLATILE_TOKEN_RE = re.compile(
     r"\b[0-9a-f]{8,40}\b|\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}",
 )
 
+# Fail-fast validation errors a HUMAN must fix in the config (Issue #345):
+# there is nothing for any agent to implement until a human edits the
+# config. These are the exact messages the Runner raises at config load
+# (`_check_pi_provider_api_key`, `load_config`); a crash loop whose journal
+# carries one of them is a deployment-config problem, not an orbi bug.
+CONFIG_CAUSE_RE = re.compile(
+    r"missing environment variable"
+    r"|API key for provider"
+    r"|must be a non-empty"
+    r"|must be a boolean"
+    r"|must be a positive integer"
+    r"|is not defined for provider",
+)
+
 
 def health_state_path(repo_dir: Path) -> Path:
     """Return the health state file of one configured repo."""
@@ -156,23 +170,105 @@ def record_pickup(repo_dir: Path) -> None:
     save_health_state(path, state)
 
 
-def count_crashes(run_command, since_minutes: int = CRASH_WINDOW_MINUTES) -> int:
-    """Count service crashes in the window from the systemd journal.
+def crash_journal_lines(
+    run_command, since_minutes: int = CRASH_WINDOW_MINUTES,
+) -> list[str]:
+    """Return the systemd journal lines for every service instance in the
+    window.
 
     One bounded `journalctl` query per service instance (the verified shape
-    from `orbi doctor`); counts only the real systemd exit lines (see
-    CRASH_EXIT_RE).
+    from `orbi doctor`). The lines are the raw scene the crash-loop alert
+    needs (Issue #345): the exit lines plus the structured fail-fast reason
+    the Runner logged before each crash.
     """
-    total = 0
+    lines: list[str] = []
     for unit in SERVICE_INSTANCES:
         output = run_command([
             "timeout", "30", "journalctl", "--user", "-u", unit,
             "--since", f"-{since_minutes}min", "--no-pager", "-q",
         ])
-        total += sum(
-            1 for line in output.splitlines() if CRASH_EXIT_RE.search(line)
-        )
-    return total
+        lines.extend(output.splitlines())
+    return lines
+
+
+def count_crashes(run_command, since_minutes: int = CRASH_WINDOW_MINUTES) -> int:
+    """Count service crashes in the window from the systemd journal.
+
+    Counts only the real systemd exit lines (see CRASH_EXIT_RE).
+    """
+    return sum(
+        1 for line in crash_journal_lines(run_command, since_minutes)
+        if CRASH_EXIT_RE.search(line)
+    )
+
+
+def classify_crash(journal_lines: list[str]) -> tuple[str, str]:
+    """Classify a crash loop as deployment-config or orbi-bug (Issue #345).
+
+    Returns ``(kind, reason_line)``. ``kind`` is ``"config"`` when the
+    journal carries a fail-fast validation error (CONFIG_CAUSE_RE) — a human
+    must edit the config, no agent can fix it; otherwise ``"bug"`` (an
+    orbi-internal defect orbi's own agent can fix). ``reason_line`` is the
+    most recent journal line that names the cause (empty when unknown), so
+    the receiving agent has the scene.
+    """
+    for line in reversed(journal_lines):
+        if CONFIG_CAUSE_RE.search(line):
+            return "config", line
+    for line in reversed(journal_lines):
+        if "ERROR" in line.upper() or "Traceback" in line:
+            return "bug", line
+    return "bug", ""
+
+
+def crash_reason_fingerprint(reason_line: str) -> str:
+    """Return the stable 16-hex fingerprint of one crash reason line.
+
+    A per-crash identity for the alert body (Issue #345): the same fail-fast
+    reason always fingerprints identically, so a recurring loop is
+    recognizable at a glance. Empty reason -> empty fingerprint.
+    """
+    if not reason_line:
+        return ""
+    return hashlib.sha256(reason_line.encode("utf-8")).hexdigest()[:16]
+
+
+def orbi_repo_from_origin_url(url: str) -> str | None:
+    """Derive ``owner/repo`` from a git origin URL.
+
+    Handles the two forms `git remote get-url origin` returns for the orbi
+    checkout: SSH (``git@github.com:owner/repo.git``) and HTTPS
+    (``https://github.com/owner/repo[.git]``). Anything else -> None
+    (undeterminable; the caller logs and skips rather than guess).
+    """
+    url = url.strip()
+    if not url:
+        return None
+    match = re.match(r"^[^@]+@[^:]+:(.+?)(?:\.git)?$", url)
+    if match:
+        return match.group(1)
+    match = re.match(r"^https?://[^/]+/(.+?)(?:\.git)?/?$", url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def orbi_repo_from_deploy_home(deploy_home: Path, run_command) -> str | None:
+    """Derive the orbi repo from the deploy home's git origin.
+
+    The deploy home is the orbi source checkout (Issue #330); its origin is
+    the orbi repo the Runner-self health alerts belong in (Issue #345).
+    A failed query or unparseable URL returns None (the caller falls back to
+    the configured override or skips — never guesses a repo).
+    """
+    try:
+        output = run_command([
+            "timeout", "30", "git", "-C", str(deploy_home),
+            "remote", "get-url", "origin",
+        ])
+    except Exception:
+        return None
+    return orbi_repo_from_origin_url(output)
 
 
 def repeated_failure_findings(state: dict) -> list[dict]:
@@ -230,13 +326,18 @@ def health_marker(check: str) -> str:
 
 
 def create_health_issue(
-    repo: str, check: str, detail: str, *, run_command,
+    repo: str, check: str, detail: str, *, run_command, dispatchable=True,
 ) -> str | None:
     """Create (or find) one deduplicated bug Issue for a health alarm.
 
     Reuses the #106 mechanism: the stable marker is written into the body
     and `gh issue list --search 'in:body ...'` finds an existing Issue, so a
     recurring alarm never creates a second Issue.
+
+    ``dispatchable`` (Issue #345): True -> the normal `bug`+`ai-ready`
+    dispatch (an orbi bug orbi's own agent can fix); False -> a
+    non-dispatchable alert (`bug` only, NO `ai-ready`) for a deployment
+    config problem only a human can fix — the Runner never picks it up.
     """
     marker = health_marker(check)
     raw = run_command([
@@ -251,6 +352,11 @@ def create_health_issue(
         existing = []
     if isinstance(existing, list) and existing:
         return existing[0].get("url")
+    closing = (
+        "该 Issue 由正常 `ai-ready` → PR → review → merge 流程处理。"
+        if dispatchable else
+        "该告警为部署配置问题，需人工修改配置后重启服务，不进入 `ai-ready` 流程。"
+    )
     body = "\n".join([
         "## Runner 健康巡检告警",
         "",
@@ -263,13 +369,16 @@ def create_health_issue(
         detail,
         "```",
         "",
-        "该 Issue 由正常 `ai-ready` → PR → review → merge 流程处理。",
+        closing,
     ])
-    run_command([
+    command = [
         "timeout", str(GH_TIMEOUT_SECONDS), "gh", "issue", "create",
         "--repo", repo, "--title", f"Runner 健康巡检告警: {check}",
-        "--body", body, "--label", "bug", "--label", "ai-ready",
-    ])
+        "--body", body, "--label", "bug",
+    ]
+    if dispatchable:
+        command += ["--label", "ai-ready"]
+    run_command(command)
     return None
 
 
@@ -307,23 +416,51 @@ def run_health_check(config: dict, *, run_command) -> list[str]:
     state_path = health_state_path(config["repo_dir"])
     state = load_health_state(state_path)
     try:
+        # Routing (Issue #345): Runner-self health alerts belong in the orbi
+        # repo, never the delivery repo by default. The configured
+        # `health_alert_repo` override wins (fork/private deployments);
+        # otherwise the orbi repo is derived from the deploy home's git
+        # origin. Undeterminable -> log and skip (bypass: never guess a
+        # repo, never file the alert in the delivery repo).
+        alert_repo = config.get("health_alert_repo")
+        if not alert_repo:
+            alert_repo = orbi_repo_from_deploy_home(
+                config["deploy_home"], run_command,
+            )
         # 1. Crash loop (#262 scene: repeated service exits, including the
         #    unit self-heal death loop — each iteration exits non-zero).
         crashes = count_crashes(run_command)
         if crashes >= CRASH_THRESHOLD:
+            journal_lines = crash_journal_lines(run_command)
+            kind, reason_line = classify_crash(journal_lines)
             LOGGER.info(
                 "health_degraded check=crash_loop crashes=%s "
-                "window_minutes=%s", crashes, CRASH_WINDOW_MINUTES,
+                "window_minutes=%s kind=%s", crashes, CRASH_WINDOW_MINUTES,
+                kind,
             )
-            create_health_issue(
-                config["source_repos"][0], "crash_loop",
-                (
+            if not alert_repo:
+                LOGGER.warning(
+                    "health_alert_repo_undetermined check=crash_loop "
+                    "crashes=%s",
+                    crashes,
+                )
+            else:
+                detail = (
                     f"service crashed {crashes} times in the last "
                     f"{CRASH_WINDOW_MINUTES} minutes"
-                ),
-                run_command=run_command,
-            )
-            alerts.append("crash_loop")
+                )
+                if reason_line:
+                    detail += (
+                        f"\ncrash reason (journal): {reason_line}\n"
+                        f"crash reason fingerprint: "
+                        f"{crash_reason_fingerprint(reason_line)}"
+                    )
+                create_health_issue(
+                    alert_repo, "crash_loop", detail,
+                    run_command=run_command,
+                    dispatchable=(kind == "bug"),
+                )
+                alerts.append("crash_loop")
         # 2. Repeated same-fingerprint run failures (#246 scene).
         for finding in repeated_failure_findings(state):
             key = (
@@ -368,16 +505,21 @@ def run_health_check(config: dict, *, run_command) -> list[str]:
                     len(ready),
                     int(time.time() - state["last_pickup_ts"]),
                 )
-                create_health_issue(
-                    config["source_repos"][0], "stale_pickup",
-                    (
-                        "no ticket pickup for "
-                        f"{int(time.time() - state['last_pickup_ts'])} "
-                        "seconds while the ai-ready queue is non-empty"
-                    ),
-                    run_command=run_command,
-                )
-                alerts.append("stale_pickup")
+                if not alert_repo:
+                    LOGGER.warning(
+                        "health_alert_repo_undetermined check=stale_pickup",
+                    )
+                else:
+                    create_health_issue(
+                        alert_repo, "stale_pickup",
+                        (
+                            "no ticket pickup for "
+                            f"{int(time.time() - state['last_pickup_ts'])} "
+                            "seconds while the ai-ready queue is non-empty"
+                        ),
+                        run_command=run_command,
+                    )
+                    alerts.append("stale_pickup")
     finally:
         save_health_state(state_path, state)
     return alerts

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -70,6 +70,33 @@ def test_load_config_defaults_base_branch_to_main(tmp_path):
     assert config["base_branch"] == "main"
 
 
+def test_load_config_health_alert_repo_default_and_override(tmp_path):
+    # Issue #345: absent -> None (derived from the deploy-home origin);
+    # present -> the verbatim `owner/repo` override.
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    assert runner.load_config(config_path)["health_alert_repo"] is None
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\n'
+        'health_alert_repo = "fork-owner/orbi-fork"\n',
+        encoding="utf-8",
+    )
+    assert runner.load_config(config_path)["health_alert_repo"] == \
+        "fork-owner/orbi-fork"
+
+
+def test_load_config_rejects_empty_health_alert_repo(tmp_path):
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\nhealth_alert_repo = ""\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        ValueError, match="health_alert_repo must be a non-empty string",
+    ):
+        runner.load_config(config_path)
+
+
 def test_load_config_defaults_deploy_home_to_repo_dir(tmp_path):
     """Issue #330: without deploy_home the deployment home IS the delivery
     checkout — the orbi-bootstrap layout keeps its exact behavior."""

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -748,6 +748,27 @@ def test_undeterminable_alert_repo_skips_the_issue(tmp_path, caplog):
     assert "health_alert_repo_undetermined" in caplog.text
 
 
+def test_stale_pickup_undeterminable_alert_repo_skips(tmp_path, caplog):
+    """Issue #345: a stale pickup with an undeterminable orbi repo is
+    skipped (bypass) — never filed in the delivery repo."""
+    write_state(tmp_path, {"runs": [],
+                           "last_pickup_ts": time.time() - 48 * 3600,
+                           "alerted": []})
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": "",
+        "journalctl --user -u orbi@2.service": "",
+        "remote get-url origin": "",
+        "--label ai-ready": json.dumps([{"number": 7}]),
+    })
+    with caplog.at_level("INFO"):
+        alerts = runner_health.run_health_check(
+            make_config(tmp_path), run_command=fake,
+        )
+    assert alerts == []
+    assert fake.commands("gh issue create") == []
+    assert "health_alert_repo_undetermined check=stale_pickup" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # process_issue recording hooks: pure bypass (never fail the delivery)
 # ---------------------------------------------------------------------------

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -63,10 +63,21 @@ class FakeRunCommand:
 
 
 REPO = "owner/repo"
+ORBI_REPO = "orbi-build/orbi"
 
 
-def make_config(tmp_path: Path) -> dict:
-    return {"repo_dir": tmp_path, "source_repos": [REPO]}
+def make_config(tmp_path: Path, *, health_alert_repo=None) -> dict:
+    return {
+        "repo_dir": tmp_path,
+        "source_repos": [REPO],
+        "deploy_home": tmp_path,
+        "health_alert_repo": health_alert_repo,
+    }
+
+
+def origin_route(url: str = f"git@github.com:{ORBI_REPO}.git") -> dict:
+    """A FakeRunCommand route answering the deploy-home origin query."""
+    return {"remote get-url origin": url}
 
 
 def write_state(tmp_path: Path, state: dict) -> Path:
@@ -427,6 +438,7 @@ def test_crash_loop_creates_one_deduplicated_bug_issue(tmp_path):
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
         "journalctl --user -u orbi@2.service": "",
+        **origin_route(),
         # No health Issue exists yet.
         'in:body "orbi-health-fingerprint:': "[]",
     })
@@ -438,6 +450,9 @@ def test_crash_loop_creates_one_deduplicated_bug_issue(tmp_path):
     assert len(creates) == 1
     create = creates[0]
     assert "--label" in create and "bug" in create and "ai-ready" in create
+    # Issue #345: the alert routes to the orbi repo (deploy-home origin),
+    # never the delivery repo.
+    assert create[create.index("--repo") + 1] == ORBI_REPO
     body = create[create.index("--body") + 1]
     marker = runner_health.health_marker("crash_loop")
     assert marker in body
@@ -461,6 +476,7 @@ def test_stale_pickup_with_ready_issues_alarms(tmp_path):
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": "",
         "journalctl --user -u orbi@2.service": "",
+        **origin_route(),
         "--label ai-ready": json.dumps([{"number": 7}]),
         'in:body "orbi-health-fingerprint=': "[]",
     })
@@ -468,7 +484,9 @@ def test_stale_pickup_with_ready_issues_alarms(tmp_path):
         make_config(tmp_path), run_command=fake,
     )
     assert alerts == ["stale_pickup"]
-    assert len(fake.commands("gh issue create")) == 1
+    creates = fake.commands("gh issue create")
+    assert len(creates) == 1
+    assert creates[0][creates[0].index("--repo") + 1] == ORBI_REPO
 
 
 def test_stale_pickup_with_empty_queue_is_idle_not_a_failure(tmp_path):
@@ -545,6 +563,189 @@ def test_health_marker_is_stable_per_check():
         runner_health.health_marker("crash_loop")
     assert runner_health.health_marker("crash_loop") != \
         runner_health.health_marker("stale_pickup")
+
+
+# ---------------------------------------------------------------------------
+# Issue #345: routing (orbi repo) and config-vs-bug classification
+# ---------------------------------------------------------------------------
+
+CONFIG_REASON_LINE = (
+    "ERROR [abc12345] Runner failed to start: API key for provider "
+    "'opencode' references missing environment variable OPENCODE_API_KEY"
+)
+BUG_REASON_LINE = (
+    "ERROR [abc12345] delivery_no_commit: nothing to commit in worktree"
+)
+
+
+def test_classify_crash_config_caused():
+    lines = [
+        CRASH_LINE,
+        CONFIG_REASON_LINE,
+        CRASH_LINE,
+    ]
+    kind, reason = runner_health.classify_crash(lines)
+    assert kind == "config"
+    assert reason == CONFIG_REASON_LINE
+
+
+def test_classify_crash_bug_caused():
+    lines = [
+        CRASH_LINE,
+        BUG_REASON_LINE,
+        CRASH_LINE,
+    ]
+    kind, reason = runner_health.classify_crash(lines)
+    assert kind == "bug"
+    assert reason == BUG_REASON_LINE
+
+
+def test_classify_crash_unknown_is_bug_with_empty_reason():
+    lines = [CRASH_LINE, CRASH_LINE]
+    assert runner_health.classify_crash(lines) == ("bug", "")
+
+
+def test_classify_crash_prefers_most_recent_config_marker():
+    # A config marker beats an earlier bug marker (newest cause wins).
+    lines = [BUG_REASON_LINE, CONFIG_REASON_LINE]
+    kind, reason = runner_health.classify_crash(lines)
+    assert kind == "config"
+    assert reason == CONFIG_REASON_LINE
+
+
+def test_crash_reason_fingerprint_is_stable_and_empty_for_blank():
+    fp = runner_health.crash_reason_fingerprint(CONFIG_REASON_LINE)
+    assert fp == runner_health.crash_reason_fingerprint(CONFIG_REASON_LINE)
+    assert len(fp) == 16
+    assert runner_health.crash_reason_fingerprint("") == ""
+
+
+def test_orbi_repo_from_origin_url_ssh_and_https():
+    assert runner_health.orbi_repo_from_origin_url(
+        f"git@github.com:{ORBI_REPO}.git",
+    ) == ORBI_REPO
+    assert runner_health.orbi_repo_from_origin_url(
+        f"https://github.com/{ORBI_REPO}.git",
+    ) == ORBI_REPO
+    assert runner_health.orbi_repo_from_origin_url(
+        f"https://github.com/{ORBI_REPO}",
+    ) == ORBI_REPO
+
+
+def test_orbi_repo_from_origin_url_rejects_garbage():
+    assert runner_health.orbi_repo_from_origin_url("") is None
+    assert runner_health.orbi_repo_from_origin_url("not a url") is None
+
+
+def test_orbi_repo_from_deploy_home_reads_the_origin(tmp_path):
+    fake = FakeRunCommand(origin_route())
+    assert runner_health.orbi_repo_from_deploy_home(
+        tmp_path, fake,
+    ) == ORBI_REPO
+
+
+def test_orbi_repo_from_deploy_home_query_failure_is_none(tmp_path):
+    fake = FakeRunCommand({"remote get-url origin": RuntimeError("no git")})
+    assert runner_health.orbi_repo_from_deploy_home(tmp_path, fake) is None
+
+
+def test_config_caused_crash_loop_is_non_dispatchable(tmp_path):
+    """Issue #345: a config-caused crash loop must NOT create an ai-ready
+    task — it is a `bug`-only alert in the orbi repo naming the cause."""
+    write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
+                           "alerted": []})
+    journal = (
+        f"{CRASH_LINE}\n{CONFIG_REASON_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": journal,
+        "journalctl --user -u orbi@2.service": "",
+        **origin_route(),
+        'in:body "orbi-health-fingerprint:': "[]",
+    })
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path), run_command=fake,
+    )
+    assert alerts == ["crash_loop"]
+    creates = fake.commands("gh issue create")
+    assert len(creates) == 1
+    create = creates[0]
+    # Routes to the orbi repo, NOT the delivery repo.
+    assert create[create.index("--repo") + 1] == ORBI_REPO
+    # Non-dispatchable: `bug` only, NO `ai-ready`.
+    assert "bug" in create
+    assert "ai-ready" not in create
+    body = create[create.index("--body") + 1]
+    assert "OPENCODE_API_KEY" in body  # the config cause is named
+    assert "ai-ready 流程" not in body
+
+
+def test_bug_caused_crash_loop_is_dispatchable_with_reason(tmp_path):
+    """Issue #345: a Runner-bug crash loop produces a bug+ai-ready issue in
+    the orbi repo carrying the journal root cause."""
+    write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
+                           "alerted": []})
+    journal = (
+        f"{CRASH_LINE}\n{BUG_REASON_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": journal,
+        "journalctl --user -u orbi@2.service": "",
+        **origin_route(),
+        'in:body "orbi-health-fingerprint:': "[]",
+    })
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path), run_command=fake,
+    )
+    assert alerts == ["crash_loop"]
+    create = fake.commands("gh issue create")[0]
+    assert create[create.index("--repo") + 1] == ORBI_REPO
+    assert "bug" in create and "ai-ready" in create
+    body = create[create.index("--body") + 1]
+    assert BUG_REASON_LINE in body  # the journal root cause is in the body
+    assert "crash reason fingerprint:" in body
+
+
+def test_health_alert_repo_override_wins(tmp_path):
+    """Issue #345: the configured override routes the alert and skips the
+    deploy-home origin lookup (fork/private deployments)."""
+    write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
+                           "alerted": []})
+    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    override = "fork-owner/orbi-fork"
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": journal,
+        "journalctl --user -u orbi@2.service": "",
+        'in:body "orbi-health-fingerprint:': "[]",
+    })
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path, health_alert_repo=override), run_command=fake,
+    )
+    assert alerts == ["crash_loop"]
+    create = fake.commands("gh issue create")[0]
+    assert create[create.index("--repo") + 1] == override
+    # No origin lookup was needed.
+    assert fake.commands("remote get-url origin") == []
+
+
+def test_undeterminable_alert_repo_skips_the_issue(tmp_path, caplog):
+    """Issue #345: when the orbi repo cannot be determined the alert is
+    skipped (bypass) — never filed in the delivery repo, never guessed."""
+    write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
+                           "alerted": []})
+    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": journal,
+        "journalctl --user -u orbi@2.service": "",
+        "remote get-url origin": "",
+    })
+    with caplog.at_level("INFO"):
+        alerts = runner_health.run_health_check(
+            make_config(tmp_path), run_command=fake,
+        )
+    assert alerts == []
+    assert fake.commands("gh issue create") == []
+    assert "health_alert_repo_undetermined" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- orbi:run=b3a7eb36 -->

Fixes #345

Health watchdog files Runner crash-loop alerts as ai-ready tasks in the delivery repo instead of routing orbi bugs to the orbi repo (run_id=b3a7eb36)
