### PR TITLE
Missing/empty provider API key crashes runner, setup AND doctor with a raw traceback; doctor should report it as a finding instead

### DIFF
--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -453,6 +453,13 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
             lines.append(
                 f"  {entry['unit']}: sha256={entry['installed_sha256']}"
             )
+    finding = config.get("pi_provider_key_finding")
+    if finding:
+        lines.append(
+            "model_endpoint: provider="
+            f"{finding['provider']} key={finding['variable']} "
+            f"{finding['state']} (file: {finding['path']})"
+        )
     # CLI source (Issue #152): the official local deployment is the
     # editable uv tool install — the tool env imports `orbi`
     # from the deployment checkout, so the ExecStartPre sync is picked
@@ -616,8 +623,18 @@ def main(argv: list[str] | None = None) -> int:
         # `python3 -m orbi.runner` entry has.
         return runner.main(["--config", str(args.config)])
 
-    config = load_config(args.config)
-    validate_config(config)
+    try:
+        config = load_config(
+            args.config,
+            check_provider_api_keys=args.command != "doctor",
+        )
+        validate_config(config)
+    except ValueError as exc:
+        if args.command == "setup":
+            print(f"setup_failed reason={exc}", file=sys.stderr)
+        else:
+            LOGGER.error("config_invalid reason=%s", exc)
+        return 1
     if args.command == "add":
         repo = args.repo or config["source_repos"][0]
         if repo not in config["source_repos"]:

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -505,8 +505,12 @@ def _load_deploy_env_file(deploy_home: Path) -> None:
         os.environ.setdefault(name, value)
 
 
-def load_config(path: Path) -> dict:
-    """Load the human-maintained TOML config and resolve its paths."""
+def load_config(path: Path, *, check_provider_api_keys: bool = True) -> dict:
+    """Load the human-maintained TOML config and resolve its paths.
+
+    ``doctor`` disables the selected provider-key gate so it can report the
+    configuration finding instead of being stopped by it.
+    """
     base = path.resolve().parent
     data = tomllib.loads(path.read_text(encoding="utf-8"))
     source_repos = data.get("source_repos")
@@ -613,10 +617,12 @@ def load_config(path: Path) -> dict:
         _config_path(pi_providers, base) if pi_providers is not None
         else None
     )
+    _load_pi_providers.last_key_finding = None
     pi_providers_data = (
         _load_pi_providers(
             pi_providers_path, pi_provider, pi_model,
             deploy_home / ".orbi" / "env",
+            check_api_key=check_provider_api_keys,
         )
         if pi_providers_path is not None else None
     )
@@ -659,6 +665,9 @@ def load_config(path: Path) -> dict:
         "release_ci_wait_seconds": release_ci_wait_seconds,
         "pi_providers": pi_providers_path,
         "pi_providers_data": pi_providers_data,
+        "pi_provider_key_finding": getattr(
+            _load_pi_providers, "last_key_finding", None,
+        ),
         # Multi-repo registry (Issue #134): the explicit per-repo entries
         # (name, path, github, base_branch). Absent section -> [] so the
         # single-repo config keeps its exact shape and flow.
@@ -829,7 +838,8 @@ def _model_wait_dead_seconds(data: dict) -> float:
 
 
 def _load_pi_providers(path: Path, pi_provider: str | None,
-                       pi_model: str | None, env_file: Path) -> dict:
+                       pi_model: str | None, env_file: Path, *,
+                       check_api_key: bool = True) -> dict:
     """Load and validate the Pi provider file (Issue #157).
 
     The file uses Pi's own `models.json` shape (`{"providers": {id:
@@ -843,6 +853,7 @@ def _load_pi_providers(path: Path, pi_provider: str | None,
     missing or empty. The key value itself is never logged; only the
     variable name is named in the error.
     """
+    _load_pi_providers.last_key_finding = None
     if not path.is_file():
         raise FileNotFoundError(path)
     try:
