### PR TITLE
Dirty deploy home blocks the ExecStartPre fast-forward with a raw git error: no structured journal line, no troubleshooting entry, self-update hard-blocked by any local edit

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -484,7 +484,10 @@ of them fails fast — nothing is retried silently.
 | The review loop exhausts its rounds | Journal `review_rounds_exhausted issue=<n> rounds=5`; the Issue is `ai-blocked` **alone** | The bounded loop is a human decision — read the findings, fix or close the PR manually; see [Operations](/operations) |
 | The PR is behind the latest base | The Issue is `ai-fix-needed` with a review comment that the PR is behind the latest base or has a merge conflict | Automatic: the next review session merges the latest `origin/<base>` into the branch in-session, resolves conflicts, re-runs the full suite |
 | The service does not start after a restart | `systemctl --user status orbi@1.service`; journal `unit_drift` / `cli_install_failed` / `transport_check_failed` lines | Follow the structured line: re-run `orbi install-units` (unit drift), the exact reinstall command it prints (stale editable install), or fix the SSH transport (see [Operations](/operations)) |
+| The journal says `Your local changes ... would be overwritten by merge` | `deploy_home_dirty files=...` from the service preflight | Preserve the patch with `git -C <deploy_home> stash && systemctl --user start orbi@1.service`, then `git -C <deploy_home> stash pop` when appropriate; or discard it with `git -C <deploy_home> checkout -- .` and retry. Local tracked edits block the self-update by design. `orbi doctor` reports `deploy_home: DRIFT`. |
 | `orbi doctor` reports `cli_source: DRIFT` | The structured `cli_source_drift` line with the exact reinstall command | Run the printed `uv tool install --force --reinstall --editable ...` command (or `orbi setup`) |
