### PR TITLE
CI tests fail on release commit: 3 tests hardcode /usr/bin/python3 but CI resolves python via shutil.which (blocks v0.3.1 release)

### DIFF
--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -22,7 +22,7 @@ These tests pin the pre-start refresh contract:
 - unchanged fingerprint: NO uv call at all (no per-tick reinstall);
 - changed or missing state (first install): ONE lock-protected
   ``uv tool install --force --reinstall --editable --python
-  /usr/bin/python3 <repo_dir>`` (the exact verified argv from
+  the resolved Python interpreter <repo_dir>`` (the exact verified argv from
   ``cli_source.reinstall_args``), then the state is recorded;
 - two instances starting in the same tick: the SAME base-sync flock
   (the lock file the service template's ``ExecStartPre`` uses) — the
@@ -466,7 +466,7 @@ def test_reinstall_argv_is_the_verified_editable_force_reinstall(tmp_path):
     """The refresh runs the EXACT verified argv (Issue #152 contract,
     asserted against the real `uv tool install --help` in
     test_cli_source.py): `--force`, `--reinstall`, `--editable`,
-    `--python /usr/bin/python3`, the deployment checkout."""
+    `--python` with the resolved interpreter, the deployment checkout."""
     _write_pyproject(tmp_path, '[project]\nname = "a"\n')
     calls = []
     cli_install.refresh_cli_install(tmp_path, run_command=_recorder(calls))
@@ -474,6 +474,6 @@ def test_reinstall_argv_is_the_verified_editable_force_reinstall(tmp_path):
     command, kwargs = calls[0]
     assert command == [
         "uv", "tool", "install", "--force", "--reinstall", "--editable",
-        "--python", "/usr/bin/python3", str(tmp_path),
+        "--python", cli_source.PYTHON_INTERPRETER, str(tmp_path),
     ]
     assert kwargs["timeout"] == cli_install.UV_INSTALL_TIMEOUT_SECONDS

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -109,8 +109,7 @@ def test_pyproject_project_metadata():
     project = data["project"]
     assert project["name"] == "orbi"
     assert project["version"] == "0.2.0"
-    # The production interpreter is /usr/bin/python3 (3.14.6); the
-    # package must not claim to run on an older minor version.
+    # The package must not claim to run on an older minor version.
     assert project["requires-python"] == ">=3.14"
     # The bootstrap intentionally has no third-party runtime
     # dependency: the release package must not hardcode dependencies.
@@ -246,7 +245,7 @@ def test_service_preflight_self_heals_the_editable_cli():
     reinstall_part = heal_argv.split("||", 1)[1].strip()
     assert reinstall_part == (
         "uv tool install --force --reinstall --editable "
-        "--python /usr/bin/python3 {{ORBI_REPO_DIR}}"
+        f"--python {cli_source.PYTHON_INTERPRETER} {{{{ORBI_REPO_DIR}}}}"
     )
     # The reinstall argv is the same as the Python-side source of truth
     # (the path is the only difference: the template carries the

--- a/tests/test_cli_source.py
+++ b/tests/test_cli_source.py
@@ -54,7 +54,7 @@ def test_reinstall_command_is_the_editable_force_reinstall():
     )
     assert command == (
         "uv tool install --force --reinstall --editable "
-        "--python /usr/bin/python3 "
+        f"--python {cli_source.PYTHON_INTERPRETER} "
         "/home/xqianliu/Documents/orbi/orbi"
     )
 


### PR DESCRIPTION
<!-- orbi:run=29552dbf -->

Fixes #396

CI tests fail on release commit: 3 tests hardcode /usr/bin/python3 but CI resolves python via shutil.which (blocks v0.3.1 release) (run_id=29552dbf)
