### PR TITLE
Delivery CI 门禁无法区分 main 既有红与 PR 引入失败：无辜 PR 烧 5 轮 review-fix 后转 ai-fix-needed（#409/PR #410 实证）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -323,6 +323,14 @@ class UnrecoverableDeliveryError(RuntimeError):
     """
 
 
+class PreExistingCIFailure(UnrecoverableDeliveryError):
+    """A failed delivery check is already failing on the PR's base.
+
+    Retrying review/fix rounds cannot change a failure that the PR did not
+    introduce, so this external precondition fails the delivery quickly.
+    """
+
+
 def is_unrecoverable_failure(exc: BaseException) -> bool:
     """Issue #50: classify one delivery failure.
 
@@ -6380,8 +6388,57 @@ def run_review(worktree: Path, pr: dict, config: dict, source_repo: str,
     )
 
 
-def check_delivery_ci(repo: str, commit: str, *, wait_seconds: float) -> None:
-    """Require GitHub checks for a delivery head to finish successfully."""
+def _main_ci_triage_url(repo: str, check_name: str) -> str | None:
+    """Find the existing auto-created main CI issue, when present."""
+    try:
+        issues = json.loads(run_command([
+            "gh", "issue", "list", "--repo", repo, "--state", "all",
+            "--search", f"CI failure: {check_name} on branch main",
+            "--json", "number,url,title", "--limit", "20",
+        ]))
+    except Exception:
+        LOGGER.exception("delivery_ci_triage_lookup_failed repo=%s check=%s",
+                         repo, check_name)
+        return None
+    if not isinstance(issues, list):
+        return None
+    prefix = f"CI failure: {check_name} on branch main"
+    for issue in issues:
+        if isinstance(issue, dict) and str(issue.get("title", "")).startswith(prefix):
+            url = issue.get("url")
+            if isinstance(url, str) and url:
+                return url
+    return None
+
+
+def _raise_if_preexisting_ci_failure(
+        repo: str, failed_names: list[str], base_commit: str | None) -> None:
+    """Raise a fast, explicit error when base has the same failed check."""
+    if not base_commit:
+        return
+    base_checks = json.loads(run_command([
+        "gh", "api", f"repos/{repo}/commits/{base_commit}/check-runs",
+        "--jq", ".check_runs",
+    ]))
+    base_failures = {
+        check.get("name") for check in base_checks
+        if check.get("status") == "completed"
+        and check.get("conclusion") not in ("success", "neutral", "skipped")
+    }
+    for name in failed_names:
+        if name not in base_failures:
+            continue
+        triage_url = _main_ci_triage_url(repo, name)
+        suffix = f"; triage: {triage_url}" if triage_url else ""
+        raise PreExistingCIFailure(
+            f"delivery gate: main is already red on check '{name}' — "
+            f"fix main first{suffix}"
+        )
+
+
+def check_delivery_ci(repo: str, commit: str, *, wait_seconds: float,
+                       base_commit: str | None = None) -> None:
+    """Require delivery checks to pass, identifying failures inherited from base."""
     def fetch() -> list[dict]:
         return json.loads(run_command([
             "gh", "api", f"repos/{repo}/commits/{commit}/check-runs",
@@ -6414,12 +6471,18 @@ def check_delivery_ci(repo: str, commit: str, *, wait_seconds: float) -> None:
         time.sleep(step)
         waited += step
         check_runs = fetch()
-    for check in check_runs:
-        if check.get("conclusion") not in ("success", "neutral", "skipped"):
-            raise RuntimeError(
-                f"delivery gate: CI check '{check.get('name')}' is "
-                f"{check.get('status')}/{check.get('conclusion')} on {commit}"
-            )
+    failed = [
+        check for check in check_runs
+        if check.get("conclusion") not in ("success", "neutral", "skipped")
+    ]
+    _raise_if_preexisting_ci_failure(
+        repo, [str(check.get("name")) for check in failed], base_commit,
+    )
+    for check in failed:
+        raise RuntimeError(
+            f"delivery gate: CI check '{check.get('name')}' is "
+            f"{check.get('status')}/{check.get('conclusion')} on {commit}"
+        )
 
 
 def merge_gate(worktree: Path, pr: dict, base_branch: str,
@@ -6491,8 +6554,13 @@ def merge_gate(worktree: Path, pr: dict, base_branch: str,
     while True:
         pending, failed = check_rollup(state)
         if failed:
+            failed_names = [item.split(chr(39))[1] for item in failed]
+            _raise_if_preexisting_ci_failure(
+                pr.get("_source_repo", source_repo or ""), failed_names,
+                pr.get("base_oid"),
+            )
             raise RuntimeError(
-                f"delivery gate: CI check '{failed[0].split(chr(39))[1]}' "
+                f"delivery gate: CI check '{failed_names[0]}' "
                 f"failed on PR #{pr['number']}: " + ", ".join(failed)
             )
         if not pending:

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -290,6 +290,8 @@ def _merge_gate_fake(pr_state="MERGEABLE", head_oid="h1",
                 }] if check_runs is None else check_runs),
                 "mergedAt": None, "mergeCommit": None,
             })
+        if command[:2] == ["gh", "api"] and "check-runs" in command[2]:
+            return json.dumps([])
         return ""
     return fake_run
 
@@ -308,6 +310,36 @@ def test_merge_gate_rejects_failed_github_ci(monkeypatch, tmp_path):
                           "main", repo_dir=tmp_path, source_repo="owner/repo")
 
 
