### PR TITLE
技术债：发布版本号与已发布 tag 不一致，release 状态机从不更新它

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3250,6 +3250,23 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         release_commit = prepare_release_version(
             worktree, declaration["version"], base_branch,
         )
+        # Version preparation creates the commit that will be tagged. Re-run
+        # the commit-specific gates so the recorded CI result and final
+        # no-open-PR check cover that exact release commit, not the frozen
+        # pre-version source commit.
+        gate_evidence = check_release_gates(
+            source_repo, base_branch, release_commit, number,
+            ci_wait_seconds=config.get(
+                "release_ci_wait_seconds", RELEASE_CI_WAIT_SECONDS,
+            ),
+            delivery_wait_seconds=config.get(
+                "release_deliveries_wait_seconds",
+                RELEASE_DELIVERIES_WAIT_SECONDS,
+            ),
+            delivery_waited_seconds=release_waited_seconds,
+            on_wait=on_ci_wait,
+            on_delivery_wait=on_delivery_wait,
+        )
         try:
             run_release_tests(
                 worktree, declaration["test_command"],

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3023,26 +3023,27 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        Issues + merged PRs; open items are surfaced as evidence, never
        released. Then verify the scope item by item
        (`verify_release_scope`).
-    5. Prepare the release version in the clean worktree: update both
-       `pyproject.toml` and `src/orbi/__init__.py`, commit, and push the
-       new release commit to the base branch; mismatched sources fail fast.
-    6. Run the declared test command in that release worktree
+    Before step 5, prepare the release version in the clean worktree:
+       update both `pyproject.toml` and `src/orbi/__init__.py`, commit, and
+       push the new release commit to the base branch; mismatched sources
+       fail fast. The subsequent steps run against that commit.
+    5. Run the declared test command in that release worktree
        (`timeout`-wrapped, Issue #95).
-    7. Tag: the remote tag must not exist or must point EXACTLY at
+    6. Tag: the remote tag must not exist or must point EXACTLY at
        the release commit (a mismatch fails — an existing tag is
        never moved); otherwise create an annotated tag at the release
        commit and push it with a plain push (never `--force`).
-    8. Publish the GitHub Release (idempotent) with the full
+    7. Publish the GitHub Release (idempotent) with the full
        verification evidence.
-    9. Sync the docs-site Release notes (Issue #275): generate
+    8. Sync the docs-site Release notes (Issue #275): generate
        `docs/release-<version>.mdx` + `docs/zh/release-<version>.mdx`
        from the published Release body, update both navigation groups,
        move the `(latest)` marker, and commit + push those docs changes
        to the base branch directly. Idempotent: identical pages are not
        overwritten; anything else fails fast.
-    10. Apply `ai-merged` and close the release Issue (terminal delivery
+    9. Apply `ai-merged` and close the release Issue (terminal delivery
        transition).
-    11. Close the Milestone whose title is EXACTLY the released
+    10. Close the Milestone whose title is EXACTLY the released
         version (Issue #214), then write the success comment (release
         URL, tag, commit, evidence, docs-site Release notes evidence,
         Milestone evidence). Exact title match only; close it only when

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2362,6 +2362,64 @@ def release_test_evidence(exc: subprocess.CalledProcessError) -> str | None:
     return evidence or None
 
 
+def prepare_release_version(worktree: Path, tag: str,
+                            base_branch: str) -> str:
+    """Commit the tag's version into both runtime metadata sources.
+
+    The release tag is the public identity (for example ``v0.3.0``), while
+    Python package metadata omits the leading ``v``.  Both existing sources
+    must be structurally recognizable and agree before either is changed;
+    otherwise a release stops before creating a tag.  The commit is pushed
+    directly to the release base, matching the release docs-sync step.
+    """
+    match = re.fullmatch(r"v([0-9]+(?:\.[0-9]+)+)", tag)
+    if match is None:
+        raise ValueError(
+            f"release version {tag!r} must be a v-prefixed numeric tag"
+        )
+    version = match.group(1)
+    pyproject = worktree / "pyproject.toml"
+    init_file = worktree / "src" / "orbi" / "__init__.py"
+    pyproject_text = pyproject.read_text(encoding="utf-8")
+    init_text = init_file.read_text(encoding="utf-8")
+    py_matches = re.findall(
+        r'(?m)^version\s*=\s*"([^"]+)"\s*$', pyproject_text,
+    )
+    init_matches = re.findall(
+        r'(?m)^__version__\s*=\s*"([^"]+)"\s*$', init_text,
+    )
+    if len(py_matches) != 1 or len(init_matches) != 1:
+        raise RuntimeError(
+            "release version sources must contain exactly one version "
+            "declaration each"
+        )
+    if py_matches[0] != init_matches[0]:
+        raise RuntimeError(
+            "release version sources disagree before release preparation"
+        )
+    updated_pyproject = re.sub(
+        r'(?m)^(version\s*=\s*)"[^"]+"(\s*)$',
+        rf'\g<1>"{version}"\g<2>', pyproject_text, count=1,
+    )
+    updated_init = re.sub(
+        r'(?m)^(__version__\s*=\s*)"[^"]+"(\s*)$',
+        rf'\g<1>"{version}"\g<2>', init_text, count=1,
+    )
+    if updated_pyproject != pyproject_text:
+        pyproject.write_text(updated_pyproject, encoding="utf-8")
+        init_file.write_text(updated_init, encoding="utf-8")
+        run_command([
+            "git", "add", "pyproject.toml", "src/orbi/__init__.py",
+        ], cwd=worktree)
+        run_command([
+            "git", "commit", "-m", f"chore: prepare release {tag}",
+        ], cwd=worktree)
+        run_command([
+            "git", "push", "origin", f"HEAD:refs/heads/{base_branch}",
+        ], cwd=worktree)
+    return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
+
+
 def release_tag_commit(repo_dir: Path, tag: str) -> str | None:
     """Return the commit the tag points to on the remote, or None.
 
@@ -2965,23 +3023,26 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        Issues + merged PRs; open items are surfaced as evidence, never
        released. Then verify the scope item by item
        (`verify_release_scope`).
-    5. Run the declared test command in a clean worktree at the
-       release commit (`timeout`-wrapped, Issue #95).
-    6. Tag: the remote tag must not exist or must point EXACTLY at
+    5. Prepare the release version in the clean worktree: update both
+       `pyproject.toml` and `src/orbi/__init__.py`, commit, and push the
+       new release commit to the base branch; mismatched sources fail fast.
+    6. Run the declared test command in that release worktree
+       (`timeout`-wrapped, Issue #95).
+    7. Tag: the remote tag must not exist or must point EXACTLY at
        the release commit (a mismatch fails — an existing tag is
        never moved); otherwise create an annotated tag at the release
        commit and push it with a plain push (never `--force`).
-    7. Publish the GitHub Release (idempotent) with the full
+    8. Publish the GitHub Release (idempotent) with the full
        verification evidence.
-    8. Sync the docs-site Release notes (Issue #275): generate
+    9. Sync the docs-site Release notes (Issue #275): generate
        `docs/release-<version>.mdx` + `docs/zh/release-<version>.mdx`
        from the published Release body, update both navigation groups,
        move the `(latest)` marker, and commit + push those docs changes
        to the base branch directly. Idempotent: identical pages are not
        overwritten; anything else fails fast.
-    9. Apply `ai-merged` and close the release Issue (terminal delivery
+    10. Apply `ai-merged` and close the release Issue (terminal delivery
        transition).
-    10. Close the Milestone whose title is EXACTLY the released
+    11. Close the Milestone whose title is EXACTLY the released
         version (Issue #214), then write the success comment (release
         URL, tag, commit, evidence, docs-site Release notes evidence,
         Milestone evidence). Exact title match only; close it only when
@@ -3182,6 +3243,11 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         )
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, release_commit,
+        )
+        # Version metadata is part of the release commit, not a post-release
+        # fix: tests and the tag must identify the exact same commit.
+        release_commit = prepare_release_version(
+            worktree, declaration["version"], base_branch,
         )
         try:
             run_release_tests(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13494,6 +13494,90 @@ def make_local_remote_pair(tmp_path):
     return work, head
 
 
+def test_prepare_release_version_updates_sources_and_commits(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "pyproject.toml").write_text(
+        '[project]\nname = "orbi"\nversion = "0.2.0"\n',
+        encoding="utf-8",
+    )
+    package = work / "src" / "orbi"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text(
+        '__version__ = "0.2.0"\n', encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
+    )
+
+    assert runner.prepare_release_version(
+        work, "v0.3.0", "main",
+    ) == "newsha"
+    assert 'version = "0.3.0"' in (work / "pyproject.toml").read_text()
+    assert '__version__ = "0.3.0"' in (package / "__init__.py").read_text()
+    assert calls == [
+        (["git", "add", "pyproject.toml", "src/orbi/__init__.py"],
+         {"cwd": work}),
+        (["git", "commit", "-m", "chore: prepare release v0.3.0"],
+         {"cwd": work}),
+        (["git", "push", "origin", "HEAD:refs/heads/main"],
+         {"cwd": work}),
+        (["git", "rev-parse", "HEAD"], {"cwd": work}),
+    ]
+
+
+def test_prepare_release_version_rejects_non_tag_version(tmp_path):
+    with pytest.raises(ValueError, match="release version"):
+        runner.prepare_release_version(tmp_path, "0.3.0", "main")
+
+
+def test_prepare_release_version_rejects_disagreeing_sources(tmp_path):
+    work = tmp_path / "release"
+    package = work / "src" / "orbi"
+    package.mkdir(parents=True)
+    (work / "pyproject.toml").write_text(
+        '[project]\nversion = "0.2.0"\n', encoding="utf-8",
+    )
+    (package / "__init__.py").write_text(
+        '__version__ = "0.1.0"\n', encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="sources disagree"):
+        runner.prepare_release_version(work, "v0.3.0", "main")
+
+
+def test_prepare_release_version_rejects_missing_source_declaration(tmp_path):
+    work = tmp_path / "release"
+    package = work / "src" / "orbi"
+    package.mkdir(parents=True)
+    (work / "pyproject.toml").write_text('[project]\n', encoding="utf-8")
+    (package / "__init__.py").write_text(
+        '__version__ = "0.2.0"\n', encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="exactly one"):
+        runner.prepare_release_version(work, "v0.3.0", "main")
+
+
+def test_prepare_release_version_is_idempotent(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    package = work / "src" / "orbi"
+    package.mkdir(parents=True)
+    (work / "pyproject.toml").write_text(
+        '[project]\nversion = "0.3.0"\n', encoding="utf-8",
+    )
+    (package / "__init__.py").write_text(
+        '__version__ = "0.3.0"\n', encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "head",
+    )
+    assert runner.prepare_release_version(work, "v0.3.0", "main") == "head"
+    assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": work})]
+
+
 def test_release_tag_commit_returns_none_for_missing_remote_tag(tmp_path):
     work, _ = make_local_remote_pair(tmp_path)
     assert runner.release_tag_commit(work, "v9.9.9") is None
@@ -13852,6 +13936,8 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
     monkeypatch.setattr(runner, "LOGGER", Mock())
     monkeypatch.setattr(runner, "release_tag_commit",
                         lambda r, t: tag_commit)
+    monkeypatch.setattr(runner, "prepare_release_version",
+                        lambda worktree, tag, base_branch: "abc123")
     monkeypatch.setattr(runner, "publish_release", lambda **k: release_url)
     # Issue #275: the docs sync step is covered by its own unit tests
     # (real git repos); here it is stubbed so the orchestration order is


### PR DESCRIPTION
<!-- orbi:run=bad969dd -->

Fixes #277

技术债：发布版本号与已发布 tag 不一致，release 状态机从不更新它 (run_id=bad969dd)