+
+The editable deployment home is self-updated before every service start. Any local tracked source edit can therefore block the fast-forward; use a dedicated local branch or stash it before retrying. The preflight emits `deploy_home_dirty` with the changed files and fix command instead of leaving only raw Git stderr.
 
 For the label lifecycle, the journal fields and the recovery rules see
 [Operations](/operations); for the review/merge contract see

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -21,7 +21,13 @@ Runner instances can run concurrently. Each tick's service instance:
    process): `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`. The checkout that is fast-forwarded is the **deployment home** — the `{{ORBI_REPO_DIR}}` placeholder renders the `deploy_home` path at install time (defaulting to `repo_dir`), so in the external single-repo mode (Issue #330) the fast-forward, the `base-sync.lock` and the CLI self-heal below all act on the orbi source checkout, never on the delivery checkout (user repo X). The fetch disables automatic maintenance so it cannot detach a Git child beyond the preflight and shared-lock lifetime.
    A dirty checkout, a failed fetch or a non-fast-forwardable state fails
    the preflight: the service does not start and the reason lands in the
-   systemd journal (fail fast). A currently running long task is never
+   systemd journal (fail fast). When tracked local edits cause the merge
+   failure, the preflight additionally emits one structured,
+   actionable `deploy_home_dirty files=... fix=...` line. Preserve the
+   edit with `git -C <deploy_home> stash`, then retry with
+   `systemctl --user start orbi@1.service` (and `stash pop` later), or
+   discard it with `git -C <deploy_home> checkout -- .`. A currently
+   running long task is never
    hot-updated or killed — while one service instance is active, systemd
    ignores further starts of THAT instance, and the next real start picks
    up the latest code. Because two instances may run `ExecStartPre` in
@@ -255,7 +261,8 @@ orbi add "task title" --repo OWNER/BACKLOG-REPO --config orbi.toml
 # repo (ai-pr-opened / ai-fix-needed / ai-merged / ai-blocked)
 orbi status --config orbi.toml
 
-# Read-only deployment/health report: repo commit, unit drift, CLI
+# Read-only deployment/health report: repo commit, deployment-home
+# cleanliness (deploy_home: clean / DRIFT), unit drift, CLI
 # source (cli_source: clean / DRIFT + the structured cli_source_drift
 # line), git transport (configured origin URL, protocol, expected SSH
 # URL, SSH probe — a failed transport is reported as `transport:

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -432,6 +432,7 @@ session、phase、last activity、具体错误），journal 显示
 | 审查循环耗尽轮数 | journal `review_rounds_exhausted issue=<n> rounds=5`；Issue **单独** `ai-blocked` | 有界循环是人工决策——读 findings，手工修 PR 或关闭；见[运维](/zh/operations) |
 | PR 落后于最新 base | Issue `ai-fix-needed`，review 评论说 PR 落后于最新 base 或有 merge 冲突 | 自动：下一个审查 session 在会话内把最新 `origin/<base>` merge 进分支、解冲突、重跑全量测试 |
 | 重启后 service 起不来 | `systemctl --user status orbi@1.service`；journal `unit_drift` / `cli_install_failed` / `transport_check_failed` 行 | 按结构化行处理：重跑 `orbi install-units`（unit 漂移）、它打印的精确重装命令（editable 安装过期）、或修 SSH transport（见[运维](/zh/operations)） |
+| journal 出现 `Your local changes ... would be overwritten by merge` | service preflight 的 `deploy_home_dirty files=...` | 用 `git -C <deploy_home> stash && systemctl --user start orbi@1.service` 保留补丁，适当时再 `git -C <deploy_home> stash pop`；或用 `git -C <deploy_home> checkout -- .` 丢弃后重试。本地 tracked 编辑按设计会阻塞 self-update；`orbi doctor` 会报告 `deploy_home: DRIFT` |
 | `orbi doctor` 报告 `cli_source: DRIFT` | 结构化 `cli_source_drift` 行带精确重装命令 | 跑它打印的 `uv tool install --force --reinstall --editable ...` 命令（或 `orbi setup`） |
 
 标签生命周期、journal 字段和恢复规则见[运维](/zh/operations)；

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -17,7 +17,11 @@ service 实例（`orbi@1.timer` → `orbi@1.service`，
 1. **先 fast-forward 代码**（`ExecStartPre`，在 Python 进程外）：
    `timeout 90s git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main`。被 fast-forward 的 checkout 是**部署 home**——`{{ORBI_REPO_DIR}}` 占位符在安装时渲染的是 `deploy_home` 路径（缺省 `repo_dir`），所以外部单仓库模式（Issue #330）下 fast-forward、`base-sync.lock` 和下面的 CLI 自愈全部作用于 orbi 源码 checkout，绝不作用于交付 checkout（用户仓库 X）。fetch 禁用自动维护，避免 Git 子进程脱离 preflight 和共享锁的生命周期。checkout
    不干净、fetch 失败或无法 fast-forward 时 preflight 失败：service 不
-   启动，原因写入 systemd journal（fail fast）。正在运行的长任务从不被
+   启动，原因写入 systemd journal（fail fast）。tracked 本地编辑导致
+   merge 失败时，preflight 还会写一条结构化、可操作的
+   `deploy_home_dirty files=... fix=...`。用 `git -C <deploy_home> stash`
+   保存编辑后以 `systemctl --user start orbi@1.service` 重试（之后可
+   `stash pop`），或用 `git -C <deploy_home> checkout -- .` 丢弃。正在运行的长任务从不被
    热更新或杀掉——一个 service 实例 active 时 systemd 忽略对**该实例**
    的后续 start 请求，下一次真正启动取到最新代码。两个实例可能在同一
    tick 运行 `ExecStartPre`，所以 fetch + fast-forward 包在一个短生命

--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -352,7 +352,7 @@ def deploy_home_dirty_files(repo_dir: Path, *, run_command) -> list[str]:
     return [
         line[3:]
         for line in status.splitlines()
-        if len(line) >= 3 and line[:2] != "??" and line[2] == " "
+        if len(line) >= 3 and line[:2] != "??"
     ]
 
 

--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -338,6 +338,24 @@ def slot_lines(state_dir: Path, capacity: int) -> list[str]:
 JOURNAL_LINES = 20
 
 
+def deploy_home_dirty_files(repo_dir: Path, *, run_command) -> list[str]:
+    """Return tracked files changed in the deployment home.
+
+    The systemd preflight cannot start Python when this checkout is dirty,
+    so doctor uses the same porcelain status contract read-only. Untracked
+    files are deliberately excluded: they cannot block the fast-forward.
+    """
+    status = run_command(
+        ["git", "status", "--short", "--untracked-files=no"],
+        cwd=repo_dir,
+    )
+    return [
+        line[3:]
+        for line in status.splitlines()
+        if len(line) >= 3 and line[:2] != "??" and line[2] == " "
+    ]
+
+
 def install_units_command(config: dict, installed_dir: Path | None) -> str:
     """Run the idempotent unit install and return the deployment report.
 
@@ -380,6 +398,19 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
     lines.append(
         f"commit: {run_command(['git', 'rev-parse', 'HEAD'], cwd=repo_dir)}"
     )
+    dirty_files = deploy_home_dirty_files(
+        config["deploy_home"], run_command=run_command,
+    )
+    if dirty_files:
+        lines.append("deploy_home: DRIFT")
+        lines.append(f"  files: {', '.join(dirty_files)}")
+        lines.append(
+            "  fix: git -C "
+            f"{config['deploy_home']} stash && "
+            "systemctl --user start orbi@1.service"
+        )
+    else:
+        lines.append("deploy_home: clean")
     # Git transport (Issue #114): the checkout's origin protocol, the
     # expected SSH URL of the first configured source repo and the SSH
     # probe. doctor is the diagnostic report: a failed transport is

--- a/systemd/orbi@.service
+++ b/systemd/orbi@.service
@@ -25,8 +25,10 @@ TimeoutStartSec=infinity
 # Issue #52: before the Runner starts, fast-forward the local main
 # checkout to the latest origin/main (outside the Python process). A
 # dirty checkout, a failed fetch or a non-fast-forwardable state fails
-# this command: the service does not start and the reason lands in the
-# systemd journal (fail fast). A currently running long task is never
+# this command: the service does not start. For the dirty-checkout
+# scene, emit one actionable structured journal line before failing;
+# Python cannot provide this diagnostic because it has not started yet.
+# A currently running long task is never
 # hot-updated or killed: while the service is active, systemd ignores
 # the timer's start request, and the next real start picks up the
 # latest code.
@@ -36,7 +38,7 @@ TimeoutStartSec=infinity
 # the SAME lock): the main worktree is never written concurrently.
 # Issue #191: disabling fetch's automatic maintenance prevents Git from
 # detaching a maintenance child beyond this preflight and flock lifetime.
-ExecStartPre=/usr/bin/timeout 90s /usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock -c 'git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main'
+ExecStartPre=/usr/bin/timeout 90s /usr/bin/flock {{ORBI_REPO_DIR}}/.orbi/base-sync.lock -c 'git fetch --no-auto-maintenance origin main && git merge --ff-only origin/main || { dirty_files="$(git status --short --untracked-files=no | cut -c4- | paste -sd, -)"; if [ -n "$dirty_files" ]; then fix="git -C {{ORBI_REPO_DIR}} stash && systemctl --user start orbi@%i.service"; echo "deploy_home_dirty files=\"$dirty_files\" fix=\"$fix\""; fi; exit 1; }'
 # Issue #248: self-heal the editable CLI install OUTSIDE Python. The #158
 # in-Runner refresh (runner.refresh_cli_install) is unreachable when the
 # console script cannot even `import orbi` (the #248 scene: the

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1469,13 +1469,18 @@ def test_doctor_report_reports_dirty_deploy_home(tmp_path, monkeypatch):
     config, installed = _deploy_world(tmp_path, drift=False)
     _fake_doctor_commands(
         monkeypatch,
-        dirty=" M src/orbi/pilot_setup.py\n?? ignored.txt\n",
+        dirty=(
+            " M src/orbi/pilot_setup.py\n"
+            " D deleted.py\n"
+            "R  old.py -> new.py\n"
+            "?? ignored.txt\n"
+        ),
     )
     monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
     report = orbi.doctor_report(config, installed)
     lines = report.splitlines()
     assert "deploy_home: DRIFT" in lines
-    assert "  files: src/orbi/pilot_setup.py" in lines
+    assert "  files: src/orbi/pilot_setup.py, deleted.py, old.py -> new.py" in lines
     assert "ignored.txt" not in report
     assert (
         "  fix: git -C " + str(config["deploy_home"])

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1108,7 +1108,8 @@ def _deploy_world(tmp_path, drift: bool = False) -> tuple[dict, Path]:
     return config, installed
 
 
-def _fake_doctor_commands(monkeypatch, ssh_down: bool = False) -> list:
+def _fake_doctor_commands(monkeypatch, ssh_down: bool = False,
+                          dirty: str = "") -> list:
     calls: list = []
 
     def fake_run(command, **kwargs):
@@ -1117,6 +1118,8 @@ def _fake_doctor_commands(monkeypatch, ssh_down: bool = False) -> list:
             return "0123456789abcdef0123456789abcdef01234567"
         if command[:2] == ["git", "config"]:
             return "git@github.com:xqliu/orbi.git"
+        if command[:2] == ["git", "status"]:
+            return dirty
         if command[:2] == ["git", "ls-remote"]:
             if ssh_down:
                 raise subprocess.CalledProcessError(
@@ -1414,6 +1417,7 @@ def test_doctor_report_clean(tmp_path, monkeypatch):
     assert lines[0] == f"repo: {config['repo_dir']}"
     assert lines[1] == "commit: 0123456789abcdef0123456789abcdef01234567"
     assert "unit_drift: clean" in lines
+    assert "deploy_home: clean" in lines
     # Both units are reported with their installed hash.
     from orbi import systemd_deploy
     status = systemd_deploy.unit_status(config["repo_dir"], installed)
@@ -1459,6 +1463,24 @@ def test_doctor_report_clean(tmp_path, monkeypatch):
         "-u", "orbi@2.service",
         "-n", "20", "--no-pager",
     ] in calls
+
+
+def test_doctor_report_reports_dirty_deploy_home(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(
+        monkeypatch,
+        dirty=" M src/orbi/pilot_setup.py\n?? ignored.txt\n",
+    )
+    monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
+    report = orbi.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert "deploy_home: DRIFT" in lines
+    assert "  files: src/orbi/pilot_setup.py" in lines
+    assert "ignored.txt" not in report
+    assert (
+        "  fix: git -C " + str(config["deploy_home"])
+        + " stash && systemctl --user start orbi@1.service"
+    ) in lines
 
 
 def test_doctor_report_reports_a_failed_transport(tmp_path, monkeypatch):

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -148,6 +148,9 @@ def test_service_fast_forwards_main_before_runner_starts():
     assert pre.startswith("/usr/bin/timeout 90s /usr/bin/flock ")
     assert "git fetch --no-auto-maintenance origin main" in pre
     assert "git merge --ff-only origin/main" in pre
+    assert "deploy_home_dirty" in pre
+    assert "git status --short --untracked-files=no" in pre
+    assert "git -C" in pre
     # The preflight runs in the main checkout (the unit's
     # WorkingDirectory), before the Python Runner.
     assert "WorkingDirectory" in section
@@ -172,7 +175,12 @@ def test_service_preflight_is_serialized_with_a_short_lived_flock():
     assert "/.orbi/base-sync.lock" in pre
     assert (
         " -c 'git fetch --no-auto-maintenance origin main && "
-        "git merge --ff-only origin/main'"
+        "git merge --ff-only origin/main"
+    ) in pre
+    assert "deploy_home_dirty" in pre
+    assert (
+        'fix="git -C {{ORBI_REPO_DIR}} stash && '
+        'systemctl --user start orbi@%i.service"'
     ) in pre
 
 


### PR DESCRIPTION
<!-- orbi:run=abd23267 -->

Fixes #352

Dirty deploy home blocks the ExecStartPre fast-forward with a raw git error: no structured journal line, no troubleshooting entry, self-update hard-blocked by any local edit (run_id=abd23267)
