### PR TITLE
orbi setup does not scaffold or report model-provider config: fresh setup ends 'ok' with no pointer to orbi.toml / pi-providers.json / .orbi/env

### DIFF
--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -454,11 +454,25 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
                 f"  {entry['unit']}: sha256={entry['installed_sha256']}"
             )
     finding = config.get("pi_provider_key_finding")
-    if finding:
+    if finding and finding.get("variable") != "-":
         lines.append(
             "model_endpoint: provider="
             f"{finding['provider']} key={finding['variable']} "
             f"{finding['state']} (file: {finding['path']})"
+        )
+    provider = pilot_setup.model_provider_status(config)
+    if provider["state"] == "ok":
+        lines.append(
+            f"model_provider: ok provider={provider['provider']} "
+            f"model={provider['model']} key={provider['key']}"
+        )
+    else:
+        lines.append(
+            "model_provider: NOT CONFIGURED "
+            f"provider_file={provider['provider_file']} "
+            f"key={provider['env_variable']} "
+            "(edit orbi.toml pi_providers/pi_provider/pi_model and "
+            f"{provider['env_file']})"
         )
     # CLI source (Issue #152): the official local deployment is the
     # editable uv tool install — the tool env imports `orbi`
@@ -627,6 +641,7 @@ def main(argv: list[str] | None = None) -> int:
         config = load_config(
             args.config,
             check_provider_api_keys=args.command != "doctor",
+            allow_missing_pi_providers=args.command in ("setup", "doctor"),
         )
         validate_config(config)
     except ValueError as exc:

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -50,7 +50,27 @@ from orbi.pi_activity import quote_value
 
 # Bumped whenever the setup output contract changes shape.
 # Issue #152 added the `cli=` line (the editable install step).
-SETUP_VERSION = 2
+SETUP_VERSION = 3
+
+PROVIDER_FILE_NAME = "pi-providers.json"
+PROVIDER_ENV_NAME = "PROVIDER_API_KEY"
+PROVIDER_STARTER = {
+    "_comment": "Edit this OpenAI-compatible provider and select it in orbi.toml.",
+    "providers": {
+        "openai": {
+            "baseUrl": "https://api.openai.com/v1",
+            "api": "openai-completions",
+            "apiKey": "$PROVIDER_API_KEY",
+            "models": [{
+                "id": "your-model",
+                "name": "Your model",
+                "contextWindow": 131072,
+                "maxTokens": 16384,
+            }],
+        },
+    },
+}
+PROVIDER_GUIDE = "See /getting-started#configure-the-model-provider"
 
 # The repo-managed single source of truth for the platform labels.
 LABELS_FILE = "labels.toml"
@@ -583,6 +603,73 @@ def check_checkout(repo_dir: Path, base_branch: str,
     }
 
 
