### PR TITLE
技术债：交付状态标签字面量在 4 处各写一遍，绕开声明的唯一事实源

### DIFF
--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -32,6 +32,14 @@ from collections.abc import Iterator
 from pathlib import Path
 
 from orbi import __version__, cli_source, git_transport, runner, systemd_deploy
+from orbi.delivery_labels import (
+    BLOCKED_LABEL,
+    FIX_NEEDED_LABEL,
+    IN_PROGRESS_LABEL,
+    MERGED_LABEL,
+    PR_OPENED_LABEL,
+    READY_LABEL,
+)
 
 from orbi.runner import (
     RunIdFilter,
@@ -57,13 +65,11 @@ LOGGER.addFilter(RunIdFilter())
 # pyproject.toml, so the two cannot drift.
 
 ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)$")
-READY_LABEL = "ai-ready"
-IN_PROGRESS_LABEL = "ai-in-progress"
 # `ai-pr-opened` (awaiting review), `ai-fix-needed` (awaiting the next
 # review session, Issue #82), `ai-merged` (the Runner merged the PR
 # itself, Issue #34) and `ai-blocked` are all result states of an
 # opened delivery (Issue #45).
-RESULT_LABELS = ("ai-pr-opened", "ai-fix-needed", "ai-merged", "ai-blocked")
+RESULT_LABELS = (PR_OPENED_LABEL, FIX_NEEDED_LABEL, MERGED_LABEL, BLOCKED_LABEL)
 
 
 def issue_number(url: str) -> int:

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -44,6 +44,14 @@ from pathlib import Path
 
 from orbi import runner
 from orbi import cli_source
+from orbi.delivery_labels import (
+    BLOCKED_LABEL,
+    FIX_NEEDED_LABEL,
+    IN_PROGRESS_LABEL,
+    MERGED_LABEL,
+    PR_OPENED_LABEL,
+    READY_LABEL,
+)
 from orbi import git_transport
 from orbi import systemd_deploy
 from orbi.pi_activity import quote_value
@@ -75,12 +83,12 @@ PROVIDER_GUIDE = "See /getting-started#configure-the-model-provider"
 # The repo-managed single source of truth for the platform labels.
 LABELS_FILE = "labels.toml"
 REQUIRED_LABELS = (
-    "ai-ready",
-    "ai-in-progress",
-    "ai-pr-opened",
-    "ai-fix-needed",
-    "ai-merged",
-    "ai-blocked",
+    READY_LABEL,
+    IN_PROGRESS_LABEL,
+    PR_OPENED_LABEL,
+    FIX_NEEDED_LABEL,
+    MERGED_LABEL,
+    BLOCKED_LABEL,
     "p0",
     # Epic marker (Issue #93): the claim scan skips `ai-epic` Issues
     # (`epic_not_claimed`), so the label is platform state the setup

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2324,7 +2324,7 @@ def create_repair_issue(*, repo: str, source_issue: int, run_id: str,
         "timeout", str(REPAIR_ISSUE_TIMEOUT_SECONDS),
         "gh", "issue", "create", "--repo", repo,
         "--title", f"修复 Release #{source_issue} 测试门禁失败",
-        "--body", body, "--label", "ai-ready", "--label", "bug",
+        "--body", body, "--label", READY_LABEL, "--label", "bug",
     ])
 
 

--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -19,11 +19,13 @@ not a hand-written `python3 orbi.py`. These tests pin:
   exact same code as the console script (development/compatibility,
   asserted against one real call).
 """
+import importlib
 import tomllib
 from pathlib import Path
 
 import pytest
 
+from orbi import delivery_labels
 from orbi import git_transport
 from orbi import pilot_setup
 from orbi import systemd_deploy
@@ -93,6 +95,36 @@ def parse_unit(path: Path) -> dict[str, dict[str, list[str]]]:
 
 
 # --- the packaging file -------------------------------------------------------
+
+
+def test_delivery_label_consumers_follow_the_authoritative_source(monkeypatch):
+    """Delivery consumers must read labels from delivery_labels, not literals."""
+    monkeypatch.setattr(delivery_labels, "READY_LABEL", "changed-ready")
+    monkeypatch.setattr(delivery_labels, "IN_PROGRESS_LABEL", "changed-progress")
+    monkeypatch.setattr(delivery_labels, "PR_OPENED_LABEL", "changed-pr")
+    monkeypatch.setattr(delivery_labels, "FIX_NEEDED_LABEL", "changed-fix")
+    monkeypatch.setattr(delivery_labels, "MERGED_LABEL", "changed-merged")
+    monkeypatch.setattr(delivery_labels, "BLOCKED_LABEL", "changed-blocked")
+
+    cli = importlib.import_module("orbi.cli")
+    importlib.reload(cli)
+    importlib.reload(pilot_setup)
+
+    assert cli.READY_LABEL == "changed-ready"
+    assert cli.IN_PROGRESS_LABEL == "changed-progress"
+    assert cli.RESULT_LABELS == (
+        "changed-pr", "changed-fix", "changed-merged", "changed-blocked",
+    )
+    assert pilot_setup.REQUIRED_LABELS[:6] == (
+        "changed-ready", "changed-progress", "changed-pr",
+        "changed-fix", "changed-merged", "changed-blocked",
+    )
+
+    # Keep the imported modules usable by the remaining tests after the
+    # monkeypatch is reverted.
+    monkeypatch.undo()
+    importlib.reload(cli)
+    importlib.reload(pilot_setup)
 
 
 def test_pyproject_declares_the_orbi_console_script():


### PR DESCRIPTION
<!-- orbi:run=76b62aed -->

Fixes #283

技术债：交付状态标签字面量在 4 处各写一遍，绕开声明的唯一事实源 (run_id=76b62aed)
