### PR TITLE
implement 失败现场被销毁：pi exit 1（空 stderr）→ ai-blocked 后 worktree/session 即删，无法取证（#352 案例：coverage 8m12s 后静默退出）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -6946,6 +6946,55 @@ def _failure_detail(exc: BaseException) -> str:
     return detail
 
 
+def _tail_text(path: Path, *, lines: int = 20, chars: int = 4000) -> str:
+    """Read a bounded tail for failure evidence without blocking cleanup."""
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return "<unavailable>"
+    tail = "\n".join(content.splitlines()[-lines:])
+    return tail[-chars:] if len(tail) > chars else tail
+
+
+def _failure_evidence(worktree: Path | None, exc: BaseException) -> str:
+    """Render the bounded evidence that survives terminal worktree cleanup.
+
+    Pi subprocess streams come from ``CalledProcessError``. The session and
+    test log are read before cleanup and only their tails are copied into the
+    failure comment, keeping the GitHub comment useful and bounded.
+    """
+    stderr = getattr(exc, "stderr", None)
+    stdout = getattr(exc, "output", None)
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode(errors="replace")
+    stderr = str(stderr) if stderr else "<empty>"
+    stdout = str(stdout) if stdout else "<empty>"
+    return_code = getattr(exc, "returncode", None)
+    session = "<unavailable>"
+    test_log = "<unavailable>"
+    if worktree is not None:
+        session_files = sorted(
+            (p for p in (worktree / ".pi-session").glob("*.jsonl")
+             if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+        )
+        if session_files:
+            session = _tail_text(session_files[-1])
+        test_path = worktree / ".orbi" / "test.log"
+        if test_path.is_file():
+            test_log = _tail_text(test_path)
+    return (
+        "\n\nFailure evidence (captured before cleanup):\n"
+        f"exit_code={return_code if return_code is not None else '<unknown>'}\n"
+        f"stderr={stderr[-4000:]}\n"
+        f"stdout_tail={stdout[-4000:]}\n"
+        f"session_last_events={session[-4000:]}\n"
+        f"test_log_tail={test_log[-4000:]}"
+    )
+
+
 def _safe_publish(*, run_id: str, issue: int, source_repo: str,
                   role: str, action: Callable[[], None]) -> None:
     """Run one progress-publishing step as a pure bypass (Issue #79).
@@ -7433,12 +7482,14 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
             )
             blocked_transition_done = True
             detail = _failure_detail(exc)
+            evidence = _failure_evidence(worktree, exc)
             body = (
                 f"{run_marker(run_id)}\n"
                 f"Orbi failed: {detail} ({run_info})"
             )
             if scene:
                 body += f" {scene}"
+            body += evidence
             comment_issue(number, repo=source_repo, body=body)
             # The blocked milestone is posted even when the worktree was
             # never created or the progress comment was never ensured:
@@ -7874,6 +7925,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     "issue=%s delivery_review_failed pr=%s", number, pr_url,
                 )
                 detail = _failure_detail(exc)
+                evidence = _failure_evidence(worktree, exc)
                 if is_unrecoverable_failure(exc):
                     # Issue #50: the ONLY opened-PR failure that leaves
                     # the automatic loop is an external precondition
@@ -7903,6 +7955,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                         "automatically (the Issue stays ai-blocked "
                         "until a human decides)"
                     )
+                    body += evidence
                     if marker:
                         body = f"{marker}\n{body}"
                     comment_issue(number, repo=source_repo, body=body)
@@ -7973,6 +8026,7 @@ def wait_for_delivery(pr_url: str, issue: dict, config: dict,
                     "ai-fix-needed and the next tick resumes the same "
                     "run, branch, worktree and PR"
                 )
+                body += evidence
                 # The full scene (run_id, branch, worktree, session,
                 # phase, last activity) is always appended: a
                 # recoverable failure always happens after the scene

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -6949,7 +6949,17 @@ def _failure_detail(exc: BaseException) -> str:
 def _tail_text(path: Path, *, lines: int = 20, chars: int = 4000) -> str:
     """Read a bounded tail for failure evidence without blocking cleanup."""
     try:
-        content = path.read_text(encoding="utf-8", errors="replace")
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            # UTF-8 characters are at most four bytes.  This is enough to
+            # retain the requested character tail without reading a huge
+            # test log or session file into memory.
+            window = min(size, chars * 4 + 1)
+            handle.seek(size - window)
+            content = handle.read(window).decode(
+                "utf-8", errors="replace",
+            )
     except (OSError, UnicodeError):
         return "<unavailable>"
     tail = "\n".join(content.splitlines()[-lines:])

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -5128,8 +5128,51 @@ def test_process_issue_failure_without_session_still_carries_scene(
     assert "session_file=-" in failure_body
 
 
+def test_failure_evidence_handles_binary_streams_and_unavailable_files(tmp_path):
+    error = subprocess.CalledProcessError(
+        2, ["pi"], output=b"binary stdout", stderr=b"binary stderr",
+    )
+
+    evidence = runner._failure_evidence(tmp_path / "missing", error)
+
+    assert "exit_code=2" in evidence
+    assert "stderr=binary stderr" in evidence
+    assert "stdout_tail=binary stdout" in evidence
+    assert "session_last_events=<unavailable>" in evidence
+    assert runner._tail_text(tmp_path / "missing.log") == "<unavailable>"
+
+
+def test_failure_evidence_includes_streams_session_and_test_tail(tmp_path):
+    worktree = tmp_path / "wt"
+    (worktree / ".pi-session").mkdir(parents=True)
+    (worktree / ".pi-session" / "session.jsonl").write_text(
+        "old event\nlatest event\n", encoding="utf-8",
+    )
+    (worktree / ".orbi").mkdir()
+    (worktree / ".orbi" / "test.log").write_text(
+        "test output\n1 failed, 2 passed\n", encoding="utf-8",
+    )
+    error = subprocess.CalledProcessError(1, ["pi"], output="stdout tail", stderr="")
+
+    evidence = runner._failure_evidence(worktree, error)
+
+    assert "exit_code=1" in evidence
+    assert "stderr=<empty>" in evidence
+    assert "stdout tail" in evidence
+    assert "latest event" in evidence
+    assert "1 failed, 2 passed" in evidence
+
+
 def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_path):
     calls = []
+    (tmp_path / "wt" / ".pi-session").mkdir(parents=True)
+    (tmp_path / "wt" / ".pi-session" / "session.jsonl").write_text(
+        "assistant event\n", encoding="utf-8",
+    )
+    (tmp_path / "wt" / ".orbi").mkdir()
+    (tmp_path / "wt" / ".orbi" / "test.log").write_text(
+        "coverage output\n1 failed\n", encoding="utf-8",
+    )
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
     monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
@@ -5173,6 +5216,10 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     assert "last_activity=2026-08-25T02:30:00Z" in failure_body
     assert 'action="bash pytest tests/"' in failure_body
     assert "result=ok" in failure_body
+    assert "exit_code=1" in failure_body
+    assert "stderr=boom" in failure_body
+    assert "assistant event" in failure_body
+    assert "1 failed" in failure_body
     # The full scene on the failure comment carries the debug entry.
     assert f"worktree={tmp_path / 'wt'}" in failure_body
     assert "branch=orbi/xqliu-muyan-ceo-issue-8-a1b2c3d4" in failure_body

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -208,6 +208,9 @@ def test_wait_for_delivery_recoverable_review_failure_stays_fix_needed(
     assert "session=" in body
     assert "phase=" in body
     assert "last_activity=" in body
+    assert "stderr=<empty>" in body
+    if isinstance(exc, subprocess.CalledProcessError):
+        assert "exit_code=1" in body
     # The SAME failure comment is written to the PR (Issue #50: the
     # failure comment must be written to Issue/PR).
     assert len(pr_comments) == 1


### PR DESCRIPTION
<!-- orbi:run=b0b8128e -->

Fixes #355

implement 失败现场被销毁：pi exit 1（空 stderr）→ ai-blocked 后 worktree/session 即删，无法取证（#352 案例：coverage 8m12s 后静默退出） (run_id=b0b8128e)
