### PR TITLE
orbi.build quickstart omits prerequisites (uv, Pi + provider, gh auth login) and external single-repo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git clone https://github.com/orbi-build/orbi.git && cd orbi
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 # 3. create configuration (only the example is committed; maintain the real configuration locally)
 cp .orbi.example.toml orbi.toml
-# 4. run one-time setup (gh auth, labels, systemd units, and checkout checks; idempotent)
+# 4. run one-time setup (checks prior gh auth, labels, systemd units, and checkout; idempotent)
 orbi setup --config orbi.toml
 # 5. manually run one tick (for initial verification; the timer schedules normal runs)
 PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
@@ -34,9 +34,20 @@ PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
 orbi doctor --config orbi.toml
 ```
 
-See [Getting started](docs/getting-started.mdx) for complete prerequisites (Python 3.14, Pi, git + gh, systemd, and a model endpoint) and a from-scratch smoke walkthrough. See [One-time setup](docs/setup.mdx) for the complete setup output contract and failure evidence.
+### Ready check (before setup)
 
-There are two deployment modes (Issue #330): **self-hosted mode** (the default, with `repo_dir` pointing to the Orbi checkout itself) and **external single-repository mode** (`deploy_home` points to the Orbi checkout and `repo_dir` points to a user repository X—after Orbi is installed once, it can target any user repository, and an `ai-ready` Issue in X will be developed). See the External single-repo mode section of [Getting started](docs/getting-started.mdx) for configuration differences.
+- `uv` installed: `uv --version`
+- Pi installed and a model provider works: `pi --version`, then
+  `pi --print "reply with the single word: ok"`
+- GitHub CLI authenticated: run `gh auth login` once, then verify with
+  `gh auth status`
+- A systemd user session is available: `systemctl --user status`
+
+Choose the configuration mode in [Getting started](docs/getting-started.mdx):
+**bootstrap mode** uses this checkout as `repo_dir`; [External single-repo
+mode](docs/getting-started.mdx#external-single-repo-mode-deploy_home) uses
+this checkout as `deploy_home` and a foreign user repository as `repo_dir`.
+See [One-time setup](docs/setup.mdx) for the setup output contract.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,19 @@ This repository is its own evidence: 99 of the most recent 106 merged PRs were d
 ## Quick start
 
 ```bash
-# 1. clone
 git clone https://github.com/orbi-build/orbi.git && cd orbi
-# 2. install the CLI (editable uv tool installation; install once from the Orbi repository; shared by both deployment modes)
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
-# 3. create configuration (only the example is committed; maintain the real configuration locally)
+```
+
+### Ready check (before setup)
+
+- `uv`: `uv --version`; Pi and its provider: `pi --version`, then `pi --print "reply with the single word: ok"`
+- GitHub CLI: run `gh auth login` once, then verify `gh auth status`
+- systemd user session: `systemctl --user status`
+
+Choose the mode in [Getting started](docs/getting-started.mdx): bootstrap uses this checkout as `repo_dir`; [External single-repo mode](docs/getting-started.mdx#external-single-repo-mode-deploy_home) uses it as `deploy_home` and a foreign repository as `repo_dir`.
+
+```bash
 cp .orbi.example.toml orbi.toml
 # 4. run one-time setup (checks prior gh auth, labels, systemd units, and checkout; idempotent)
 orbi setup --config orbi.toml
@@ -33,21 +41,6 @@ PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
 # 6. verify deployment health
 orbi doctor --config orbi.toml
 ```
-
-### Ready check (before setup)
-
-- `uv` installed: `uv --version`
-- Pi installed and a model provider works: `pi --version`, then
-  `pi --print "reply with the single word: ok"`
-- GitHub CLI authenticated: run `gh auth login` once, then verify with
-  `gh auth status`
-- A systemd user session is available: `systemctl --user status`
-
-Choose the configuration mode in [Getting started](docs/getting-started.mdx):
-**bootstrap mode** uses this checkout as `repo_dir`; [External single-repo
-mode](docs/getting-started.mdx#external-single-repo-mode-deploy_home) uses
-this checkout as `deploy_home` and a foreign user repository as `repo_dir`.
-See [One-time setup](docs/setup.mdx) for the setup output contract.
 
 ## What it does
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,11 +30,19 @@ Pi 在隔离 worktree 中完成开发、测试并创建 PR，再经过独立审�
 ## 快速开始
 
 ```bash
