### PR TITLE
Non-JSON preamble on gh stdout produces an opaque 'cannot parse gh repo view output' setup failure

### DIFF
--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -313,9 +313,19 @@ def check_repo(repo: str, run_command) -> dict:
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
-        raise SetupError(
-            f"cannot parse gh repo view output for {repo}: {raw!r}"
-        ) from exc
+        data = None
+        for line in raw.splitlines():
+            try:
+                candidate = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(candidate, dict):
+                data = candidate
+                break
+        if data is None:
+            raise SetupError(
+                f"cannot parse gh repo view output for {repo}: {raw!r}"
+            ) from exc
     if not isinstance(data, dict):
         raise SetupError(
             f"cannot parse gh repo view output for {repo}: {raw!r}"

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -416,6 +416,25 @@ def test_check_repo_reports_permission_and_default_branch():
     }
 
 
+def test_check_repo_parses_json_after_a_wrapper_preamble():
+    raw = (
+        "mise ~/.config/mise/config.toml tools: gh@2.100.0\n"
+        "0\n"
+        '{"nameWithOwner":"xqliu/orbi",'
+        '"viewerPermission":"WRITE",'
+        '"defaultBranchRef":{"name":"main"}}'
+    )
+    result = pilot_setup.check_repo(
+        "xqliu/orbi",
+        run_command=lambda command, **kwargs: raw,
+    )
+    assert result == {
+        "repo": "xqliu/orbi",
+        "permission": "WRITE",
+        "default_branch": "main",
+    }
+
+
 def test_check_repo_fails_fast_on_a_read_only_repo():
     with pytest.raises(pilot_setup.SetupError, match="permission"):
         pilot_setup.check_repo(


### PR DESCRIPTION
<!-- orbi:run=e41c59bc -->

Fixes #340

Non-JSON preamble on gh stdout produces an opaque 'cannot parse gh repo view output' setup failure (run_id=e41c59bc)