+def scaffold_model_config(config: dict) -> dict:
+    """Create the non-secret provider starter and key slot idempotently."""
+    deploy_home = Path(config["deploy_home"])
+    state_dir = deploy_home / ".orbi"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    provider_path = config.get("pi_providers") or state_dir / PROVIDER_FILE_NAME
+    provider_path = Path(provider_path)
+    provider_created = False
+    if not provider_path.exists():
+        provider_path.write_text(
+            json.dumps(PROVIDER_STARTER, indent=2) + "\n", encoding="utf-8",
+        )
+        provider_created = True
+    env_path = state_dir / "env"
+    env_text = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    env_created = PROVIDER_ENV_NAME not in {
+        line.split("=", 1)[0].removeprefix("export ").strip()
+        for line in env_text.splitlines() if "=" in line
+    }
+    if env_created:
+        with env_path.open("a", encoding="utf-8") as handle:
+            if env_text and not env_text.endswith("\n"):
+                handle.write("\n")
+            handle.write(f"# API key for the starter provider\n{PROVIDER_ENV_NAME}=\n")
+    env_path.touch(mode=0o600, exist_ok=True)
+    env_path.chmod(0o600)
+    return {
+        "provider_file": str(provider_path),
+        "provider_created": provider_created,
+        "env_file": str(env_path),
+        "env_variable": PROVIDER_ENV_NAME,
+        "env_created": env_created,
+    }
+
+
+def model_provider_status(config: dict) -> dict:
+    """Return a safe, value-free provider status for setup and doctor."""
+    provider = config.get("pi_provider")
+    model = config.get("pi_model")
+    path = config.get("pi_providers")
+    if path is None:
+        path = Path(config["deploy_home"]) / ".orbi" / PROVIDER_FILE_NAME
+    finding = config.get("pi_provider_key_finding")
+    env_file = Path(config["deploy_home"]) / ".orbi" / "env"
+    if not provider or not model or not config.get("pi_providers_data"):
+        return {
+            "state": "NOT CONFIGURED", "provider_file": str(path),
+            "env_file": str(env_file), "env_variable": PROVIDER_ENV_NAME,
+        }
+    if finding:
+        return {
+            "state": "NOT CONFIGURED", "provider": provider, "model": model,
+            "key": f"{finding['variable']}={finding['state']}",
+            "provider_file": str(path), "env_file": str(env_file),
+            "env_variable": finding["variable"],
+        }
+    entry = config["pi_providers_data"]["providers"][provider]
+    key = entry.get("apiKey") if isinstance(entry, dict) else None
+    variable = (re.fullmatch(r"\$(?:\{)?([A-Za-z_][A-Za-z0-9_]*)\}?", key or ""))
+    key_name = variable.group(1) if variable else "literal"
+    return {
+        "state": "ok", "provider": provider, "model": model,
+        "key": f"{key_name}=set", "provider_file": str(path),
+        "env_file": str(env_file), "env_variable": key_name,
+    }
+
+
 def check_optional_proxy(run_command) -> dict:
     """Health-check the optional local-llm-kv-cache proxy (never raises).
 
@@ -670,6 +757,7 @@ def run_setup(config: dict, installed_dir: Path | None, *,
         run_command=run_command,
     )
     optional_proxy = check_optional_proxy(run_command)
+    scaffold = scaffold_model_config(config)
     return {
         "setup": "ok",
         "version": SETUP_VERSION,
@@ -680,6 +768,10 @@ def run_setup(config: dict, installed_dir: Path | None, *,
         "timer": units["timer"],
         "checkout": checkout,
         "optional_proxy": optional_proxy,
+        "model_provider": {
+            **model_provider_status(config),
+            **scaffold,
+        },
     }
 
 
@@ -738,6 +830,20 @@ def format_setup(result: dict) -> list[str]:
         f"migrated={'true' if checkout['migrated'] else 'false'} "
         f"ssh_reachable={reachable_text}"
     )
+    provider = result.get("model_provider")
+    if provider and provider["state"] == "ok":
+        lines.append(
+            f"model_provider=ok provider={provider['provider']} "
+            f"model={provider['model']} key={provider['key']}"
+        )
+    elif provider:
+        lines.append(
+            "model_provider=NOT CONFIGURED — edit orbi.toml "
+            "(pi_providers/pi_provider/pi_model), fill "
+            f"{provider['provider_file']} and put the key in "
+            f"{provider['env_file']} ({provider['env_variable']})"
+        )
+        lines.append(f"model_provider_guide={PROVIDER_GUIDE}")
     proxy = result["optional_proxy"]
     lines.append(
         f"model_endpoint=optional optional_proxy={proxy['proxy']} "

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -629,7 +629,10 @@ def load_config(path: Path, *, check_provider_api_keys: bool = True,
                 check_api_key=check_provider_api_keys,
             )
         except FileNotFoundError:
-            if not allow_missing_pi_providers:
+            # A missing path is the setup/doctor diagnostic case.  Preserve
+            # fail-fast behavior for an existing non-file path (for example,
+            # a directory), which is an invalid provider configuration.
+            if not allow_missing_pi_providers or pi_providers_path.exists():
                 raise
             _load_pi_providers.last_key_finding = {
                 "provider": pi_provider or "-",

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -506,7 +506,8 @@ def _load_deploy_env_file(deploy_home: Path) -> None:
         os.environ.setdefault(name, value)
 
 
-def load_config(path: Path, *, check_provider_api_keys: bool = True) -> dict:
+def load_config(path: Path, *, check_provider_api_keys: bool = True,
+                allow_missing_pi_providers: bool = False) -> dict:
     """Load the human-maintained TOML config and resolve its paths.
 
     ``doctor`` disables the selected provider-key gate so it can report the
@@ -619,14 +620,24 @@ def load_config(path: Path, *, check_provider_api_keys: bool = True) -> dict:
         else None
     )
     _load_pi_providers.last_key_finding = None