-# 1. clone
 git clone https://github.com/orbi-build/orbi.git && cd orbi
-# 2. 安装 CLI（editable uv tool 安装，从 orbi 仓库安装一次；两种部署模式共用）
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
-# 3. 创建配置（仓库只提交 example，真实配置本地维护）
+```
+
+### 就绪检查（setup 之前）
+
+- `uv`：`uv --version`；Pi 和其 provider：`pi --version`，然后运行 `pi --print "reply with the single word: ok"`
+- GitHub CLI：先运行一次 `gh auth login`，再验证 `gh auth status`
+- systemd user session：`systemctl --user status`
+
+按 [Getting started](docs/zh/getting-started.mdx) 选择模式：自举模式使用本 checkout 作为 `repo_dir`；[External single-repo mode](docs/zh/getting-started.mdx#external-single-repo-mode-deploy_home) 使用本 checkout 作为 `deploy_home`，外部仓库作为 `repo_dir`。
+
+```bash
 cp .orbi.example.toml orbi.toml
 # 4. 一次性 setup（检查既有 gh auth、labels、systemd units、checkout；幂等）
 orbi setup --config orbi.toml
@@ -43,19 +51,6 @@ PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
 # 6. 验证部署健康
 orbi doctor --config orbi.toml
 ```
-
-### 就绪检查（setup 之前）
-
-- 已安装 `uv`：`uv --version`
-- 已安装 Pi 且模型 provider 可用：`pi --version`，然后运行
-  `pi --print "reply with the single word: ok"`
-- GitHub CLI 已认证：先运行一次 `gh auth login`，再用 `gh auth status` 验证
-- 有可用的 systemd user session：`systemctl --user status`
-
-按 [Getting started](docs/zh/getting-started.mdx) 选择配置模式：**自举模式**使用
-本 Orbi checkout 作为 `repo_dir`；[External single-repo mode](docs/zh/getting-started.mdx#external-single-repo-mode-deploy_home)
-使用本 Orbi checkout 作为 `deploy_home`，并把 `repo_dir` 指向外部用户仓库。
-[One-time setup](docs/zh/setup.mdx) 说明 setup 的输出契约。
 
 ## 它能做什么
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,7 +36,7 @@ git clone https://github.com/orbi-build/orbi.git && cd orbi
 uv tool install --force --reinstall --editable --python /usr/bin/python3 .
 # 3. 创建配置（仓库只提交 example，真实配置本地维护）
 cp .orbi.example.toml orbi.toml
-# 4. 一次性 setup（gh auth、labels、systemd units、checkout 检查；幂等）
+# 4. 一次性 setup（检查既有 gh auth、labels、systemd units、checkout；幂等）
 orbi setup --config orbi.toml
 # 5. 手动跑一个 tick（首次验证；日常由 timer 调度）
 PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
@@ -44,15 +44,18 @@ PYTHONPATH=src python3 -m orbi.runner --config orbi.toml
 orbi doctor --config orbi.toml
 ```
 
-完整前提（Python 3.14、Pi、git + gh、systemd、模型端点）与从 0 开始的 smoke
-walkthrough 见 [Getting started](docs/zh/getting-started.mdx)；setup 的完整输出
-契约与失败现场见 [One-time setup](docs/zh/setup.mdx)。
+### 就绪检查（setup 之前）
 
