### PR TITLE
no_ready_issue 时自动给 release ticket 补 ai-ready —— 开发队列空即触发发布，消除人工打标断点

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3794,6 +3794,35 @@ def rewrite_active_milestone_line(config_path: Path, new_value: str) -> None:
     config_path.write_bytes(updated.encode("utf-8"))
 
 
+def arm_release_ticket(repo: str, active_milestone: str) -> None:
+    """Arm one open release ticket for the current milestone on idle.
+
+    This is an idle-path bypass: callers deliberately catch failures so a
+    GitHub label operation cannot change the outcome of the main tick.
+    """
+    search = (
+        f"label:{RELEASE_LABEL} -label:{READY_LABEL} "
+        f'milestone:"{active_milestone}"'
+    )
+    raw = run_command([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--search", search, "--json", "number", "--limit", "200",
+    ], timeout=30)
+    issues = parse_issue_array(raw)
+    if not issues:
+        return
+    number = issues[0].get("number")
+    if not isinstance(number, int):
+        raise RuntimeError(f"release ticket has invalid issue number: {number!r}")
+    run_command([
+        "gh", "issue", "edit", str(number), "--repo", repo,
+        "--add-label", READY_LABEL,
+    ], timeout=30)
+    LOGGER.info(
+        "release_ticket_armed issue=#%s milestone=%s", number, active_milestone,
+    )
+
+
 def advance_active_milestone_on_idle(
     repo: str, active_milestone: str, config_path: Path,
 ) -> tuple[str, str | None]:
@@ -8526,10 +8555,21 @@ def main(argv: list[str] | None = None) -> int:
                 "source_repos=%s outcome=no_ready_issue",
                 config["source_repos"],
             )
-            # Issue #274: this is the sole trigger for validating and
-            # advancing the configured milestone. An absent setting keeps
-            # the historical idle path with no extra API request.
+            # Issue #385: arm a release ticket as a pure bypass. A failed
+            # label operation must not change the idle outcome.
             if config["active_milestone"] is not None:
+                try:
+                    arm_release_ticket(
+                        config["source_repos"][0],
+                        config["active_milestone"],
+                    )
+                except Exception:
+                    LOGGER.exception(
+                        "release_ticket_arm_failed repo=%s milestone=%s",
+                        config["source_repos"][0],
+                        config["active_milestone"],
+                    )
+                # Issue #274: validate and advance only after the arm attempt.
                 advance_active_milestone_on_idle(
                     config["source_repos"][0],
                     config["active_milestone"],

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4942,6 +4942,79 @@ def test_advance_active_milestone_rejects_duplicate_title(monkeypatch, tmp_path)
         runner.advance_active_milestone_on_idle("owner/repo", "v0.3.0", config)
 
 
+def test_arm_release_ticket_adds_ready_to_matching_open_issue(
+    monkeypatch, caplog,
+):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[0:3] == ["gh", "issue", "list"]:
+            return json.dumps([{"number": 385}])
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        runner.arm_release_ticket("owner/repo", "v0.4.0")
+
+    assert calls == [
+        [
+            "gh", "issue", "list", "--repo", "owner/repo", "--state", "open",
+            "--search",
+            'label:ai-release -label:ai-ready milestone:"v0.4.0"',
+            "--json", "number", "--limit", "200",
+        ],
+        [
+            "gh", "issue", "edit", "385", "--repo", "owner/repo",
+            "--add-label", "ai-ready",
+        ],
+    ]
+    assert "release_ticket_armed issue=#385 milestone=v0.4.0" in caplog.text
+
+
+def test_arm_release_ticket_does_nothing_when_no_ticket_matches(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append(command) or "[]",
+    )
+
+    runner.arm_release_ticket("owner/repo", "v0.4.0")
+
+    assert len(calls) == 1
+
+
+def test_arm_release_ticket_rejects_malformed_issue_number(monkeypatch):
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: '[{"number": "385"}]',
+    )
+
+    with pytest.raises(RuntimeError, match="invalid issue number"):
+        runner.arm_release_ticket("owner/repo", "v0.4.0")
+
+
+def test_main_idle_release_arm_failure_is_bypassed(monkeypatch, tmp_path, caplog):
+    _write_prompts(tmp_path)
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.4.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runner, "pick_next_delivery", lambda *args: None)
+    monkeypatch.setattr(
+        runner, "arm_release_ticket",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("permission denied")),
+    )
+    monkeypatch.setattr(runner, "advance_active_milestone_on_idle", lambda *args: None)
+
+    with caplog.at_level("ERROR"):
+        assert runner.main(["--config", str(config)]) == 0
+
+    assert "release_ticket_arm_failed" in caplog.text
+    assert "permission denied" in caplog.text
+
+
 def _write_prompts(tmp_path):
     for name in ("prompt.md", "prompt_review.md"):
         (tmp_path / name).write_text("prompt", encoding="utf-8")
@@ -4977,6 +5050,7 @@ def test_main_passes_configured_active_milestone_to_the_claim_scan(
         return None
 
     monkeypatch.setattr(runner, "pick_next_delivery", fake_pick)
+    monkeypatch.setattr(runner, "arm_release_ticket", lambda *args: None)
     monkeypatch.setattr(runner, "advance_active_milestone_on_idle", lambda *args: None)
     assert runner.main(["--config", str(config)]) == 0
     assert seen["milestone"] == "v0.2.0"
@@ -4993,6 +5067,7 @@ def test_main_advances_milestone_only_after_no_ready_issue(
     )
     calls = []
     monkeypatch.setattr(runner, "pick_next_delivery", lambda *args: None)
+    monkeypatch.setattr(runner, "arm_release_ticket", lambda *args: None)
     monkeypatch.setattr(
         runner, "advance_active_milestone_on_idle",
         lambda *args: calls.append(args),


### PR DESCRIPTION
<!-- orbi:run=78374871 -->

Fixes #385

no_ready_issue 时自动给 release ticket 补 ai-ready —— 开发队列空即触发发布，消除人工打标断点 (run_id=78374871)
