### PR TITLE
CI: actions/checkout@v4 and actions/setup-python@v5 trigger Node.js 20 deprecation warnings (forced to Node 24)

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the triage script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.14 (the CI convention)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,19 @@ jobs:
       # with `git cat-file` / `git rev-parse` / `git merge-base --is-ancestor`
       # against the checkout. The default shallow checkout (fetch-depth: 1)
       # runs `git fetch --no-tags` (verified against the official
-      # actions/checkout@v4 source), so the tag object is absent and the
+      # actions/checkout@v5 source), so the tag object is absent and the
       # test fails with `could not get object info` (Issue #126).
       # fetch-depth: 0 makes the action fetch all branches and
       # +refs/tags/*:refs/tags/* without --depth (full history plus every
       # tag object), so the release verification uses the real remote
       # objects. No tags are moved, overwritten, or rewritten.
       - name: Check out the repository (full history + all tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.14 (production minor version)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/tests/test_ci_failure_issue_workflow.py
+++ b/tests/test_ci_failure_issue_workflow.py
@@ -119,13 +119,14 @@ def test_no_step_can_fake_success():
 
 def test_checkout_and_pinned_python_like_ci():
     """Same interpreter convention as the CI workflow (Python 3.14) and a
-    real checkout of the triage script."""
+    real checkout of the triage script, using Node 24-compatible actions."""
     steps = steps_of(load_workflow())
     uses = [str(step.get("uses", "")) for step in steps]
-    assert any(u.startswith("actions/checkout@v4") for u in uses), uses
+    assert uses.count("actions/checkout@v5") == 1, uses
     setup = [
         step for step in steps
         if str(step.get("uses", "")).startswith("actions/setup-python")
     ]
     assert len(setup) == 1, uses
+    assert uses.count("actions/setup-python@v6") == 1, uses
     assert str(setup[0].get("with", {}).get("python-version")) == "3.14"

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -101,7 +101,7 @@ def test_ci_workflow_checkout_fetches_full_history_and_tags():
     cat-file` / `git rev-parse` / `git merge-base --is-ancestor`
     against the checkout. The default shallow checkout (fetch-depth: 1)
     runs `git fetch --no-tags` (verified against the official
-    actions/checkout@v4 source: git-command-manager.ts), so the tag
+    actions/checkout@v5 source: git-command-manager.ts), so the tag
     object is absent in the CI environment and the test fails with
     `could not get object info`. `fetch-depth: 0` makes the action
     fetch all branches and `+refs/tags/*:refs/tags/*` without `--depth`
@@ -120,6 +120,19 @@ def test_ci_workflow_checkout_fetches_full_history_and_tags():
         f"(fetch-depth: 0) so the annotated tag objects exist for the "
         f"release reconciliation tests, got: {with_options!r}"
     )
+
+
+def test_workflows_use_node_24_compatible_actions():
+    workflow_dir = REPO_ROOT / ".github"
+    workflow_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in workflow_dir.rglob("*")
+        if path.is_file()
+    )
+    assert "actions/checkout@v4" not in workflow_text
+    assert "actions/setup-python@v5" not in workflow_text
+    assert "actions/checkout@v5" in workflow_text
+    assert "actions/setup-python@v6" in workflow_text
 
 
 def test_ci_workflow_pins_python_3_14_like_production():


### PR DESCRIPTION
<!-- orbi:run=d4247b75 -->

Fixes #353

CI: actions/checkout@v4 and actions/setup-python@v5 trigger Node.js 20 deprecation warnings (forced to Node 24) (run_id=d4247b75)
