### PR TITLE
2 个测试硬编码版本 0.2.0：release commit 把版本 bump 到 0.3.2 后 CI tests 必红，阻塞 v0.3.2 发布（#380 实证）

### DIFF
--- a/tests/test_cli_packaging.py
+++ b/tests/test_cli_packaging.py
@@ -137,10 +137,12 @@ def test_pyproject_declares_the_orbi_console_script():
 
 
 def test_pyproject_project_metadata():
+    import orbi
+
     data = load_pyproject()
     project = data["project"]
     assert project["name"] == "orbi"
-    assert project["version"] == "0.3.2"
+    assert project["version"] == orbi.__version__
     # The package must not claim to run on an older minor version.
     assert project["requires-python"] == ">=3.14"
     # The bootstrap intentionally has no third-party runtime

--- a/tests/test_src_layout.py
+++ b/tests/test_src_layout.py
@@ -141,7 +141,9 @@ def test_console_script_works_from_the_editable_install(tmp_path):
         assert command in result.stdout
     result = _run([str(cli), "--version"])
     assert result.returncode == 0, result.stderr
-    assert "orbi 0.3.2" in result.stdout
+    version = _import_probe(python, "import orbi; print(orbi.__version__)")
+    assert version.returncode == 0, version.stderr
+    assert f"orbi {version.stdout.strip()}" in result.stdout
 
 
 # --- the checkout root cannot shadow the installed package ------------------


### PR DESCRIPTION
<!-- orbi:run=2aaa5a12 -->

Fixes #442

2 个测试硬编码版本 0.2.0：release commit 把版本 bump 到 0.3.2 后 CI tests 必红，阻塞 v0.3.2 发布（#380 实证） (run_id=2aaa5a12)