+def test_merge_gate_rejects_preexisting_failed_ci_as_unrecoverable(
+        monkeypatch, tmp_path):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "pr"] and "view" in command:
+            return json.dumps({
+                "state": "OPEN", "mergeable": "MERGEABLE", "headRefOid": "h1",
+                "statusCheckRollup": [{
+                    "name": "tests", "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                }],
+            })
+        if command[:2] == ["gh", "api"] and "check-runs" in command[2]:
+            return json.dumps([{
+                "name": "tests", "status": "completed",
+                "conclusion": "failure",
+            }])
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([{"title": "CI failure: tests on branch main (push)",
+                                "url": "https://github.com/o/r/issues/402"}])
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(runner.PreExistingCIFailure, match="main is already red"):
+        runner.merge_gate(
+            tmp_path, {"number": 4, "url": "u", "base_ref": "main",
+                       "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
+            "main", repo_dir=tmp_path, source_repo="owner/repo",
+        )
+
+
 def test_merge_gate_rejects_failed_status_context(monkeypatch, tmp_path):
     monkeypatch.setattr(
         runner, "run_command",
@@ -321,6 +353,39 @@ def test_merge_gate_rejects_failed_status_context(monkeypatch, tmp_path):
                        "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
             "main", repo_dir=tmp_path,
         )
+
+
+def test_check_delivery_ci_distinguishes_pr_failure_from_base(
+        monkeypatch):
+    responses = {
+        "h1": [{"name": "tests", "status": "completed", "conclusion": "failure"}],
+        "b1": [{"name": "tests", "status": "completed", "conclusion": "success"}],
+    }
+
+    def fake_run(command, **kwargs):
+        commit = command[2].split("/")[-2]
+        return json.dumps(responses[commit])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="CI check 'tests'"):
+        runner.check_delivery_ci("owner/repo", "h1", wait_seconds=0,
+                                 base_commit="b1")
+
+
+def test_check_delivery_ci_reports_base_failure_and_triage(monkeypatch):
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([{
+                "name": "tests", "status": "completed", "conclusion": "failure",
+            }])
+        return json.dumps([{"title": "CI failure: tests on branch main (push)",
+                            "url": "https://github.com/o/r/issues/402"}])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(runner.PreExistingCIFailure, match="#?main is already red") as exc:
+        runner.check_delivery_ci("owner/repo", "h1", wait_seconds=0,
+                                 base_commit="b1")
+    assert "issues/402" in str(exc.value)
 
 
 def test_merge_gate_waits_for_pending_github_ci_then_merges(

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -388,6 +388,54 @@ def test_check_delivery_ci_reports_base_failure_and_triage(monkeypatch):
     assert "issues/402" in str(exc.value)
 
 
+def test_preexisting_ci_triage_lookup_is_best_effort(monkeypatch):
+    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "{}")
+    assert runner._main_ci_triage_url("owner/repo", "tests") is None
+
+    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "not json")
+    assert runner._main_ci_triage_url("owner/repo", "tests") is None
+
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda *_args, **_kwargs: json.dumps([{"title": "other", "url": ""}]),
+    )
+    assert runner._main_ci_triage_url("owner/repo", "tests") is None
+
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda *_args, **_kwargs: json.dumps([{
+            "title": "CI failure: tests on branch main (push)", "url": 42,
+        }]),
+    )
+    assert runner._main_ci_triage_url("owner/repo", "tests") is None
+
+
+def test_preexisting_ci_check_skips_base_lookup_without_base(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise AssertionError("base lookup should be skipped")
+
+    monkeypatch.setattr(runner, "run_command", fail)
+    runner._raise_if_preexisting_ci_failure("owner/repo", ["tests"], None)
+
+
+def test_check_delivery_ci_polls_pending_checks(monkeypatch):
+    pages = [
+        [{"name": "tests", "status": "queued", "conclusion": None}],
+        [{"name": "tests", "status": "completed", "conclusion": "success"}],
+    ]
+    monkeypatch.setattr(
+        runner, "run_command", lambda *_args, **_kwargs: json.dumps(pages.pop(0)),
+    )
+    monkeypatch.setattr(runner.time, "sleep", lambda _seconds: None)
+    runner.check_delivery_ci("owner/repo", "h1", wait_seconds=30)
+
+
+def test_check_delivery_ci_times_out_without_check_runs(monkeypatch):
+    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "[]")
+    with pytest.raises(RuntimeError, match="no check runs reported"):
+        runner.check_delivery_ci("owner/repo", "h1", wait_seconds=0)
+
+
 def test_merge_gate_waits_for_pending_github_ci_then_merges(
         monkeypatch, tmp_path):
     pages = [

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -411,10 +411,7 @@ def test_preexisting_ci_triage_lookup_is_best_effort(monkeypatch):
 
 
 def test_preexisting_ci_check_skips_base_lookup_without_base(monkeypatch):
-    def fail(*_args, **_kwargs):
-        raise AssertionError("base lookup should be skipped")
-
-    monkeypatch.setattr(runner, "run_command", fail)
+    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "unused")
     runner._raise_if_preexisting_ci_failure("owner/repo", ["tests"], None)
 
 


### PR DESCRIPTION
<!-- orbi:run=1f48e69a -->

Fixes #413

Delivery CI 门禁无法区分 main 既有红与 PR 引入失败：无辜 PR 烧 5 轮 review-fix 后转 ai-fix-needed（#409/PR #410 实证） (run_id=1f48e69a)