-    pi_providers_data = (
-        _load_pi_providers(
-            pi_providers_path, pi_provider, pi_model,
-            deploy_home / ".orbi" / "env",
-            check_api_key=check_provider_api_keys,
-        )
-        if pi_providers_path is not None else None
-    )
+    pi_providers_data = None
+    if pi_providers_path is not None:
+        try:
+            pi_providers_data = _load_pi_providers(
+                pi_providers_path, pi_provider, pi_model,
+                deploy_home / ".orbi" / "env",
+                check_api_key=check_provider_api_keys,
+            )
+        except FileNotFoundError:
+            if not allow_missing_pi_providers:
+                raise
+            _load_pi_providers.last_key_finding = {
+                "provider": pi_provider or "-",
+                "variable": "-",
+                "path": pi_providers_path,
+                "env_file": deploy_home / ".orbi" / "env",
+                "state": "file missing",
+            }
     return {
         "source_repos": source_repos,
         "repo_dir": repo_dir,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -15828,3 +15828,14 @@ def test_load_config_allows_missing_provider_file_for_setup_diagnostics(tmp_path
     config = runner.load_config(config_path, allow_missing_pi_providers=True)
     assert config["pi_providers_data"] is None
     assert config["pi_provider_key_finding"]["state"] == "file missing"
+
+
+def test_load_config_does_not_treat_provider_directory_as_missing(tmp_path):
+    config_path = tmp_path / "orbi.toml"
+    (tmp_path / "providers").mkdir()
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\n'
+        'pi_providers = "providers"\n', encoding="utf-8",
+    )
+    with pytest.raises(FileNotFoundError):
+        runner.load_config(config_path, allow_missing_pi_providers=True)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -15817,3 +15817,14 @@ def test_runtime_excludes_never_hide_a_modified_tracked_file(tmp_path):
         ["git", "status", "--porcelain"], cwd=wt,
         capture_output=True, text=True, check=True,
     ).stdout == " M src.py\n"
