### PR TITLE
Optional model-proxy health-check failure is logged as ERROR command_failed in setup output

### DIFF
--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -35,6 +35,7 @@ agents and scripts can parse it.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 import shutil
@@ -582,10 +583,13 @@ def check_optional_proxy(run_command) -> dict:
     when curl itself is missing.
     """
     try:
-        run_command([
-            "curl", "-fsS", "-m", str(OPTIONAL_PROXY_TIMEOUT),
-            OPTIONAL_PROXY_URL,
-        ])
+        run_command(
+            [
+                "curl", "-fsS", "-m", str(OPTIONAL_PROXY_TIMEOUT),
+                OPTIONAL_PROXY_URL,
+            ],
+            failure_log_level=logging.INFO,
+        )
         status = "healthy"
     except FileNotFoundError:
         status = "unavailable"

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -1281,8 +1281,14 @@ def single_line(value: str) -> str:
 def run_command(command: list[str], *, cwd: Path | None = None,
                 timeout: int | None = None,
                 log_command: list[str] | None = None,
-                log_stdout: bool = False) -> str:
-    """Run one external command; log context and fail fast on any error."""
+                log_stdout: bool = False,
+                failure_log_level: int = logging.ERROR) -> str:
+    """Run one external command; log context and fail fast on any error.
+
+    ``failure_log_level`` is INFO for probes whose failure is an expected
+    status result, such as an optional component health check. The command
+    still raises, so callers retain control over whether the failure blocks.
+    """
     LOGGER.info(
         "command=%s cwd=%s",
         single_line(" ".join(log_command or command)), cwd or Path.cwd(),
@@ -1297,21 +1303,23 @@ def run_command(command: list[str], *, cwd: Path | None = None,
             timeout=timeout,
         )
     except subprocess.CalledProcessError as exc:
-        LOGGER.error(
+        LOGGER.log(
+            failure_log_level,
             "command_failed returncode=%s stdout=%s stderr=%s",
             exc.returncode, (exc.stdout or "").rstrip(),
             (exc.stderr or "").rstrip(),
         )
         raise
     except subprocess.TimeoutExpired as exc:
-        LOGGER.error(
+        LOGGER.log(
+            failure_log_level,
             "command_timeout timeout=%s stdout=%s stderr=%s",
             timeout, (exc.stdout or "").rstrip(),
             (exc.stderr or "").rstrip(),
         )
         raise
     except OSError as exc:
-        LOGGER.error("command_spawn_failed error=%s", exc)
+        LOGGER.log(failure_log_level, "command_spawn_failed error=%s", exc)
         raise
     if result.stderr:
         LOGGER.info("stderr=%s", result.stderr.rstrip())

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -980,6 +980,27 @@ def test_check_optional_proxy_reports_unhealthy_without_raising():
     assert result["optional"] is True
 
 
+def test_check_optional_proxy_logs_probe_failure_below_error(
+    monkeypatch, caplog,
+):
+    def failing_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            7, args[0], stderr="Connection refused",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", failing_run)
+    with caplog.at_level("INFO"):
+        result = pilot_setup.check_optional_proxy(
+            run_command=runner.run_command,
+        )
+
+    assert result["proxy"] == "unhealthy"
+    failures = [record for record in caplog.records
+                if "command_failed" in record.message]
+    assert len(failures) == 1
+    assert failures[0].levelname == "INFO"
+
+
 def test_check_optional_proxy_reports_a_missing_curl_without_raising():
     result = pilot_setup.check_optional_proxy(
         run_command=lambda command, **kwargs: (


### PR DESCRIPTION
<!-- orbi:run=ed03ac15 -->

Fixes #341

Optional model-proxy health-check failure is logged as ERROR command_failed in setup output (run_id=ed03ac15)