@@ -905,7 +916,12 @@ def _load_pi_providers(path: Path, pi_provider: str | None,
         # Only the SELECTED provider's key must resolve: an unselected
         # provider with a missing key just stays unavailable in Pi
         # (verified against real Pi 0.84.3), it never breaks the run.
-        _check_pi_provider_api_key(path, pi_provider, entry, env_file)
+        finding = _pi_provider_api_key_finding(
+            path, pi_provider, entry, env_file,
+        )
+        _load_pi_providers.last_key_finding = finding
+        if finding and check_api_key:
+            raise ValueError(finding["error"])
         if pi_model is not None:
             model_ids = [
                 model["id"] for model in entry.get("models", [])
@@ -918,33 +934,43 @@ def _load_pi_providers(path: Path, pi_provider: str | None,
     return data
 
 
-def _check_pi_provider_api_key(path: Path, provider_id: str,
-                               entry: dict, env_file: Path) -> None:
-    """Fail fast when an `apiKey` env-var reference is unresolved.
-
-    Pi's value-resolution syntax (`docs/models.md`): `$VAR` or
-    `${VAR}` interpolates the named environment variable; a missing
-    variable leaves the value unresolved and Pi would only fail at
-    request time. The Runner fails at config load instead (before any
-    slot or claim). Only the variable NAME is reported — never a key
-    value. The error names BOTH remedies (Issue #348): export the
-    variable in the shell, or add it to the deploy-home env file the
-    unit loads via `EnvironmentFile`.
-    """
+def _pi_provider_api_key_finding(path: Path, provider_id: str,
+                                  entry: dict, env_file: Path) -> dict | None:
+    """Return an unresolved selected-provider key finding, without key data."""
     api_key = entry.get("apiKey")
     if not isinstance(api_key, str) or not api_key:
-        return
-    for match in re.finditer(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)", api_key):
+        return None
+    for match in re.finditer(
+        r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)",
+        api_key,
+    ):
         name = match.group(1) or match.group(2)
-        value = os.environ.get(name)
-        if not value:
-            raise ValueError(
+        if name not in os.environ:
+            state = "is not set"
+        elif os.environ[name] == "":
+            state = "is set but empty"
+        else:
+            continue
+        return {
+            "provider": provider_id, "variable": name, "path": path,
+            "env_file": env_file,
+            "state": state,
+            "error": (
                 f"API key for provider {provider_id!r} references "
-                f"missing environment variable {name} "
+                f"environment variable {name} {state} "
                 f"(pi_providers file {path}). Export {name} in your "
-                f"shell or add it to {env_file} (the unit's "
-                f"EnvironmentFile)."
-            )
+                f"shell or add it to {env_file} (the unit's EnvironmentFile)."
+            ),
+        }
+    return None
+
+
+def _check_pi_provider_api_key(path: Path, provider_id: str,
+                               entry: dict, env_file: Path) -> None:
+    """Fail fast when an `apiKey` env-var reference is unresolved."""
+    finding = _pi_provider_api_key_finding(path, provider_id, entry, env_file)
+    if finding:
+        raise ValueError(finding["error"])
 
 
 def _expand_pi_api_key_refs(api_key: str) -> str:
@@ -8142,8 +8168,12 @@ def main(argv: list[str] | None = None) -> int:
     if threading.current_thread() is threading.main_thread():
         signal.signal(signal.SIGTERM, _handle_stop)
 
-    config = load_config(args.config)
-    validate_config(config)
+    try:
+        config = load_config(args.config)
+        validate_config(config)
+    except ValueError as exc:
+        LOGGER.error("config_invalid reason=%s", exc)
+        return 1
     # Editable CLI install refresh (Issue #158): BEFORE any slot or
     # claim the tool env's editable metadata must match the checkout's
     # packaging inputs — a merged packaging change (entry point,

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -965,18 +965,10 @@ def _pi_provider_api_key_finding(path: Path, provider_id: str,
     return None
 
 
-def _check_pi_provider_api_key(path: Path, provider_id: str,
-                               entry: dict, env_file: Path) -> None:
-    """Fail fast when an `apiKey` env-var reference is unresolved."""
-    finding = _pi_provider_api_key_finding(path, provider_id, entry, env_file)
-    if finding:
-        raise ValueError(finding["error"])
-
-
 def _expand_pi_api_key_refs(api_key: str) -> str:
     """Resolve `$VAR` / `${VAR}` references in an `apiKey` (Issue #303).
 
-    Same reference syntax `_check_pi_provider_api_key` validates (Pi's
+    Same reference syntax `_pi_provider_api_key_finding` validates (Pi's
     `docs/models.md`): every reference whose environment variable is
     set and non-empty is replaced by the real value; a reference whose
     variable is missing or empty — only possible for a non-selected

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -20,6 +20,22 @@ from orbi import pi_activity
 from tests.test_progress_wiring import make_fake_gh
 
 
+def test_runner_main_config_failure_is_one_structured_log_line(
+    monkeypatch, caplog,
+):
+    monkeypatch.setattr(
+        runner, "load_config",
+        lambda path: (_ for _ in ()).throw(
+            ValueError("API key for provider 'ollama' references environment variable OLLAMA_API_KEY is not set")
+        ),
+    )
+    with caplog.at_level("ERROR"):
+        assert runner.main(["--config", "orbi.toml"]) == 1
+    assert [record.message for record in caplog.records] == [
+        "config_invalid reason=API key for provider 'ollama' references environment variable OLLAMA_API_KEY is not set"
+    ]
+
+
 def test_parse_issue_list_returns_first_issue():
     issue = {"number": 7, "title": "ship", "body": "do it"}
     assert runner.parse_issue_list(json.dumps([issue])) == issue
@@ -10615,8 +10631,8 @@ def test_load_config_pi_providers_rejects_missing_api_key_env(
     )
     with pytest.raises(
         ValueError,
-        match="API key for provider 'groq' references missing "
-              "environment variable GROQ_API_KEY",
+        match="API key for provider 'groq' references environment variable "
+              "GROQ_API_KEY is not set",
     ):
         runner.load_config(config_path)
 
@@ -10631,10 +10647,34 @@ def test_load_config_pi_providers_rejects_empty_api_key_env(
     )
     with pytest.raises(
         ValueError,
-        match="API key for provider 'groq' references missing "
-              "environment variable GROQ_API_KEY",
+        match="API key for provider 'groq' references environment variable "
+              "GROQ_API_KEY is set but empty",
     ):
         runner.load_config(config_path)
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [("unset", "is not set"), ("empty", "is set but empty")],
+)
+def test_load_config_doctor_mode_keeps_provider_key_finding(
+    tmp_path, monkeypatch, environment, expected,
+):
+    if environment == "unset":
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("GROQ_API_KEY", "")
+    config_path = _providers_config(
+        tmp_path, GROQ_PROVIDERS,
+        pi_provider='"groq"', pi_model='"qwen/qwen3.8-27b"',
+    )
+    config = runner.load_config(
+        config_path, check_provider_api_keys=False,
+    )
+    finding = config["pi_provider_key_finding"]
+    assert finding["variable"] == "GROQ_API_KEY"
+    assert finding["state"] == expected
+    assert "GROQ_API_KEY" in finding["error"]
 
 
 def test_load_config_pi_providers_accepts_groq_example(tmp_path, monkeypatch):
@@ -11464,7 +11504,7 @@ def test_load_config_pi_providers_braced_env_reference(tmp_path, monkeypatch):
         pi_model='"qwen/qwen3.8-27b"',
     )
     with pytest.raises(
-        ValueError, match="missing environment variable GROQ_API_KEY",
+        ValueError, match="environment variable GROQ_API_KEY is not set",
     ):
         runner.load_config(config_path)
     monkeypatch.setenv("GROQ_API_KEY", "test-key")
@@ -11520,7 +11560,7 @@ def test_load_config_api_key_missing_everywhere_names_both_remedies(
     )
     with pytest.raises(
         ValueError,
-        match=r"missing environment variable GROQ_API_KEY.*"
+        match=r"environment variable GROQ_API_KEY is not set.*"
         r"Export GROQ_API_KEY.*\.orbi/env",
     ):
         runner.load_config(config_path)
@@ -11536,7 +11576,7 @@ def test_load_config_env_file_absent_missing_key_still_fails(
         pi_model='"qwen/qwen3.8-27b"',
     )
     with pytest.raises(
-        ValueError, match="missing environment variable GROQ_API_KEY",
+        ValueError, match="environment variable GROQ_API_KEY is not set",
     ):
         runner.load_config(config_path)
 

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1405,6 +1405,24 @@ def test_main_setup_config_failure_prints_structured_reason(
     assert "Traceback" not in captured.err
 
 
+def test_main_non_setup_config_failure_logs_structured_reason(
+    monkeypatch, tmp_path, caplog,
+):
+    config = _setup_world(tmp_path)
+    monkeypatch.setattr(
+        orbi, "load_config",
+        lambda path, **kwargs: (_ for _ in ()).throw(
+            ValueError("invalid configuration"),
+        ),
+    )
+    with caplog.at_level("ERROR"):
+        assert orbi.main(["status", "--config", str(config)]) == 1
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message.endswith(
+        "config_invalid reason=invalid configuration",
+    )
+
+
 def test_main_setup_failure_prints_the_reason_and_returns_nonzero(
     monkeypatch, tmp_path, capsys,
 ):

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1389,6 +1389,22 @@ def test_main_setup_repo_override_is_passed_through(
     assert seen["repos"] == ["xqliu/orbi"]
 
 
+def test_main_setup_config_failure_prints_structured_reason(
+    monkeypatch, tmp_path, capsys,
+):
+    config = _setup_world(tmp_path)
+    monkeypatch.setattr(
+        orbi, "load_config",
+        lambda path, **kwargs: (_ for _ in ()).throw(
+            ValueError("API key for provider 'ollama' references environment variable OLLAMA_API_KEY is not set")
+        ),
+    )
+    assert orbi.main(["setup", "--config", str(config)]) == 1
+    captured = capsys.readouterr()
+    assert captured.err.startswith("setup_failed reason=API key")
+    assert "Traceback" not in captured.err
+
+
 def test_main_setup_failure_prints_the_reason_and_returns_nonzero(
     monkeypatch, tmp_path, capsys,
 ):
@@ -1406,6 +1422,21 @@ def test_main_setup_failure_prints_the_reason_and_returns_nonzero(
     err = capsys.readouterr().err
     assert "setup_failed" in err
     assert "insufficient permission" in err
+
+
+def test_doctor_report_reports_provider_key_finding(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
+    config["pi_provider_key_finding"] = {
+        "provider": "ollama", "variable": "OLLAMA_API_KEY",
+        "state": "is set but empty", "path": tmp_path / ".orbi/pi-providers.json",
+    }
+    report = orbi.doctor_report(config, installed)
+    assert (
+        "model_endpoint: provider=ollama key=OLLAMA_API_KEY "
+        f"is set but empty (file: {tmp_path / '.orbi/pi-providers.json'})"
+    ) in report.splitlines()
 
 
 def test_doctor_report_clean(tmp_path, monkeypatch):


### PR DESCRIPTION
<!-- orbi:run=b453aaad -->

Fixes #343

Missing/empty provider API key crashes runner, setup AND doctor with a raw traceback; doctor should report it as a finding instead (run_id=b453aaad)
