### PR TITLE
技术债：run marker 格式有 4 份独立定义，两处严格程度不一致

### DIFF
--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -21,6 +21,7 @@ import re
 from typing import Callable
 
 # One marker per run: hidden in the rendered comment, exact for lookup.
+RUN_ID_PATTERN = re.compile(r"[0-9a-f]{8}")
 RUN_MARKER_PATTERN = re.compile(r"<!-- orbi:run=([0-9a-f]{8}) -->")
 RUN_MARKER_TEMPLATE = "<!-- orbi:run={run_id} -->"
 # Standalone milestone comments share this prefix so they are recognizable.
@@ -31,9 +32,16 @@ MILESTONE_PREFIX = "Orbi:"
 PROGRESS_HEADER = "**Orbi progress**"
 
 
-def run_marker(run_id: str) -> str:
-    """Return the hidden HTML marker that identifies one run's comment."""
-    return RUN_MARKER_TEMPLATE.format(run_id=run_id)
+def validate_run_id(run_id: object) -> str:
+    """Fail fast unless ``run_id`` identifies exactly one task attempt."""
+    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError(f"invalid run id: {run_id!r}")
+    return run_id
+
+
+def run_marker(run_id: object) -> str:
+    """Return the hidden HTML marker that identifies one valid run."""
+    return RUN_MARKER_TEMPLATE.format(run_id=validate_run_id(run_id))
 
 
 def find_run_comment(comments: list[dict], run_id: str) -> dict | None:

--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -17,9 +17,11 @@ no fallback or retry.
 from __future__ import annotations
 
 import json
+import re
 from typing import Callable
 
 # One marker per run: hidden in the rendered comment, exact for lookup.
+RUN_MARKER_PATTERN = re.compile(r"<!-- orbi:run=([0-9a-f]{8}) -->")
 RUN_MARKER_TEMPLATE = "<!-- orbi:run={run_id} -->"
 # Standalone milestone comments share this prefix so they are recognizable.
 MILESTONE_PREFIX = "Orbi:"

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -98,7 +98,13 @@ from orbi.delivery_labels import (
     label_patch,
     needs_human_intervention,
 )
-from orbi.progress import ProgressPublisher, format_elapsed, progress_body
+from orbi.progress import (
+    RUN_MARKER_PATTERN,
+    ProgressPublisher,
+    format_elapsed,
+    progress_body,
+    run_marker,
+)
 from orbi import runner_health
 from orbi.systemd_deploy import (
     TIMER_INSTANCES,
@@ -379,10 +385,6 @@ def current_run_id() -> str | None:
     """Return the run id bound to this tick, or None before the claim."""
     return _CURRENT_RUN_ID
 
-
-def run_marker(run_id: str) -> str:
-    """Return the stable machine-readable run marker for GitHub text."""
-    return f"<!-- orbi:run={validate_run_id(run_id)} -->"
 
 # Stop scene (Issue #48): when systemd (or any caller) stops the Runner
 # with SIGTERM, the journal must show which Issue context was active
@@ -2442,7 +2444,7 @@ def publish_release(*, repo: str, tag: str, version: str,
         "",
         f"- {test_evidence}",
         "",
-        f"<!-- orbi:run={run_id} -->",
+        run_marker(run_id),
         f"run_id={run_id}",
     ])
     try:
@@ -3816,7 +3818,7 @@ def block_scene_failure(issue: dict, error: ValueError, repo: str,
         body = comment.get("body")
         if not isinstance(body, str):
             continue
-        match = re.search(r"<!-- orbi:run=([0-9a-f]{8}) -->", body)
+        match = RUN_MARKER_PATTERN.search(body)
         if match:
             marker = run_marker(match.group(1))
             break

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -104,6 +104,7 @@ from orbi.progress import (
     format_elapsed,
     progress_body,
     run_marker,
+    validate_run_id,
 )
 from orbi import runner_health
 from orbi.systemd_deploy import (
@@ -207,7 +208,8 @@ ROLE_TICKET = "ticket"
 # every journal line of the attempt starts with `[run_id]`, so a single
 # grep reconstructs the whole timeline. The filter rewrites the message in
 # place, so every handler (journal, caplog) sees the same prefixed text.
-RUN_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+# Run marker validation and rendering live in progress.py so every caller
+# enforces the same strict eight-hex-digit contract.
 _CURRENT_RUN_ID: str | None = None
 
 # GitHub labels are the only state store (Issue #45). The delivery
@@ -366,13 +368,6 @@ LOGGER.addFilter(RunIdFilter())
 # prefix as every other Runner line (the RunIdFilter is attached per
 # logger; the health module must not import this one — circular).
 runner_health.LOGGER.addFilter(RunIdFilter())
-
-
-def validate_run_id(run_id: object) -> str:
-    """Fail fast unless `run_id` is the 8-hex id of one task attempt."""
-    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
-        raise ValueError(f"invalid run id: {run_id!r}")
-    return run_id
 
 
 def set_run_id(run_id: str) -> None:

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -37,6 +37,7 @@ import time
 from pathlib import Path
 
 from orbi.delivery_labels import READY_LABEL
+from orbi.progress import run_marker
 from orbi.systemd_deploy import SERVICE_INSTANCES
 
 LOGGER = logging.getLogger("orbi.health")
@@ -390,7 +391,7 @@ def repeat_failure_comment(finding: dict) -> str:
     """
     run_id = finding["run_ids"][0]
     return "\n".join([
-        f"<!-- orbi:run={run_id} -->",
+        run_marker(run_id),
         (
             f"Orbi health check: issue #{finding['issue']} failed "
             f"{finding['count']} consecutive runs with the same failure "

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock
 import pytest
 
 import orbi.runner as runner
-from orbi import pi_activity
+from orbi import pi_activity, progress
 from tests.test_progress_wiring import make_fake_gh
 
 
@@ -2433,10 +2433,8 @@ def test_run_marker_is_stable_machine_readable_comment():
     assert runner.run_marker("e07383c2") == "<!-- orbi:run=e07383c2 -->"
 
 
-def test_run_marker_rejects_missing_or_invalid_run_id():
-    for bad in ("", "run1", None):
-        with pytest.raises(ValueError, match="invalid run id"):
-            runner.run_marker(bad)
+def test_run_marker_is_shared_with_progress_formatter():
+    assert runner.run_marker is progress.run_marker
 
 
 def test_set_run_id_binds_the_attempt_and_current_run_id_reads_it(monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -5676,7 +5676,7 @@ def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="orbi/xqliu-orbi-issue-24-run1",
         )
     assert result == "final answer"
@@ -5686,7 +5686,7 @@ def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
               if " run_start " in line]
     assert len(starts) == 1
     start = starts[0]
-    assert "run=run1" in start
+    assert "run=deadbeef" in start
     assert "issue=xqliu/orbi#24" in start
     assert "role=implement" in start
     assert "branch=orbi/xqliu-orbi-issue-24-run1" in start
@@ -5720,7 +5720,7 @@ def test_stream_pi_run_start_never_follows_pre_existing_session_file(
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     starts = [line for line in caplog.text.splitlines()
@@ -5740,7 +5740,7 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -5755,7 +5755,7 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     # No redundant `run=` field on the high-frequency lines (Issue #57);
     # the `[run_id]` prefix is the run-id carrier (bound-run tests and
     # the e2e suite cover the prefix itself).
-    assert "run=run1" not in line
+    assert "run=deadbeef" not in line
     assert "issue=xqliu/orbi#24" in line
     assert "role=implement" in line
     assert "phase=test" in line
@@ -5770,7 +5770,7 @@ def test_stream_pi_logs_activity_and_heartbeat_lines(tmp_path, caplog):
     # The idle tail produced heartbeats at the poll interval.
     assert len(heartbeats) >= 1
     for line in heartbeats:
-        assert "run=run1" not in line
+        assert "run=deadbeef" not in line
         assert "role=implement" in line
         assert ("phase=request_pending" in line
                 or "phase=test" in line)
@@ -5920,7 +5920,7 @@ def test_stream_pi_activity_keeps_action_after_tool_result(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -5945,7 +5945,7 @@ def test_stream_pi_heartbeat_interval_is_stable(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -5970,7 +5970,7 @@ def test_stream_pi_success_logs_no_run_end(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert " run_end " not in caplog.text
@@ -5984,7 +5984,7 @@ def test_stream_pi_logs_command_redacted_and_stderr(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b", log_command=["pi", "--print", "<redacted>"],
         )
     assert "command=pi --print <redacted>" in caplog.text
@@ -6003,7 +6003,7 @@ def test_stream_pi_logs_run_failed_with_full_scene_and_reraises(
     ) as excinfo:
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert excinfo.value.returncode == 3
@@ -6014,7 +6014,7 @@ def test_stream_pi_logs_run_failed_with_full_scene_and_reraises(
                 if " run_failed " in line]
     assert len(failures) == 1
     failure = failures[0]
-    assert "run=run1" in failure
+    assert "run=deadbeef" in failure
     assert "issue=xqliu/orbi#24" in failure
     assert "role=implement" in failure
     assert "phase=test" in failure
@@ -6037,7 +6037,7 @@ def test_stream_pi_heartbeats_when_session_is_idle(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     heartbeats = [line for line in caplog.text.splitlines()
@@ -6055,7 +6055,7 @@ def test_stream_pi_heartbeats_when_no_session_file_appears(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     heartbeats = [line for line in caplog.text.splitlines()
@@ -6096,7 +6096,7 @@ def test_stream_pi_logs_process_spawned_after_popen(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = [line for line in caplog.text.splitlines()
@@ -6125,7 +6125,7 @@ def test_stream_pi_logs_startup_milestones_in_order(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6179,7 +6179,7 @@ def test_stream_pi_activity_lines_show_startup_sub_phase(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6202,7 +6202,7 @@ def test_stream_pi_startup_failed_without_session_file(tmp_path, caplog):
         with pytest.raises(subprocess.CalledProcessError):
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     lines = [line for line in caplog.text.splitlines()
@@ -6236,7 +6236,7 @@ def test_stream_pi_startup_failed_without_first_request(tmp_path, caplog):
         with pytest.raises(subprocess.CalledProcessError) as excinfo:
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     assert not isinstance(excinfo.value, runner.RecoverablePiProcessError)
@@ -6269,7 +6269,7 @@ def test_stream_pi_startup_failed_early_exit_after_first_request(
         with pytest.raises(subprocess.CalledProcessError):
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     lines = [line for line in caplog.text.splitlines()
@@ -6325,7 +6325,7 @@ def test_stream_pi_startup_failed_auth_failure(tmp_path, caplog):
         with pytest.raises(subprocess.CalledProcessError):
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     lines = [line for line in caplog.text.splitlines()
@@ -6347,7 +6347,7 @@ def test_stream_pi_startup_failed_network_timeout(tmp_path, caplog):
         with pytest.raises(subprocess.CalledProcessError):
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     lines = [line for line in caplog.text.splitlines()
@@ -6367,7 +6367,7 @@ def test_stream_pi_no_startup_failed_after_first_response(tmp_path, caplog):
         with pytest.raises(subprocess.CalledProcessError):
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
-                run_id="run1", issue=24, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
                 branch="b",
             )
     assert not any(" startup_failed " in line
@@ -6405,7 +6405,7 @@ def test_stream_pi_model_wait_then_resumed_no_warning_spam(
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6417,7 +6417,7 @@ def test_stream_pi_model_wait_then_resumed_no_warning_spam(
     wait = waits[0]
     # The transition lines carry no redundant `run=` field (Issue #57);
     # the `[run_id]` prefix is the run-id carrier.
-    assert "run=run1" not in wait
+    assert "run=deadbeef" not in wait
     assert "issue=xqliu/orbi#24" in wait
     assert "role=implement" in wait
     assert "phase=test" in wait
@@ -6426,7 +6426,7 @@ def test_stream_pi_model_wait_then_resumed_no_warning_spam(
     assert "branch=" not in wait
     assert f"worktree={tmp_path}" not in wait
     resume = resumed[0]
-    assert "run=run1" not in resume
+    assert "run=deadbeef" not in resume
     assert "state=resumed" in resume
     assert "phase=test" in resume
     # While waiting, the heartbeats carry the model_wait state and the
@@ -6462,7 +6462,7 @@ def test_stream_pi_no_model_wait_after_assistant_text(tmp_path, caplog):
     with caplog.at_level("INFO"):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert " model_wait " not in caplog.text
@@ -6487,7 +6487,7 @@ def test_stream_pi_logs_idle_warning_once_when_session_stalls(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.5,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6496,7 +6496,7 @@ def test_stream_pi_logs_idle_warning_once_when_session_stalls(
     idle = idles[0]
     # No redundant `run=` field (Issue #57); the `[run_id]` prefix is
     # the run-id carrier.
-    assert "run=run1" not in idle
+    assert "run=deadbeef" not in idle
     assert "issue=xqliu/orbi#24" in idle
     assert "role=implement" in idle
     # Issue #176: no session file was ever created, so the sub-phase is
@@ -6531,7 +6531,7 @@ def test_stream_pi_logs_pi_resumed_after_idle_warning(tmp_path, caplog):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.4,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6542,7 +6542,7 @@ def test_stream_pi_logs_pi_resumed_after_idle_warning(tmp_path, caplog):
     # resumed comes after the warning and carries no redundant `run=`
     # field (Issue #57).
     assert lines.index(resumed[0]) > lines.index(idles[0])
-    assert "run=run1" not in resumed[0]
+    assert "run=deadbeef" not in resumed[0]
     assert "issue=xqliu/orbi#24" in resumed[0]
     assert "role=implement" in resumed[0]
     assert "phase=starting" in resumed[0]
@@ -6573,7 +6573,7 @@ def test_stream_pi_no_idle_warning_during_model_wait(tmp_path, caplog):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.5,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert " pi_idle " not in caplog.text
@@ -6664,7 +6664,7 @@ def test_stream_pi_drains_pipe_data_written_after_exit(
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
             ["fake"], cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == "late stdout data"
@@ -6703,7 +6703,7 @@ def test_stream_pi_hung_model_request_killed_when_upstream_gone(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=0.5,
-            run_id="run1", issue=75, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=75, source_repo="xqliu/orbi",
             branch="b",
         )
     # The failure message names the hung model request and the stale
@@ -6771,7 +6771,7 @@ def test_stream_pi_frozen_model_wait_just_before_default_survives(
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=228, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=228, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == "final answer"
@@ -6792,7 +6792,7 @@ def test_stream_pi_frozen_model_wait_at_default_kills_with_configured_threshold(
     ):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=228, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=228, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6819,7 +6819,7 @@ def test_stream_pi_explicit_short_override_kills_before_default(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=1.0,
-            run_id="run1", issue=228, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=228, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -6843,7 +6843,7 @@ def test_stream_pi_frozen_model_wait_at_ten_minutes_survives_default(
     with caplog.at_level("INFO"):
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=228, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=228, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == "final answer"
@@ -6882,7 +6882,7 @@ def test_stream_pi_slow_model_still_generating_is_not_killed(
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=0.4,
-            run_id="run1", issue=75, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=75, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == "final answer"
@@ -6908,7 +6908,7 @@ def test_stream_pi_no_upstream_kill_before_model_wait(tmp_path, caplog):
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=0.5,
-            run_id="run1", issue=75, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=75, source_repo="xqliu/orbi",
             branch="b",
         )
     assert "model_wait_dead" not in caplog.text
@@ -7019,7 +7019,7 @@ def test_stream_pi_hung_model_request_killed_despite_live_upstream(
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
                 model_wait_dead_seconds=0.5,
-                run_id="run1", issue=218, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=218, source_repo="xqliu/orbi",
                 branch="b",
             )
     finally:
@@ -7100,7 +7100,7 @@ def test_stream_pi_dropped_connection_model_wait_dead_upstream_false(
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
                 model_wait_dead_seconds=0.5,
-                run_id="run1", issue=169, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=169, source_repo="xqliu/orbi",
                 branch="b",
             )
     finally:
@@ -7140,7 +7140,7 @@ def test_stream_pi_swallowed_model_request_killed_fast(tmp_path, caplog,
             model_wait_dead_seconds=10.0,
             model_wait_probe_url="http://127.0.0.1:18082/slots",
             model_wait_probe_seconds=0.5,
-            run_id="run1", issue=233, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=233, source_repo="xqliu/orbi",
             branch="b",
         )
     assert "model_wait" in str(excinfo.value)
@@ -7218,7 +7218,7 @@ def test_stream_pi_swallow_not_fired_while_a_slot_is_processing(
             model_wait_dead_seconds=0.5,
             model_wait_probe_url="http://127.0.0.1:18082/slots",
             model_wait_probe_seconds=0.2,
-            run_id="run1", issue=233, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=233, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7249,7 +7249,7 @@ def test_stream_pi_swallow_probe_failure_is_inconclusive(
             model_wait_dead_seconds=0.5,
             model_wait_probe_url="http://127.0.0.1:18082/slots",
             model_wait_probe_seconds=0.2,
-            run_id="run1", issue=233, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=233, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7274,7 +7274,7 @@ def test_stream_pi_unconfigured_probe_keeps_dead_bound(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=0.5,
-            run_id="run1", issue=233, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=233, source_repo="xqliu/orbi",
             branch="b",
         )
     # The probe was never called (no URL configured).
@@ -7365,7 +7365,7 @@ def test_stream_pi_timeout_tool_inside_deadline_not_killed(
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=105, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=105, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == ""
@@ -7373,7 +7373,7 @@ def test_stream_pi_timeout_tool_inside_deadline_not_killed(
     waits = [line for line in lines if " pi_idle_wait " in line]
     assert len(waits) == 1, f"exactly one wait decision: {lines}"
     wait = waits[0]
-    assert "run=run1" in wait
+    assert "run=deadbeef" in wait
     assert "issue=xqliu/orbi#105" in wait
     assert "pid=" in wait
     assert "cmdline=" in wait
@@ -7495,7 +7495,7 @@ def test_stream_pi_timeout_tool_deadline_grace_window_not_killed(
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=105, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=105, source_repo="xqliu/orbi",
             branch="b", progress=progress,
         )
     # The tool was TERMed by the runner (the wrapper failed to end it:
@@ -7553,7 +7553,7 @@ def test_stream_pi_timeout_tool_past_deadline_still_terminated(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=105, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=105, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7588,7 +7588,7 @@ def test_stream_pi_idle_recovery_state_wait_visible_in_progress_callback(
     runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
         idle_warn_seconds=0.3,
-        run_id="run1", issue=105, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=105, source_repo="xqliu/orbi",
         branch="b", progress=progress,
     )
     assert "wait" in seen
@@ -7619,7 +7619,7 @@ def test_stream_pi_wait_state_cleared_when_waited_tool_exits(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=105, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=105, source_repo="xqliu/orbi",
             branch="b", progress=progress,
         )
     lines = caplog.text.splitlines()
@@ -7767,7 +7767,7 @@ def test_stream_pi_idle_recovery_terms_hung_descendant_and_resumes(
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=94, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
             branch="b",
         )
     assert result == ""
@@ -7777,7 +7777,7 @@ def test_stream_pi_idle_recovery_terms_hung_descendant_and_resumes(
     terms = [line for line in lines if " pi_idle_term " in line]
     assert len(terms) == 1, f"exactly one TERM step: {lines}"
     term = terms[0]
-    assert "run=run1" in term
+    assert "run=deadbeef" in term
     assert "issue=xqliu/orbi#94" in term
     assert "role=implement" in term
     assert "pid=" in term
@@ -7811,7 +7811,7 @@ def test_stream_pi_idle_recovery_kills_descendant_that_ignores_term(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=94, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7820,7 +7820,7 @@ def test_stream_pi_idle_recovery_kills_descendant_that_ignores_term(
     assert len(terms) == 1 and "result=sent" in terms[0]
     assert len(kills) == 1, f"exactly one KILL step: {lines}"
     kill = kills[0]
-    assert "run=run1" in kill
+    assert "run=deadbeef" in kill
     assert "pid=" in kill
     assert "cmdline=" in kill
     assert "result=sent" in kill  # the SIGKILL was delivered
@@ -7849,7 +7849,7 @@ def test_stream_pi_idle_recovery_kills_pi_session_after_three_idle_cycles(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=94, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7864,7 +7864,7 @@ def test_stream_pi_idle_recovery_kills_pi_session_after_three_idle_cycles(
     assert len(failures) == 1
     failure = failures[0]
     assert "reason=idle_recovery_stale_" in failure
-    assert "run=run1" in failure
+    assert "run=deadbeef" in failure
     assert "issue=xqliu/orbi#94" in failure
     assert f"worktree={tmp_path}" in failure
 
@@ -7892,7 +7892,7 @@ def test_stream_pi_idle_recovery_without_descendants_still_terminates(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             idle_warn_seconds=0.3,
-            run_id="run1", issue=94, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
             branch="b",
         )
     lines = caplog.text.splitlines()
@@ -7922,7 +7922,7 @@ def test_stream_pi_idle_recovery_never_signals_non_descendants(
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.1,
                 idle_warn_seconds=0.3,
-                run_id="run1", issue=94, source_repo="xqliu/orbi",
+                run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
                 branch="b",
             )
         # The bystander is untouched: still running, and its pid never
@@ -7951,7 +7951,7 @@ def test_stream_pi_idle_recovery_never_fires_during_model_wait(
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             model_wait_dead_seconds=0.5,
-            run_id="run1", issue=94, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
             branch="b",
         )
     assert " pi_idle_term " not in caplog.text
@@ -7978,7 +7978,7 @@ def test_stream_pi_idle_recovery_state_visible_in_progress_callback(
     runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
         idle_warn_seconds=0.3,
-        run_id="run1", issue=94, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=94, source_repo="xqliu/orbi",
         branch="b", progress=progress,
     )
     assert "term" in seen
@@ -7995,7 +7995,7 @@ def test_stream_pi_times_out_and_kills_process(tmp_path, caplog):
     ) as excinfo:
         runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1, timeout=0.5,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b",
         )
     assert excinfo.value.timeout == 0.5
@@ -8034,7 +8034,7 @@ def test_stream_pi_invokes_progress_callback_while_child_is_running(
 
     result = runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
-        run_id="run1", issue=24, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
         branch="b", progress=progress,
     )
     assert result == "final answer"
@@ -8080,14 +8080,14 @@ def test_stream_pi_live_progress_patches_github_before_child_exits(
 
     publisher = FakePublisher()
     throttle = runner.LiveProgressThrottle(
-        publisher, issue=24, title="Live progress", run_id="run1",
+        publisher, issue=24, title="Live progress", run_id="deadbeef",
         role="implement", branch="b", worktree=tmp_path,
         started=time.monotonic(), pr_url=None, review_round=0,
         priority="normal",
     )
     result = runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
-        run_id="run1", issue=24, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
         branch="b", progress=throttle,
     )
     assert result == "done"
@@ -8096,7 +8096,7 @@ def test_stream_pi_live_progress_patches_github_before_child_exits(
     assert len(patches) >= 2
     # The live comment carries the run marker and the live phase.
     assert all(
-        body.startswith("<!-- orbi:run=run1 -->")
+        body.startswith("<!-- orbi:run=deadbeef -->")
         for body in patches
     )
     assert any("- phase: test" in body for body in patches)
@@ -8119,12 +8119,12 @@ def test_stream_pi_progress_callback_error_never_interrupts_run(
     with caplog.at_level("ERROR"):
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
-            run_id="run1", issue=24, source_repo="xqliu/orbi",
+            run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
             branch="b", progress=boom,
         )
     assert result == "final answer"
     assert "progress_publish_failed" in caplog.text
-    assert "run=run1" in caplog.text
+    assert "run=deadbeef" in caplog.text
     assert "role=implement" in caplog.text
 
 
@@ -8141,7 +8141,7 @@ def test_live_progress_throttle_patches_on_change_and_cadence():
 
     publisher = FakePublisher()
     throttle = runner.LiveProgressThrottle(
-        publisher, issue=1, title="Throttle task", run_id="run1",
+        publisher, issue=1, title="Throttle task", run_id="deadbeef",
         role="implement", branch="b", worktree=Path("/w"),
         started=time.monotonic(), pr_url=None, review_round=0,
         priority="normal",
@@ -8188,7 +8188,7 @@ def test_live_progress_throttle_patches_on_recovery_change():
 
     publisher = FakePublisher()
     throttle = runner.LiveProgressThrottle(
-        publisher, issue=94, title="Idle recovery", run_id="run1",
+        publisher, issue=94, title="Idle recovery", run_id="deadbeef",
         role="implement", branch="b", worktree=Path("/w"),
         started=time.monotonic(), pr_url=None, review_round=0,
         priority="normal",
@@ -11627,7 +11627,7 @@ def test_stream_pi_sets_pi_env_on_the_process(tmp_path):
     result = runner.stream_pi(
         [sys.executable, "-c", script],
         cwd=tmp_path, poll_interval=0.1,
-        run_id="run1", issue=24, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
         branch="b", pi_env={"PI_CODING_AGENT_DIR": "/agent-dir"},
     )
     assert result == "/agent-dir"
@@ -11644,7 +11644,7 @@ def test_stream_pi_without_pi_env_keeps_inherited_env(tmp_path, monkeypatch):
     result = runner.stream_pi(
         [sys.executable, "-c", script],
         cwd=tmp_path, poll_interval=0.1,
-        run_id="run1", issue=24, source_repo="xqliu/orbi",
+        run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
         branch="b",
     )
     assert result == "inherited"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -13,8 +13,8 @@ from orbi import progress
 
 
 def test_run_marker_is_hidden_html_comment_with_run_id():
-    marker = progress.run_marker("abc123")
-    assert marker == "<!-- orbi:run=abc123 -->"
+    marker = progress.run_marker("abc12345")
+    assert marker == "<!-- orbi:run=abc12345 -->"
 
 
 def test_run_marker_pattern_extracts_the_run_id():
@@ -25,13 +25,19 @@ def test_run_marker_pattern_extracts_the_run_id():
     assert match.group(1) == "abc12345"
 
 
+def test_run_marker_rejects_missing_or_invalid_run_id():
+    for bad in ("", "run1", None):
+        with pytest.raises(ValueError, match="invalid run id"):
+            progress.run_marker(bad)
+
+
 def test_find_run_comment_returns_comment_carrying_the_marker():
     comments = [
         {"id": 1, "body": "Orbi started Pi: ..."},
-        {"id": 2, "body": "<!-- orbi:run=abc123 -->\n**progress**"},
+        {"id": 2, "body": "<!-- orbi:run=abc12345 -->\n**progress**"},
         {"id": 3, "body": "another run <!-- orbi:run=other -->"},
     ]
-    found = progress.find_run_comment(comments, "abc123")
+    found = progress.find_run_comment(comments, "abc12345")
     assert found == comments[1]
 
 
@@ -40,19 +46,19 @@ def test_find_run_comment_returns_none_when_marker_absent():
         {"id": 1, "body": "Orbi started Pi: ..."},
         {"id": 2, "body": "<!-- orbi:run=other -->"},
     ]
-    assert progress.find_run_comment(comments, "abc123") is None
+    assert progress.find_run_comment(comments, "abc12345") is None
 
 
 def test_find_run_comment_returns_first_match_for_duplicate_markers():
     comments = [
-        {"id": 1, "body": "<!-- orbi:run=abc123 -->first"},
-        {"id": 2, "body": "<!-- orbi:run=abc123 -->second"},
+        {"id": 1, "body": "<!-- orbi:run=abc12345 -->first"},
+        {"id": 2, "body": "<!-- orbi:run=abc12345 -->second"},
     ]
-    assert progress.find_run_comment(comments, "abc123")["id"] == 1
+    assert progress.find_run_comment(comments, "abc12345")["id"] == 1
 
 
 def test_find_run_comment_ignores_comments_without_body():
-    assert progress.find_run_comment([{"id": 1}], "abc123") is None
+    assert progress.find_run_comment([{"id": 1}], "abc12345") is None
 
 
 @pytest.mark.parametrize(
@@ -139,7 +145,7 @@ def test_issue_field_fails_fast_on_non_int_issue():
 def test_progress_body_issue_line_carries_number_and_title():
     # Issue #100: every progress scene renders `#<number> <title>`.
     body = progress.progress_body({
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 89,
         "issue_title": "Bug: resume 使用评论里的 PR URL，不再 verify_pr",
         "role": "implement",
@@ -163,7 +169,7 @@ def test_progress_body_issue_line_carries_number_and_title():
 
 def test_progress_body_issue_line_is_single_line_for_any_title():
     state = {
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 7,
         "issue_title": "a\n\nb  c",
         "role": "review",
@@ -187,7 +193,7 @@ def test_progress_body_fails_fast_without_issue_title():
     # A state without the title is a contract violation: fail fast,
     # never render a bare `#<number>` (that would hide the violation).
     state = {
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 18,
         "role": "implement",
         "phase": "starting",
@@ -206,7 +212,7 @@ def test_progress_body_fails_fast_without_issue_title():
 
 def test_progress_body_starts_with_hidden_run_marker():
     body = progress.progress_body({
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 18,
         "issue_title": "Publish progress",
         "role": "implement",
@@ -216,12 +222,12 @@ def test_progress_body_starts_with_hidden_run_marker():
         "last_action": "bash pytest tests/",
         "tests": "156 passed",
         "review_round": 0,
-        "branch": "orbi/xqliu-orbi-issue-18-abc123",
+        "branch": "orbi/xqliu-orbi-issue-18-abc12345",
         "pr": None,
         "session": "sess-1",
     })
     lines = body.splitlines()
-    assert lines[0] == "<!-- orbi:run=abc123 -->"
+    assert lines[0] == "<!-- orbi:run=abc12345 -->"
     assert "**Orbi progress**" in body
     assert "- issue: #18 Publish progress" in body
     assert "- role: implement" in body
@@ -231,14 +237,14 @@ def test_progress_body_starts_with_hidden_run_marker():
     assert "- last action: bash pytest tests/" in body
     assert "- tests: 156 passed" in body
     assert "- review/fix round: 0" in body
-    assert "- branch: orbi/xqliu-orbi-issue-18-abc123" in body
+    assert "- branch: orbi/xqliu-orbi-issue-18-abc12345" in body
     assert "- PR: -" in body
     assert "- session: sess-1" in body
 
 
 def test_progress_body_marks_missing_values_as_dash():
     body = progress.progress_body({
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 18,
         "issue_title": "Publish progress",
         "role": "implement",
@@ -260,7 +266,7 @@ def test_progress_body_marks_missing_values_as_dash():
 
 def test_progress_body_shows_pr_url_when_present():
     body = progress.progress_body({
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 18,
         "issue_title": "Publish progress",
         "role": "implement",
@@ -285,7 +291,7 @@ def test_progress_body_shows_priority_field():
     (`p0` for urgent Issues, `normal` otherwise) right after the role,
     so a mobile user sees at a glance that this run is a P0."""
     state = {
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 7,
         "issue_title": "p0 outage",
         "role": "implement",
@@ -315,7 +321,7 @@ def test_progress_body_shows_recovery_field_only_when_active():
     is recovering a stalled session; without it the body is exactly
     the pre-#94 shape (no empty recovery line)."""
     state = {
-        "run_id": "abc123",
+        "run_id": "abc12345",
         "issue": 94,
         "issue_title": "Idle recovery",
         "role": "implement",
@@ -362,7 +368,7 @@ def make_publisher(run_command=None, comments=None, posted=None,
         return ""
 
     publisher = progress.ProgressPublisher(
-        18, "xqliu/orbi", "abc123",
+        18, "xqliu/orbi", "abc12345",
         run_command=fake_run_command,
     )
     return publisher, calls
@@ -383,7 +389,7 @@ def test_progress_comment_writes_use_body_free_log_commands():
         return ""
 
     publisher = progress.ProgressPublisher(
-        18, "xqliu/orbi", "abc123", run_command=fake_run_command,
+        18, "xqliu/orbi", "abc12345", run_command=fake_run_command,
     )
     publisher.ensure("body with\nfull markdown")
     publisher.patch("updated body with\nfull markdown")
@@ -417,7 +423,7 @@ def test_publisher_ensure_patches_existing_progress_comment():
     existing = {
         "id": 7,
         "body": (
-            "<!-- orbi:run=abc123 -->\n\n"
+            "<!-- orbi:run=abc12345 -->\n\n"
             "**Orbi progress**\n\n- issue: #18"
         ),
     }
@@ -444,10 +450,10 @@ def test_publisher_ensure_never_hijacks_scene_comments():
     # The run's scene comments (started Pi / opened PR) and milestones
     # carry the run marker too: ensure must create a fresh progress
     # comment instead of PATCHing one of them (Issue #18).
-    scene = {"id": 3, "body": "<!-- orbi:run=abc123 -->started Pi"}
+    scene = {"id": 3, "body": "<!-- orbi:run=abc12345 -->started Pi"}
     milestone = {
         "id": 4,
-        "body": "<!-- orbi:run=abc123 -->Orbi: started",
+        "body": "<!-- orbi:run=abc12345 -->Orbi: started",
     }
     publisher, calls = make_publisher(comments=[scene, milestone])
     comment_id = publisher.ensure("initial body")
@@ -460,20 +466,20 @@ def test_publisher_ensure_never_hijacks_scene_comments():
 
 def test_find_progress_comment_requires_marker_and_header():
     comments = [
-        {"id": 1, "body": "<!-- orbi:run=abc123 -->scene"},
+        {"id": 1, "body": "<!-- orbi:run=abc12345 -->scene"},
         {"id": 2, "body": "**Orbi progress**"},
         {
             "id": 3,
             "body": (
-                "<!-- orbi:run=abc123 -->\n\n"
+                "<!-- orbi:run=abc12345 -->\n\n"
                 "**Orbi progress**"
             ),
         },
         {"id": 4},
     ]
-    found = progress.find_progress_comment(comments, "abc123")
+    found = progress.find_progress_comment(comments, "abc12345")
     assert found["id"] == 3
-    assert progress.find_progress_comment(comments, "other") is None
+    assert progress.find_progress_comment(comments, "deadbeef") is None
 
 
 def test_publisher_ensure_rejects_non_list_comment_payload():
@@ -487,7 +493,7 @@ def test_publisher_patch_updates_the_tracked_comment():
         {
             "id": 7,
             "body": (
-                "<!-- orbi:run=abc123 -->\n\n"
+                "<!-- orbi:run=abc12345 -->\n\n"
                 "**Orbi progress**"
             ),
         },
@@ -510,7 +516,7 @@ def test_publisher_patch_uses_the_github_update_comment_endpoint():
         {
             "id": 7,
             "body": (
-                "<!-- orbi:run=abc123 -->\n\n"
+                "<!-- orbi:run=abc12345 -->\n\n"
                 "**Orbi progress**"
             ),
         },
@@ -544,8 +550,8 @@ def test_publisher_milestone_posts_short_standalone_comment():
             "gh", "api", "repos/xqliu/orbi/issues/18/comments",
             "--method", "POST",
             "--field",
-            "body=<!-- orbi:run=abc123 -->\n"
-            "Orbi: tests passed run_id=abc123",
+            "body=<!-- orbi:run=abc12345 -->\n"
+            "Orbi: tests passed run_id=abc12345",
         ],
     ]
     # A milestone never touches the tracked progress comment.
@@ -580,7 +586,7 @@ def test_publisher_finish_patches_final_summary_into_tracked_comment():
         {
             "id": 7,
             "body": (
-                "<!-- orbi:run=abc123 -->\n\n"
+                "<!-- orbi:run=abc12345 -->\n\n"
                 "**Orbi progress**"
             ),
         },

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -17,6 +17,14 @@ def test_run_marker_is_hidden_html_comment_with_run_id():
     assert marker == "<!-- orbi:run=abc123 -->"
 
 
+def test_run_marker_pattern_extracts_the_run_id():
+    match = progress.RUN_MARKER_PATTERN.search(
+        "started <!-- orbi:run=abc12345 -->"
+    )
+    assert match is not None
+    assert match.group(1) == "abc12345"
+
+
 def test_find_run_comment_returns_comment_carrying_the_marker():
     comments = [
         {"id": 1, "body": "Orbi started Pi: ..."},

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -160,12 +160,12 @@ def test_health_state_path_lives_in_state_dir(tmp_path):
 
 def test_state_roundtrip(tmp_path):
     path = write_state(tmp_path, {
-        "runs": [run_entry(REPO, 41, "r1", "fp1")],
+        "runs": [run_entry(REPO, 41, "00000001", "fp1")],
         "last_pickup_ts": 1234.5,
         "alerted": ["owner/repo#41:fp1"],
     })
     state = runner_health.load_health_state(path)
-    assert state["runs"][0]["run_id"] == "r1"
+    assert state["runs"][0]["run_id"] == "00000001"
     assert state["last_pickup_ts"] == 1234.5
     assert state["alerted"] == ["owner/repo#41:fp1"]
 
@@ -223,9 +223,9 @@ def test_record_run_attempt_bounds_history(tmp_path):
 def test_three_consecutive_same_fingerprint_failures_are_a_finding():
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp1"),
-            run_entry(REPO, 41, "r3", "fp1"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp1"),
+            run_entry(REPO, 41, "00000003", "fp1"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
@@ -237,14 +237,14 @@ def test_three_consecutive_same_fingerprint_failures_are_a_finding():
     assert finding["fingerprint"] == "fp1"
     assert finding["count"] == 3
     # Newest failing run first (its marker goes on the alert comment).
-    assert finding["run_ids"] == ["r3", "r2", "r1"]
+    assert finding["run_ids"] == ["00000003", "00000002", "00000001"]
 
 
 def test_two_failures_are_below_threshold():
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp1"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp1"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
@@ -254,11 +254,11 @@ def test_two_failures_are_below_threshold():
 def test_success_breaks_the_streak():
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp1"),
-            run_entry(REPO, 41, "r3", "fp1"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp1"),
+            run_entry(REPO, 41, "00000003", "fp1"),
             # The delivery eventually succeeded: the old streak is history.
-            run_entry(REPO, 41, "r4", "fp1", outcome="pr_opened"),
+            run_entry(REPO, 41, "00000004", "fp1", outcome="pr_opened"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
@@ -269,9 +269,9 @@ def test_different_fingerprints_are_not_the_same_pit():
     # Normal multi-round review/fix: every round fails differently.
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp2"),
-            run_entry(REPO, 41, "r3", "fp3"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp2"),
+            run_entry(REPO, 41, "00000003", "fp3"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
@@ -281,10 +281,10 @@ def test_different_fingerprints_are_not_the_same_pit():
 def test_other_issues_do_not_break_the_streak():
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 42, "x1", "fp9"),
-            run_entry(REPO, 41, "r2", "fp1"),
-            run_entry(REPO, 41, "r3", "fp1"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 42, "10000001", "fp9"),
+            run_entry(REPO, 41, "00000002", "fp1"),
+            run_entry(REPO, 41, "00000003", "fp1"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
@@ -297,20 +297,20 @@ def test_other_issues_do_not_break_the_streak():
 def test_a_new_streak_after_an_old_one_is_counted_from_the_newest():
     state = {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp1"),
-            run_entry(REPO, 41, "r3", "fp1"),
-            run_entry(REPO, 41, "r4", "fp1", outcome="pr_opened"),
-            run_entry(REPO, 41, "r5", "fp2"),
-            run_entry(REPO, 41, "r6", "fp2"),
-            run_entry(REPO, 41, "r7", "fp2"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp1"),
+            run_entry(REPO, 41, "00000003", "fp1"),
+            run_entry(REPO, 41, "00000004", "fp1", outcome="pr_opened"),
+            run_entry(REPO, 41, "00000005", "fp2"),
+            run_entry(REPO, 41, "00000006", "fp2"),
+            run_entry(REPO, 41, "00000007", "fp2"),
         ],
         "last_pickup_ts": None, "alerted": [],
     }
     findings = runner_health.repeated_failure_findings(state)
     assert len(findings) == 1
     assert findings[0]["fingerprint"] == "fp2"
-    assert findings[0]["run_ids"] == ["r7", "r6", "r5"]
+    assert findings[0]["run_ids"] == ["00000007", "00000006", "00000005"]
 
 
 # ---------------------------------------------------------------------------
@@ -398,9 +398,9 @@ def test_healthy_tick_produces_no_alerts_and_no_github_traffic(tmp_path):
 def test_repeated_failure_alerts_once_with_the_latest_run_marker(tmp_path):
     write_state(tmp_path, {
         "runs": [
-            run_entry(REPO, 41, "r1", "fp1"),
-            run_entry(REPO, 41, "r2", "fp1"),
-            run_entry(REPO, 41, "r3", "fp1"),
+            run_entry(REPO, 41, "00000001", "fp1"),
+            run_entry(REPO, 41, "00000002", "fp1"),
+            run_entry(REPO, 41, "00000003", "fp1"),
         ],
         "last_pickup_ts": time.time(), "alerted": [],
     })
@@ -419,8 +419,8 @@ def test_repeated_failure_alerts_once_with_the_latest_run_marker(tmp_path):
     assert "41" in comment
     assert "--repo" in comment and REPO in comment
     body = comment[comment.index("--body") + 1]
-    assert "<!-- orbi:run=r3 -->" in body
-    assert "run_id=r3" in body
+    assert "<!-- orbi:run=00000003 -->" in body
+    assert "run_id=00000003" in body
     assert "fp1" in body
 
     # The next tick must NOT comment again (deduped via the state file).


### PR DESCRIPTION
<!-- orbi:run=15a461f2 -->

Fixes #284

技术债：run marker 格式有 4 份独立定义，两处严格程度不一致 (run_id=15a461f2)