+
+
+def test_load_config_allows_missing_provider_file_for_setup_diagnostics(tmp_path):
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text(
+        'source_repos = ["owner/repo"]\n'
+        'pi_providers = "missing.json"\n', encoding="utf-8",
+    )
+    config = runner.load_config(config_path, allow_missing_pi_providers=True)
+    assert config["pi_providers_data"] is None
+    assert config["pi_provider_key_finding"]["state"] == "file missing"

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1772,3 +1772,18 @@ def test_main_doctor_prints_report_and_returns_zero(
     assert seen["installed_dir"] == tmp_path / "u"
     out = capsys.readouterr().out
     assert "unit_drift: clean" in out
+
+
+def test_doctor_report_reports_configured_model_provider(tmp_path, monkeypatch):
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
+    config.update({
+        "pi_providers": tmp_path / "providers.json",
+        "pi_provider": "openai", "pi_model": "gpt",
+        "pi_providers_data": {"providers": {
+            "openai": {"apiKey": "$OPENAI_API_KEY"},
+        }},
+    })
+    report = orbi.doctor_report(config, installed)
+    assert "model_provider: ok provider=openai model=gpt key=OPENAI_API_KEY=set" in report

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -1680,3 +1680,101 @@ def test_run_setup_routes_home_files_to_deploy_home(tmp_path, monkeypatch):
     assert seen["units"] == home
     # The delivery checkout stays the transport-checked repo.
     assert seen["checkout"] == repo
+
+
+def test_scaffold_model_config_is_idempotent_and_private(tmp_path):
+    config = {"deploy_home": tmp_path, "pi_providers": None}
+    first = pilot_setup.scaffold_model_config(config)
+    provider = Path(first["provider_file"])
+    env = Path(first["env_file"])
+    assert provider == tmp_path / ".orbi" / "pi-providers.json"
+    assert json.loads(provider.read_text())["providers"]["openai"]["apiKey"] == "$PROVIDER_API_KEY"
+    assert "PROVIDER_API_KEY=" in env.read_text()
+    assert oct(env.stat().st_mode & 0o777) == "0o600"
+    provider.write_text('{"providers": {"custom": {}}}\n', encoding="utf-8")
+    env.write_text("EXISTING=value\n", encoding="utf-8")
+    second = pilot_setup.scaffold_model_config(config)
+    assert second["provider_created"] is False
+    assert provider.read_text() == '{"providers": {"custom": {}}}\n'
+    assert env.read_text().startswith("EXISTING=value\n")
+    assert "PROVIDER_API_KEY=" in env.read_text()
+
+
+def test_format_setup_reports_model_provider_pointer(tmp_path):
+    result = sample_result()
+    result["model_provider"] = {
+        "state": "NOT CONFIGURED",
+        "provider_file": str(tmp_path / ".orbi" / "pi-providers.json"),
+        "env_file": str(tmp_path / ".orbi" / "env"),
+        "env_variable": "PROVIDER_API_KEY",
+    }
+    lines = pilot_setup.format_setup(result)
+    line = next(line for line in lines if line.startswith("model_provider="))
+    assert "NOT CONFIGURED" in line
+    assert "orbi.toml" in line
+    assert "PROVIDER_API_KEY" in line
+    assert str(tmp_path / ".orbi" / "env") in line
+
+
+def test_scaffold_model_config_preserves_existing_content_without_newline(tmp_path):
+    env = tmp_path / ".orbi" / "env"
+    env.parent.mkdir()
+    env.write_text("EXISTING=value", encoding="utf-8")
+    result = pilot_setup.scaffold_model_config({"deploy_home": tmp_path})
+    assert env.read_text() == "EXISTING=value\n# API key for the starter provider\nPROVIDER_API_KEY=\n"
+    assert result["env_created"] is True
+
+
+def test_model_provider_status_reports_missing_key_without_secret(tmp_path):
+    path = tmp_path / "providers.json"
+    finding = {"variable": "GROQ_API_KEY", "state": "is not set"}
+    result = pilot_setup.model_provider_status({
+        "deploy_home": tmp_path, "pi_providers": path,
+        "pi_provider": "groq", "pi_model": "model",
+        "pi_providers_data": {"providers": {"groq": {}}},
+        "pi_provider_key_finding": finding,
+    })
+    assert result["state"] == "NOT CONFIGURED"
+    assert result["key"] == "GROQ_API_KEY=is not set"
+
+
+def test_model_provider_status_reports_configured_provider_and_model(tmp_path):
+    result = pilot_setup.model_provider_status({
+        "deploy_home": tmp_path,
+        "pi_providers": tmp_path / "providers.json",
+        "pi_provider": "openai", "pi_model": "gpt",
+        "pi_providers_data": {"providers": {
+            "openai": {"apiKey": "${OPENAI_API_KEY}"},
+        }},
+    })
+    assert result["state"] == "ok"
+    assert result["provider"] == "openai"
+    assert result["model"] == "gpt"
+    assert result["key"] == "OPENAI_API_KEY=set"
+
+
+def test_model_provider_status_reports_literal_key_as_set(tmp_path):
+    result = pilot_setup.model_provider_status({
+        "deploy_home": tmp_path, "pi_providers": tmp_path / "providers.json",
+        "pi_provider": "local", "pi_model": "model",
+        "pi_providers_data": {"providers": {"local": {"apiKey": "local"}}},
+    })
+    assert result["key"] == "literal=set"
+
+
+def test_scaffold_model_config_does_not_append_existing_key(tmp_path):
+    env = tmp_path / ".orbi" / "env"
+    env.parent.mkdir()
+    env.write_text("PROVIDER_API_KEY=already-set\n", encoding="utf-8")
+    result = pilot_setup.scaffold_model_config({"deploy_home": tmp_path})
+    assert result["env_created"] is False
+    assert env.read_text() == "PROVIDER_API_KEY=already-set\n"
+
+
+def test_format_setup_reports_configured_model_provider(tmp_path):
+    result = sample_result()
+    result["model_provider"] = {
+        "state": "ok", "provider": "openai", "model": "gpt",
+        "key": "OPENAI_API_KEY=set",
+    }
+    assert "model_provider=ok provider=openai model=gpt key=OPENAI_API_KEY=set" in pilot_setup.format_setup(result)


### PR DESCRIPTION
<!-- orbi:run=6e369cf0 -->

Fixes #344

orbi setup does not scaffold or report model-provider config: fresh setup ends 'ok' with no pointer to orbi.toml / pi-providers.json / .orbi/env (run_id=6e369cf0)