-两种部署模式（Issue #330）：**自举模式**（默认，`repo_dir` 就是 orbi
-checkout 自身）与**外部单仓库模式**（`deploy_home` 指向 orbi checkout、
-`repo_dir` 指向用户仓库 X——orbi 安装一次后指向任意用户仓库，X 里开
-`ai-ready` issue 即被开发）。配置差异见 [Getting started](docs/zh/getting-started.mdx)
-的 External single-repo mode 一节。
+- 已安装 `uv`：`uv --version`
+- 已安装 Pi 且模型 provider 可用：`pi --version`，然后运行
+  `pi --print "reply with the single word: ok"`
+- GitHub CLI 已认证：先运行一次 `gh auth login`，再用 `gh auth status` 验证
+- 有可用的 systemd user session：`systemctl --user status`
+
+按 [Getting started](docs/zh/getting-started.mdx) 选择配置模式：**自举模式**使用
+本 Orbi checkout 作为 `repo_dir`；[External single-repo mode](docs/zh/getting-started.mdx#external-single-repo-mode-deploy_home)
+使用本 Orbi checkout 作为 `deploy_home`，并把 `repo_dir` 指向外部用户仓库。
+[One-time setup](docs/zh/setup.mdx) 说明 setup 的输出契约。
 
 ## 它能做什么
 

--- a/tests/test_readme_homepage.py
+++ b/tests/test_readme_homepage.py
@@ -184,6 +184,9 @@ def test_homepage_quickstart_lists_ready_prerequisites_and_checks():
         ):
             assert requirement in quickstart, f"{path.name} omits prerequisite {requirement!r}"
             assert check in quickstart, f"{path.name} omits readiness check {check!r}"
+        assert quickstart.index("### ") < quickstart.index("orbi setup"), (
+            f"{path.name} shows the setup command before its ready check"
+        )
 
 
 def test_homepage_quickstart_links_both_configuration_modes():

--- a/tests/test_readme_homepage.py
+++ b/tests/test_readme_homepage.py
@@ -118,7 +118,8 @@ def test_readme_relative_links_resolve_for_each_language():
         assert path.is_file(), f"missing README: {path}"
         links = re.findall(r"\]\(([^)]+)\)", path.read_text(encoding="utf-8"))
         relative = [link for link in links if not link.startswith(("http://", "https://", "#"))]
-        missing = [link for link in relative if not (REPO_ROOT / link).exists()]
+        relative_paths = [link.split("#", 1)[0] for link in relative]
+        missing = [link for link, path in zip(relative, relative_paths) if not (REPO_ROOT / path).exists()]
         assert not missing, f"{path.name} has missing relative links: {missing}"
 
 
@@ -159,6 +160,41 @@ def test_readme_does_not_duplicate_docs_mechanism_sections():
         "README duplicates docs mechanism detail: "
         f"{found} — keep a one-sentence summary + the docs link instead"
     )
+
+
+def quickstart_section(text: str) -> str:
+    """Return the homepage quickstart, excluding later overview prose."""
+    match = re.search(r"^## (?:Quick start|快速开始)\n(.*?)(?=^## )", text, re.DOTALL | re.MULTILINE)
+    assert match is not None, "homepage is missing its quickstart section"
+    return match.group(1)
+
+
+def test_homepage_quickstart_lists_ready_prerequisites_and_checks():
+    """Issue #342: the quickstart must expose every preflight dependency and
+    its real check before showing the setup command."""
+    for path in (README, README_ZH):
+        text = path.read_text(encoding="utf-8")
+        quickstart = quickstart_section(text)
+        for requirement, check in (
+            ("uv", "uv --version"),
+            ("Pi", "pi --version"),
+            ("gh auth login", "gh auth status"),
+            ("systemd", "systemctl --user status"),
+            ("pi --print", "reply with the single word: ok"),
+        ):
+            assert requirement in quickstart, f"{path.name} omits prerequisite {requirement!r}"
+            assert check in quickstart, f"{path.name} omits readiness check {check!r}"
+
+
+def test_homepage_quickstart_links_both_configuration_modes():
+    """Issue #342: a homepage-only reader must find the getting-started
+    guide and the external single-repo configuration section."""
+    for path in (README, README_ZH):
+        quickstart = quickstart_section(path.read_text(encoding="utf-8"))
+        assert "getting-started.mdx" in quickstart
+        assert "External single-repo mode" in " ".join(quickstart.split())
+        assert "deploy_home" in quickstart
+        assert "repo_dir" in quickstart
 
 
 def test_first_screen_says_what_orbi_is_and_how_to_start():


### PR DESCRIPTION
<!-- orbi:run=3cdf0348 -->

Fixes #342

orbi.build quickstart omits prerequisites (uv, Pi + provider, gh auth login) and external single-repo mode (run_id=3cdf0348)
