### PR TITLE
ci_failure_triage.py create_issue 不带 milestone：自动创建的 CI failure ticket 全部没有当前 milestone

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -52,6 +52,5 @@ jobs:
       - name: Triage the completed CI run (create / update / close the bug Issue)
         env:
           GH_TOKEN: ${{ github.token }}
-          # Keep this title aligned with the Runner's active_milestone.
-          ORBI_ACTIVE_MILESTONE: v0.3.1
+          ORBI_ACTIVE_MILESTONE: ${{ vars.ORBI_ACTIVE_MILESTONE }}
         run: python3 ci_failure_triage.py

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -52,4 +52,6 @@ jobs:
       - name: Triage the completed CI run (create / update / close the bug Issue)
         env:
           GH_TOKEN: ${{ github.token }}
+          # Keep this title aligned with the Runner's active_milestone.
+          ORBI_ACTIVE_MILESTONE: v0.3.1
         run: python3 ci_failure_triage.py

--- a/ci_failure_triage.py
+++ b/ci_failure_triage.py
@@ -337,11 +337,52 @@ def index_open_issues(owner: str, repo: str) -> dict[str, dict]:
     return index
 
 
-def create_issue(owner: str, repo: str, title: str, body: str) -> None:
+def resolve_active_milestone(owner: str, repo: str) -> int | None:
+    """Resolve the configured active milestone title to its REST number.
+
+    The workflow supplies the title from the repository variable
+    ``ORBI_ACTIVE_MILESTONE``.  Milestone lookup is deliberately a bypass:
+    an unavailable, missing, or malformed milestone cannot prevent a CI
+    failure Issue from being created.
+    """
+    title = os.environ.get("ORBI_ACTIVE_MILESTONE")
+    if not title:
+        log("milestone_fallback reason=active_milestone_not_configured")
+        return None
+    endpoint = f"repos/{owner}/{repo}/milestones?state=open&per_page=100"
+    try:
+        milestones = gh_api(endpoint)
+    except GhApiError as exc:
+        log(f"milestone_fallback reason=lookup_failed detail={exc.detail}")
+        return None
+    if not isinstance(milestones, list):
+        log("milestone_fallback reason=malformed_response")
+        return None
+    matches = [
+        item for item in milestones
+        if isinstance(item, dict)
+        and item.get("title") == title
+        and isinstance(item.get("number"), int)
+    ]
+    if len(matches) != 1:
+        reason = "not_found" if not matches else "ambiguous_or_malformed"
+        log(f"milestone_fallback reason={reason} title={title!r}")
+        return None
+    return matches[0]["number"]
+
+
+def create_issue(
+    owner: str, repo: str, title: str, body: str, milestone: int | None = None,
+) -> None:
     gh_api(
         f"repos/{owner}/{repo}/issues",
         method="POST",
-        payload={"title": title, "body": body, "labels": list(ISSUE_LABELS)},
+        payload={
+            "title": title,
+            "body": body,
+            "labels": list(ISSUE_LABELS),
+            "milestone": milestone,
+        },
     )
 
 
@@ -371,6 +412,7 @@ def triage_failure(run: dict, owner: str, repo: str, jobs: list) -> None:
         log(f"ignored reason=no_failed_jobs run_id={run.get('id')}")
         return
     index = index_open_issues(owner, repo)
+    milestone = resolve_active_milestone(owner, repo)
     for item in failed:
         value = fingerprint(
             run.get("event"), run.get("head_branch", ""), item["name"],
@@ -381,6 +423,7 @@ def triage_failure(run: dict, owner: str, repo: str, jobs: list) -> None:
                 owner, repo,
                 issue_title(run, item, pr_number),
                 build_failure_body(run, item, pr_number, value),
+                milestone,
             )
             log(f"created issue job={item['name']} run_id={run.get('id')}")
         else:

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -1336,6 +1336,57 @@ def validate_config(config: dict) -> None:
             )
 
 
