### PR TITLE
Doubled issue announcements: scene comment and publisher milestone both post at 'PR opened' and 'started' (same payload, 1s apart)

### DIFF
--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -5,9 +5,9 @@ The runner keeps exactly one live progress comment per run on the source
 Issue. The comment carries a hidden HTML run marker
 (`<!-- orbi:run=<run_id> -->`) so a restarted process finds the same
 comment again and keeps PATCHing it in place — no database, no new
-heartbeat comments. Milestone events (started, plan ready, tests
-passed/failed, review findings, PR opened, merged, blocked)
-are published as short standalone comments so GitHub Mobile pushes a
+heartbeat comments. Milestone events without a resume scene (plan
+ready, tests passed/failed, review findings, merged, blocked) are
+published as short standalone comments so GitHub Mobile pushes a
 notification for each one.
 
 All GitHub traffic goes through the reused `runner.run_command`

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -17,8 +17,9 @@ Throughout the whole lifecycle the Runner publishes live progress
 automatically (Issue #18): one per-run GitHub progress comment carrying a
 hidden run marker is PATCHed in place on every activity change and at most
 every 30 seconds while any Pi session (implementer or reviewer) runs, and
-short milestone comments (started, plan ready, tests passed/failed, review
-findings, PR opened, merged, blocked) notify GitHub Mobile. No human
+short milestone comments (plan ready, tests passed/failed, review findings,
+merged, blocked) notify GitHub Mobile; started and PR-opened scene comments
+also notify while remaining available for resume parsing. No human
 command, poll or status check is part of the normal workflow.
 """
 from __future__ import annotations
@@ -7313,13 +7314,6 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
                 ),
             )),
         )
-        _safe_publish(
-            run_id=run_id, issue=number, source_repo=source_repo,
-            role=ROLE_IMPLEMENT,
-            action=lambda: publisher.milestone(
-                f"started: {run_info} branch={branch} worktree={worktree}"
-            ),
-        )
         run_pi(
             issue, worktree, config, source_repo, branch=branch,
             resume_context=resume_ctx,
@@ -7352,10 +7346,9 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,
         )
-        # The PR opened milestone announces the delivery: the
-        # implementer always commits the delivery on top of the frozen
-        # base, so the head always advanced. (Issue #82 removed the
-        # fixer's `fix pushed` milestone: findings are fixed by the
+        # The implementer always commits the delivery on top of the
+        # frozen base, so the head always advanced. (Issue #82 removed
+        # the fixer's `fix pushed` milestone: findings are fixed by the
         # review session, which records its own round comments.)
         apply_label_patch(
             number, repo=source_repo, event=EVENT_PR_OPENED,
@@ -7375,13 +7368,6 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> str | None:
         comment_issue(
             number, repo=source_repo,
             body=opened_pr_comment_body(run_id, run_info, pr_url),
-        )
-        _safe_publish(
-            run_id=run_id, issue=number, source_repo=source_repo,
-            role=ROLE_IMPLEMENT,
-            action=lambda: publisher.milestone(
-                f"PR opened: {pr_url} ({run_info})"
-            ),
         )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4276,7 +4276,8 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert runner.process_issue(issue, config, "xqliu/muyan-ceo") == "https://github.com/muyantech/orbi/pull/4"
     assert calls[0] == ("edit", (4,), {"repo": "xqliu/muyan-ceo", "add": "ai-in-progress"})
     # The run state is published automatically: exactly one progress
-    # comment (hidden run marker) plus the started / PR opened milestones.
+    # comment (hidden run marker); started and PR-opened scenes are
+    # separate resume announcements.
     progress_posts = [
         body for body in posted
         if "**Orbi progress**" in body
@@ -4286,17 +4287,6 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     # The PR URL is only known after verify_pr: the initial POST shows
     # `- PR: -`, the final delivery PATCH carries the URL.
     assert "- PR: -" in progress_posts[0]
-    assert any("Orbi: started" in body for body in posted)
-    started = [body for body in posted if "Orbi: started" in body][0]
-    assert "base_branch=main" in started
-    assert "base_sha=abc123def456" in started
-    assert "run_id=a1b2c3d4" in started
-    assert "branch=orbi/xqliu-muyan-ceo-issue-4-a1b2c3d4" in started
-    assert "worktree=" + str(tmp_path / "wt") in started
-    pr_opened = [body for body in posted if "Orbi: PR opened" in body]
-    assert pr_opened
-    assert "https://github.com/muyantech/orbi/pull/4" in pr_opened[0]
-    assert "run_id=a1b2c3d4" in pr_opened[0]
     # The scene comments (started Pi / opened PR) still carry the run scene.
     scene_comments = [
         call for call in gh_calls
@@ -4305,6 +4295,11 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert len(scene_comments) == 2
     start_body = scene_comments[0][-1]
     assert "Orbi started Pi:" in start_body
+    assert "base_branch=main" in start_body
+    assert "base_sha=abc123def456" in start_body
+    assert "run_id=a1b2c3d4" in start_body
+    assert "branch=orbi/xqliu-muyan-ceo-issue-4-a1b2c3d4" in start_body
+    assert "worktree=" + str(tmp_path / "wt") in start_body
     assert "<!-- orbi:run=a1b2c3d4 -->" in start_body
     opened_body = scene_comments[1][-1]
     assert "Orbi opened PR: https://github.com/muyantech/orbi/pull/4" in opened_body

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -436,8 +436,8 @@ def test_process_issue_p0_progress_comment_and_milestones_carry_priority(
 ):
     """Issue #101: a P0 pickup (the scan's issue dict carries `labels`)
     shows `priority: p0` in the progress comment and `priority=p0` in
-    the journal/scene text (run_info, started milestone, started-Pi
-    scene comment) — the explicit field is visible end to end."""
+    the journal/scene text (run_info and started-Pi scene comment) —
+    the explicit field is visible end to end."""
     calls, posted = make_fake_gh(monkeypatch)
     patch_process_deps(monkeypatch, tmp_path)
     edit = Mock()
@@ -451,14 +451,6 @@ def test_process_issue_p0_progress_comment_and_milestones_carry_priority(
     ]
     assert len(progress_posts) == 1
     assert "- priority: p0" in progress_posts[0]
-    milestones = [
-        body for body in posted
-        if any(line.startswith(progress.MILESTONE_PREFIX)
-               for line in body.splitlines())
-    ]
-    started = [b for b in milestones if "Orbi: started" in b]
-    assert started, f"no started milestone: {milestones}"
-    assert "priority=p0" in started[0]
     # The started-Pi scene comment (run_info) carries the priority too.
     scene_comments = [
         call for call in calls
@@ -568,24 +560,26 @@ def test_process_issue_passes_issue_number_to_deliver_pr(
     )
 
 
-def test_process_issue_posts_started_and_pr_opened_milestones(
+def test_process_issue_posts_one_scene_announcement_per_delivery_transition(
     monkeypatch, tmp_path,
 ):
+    """Started and PR-opened scenes are resume state, not duplicate
+    milestones: each transition gets exactly one Issue announcement."""
     calls, posted = make_fake_gh(monkeypatch)
     patch_process_deps(monkeypatch, tmp_path)
     runner.process_issue(make_issue(), make_config(tmp_path),
                          "xqliu/orbi")
-    milestones = [
-        body for body in posted
-        if any(line.startswith(progress.MILESTONE_PREFIX)
-               for line in body.splitlines())
+
+    comments = [
+        command[-1] for command in calls
+        if command[:2] == ["gh", "issue"] and "comment" in command
     ]
-    assert any("Orbi: started" in body for body in milestones)
-    assert any(
-        "Orbi: PR opened" in body
-        and "https://github.com/xqliu/orbi/pull/40" in body
-        for body in milestones
-    )
+    started = [body for body in comments if "Orbi started Pi:" in body]
+    opened = [body for body in comments if "Orbi opened PR:" in body]
+    assert len(started) == 1
+    assert len(opened) == 1
+    assert not any("Orbi: started" in body for body in posted)
+    assert not any("Orbi: PR opened" in body for body in posted)
 
 
 def test_process_issue_finishes_progress_comment_with_delivery_summary(
@@ -767,8 +761,7 @@ def test_process_issue_never_posts_fix_pushed_on_a_fresh_claim(
 ):
     # The implementer always commits the delivery on top of the frozen
     # base, so the head always advanced: a fresh claim must not turn
-    # that into a `fix pushed` milestone (the PR opened milestone
-    # announces the delivery; Issue #82 removed the fixer and its
+    # that into a `fix pushed` milestone. Issue #82 removed the fixer and its
     # `fix pushed` milestone — findings are fixed by the review
     # session, which records its own round comments).
     calls, posted = make_fake_gh(monkeypatch)
@@ -781,7 +774,6 @@ def test_process_issue_never_posts_fix_pushed_on_a_fresh_claim(
         if any(line.startswith(progress.MILESTONE_PREFIX)
                for line in body.splitlines())
     ]
-    assert milestones
     assert not any("fix pushed" in body for body in milestones)
 
 
@@ -888,12 +880,11 @@ def test_process_issue_delivered_patch_failure_does_not_fail_delivery(
     assert "Orbi delivered" in last_body
 
 
-def test_process_issue_pr_opened_milestone_failure_does_not_fail_delivery(
+def test_process_issue_pr_opened_scene_has_no_duplicate_milestone(
     monkeypatch, tmp_path, caplog,
 ):
-    """The `PR opened` milestone POST failing after the label transition
-    is the same contract: logged, not fatal; the scene comment and the
-    delivered finish still run (independent publishing steps)."""
+    """The PR-opened scene remains the delivery record and has no
+    duplicate milestone; the delivered finish still runs."""
     calls, posted = make_failing_gh(
         monkeypatch,
         lambda command: (
@@ -914,9 +905,8 @@ def test_process_issue_pr_opened_milestone_failure_does_not_fail_delivery(
 
     assert pr_url == "https://github.com/xqliu/orbi/pull/40"
     assert not any(kwargs.get("add") == "ai-blocked" for kwargs in edits)
-    assert any("progress_publish_failed" in line
-               for line in caplog.text.splitlines()), caplog.text
-    # The delivered finish still ran (independent step)...
+    # No duplicate PR-opened milestone is attempted. The delivered
+    # finish still ran (independent step)...
     delivered_patches = [c for c in calls if _progress_patch_of(c)]
     assert delivered_patches, "the delivered finish was not attempted"
     last_body = delivered_patches[-1][
@@ -1104,12 +1094,11 @@ def test_process_issue_ensure_failure_does_not_fail_delivery(
     assert not any("Orbi: blocked" in body for body in posted)
 
 
-def test_process_issue_started_milestone_failure_does_not_fail_delivery(
+def test_process_issue_started_scene_has_no_duplicate_milestone(
     monkeypatch, tmp_path, caplog,
 ):
-    """Issue #79: the `started` milestone POST failing before `run_pi`
-    is the same contract: logged, not fatal; Pi still runs and the PR
-    is still opened."""
+    """The started scene remains the announcement before `run_pi`;
+    no duplicate milestone is attempted."""
     calls, posted = make_failing_gh(
         monkeypatch,
         lambda command: (
@@ -1131,9 +1120,8 @@ def test_process_issue_started_milestone_failure_does_not_fail_delivery(
     assert pr_url == "https://github.com/xqliu/orbi/pull/40"
     assert runner.run_pi.called
     assert not any(kwargs.get("add") == "ai-blocked" for kwargs in edits)
-    assert any("progress_publish_failed" in line
-               for line in caplog.text.splitlines()), caplog.text
-    # The ensure itself succeeded (only the milestone failed)...
+    # The ensure itself succeeded; the scene comment is the sole
+    # started announcement...
     assert any("Orbi progress" in body for body in posted)
     # ...and the failed milestone was not posted.
     assert not any("Orbi: started" in body for body in posted)
@@ -1180,8 +1168,9 @@ def test_process_issue_plan_test_milestone_failures_do_not_fail_delivery(
     # The failed milestones were not posted...
     assert not any("Orbi: plan ready" in body for body in posted)
     assert not any("Orbi: tests passed" in body for body in posted)
-    # ...but the delivery record still completed.
-    assert any("Orbi: PR opened" in body for body in posted)
+    # ...and the delivery record still completed without a duplicate
+    # PR-opened announcement.
+    assert not any("Orbi: PR opened" in body for body in posted)
 
 
 def test_process_issue_failure_path_progress_failure_keeps_blocked_transition(

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -451,10 +451,9 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     worktree = worktree_for(clone, run_id)
     assert worktree.is_dir()
     # The started Pi scene comment is posted first; the live progress
-    # comment (gh api) and the milestones follow, the opened PR scene
-    # comment comes before its milestone.
+    # comment and unaffected milestones follow, then the opened PR scene.
     started = comments[0]
-    opened = comments[4]
+    opened = comments[3]
     assert "Orbi started Pi:" in started
     assert f"Orbi opened PR: {PR_URL}" in opened
     assert f"run_id={run_id}" in opened
@@ -551,11 +550,10 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
         assert message.startswith(f"[{run_id}]"), message
 
     # One PR, one branch, one worktree, one run id: nothing was
-    # recreated. Six comments from the first delivery (started Pi,
-    # progress, started milestone, plan ready milestone, opened PR,
-    # PR opened milestone) plus two from the review (merged milestone,
-    # merged PR comment).
-    assert len(comments) == 8
+    # recreated. Four comments from the first delivery (started Pi,
+    # progress, plan ready milestone, opened PR) plus two from the
+    # review (merged milestone, merged PR comment).
+    assert len(comments) == 6
     merged_comment = [
         body for body in comments
         if "Orbi merged PR:" in body

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -367,9 +367,9 @@ def test_e2e_one_run_id_carries_every_event_of_the_attempt(
         assert message.startswith(f"[{run_id}]"), message
 
     # 2. Every Issue comment carries the visible field and the hidden
-    # marker: the live progress comment, the started / plan ready / PR
-    # opened milestones and the two scene comments.
-    assert len(comments) == 6
+    # marker: the live progress comment, the unaffected plan-ready
+    # milestone and the two scene comments.
+    assert len(comments) == 4
     for body in comments:
         assert f"run_id={run_id}" in body
         assert f"<!-- orbi:run={run_id} -->" in body
@@ -416,15 +416,15 @@ def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
     )
 
     # Comments are not confused: each attempt carries exactly its own
-    # id (six comments per attempt: started Pi, progress, started
-    # milestone, plan ready milestone, opened PR, PR opened milestone).
-    assert len(comments) == 12
+    # id (four comments per attempt: started Pi, progress, plan ready
+    # milestone, opened PR).
+    assert len(comments) == 8
     assert "<!-- orbi:run=a1b2c3d4 -->" in comments[0]
     assert "b2c3d4e5" not in comments[0]
     assert "<!-- orbi:run=a1b2c3d4 -->" in comments[1]
-    assert "<!-- orbi:run=b2c3d4e5 -->" in comments[6]
-    assert "a1b2c3d4" not in comments[6]
-    assert "<!-- orbi:run=b2c3d4e5 -->" in comments[7]
+    assert "<!-- orbi:run=b2c3d4e5 -->" in comments[4]
+    assert "a1b2c3d4" not in comments[4]
+    assert "<!-- orbi:run=b2c3d4e5 -->" in comments[5]
 
     # The journal timeline splits cleanly into the two runs.
     first_lines = [
@@ -453,9 +453,8 @@ def test_e2e_failed_attempt_marks_blocked_with_same_run_id(
                                 REPO) is None
 
     # The failure report carries the same run id as the start comment
-    # (progress + started milestone + started Pi + failure + blocked
-    # milestone).
-    assert len(comments) == 5
+    # (progress + started Pi + failure + blocked milestone).
+    assert len(comments) == 4
     start = [c for c in comments if "Orbi started Pi:" in c][0]
     failure = [c for c in comments if "Orbi failed:" in c][0]
     assert "<!-- orbi:run=a1b2c3d4 -->" in start


### PR DESCRIPTION
<!-- orbi:run=0c74ab92 -->

Fixes #366

Doubled issue announcements: scene comment and publisher milestone both post at 'PR opened' and 'started' (same payload, 1s apart) (run_id=0c74ab92)