+def sync_active_milestone_variable(
+    repo: str, milestone: str | None, *,
+    run_command: Callable[..., str] | None = None,
+) -> None:
+    """Keep the triage workflow's read-only milestone variable current.
+
+    This is deliberately a bypass: a GitHub variable outage must not stop
+    the Runner's issue delivery tick.  The workflow consumes this value via
+    ``vars.ORBI_ACTIVE_MILESTONE`` and the triage script resolves its title.
+    """
+    command_runner = run_command or globals()["run_command"]
+    endpoint = f"repos/{repo}/actions/variables/ORBI_ACTIVE_MILESTONE"
+    try:
+        raw = command_runner(["gh", "api", endpoint], timeout=30)
+        current = json.loads(raw)
+        if not isinstance(current, dict):
+            raise ValueError("variable response is not an object")
+        if milestone is None:
+            command_runner(
+                ["gh", "api", "-X", "DELETE", endpoint], timeout=30,
+            )
+            LOGGER.info("active_milestone_variable_removed repo=%s", repo)
+            return
+        if current.get("value") == milestone:
+            LOGGER.info("active_milestone_variable_unchanged repo=%s", repo)
+            return
+        command_runner(
+            ["gh", "api", "-X", "PATCH", endpoint, "-f", f"name=ORBI_ACTIVE_MILESTONE",
+             "-f", f"value={milestone}"], timeout=30,
+        )
+        LOGGER.info("active_milestone_variable_updated repo=%s", repo)
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode != 1 or "404" not in (exc.stderr or ""):
+            LOGGER.exception("active_milestone_variable_sync_failed repo=%s", repo)
+            return
+        if milestone is None:
+            LOGGER.info("active_milestone_variable_absent repo=%s", repo)
+            return
+        try:
+            command_runner(
+                ["gh", "api", "-X", "POST", "repos/{}/actions/variables".format(repo),
+                 "-f", "name=ORBI_ACTIVE_MILESTONE", "-f", f"value={milestone}"],
+                timeout=30,
+            )
+            LOGGER.info("active_milestone_variable_created repo=%s", repo)
+        except Exception:
+            LOGGER.exception("active_milestone_variable_sync_failed repo=%s", repo)
+    except Exception:
+        LOGGER.exception("active_milestone_variable_sync_failed repo=%s", repo)
+
+
 def single_line(value: str) -> str:
     """Flatten a log value to one journal line (Issue #143).
 
@@ -8452,6 +8503,13 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         LOGGER.error("config_invalid reason=%s", exc)
         return 1
+    # Issue #399: publish the configured active milestone for the CI
+    # triage workflow. This is a bypass; delivery must continue when the
+    # variable API is unavailable.
+    sync_active_milestone_variable(
+        config["source_repos"][0], config["active_milestone"],
+        run_command=run_command,
+    )
     # Editable CLI install refresh (Issue #158): BEFORE any slot or
     # claim the tool env's editable metadata must match the checkout's
     # packaging inputs — a merged packaging change (entry point,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -983,6 +983,67 @@ def test_run_command_logs_optional_timeout_and_reraises(tmp_path, caplog):
     assert "command_timeout timeout=7 stdout=partial stderr=wait" in caplog.text
 
 
+def test_sync_active_milestone_variable_skips_matching_value():
+    calls = []
+
+    def command(args, **kwargs):
+        calls.append((args, kwargs))
+        return '{"name":"ORBI_ACTIVE_MILESTONE","value":"v1"}'
+
+    runner.sync_active_milestone_variable("owner/repo", "v1", run_command=command)
+    assert len(calls) == 1
+    assert calls[0][1] == {"timeout": 30}
+
+
+def test_sync_active_milestone_variable_patches_different_value():
+    calls = []
+
+    def command(args, **kwargs):
+        calls.append(args)
+        return '{"name":"ORBI_ACTIVE_MILESTONE","value":"v0"}' if len(calls) == 1 else "{}"
+
+    runner.sync_active_milestone_variable("owner/repo", "v1", run_command=command)
+    assert calls[1][:5] == ["gh", "api", "-X", "PATCH", "repos/owner/repo/actions/variables/ORBI_ACTIVE_MILESTONE"]
+    assert "value=v1" in calls[1]
+
+
+def test_sync_active_milestone_variable_creates_missing_value():
+    calls = []
+
+    def command(args, **kwargs):
+        calls.append(args)
+        if len(calls) == 1:
+            raise subprocess.CalledProcessError(1, args, stderr="HTTP 404")
+        return "{}"
+
+    runner.sync_active_milestone_variable("owner/repo", "v1", run_command=command)
+    assert calls[1][:4] == ["gh", "api", "-X", "POST"]
+    assert "value=v1" in calls[1]
+
+
+def test_sync_active_milestone_variable_removes_stale_value():
+    calls = []
+
+    def command(args, **kwargs):
+        calls.append(args)
+        return '{"name":"ORBI_ACTIVE_MILESTONE","value":"v0"}' if len(calls) == 1 else "{}"
+
+    runner.sync_active_milestone_variable("owner/repo", None, run_command=command)
+    assert calls[1] == [
+        "gh", "api", "-X", "DELETE",
+        "repos/owner/repo/actions/variables/ORBI_ACTIVE_MILESTONE",
+    ]
+
+
+def test_sync_active_milestone_variable_failure_is_bypass(caplog):
+    def command(args, **kwargs):
+        raise RuntimeError("offline")
+
+    with caplog.at_level("ERROR"):
+        runner.sync_active_milestone_variable("owner/repo", "v1", run_command=command)
+    assert "active_milestone_variable_sync_failed" in caplog.text
+
+
 def test_single_line_flattens_line_breaks_to_visible_escapes():
     assert runner.single_line("a\nb") == "a\\nb"
     assert runner.single_line("a\r\nb") == "a\\nb"

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -99,6 +99,10 @@ def ep_create():
     return f"repos/{OWNER_REPO}/issues"
 
 
+def ep_milestones():
+    return f"repos/{OWNER_REPO}/milestones?state=open&per_page=100"
+
+
 def ep_comment(number):
     return f"repos/{OWNER_REPO}/issues/{number}/comments"
 
@@ -354,6 +358,7 @@ def test_failure_creates_one_issue_with_full_evidence(gh, monkeypatch, tmp_path,
     assert len(creates) == 1
     payload = creates[0]["payload"]
     assert payload["labels"] == ["bug", "ai-ready"]
+    assert payload["milestone"] is None
     assert payload["title"] == "CI failure: tests on branch main (push)"
     body = payload["body"]
     # The full evidence contract: workflow, job, event, branch, commit SHA,
@@ -374,6 +379,63 @@ def test_failure_creates_one_issue_with_full_evidence(gh, monkeypatch, tmp_path,
     # A push run must not spend the PR-resolution call.
     assert gh.calls_to(ep_pulls(), "GET") == []
     assert "ci_triage created" in capsys.readouterr().err
+
+
+def test_active_milestone_title_resolves_to_open_milestone_number(gh, monkeypatch):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v0.3.1")
+    gh.routes[ep_milestones()] = [
+        {"number": 7, "title": "v0.3.1", "state": "open"},
+    ]
+    assert mod.resolve_active_milestone(
+        OWNER_REPO.split("/")[0], OWNER_REPO.split("/")[1],
+    ) == 7
+
+
+def test_milestone_lookup_failure_logs_fallback_and_returns_none(gh, monkeypatch, capsys):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v0.3.1")
+    gh.error = (ep_milestones(), "HTTP 403")
+    assert mod.resolve_active_milestone("orbi-run", "test-repo") is None
+    assert "milestone_fallback" in capsys.readouterr().err
+
+
+def test_malformed_milestone_response_logs_fallback(gh, monkeypatch, capsys):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v0.3.1")
+    gh.routes[ep_milestones()] = {"milestones": []}
+    assert mod.resolve_active_milestone("orbi-run", "test-repo") is None
+    assert "reason=malformed_response" in capsys.readouterr().err
+
+
+def test_ambiguous_milestone_match_logs_fallback(gh, monkeypatch, capsys):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v0.3.1")
+    gh.routes[ep_milestones()] = [
+        {"number": 7, "title": "v0.3.1"},
+        {"number": 8, "title": "v0.3.1"},
+    ]
+    assert mod.resolve_active_milestone("orbi-run", "test-repo") is None
+    assert "reason=ambiguous_or_malformed" in capsys.readouterr().err
+
+
+def test_create_issue_payload_includes_resolved_milestone(gh, monkeypatch, tmp_path):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v0.3.1")
+    write_event(monkeypatch, tmp_path, run_event())
+    gh.routes[ep_milestones()] = [{"number": 7, "title": "v0.3.1", "state": "open"}]
+    gh.routes[ep_jobs()] = {"total_count": 1, "jobs": [job()]}
+    gh.routes[ep_issues_list()] = []
+    mod.main()
+    assert gh.calls_to(ep_create(), "POST")[0]["payload"]["milestone"] == 7
+
+
+def test_missing_active_milestone_logs_fallback_and_creates_without_milestone(
+    gh, monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("ORBI_ACTIVE_MILESTONE", "v9.9.9")
+    write_event(monkeypatch, tmp_path, run_event())
+    gh.routes[ep_milestones()] = [{"number": 7, "title": "v0.3.1", "state": "open"}]
+    gh.routes[ep_jobs()] = {"total_count": 1, "jobs": [job()]}
+    gh.routes[ep_issues_list()] = []
+    mod.main()
+    assert gh.calls_to(ep_create(), "POST")[0]["payload"]["milestone"] is None
+    assert "milestone_fallback" in capsys.readouterr().err
 
 
 def test_failure_resolves_the_pr_number_for_pull_request_runs(


### PR DESCRIPTION
<!-- orbi:run=d5b5d396 -->

Fixes #399

ci_failure_triage.py create_issue 不带 milestone：自动创建的 CI failure ticket 全部没有当前 milestone (run_id=d5b5d396)
