### PR TITLE
多实例部署缺口：setup/install-units 无每实例单元命名（第二个引擎实例要手搓 systemd 单元）；setup 干净门禁会被引擎自建的 .worktrees/ 绊倒

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -157,6 +157,7 @@ directory):
 | `source_repos` | yes | — | One `owner/repo` task pool scanned each tick. Multiple entries fail fast because the current execution layer has only one checkout; multi-repo workspaces are not available yet |
 | `repo_dir` | no | `.` | The delivery checkout: the repository whose Issues the Runner delivers. Task worktrees are created from its frozen `origin/<base_branch>` SHA, PRs open against it, and the slot locks live in `<repo_dir>/.orbi/slots/`. In bootstrap mode this is the orbi checkout itself; in the external single-repo mode (Issue #330) it is a foreign user repo X |
 | `deploy_home` | no | `repo_dir` | The orbi SOURCE checkout (Issue #330): the editable CLI install source (the self-update), the `systemd/` unit templates, `labels.toml`, and the prompt defaults (`prompts/prompt.md`, `prompts/prompt_review.md` when unset). Absent = `repo_dir` (bootstrap mode, unchanged). Set it to the orbi checkout when `repo_dir` is a foreign repo X. Must be a non-empty string; a missing directory fails the start fast |
+| `unit_name` | no | unset | Optional per-deployment systemd name. `website` installs `orbi-website@1/2.timer` and matching services; unset keeps the compatible `orbi@1/2` names. |
 | `workspace_root` | no | `..` | Directory that contains the task worktrees and the repositories the agent may modify |
 | `prompt` | no | `prompts/prompt.md` | Implementer prompt template (placeholders like `{{SOURCE_REPO}}` are rendered by the Runner) |
 | `prompt_review` | no | `prompts/prompt_review.md` | Review prompt template for the independent post-PR review session |
@@ -246,6 +247,13 @@ checkout — and `workspace_root` is the directory the implementer agent
 is told contains the repositories it may touch (the
 `{{WORKSPACE_ROOT}}` prompt placeholder); unset `prompt` /
 `prompt_review` resolve against `deploy_home`.)
+
+For a second engine instance, give its config a distinct `unit_name`
+(for example `unit_name = "website"`), then run `orbi setup`. It installs
+and checks `orbi-website@1/2.service` and `orbi-website@1/2.timer`; no
+hand-written systemd units or `ORBI_CONFIG` override is needed. Setup also
+keeps Runner-created `<repo_dir>/.worktrees/` out of checkout cleanliness
+using the repository's local git exclude.
 
 Everything else — steps 4–8 (model provider, `orbi setup`, the manual
 tick, the smoke walkthrough, the timers) — is unchanged: `orbi setup`

--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -372,9 +372,14 @@ def install_units_command(config: dict, installed_dir: Path | None) -> str:
     # Issue #330: the unit templates live in the deployment home (they
     # render the home path into {{ORBI_REPO_DIR}}), never in the delivery
     # checkout.
+    kwargs = {
+        "max_concurrency": config["max_concurrency"],
+        "run_command": run_command,
+    }
+    if config.get("unit_name") is not None:
+        kwargs["unit_name"] = config["unit_name"]
     result = systemd_deploy.install_units(
-        config["deploy_home"], installed_dir,
-        max_concurrency=config["max_concurrency"], run_command=run_command,
+        config["deploy_home"], installed_dir, **kwargs,
     )
     lines = [
         (
@@ -382,7 +387,7 @@ def install_units_command(config: dict, installed_dir: Path | None) -> str:
             f"installed_dir={result['installed_dir']}"
         ),
     ]
-    for name in systemd_deploy.UNIT_NAMES:
+    for name in systemd_deploy.unit_names(config.get("unit_name")):
         entry = result["units"][name]
         lines.append(f"unit={name} sha256={entry['sha256']}")
     return "\n".join(lines)
@@ -441,7 +446,12 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
         lines.append(f"transport: FAILED {exc}")
     # Issue #330: unit drift is compared against the deployment home's
     # templates (the same comparison the pre-start check uses).
-    status = systemd_deploy.unit_status(config["deploy_home"], installed_dir)
+    if config.get("unit_name") is None:
+        status = systemd_deploy.unit_status(config["deploy_home"], installed_dir)
+    else:
+        status = systemd_deploy.unit_status(
+            config["deploy_home"], installed_dir, config["unit_name"],
+        )
     drifted = [entry for entry in status if entry["drifted"]]
     if drifted:
         lines.append("unit_drift: DRIFT")
@@ -503,8 +513,8 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
     # `systemctl show` rejects the bare template name, and `journalctl
     # -u` with a template-name glob fails when no instance exists —
     # instance names always work).
-    for unit in (*systemd_deploy.TIMER_INSTANCES,
-                 *systemd_deploy.SERVICE_INSTANCES):
+    for unit in (*systemd_deploy.timer_instances(config.get("unit_name")),
+                 *systemd_deploy.service_instances(config.get("unit_name"))):
         state = run_command([
             "systemctl", "--user", "show", "-p", "ActiveState",
             "--value", unit,
@@ -518,7 +528,7 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
         current = current_issue(repo)
         lines.append(f"  current: {format_issue(current) if current else '-'}")
     journal_args: list[str] = ["journalctl", "--user"]
-    for unit in systemd_deploy.SERVICE_INSTANCES:
+    for unit in systemd_deploy.service_instances(config.get("unit_name")):
         journal_args.extend(["-u", unit])
     journal = run_command(journal_args + [
         "-n", str(JOURNAL_LINES), "--no-pager",

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -42,6 +42,8 @@ import shutil
 import tomllib
 from pathlib import Path
 
+LOGGER = logging.getLogger("orbi.pilot_setup")
+
 from orbi import runner
 from orbi import cli_source
 from orbi.delivery_labels import (
@@ -284,7 +286,7 @@ def install_cli_step(repo_dir: Path, module_file: Path, *,
     }
 
 
-def check_commands(run_command) -> dict:
+def check_commands(run_command, unit_name: str | None = None) -> dict:
     """Verify the required commands and the systemctl --user bus.
 
     ``git``, ``gh``, ``uv`` and the installed ``orbi`` CLI must be on
@@ -312,7 +314,7 @@ def check_commands(run_command) -> dict:
     # units are installed — the probe only needs the user bus).
     probe = [
         "systemctl", "--user", "show", "-p", "LoadState", "--value",
-        systemd_deploy.TIMER_INSTANCES[0],
+        systemd_deploy.timer_instances(unit_name)[0],
     ]
     try:
         run_command(probe)
@@ -501,7 +503,7 @@ def unit_is_enabled(run_command, instance: str) -> bool:
 
 def install_units_step(repo_dir: Path, installed_dir: Path | None,
                        *, max_concurrency: int = len(systemd_deploy.TIMER_INSTANCES),
-                       run_command) -> dict:
+                       unit_name: str | None = None, run_command) -> dict:
     """Install the repo's user units and report their live state.
 
     Reuses the idempotent ``systemd_deploy.install_units`` (copy the
@@ -513,10 +515,10 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
     (``list-timers``).
     """
     try:
-        result = systemd_deploy.install_units(
-            repo_dir, installed_dir, max_concurrency=max_concurrency,
-            run_command=run_command,
-        )
+        kwargs = {"max_concurrency": max_concurrency, "run_command": run_command}
+        if unit_name is not None:
+            kwargs["unit_name"] = unit_name
+        result = systemd_deploy.install_units(repo_dir, installed_dir, **kwargs)
     except Exception as exc:
         raise SetupError(
             f"systemd units install failed: {exc}"
@@ -525,7 +527,7 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
         "systemctl", "--user", "list-timers", "--no-pager",
     ])
     instances = {}
-    for instance in systemd_deploy.TIMER_INSTANCES:
+    for instance in systemd_deploy.timer_instances(unit_name):
         try:
             enabled = unit_is_enabled(run_command, instance)
         except subprocess.CalledProcessError as exc:
@@ -540,7 +542,7 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
             ]) == "active",
             "next": timer_next_trigger(list_timers, instance),
         }
-    service = result["units"][systemd_deploy.SERVICE_UNIT]
+    service = result["units"][systemd_deploy.unit_names(unit_name)[0]]
     return {
         "service": {
             "installed": True,
@@ -553,6 +555,30 @@ def install_units_step(repo_dir: Path, installed_dir: Path | None,
             "instances": instances,
         },
     }
+
+
+def ensure_worktrees_ignored(repo_dir: Path, *, run_command) -> bool:
+    """Keep Runner-created worktrees out of the main checkout status."""
+    if not (Path(repo_dir) / ".worktrees").is_dir():
+        return False
+    try:
+        run_command(["git", "check-ignore", "--quiet", "--", ".worktrees/"], cwd=repo_dir)
+        return False
+    except subprocess.CalledProcessError:
+        exclude = Path(run_command(
+            ["git", "rev-parse", "--git-path", "info/exclude"], cwd=repo_dir,
+        ))
+        if not exclude.is_absolute():
+            exclude = Path(repo_dir) / exclude
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        existing = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+        if ".worktrees/" not in existing.splitlines():
+            exclude.write_text(
+                existing + ("\n" if existing and not existing.endswith("\n") else "")
+                + ".worktrees/\n", encoding="utf-8",
+            )
+        LOGGER.info("worktrees_gitignore_added repo_dir=%s path=%s", repo_dir, exclude)
+        return True
 
 
 def check_checkout(repo_dir: Path, base_branch: str,
@@ -582,6 +608,9 @@ def check_checkout(repo_dir: Path, base_branch: str,
         )
         branch = run_command(
             ["git", "branch", "--show-current"], cwd=repo_dir,
+        )
+        worktrees_gitignore_added = ensure_worktrees_ignored(
+            repo_dir, run_command=run_command,
         )
         dirty = run_command(
             ["git", "status", "--porcelain"], cwd=repo_dir,
@@ -623,6 +652,7 @@ def check_checkout(repo_dir: Path, base_branch: str,
         "remote_protocol": transport["protocol"],
         "migrated": transport["migrated"],
         "ssh_reachable": transport["ssh_reachable"],
+        **({"worktrees_gitignore_added": True} if worktrees_gitignore_added else {}),
     }
 
 
@@ -753,7 +783,7 @@ def run_setup(config: dict, installed_dir: Path | None, *,
     # (repo_dir) may be a foreign repo without any of them.
     deploy_home = config["deploy_home"]
     defs = load_label_defs(deploy_home / LABELS_FILE)
-    check_commands(run_command)
+    check_commands(run_command, config.get("unit_name"))
     # Issue #152: the CLI source step precedes every other step — the
     # running CLI must import from the deployment checkout, otherwise
     # the unit migration below (and the pre-start self-heal it
@@ -770,11 +800,13 @@ def run_setup(config: dict, installed_dir: Path | None, *,
             **info,
             "labels": {"aligned": labels["aligned"], "total": labels["total"]},
         })
-    units = install_units_step(
-        deploy_home, installed_dir,
-        max_concurrency=config["max_concurrency"],
-        run_command=run_command,
-    )
+    unit_kwargs = {
+        "max_concurrency": config["max_concurrency"],
+        "run_command": run_command,
+    }
+    if config.get("unit_name") is not None:
+        unit_kwargs["unit_name"] = config["unit_name"]
+    units = install_units_step(deploy_home, installed_dir, **unit_kwargs)
     checkout = check_checkout(
         repo_dir, config["base_branch"], config["source_repos"],
         run_command=run_command,
@@ -785,6 +817,7 @@ def run_setup(config: dict, installed_dir: Path | None, *,
         "setup": "ok",
         "version": SETUP_VERSION,
         "base_branch": config["base_branch"],
+        "unit_name": config.get("unit_name"),
         "repos": repo_results,
         "cli": cli,
         "service": units["service"],
@@ -830,7 +863,7 @@ def format_setup(result: dict) -> list[str]:
         f"sha256={service['sha256']}"
     )
     timer = result["timer"]
-    for instance in systemd_deploy.TIMER_INSTANCES:
+    for instance in systemd_deploy.timer_instances(result.get("unit_name")):
         entry = timer["instances"][instance]
         lines.append(
             f"timer={instance} "
@@ -852,6 +885,8 @@ def format_setup(result: dict) -> list[str]:
         f"protocol={checkout['remote_protocol']} "
         f"migrated={'true' if checkout['migrated'] else 'false'} "
         f"ssh_reachable={reachable_text}"
+        + (" worktrees_gitignore_added=true"
+           if checkout.get("worktrees_gitignore_added") else "")
     )
     provider = result.get("model_provider")
     if provider and provider["state"] == "ok":

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -577,7 +577,7 @@ def ensure_worktrees_ignored(repo_dir: Path, *, run_command) -> bool:
                 existing + ("\n" if existing and not existing.endswith("\n") else "")
                 + ".worktrees/\n", encoding="utf-8",
             )
-        LOGGER.info("worktrees_gitignore_added repo_dir=%s path=%s", repo_dir, exclude)
+        LOGGER.info("worktrees_exclude_added repo=%s path=%s", repo_dir, exclude)
         return True
 
 
@@ -609,7 +609,7 @@ def check_checkout(repo_dir: Path, base_branch: str,
         branch = run_command(
             ["git", "branch", "--show-current"], cwd=repo_dir,
         )
-        worktrees_gitignore_added = ensure_worktrees_ignored(
+        worktrees_exclude_added = ensure_worktrees_ignored(
             repo_dir, run_command=run_command,
         )
         dirty = run_command(
@@ -652,7 +652,7 @@ def check_checkout(repo_dir: Path, base_branch: str,
         "remote_protocol": transport["protocol"],
         "migrated": transport["migrated"],
         "ssh_reachable": transport["ssh_reachable"],
-        **({"worktrees_gitignore_added": True} if worktrees_gitignore_added else {}),
+        **({"worktrees_exclude_added": True} if worktrees_exclude_added else {}),
     }
 
 
@@ -885,8 +885,8 @@ def format_setup(result: dict) -> list[str]:
         f"protocol={checkout['remote_protocol']} "
         f"migrated={'true' if checkout['migrated'] else 'false'} "
         f"ssh_reachable={reachable_text}"
-        + (" worktrees_gitignore_added=true"
-           if checkout.get("worktrees_gitignore_added") else "")
+        + (" worktrees_exclude_added=true"
+           if checkout.get("worktrees_exclude_added") else "")
     )
     provider = result.get("model_provider")
     if provider and provider["state"] == "ok":

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -588,6 +588,11 @@ def load_config(path: Path, *, check_provider_api_keys: bool = True,
         raise ValueError("source_repos must be a non-empty list")
     if not all(isinstance(repo, str) and repo for repo in source_repos):
         raise ValueError("source_repos must contain non-empty strings")
+    unit_name = data.get("unit_name")
+    if unit_name is not None and (
+        not isinstance(unit_name, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", unit_name)
+    ):
+        raise ValueError("unit_name must contain only letters, numbers, '-' or '_'")
     base_branch = data.get("base_branch", "main")
     if not isinstance(base_branch, str) or not base_branch:
         raise ValueError("base_branch must be a non-empty string")
@@ -719,6 +724,7 @@ def load_config(path: Path, *, check_provider_api_keys: bool = True,
         "source_repos": source_repos,
         "repo_dir": repo_dir,
         "deploy_home": deploy_home,
+        "unit_name": unit_name,
         "health_alert_repo": health_alert_repo,
         "workspace_root": _config_path(data.get("workspace_root", ".."), base),
         # Issue #330: when deploy_home is EXPLICIT the prompt defaults
@@ -9051,10 +9057,11 @@ def main(argv: list[str] | None = None) -> int:
     # structured `unit_drift` line per unit and fails fast: this
     # start takes no slot, claims no Issue and changes no label.
     try:
-        check_unit_drift(config["deploy_home"])
+        check_unit_drift(config["deploy_home"], unit_name=config.get("unit_name"))
     except UnitDriftError:
         sync_drifted_units(
             config["deploy_home"],
+            unit_name=config.get("unit_name"),
             max_concurrency=config["max_concurrency"],
             run_command=run_command,
         )

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -5859,6 +5859,7 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
 # the tracked `.gitignore` stays as the fallback layer.
 RUNNER_RUNTIME_EXCLUDES = (
     ".orbi/",
+    ".worktrees/",
     ".pi-session/",
     ".pi/",
     "plan.md",

--- a/src/orbi/systemd_deploy.py
+++ b/src/orbi/systemd_deploy.py
@@ -73,6 +73,21 @@ class UnitConflictError(RuntimeError):
     """An existing unit belongs to a different deployment checkout."""
 
 
+def unit_names(unit_name: str | None = None) -> tuple[str, str]:
+    prefix = "orbi" if unit_name is None else f"orbi-{unit_name}"
+    return f"{prefix}@.service", f"{prefix}@.timer"
+
+
+def timer_instances(unit_name: str | None = None) -> tuple[str, str]:
+    prefix = "orbi" if unit_name is None else f"orbi-{unit_name}"
+    return f"{prefix}@1.timer", f"{prefix}@2.timer"
+
+
+def service_instances(unit_name: str | None = None) -> tuple[str, str]:
+    prefix = "orbi" if unit_name is None else f"orbi-{unit_name}"
+    return f"{prefix}@1.service", f"{prefix}@2.service"
+
+
 def installed_config(unit_path: Path) -> Path | None:
     """Return the ORBI_CONFIG value from an installed service unit."""
     if not unit_path.is_file():
@@ -91,9 +106,11 @@ def installed_config(unit_path: Path) -> Path | None:
     return Path(value).expanduser().resolve()
 
 
-def reject_different_deployment(repo_dir: Path, installed_dir: Path) -> None:
+def reject_different_deployment(repo_dir: Path, installed_dir: Path,
+                                unit_name: str | None = None) -> None:
     """Refuse to overwrite units owned by another checkout."""
-    existing = installed_config(installed_dir / SERVICE_UNIT)
+    service_unit, _ = unit_names(unit_name)
+    existing = installed_config(installed_dir / service_unit)
     if existing is None:
         return
     expected = (Path(repo_dir).resolve() / "orbi.toml").resolve()
@@ -107,7 +124,7 @@ def reject_different_deployment(repo_dir: Path, installed_dir: Path) -> None:
     LOGGER.error(
         "unit_conflict unit=%s installed_config=%s expected_config=%s "
         "action=uninstall_existing_deployment",
-        SERVICE_UNIT, existing, expected,
+        service_unit, existing, expected,
     )
     raise UnitConflictError(message)
 
@@ -153,7 +170,8 @@ def render_unit_template(template_text: str, repo_dir: Path) -> str:
     )
 
 
-def unit_status(repo_dir: Path, installed_dir: Path) -> list[dict]:
+def unit_status(repo_dir: Path, installed_dir: Path,
+                unit_name: str | None = None) -> list[dict]:
     """Compare the installed units against the repo templates.
 
     One entry per unit (service and timer, in order): the repo and
@@ -164,8 +182,9 @@ def unit_status(repo_dir: Path, installed_dir: Path) -> list[dict]:
     repo_dir = Path(repo_dir)
     installed_dir = Path(installed_dir)
     entries: list[dict] = []
-    for name in UNIT_NAMES:
-        repo_path = repo_unit_dir(repo_dir) / name
+    names = unit_names(unit_name)
+    for template_name, name in zip(UNIT_NAMES, names):
+        repo_path = repo_unit_dir(repo_dir) / template_name
         installed_path = installed_dir / name
         if repo_path.is_file():
             # Issue #262: the installed unit is the RENDERED template
@@ -224,7 +243,8 @@ def drift_lines(status: list[dict]) -> list[str]:
 
 
 def check_unit_drift(repo_dir: Path,
-                     installed_dir: Path | None = None) -> None:
+                     installed_dir: Path | None = None,
+                     unit_name: str | None = None) -> None:
     """Pre-start deployment check (Issue #103).
 
     Compares BOTH installed units against the repo templates. Clean:
@@ -235,7 +255,7 @@ def check_unit_drift(repo_dir: Path,
     """
     if installed_dir is None:
         installed_dir = installed_unit_dir()
-    status = unit_status(repo_dir, installed_dir)
+    status = unit_status(repo_dir, installed_dir, unit_name)
     lines = drift_lines(status)
     if not lines:
         LOGGER.info("unit_drift clean installed_dir=%s", installed_dir)
@@ -251,7 +271,7 @@ def check_unit_drift(repo_dir: Path,
 def sync_drifted_units(repo_dir: Path,
                        installed_dir: Path | None = None,
                        *, max_concurrency: int = len(TIMER_INSTANCES),
-                       run_command) -> list[dict]:
+                       unit_name: str | None = None, run_command) -> list[dict]:
     """Pre-start self-heal for drifted units (Issue #142).
 
     The normal scene: a template change merged to main, the
@@ -272,14 +292,14 @@ def sync_drifted_units(repo_dir: Path,
     if installed_dir is None:
         installed_dir = installed_unit_dir()
     installed_dir = Path(installed_dir)
-    before = unit_status(repo_dir, installed_dir)
+    before = unit_status(repo_dir, installed_dir, unit_name)
     if not any(entry["drifted"] for entry in before):
         return []
     result = install_units(
         repo_dir, installed_dir, max_concurrency=max_concurrency,
-        run_command=run_command,
+        unit_name=unit_name, run_command=run_command,
     )
-    after = unit_status(repo_dir, installed_dir)
+    after = unit_status(repo_dir, installed_dir, unit_name)
     lines = drift_lines(after)
     if lines:
         for line in lines:
@@ -340,7 +360,7 @@ def migrate_legacy_units(installed_dir: Path, *, run_command) -> bool:
 
 def install_units(repo_dir: Path, installed_dir: Path | None = None,
                   *, max_concurrency: int = len(TIMER_INSTANCES),
-                  run_command) -> dict:
+                  unit_name: str | None = None, run_command) -> dict:
     """Idempotently install the repo templates as the user units.
 
     Overwrites BOTH installed template units with the repo templates
@@ -365,7 +385,9 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
     if installed_dir is None:
         installed_dir = installed_unit_dir()
     installed_dir = Path(installed_dir)
-    reject_different_deployment(repo_dir, installed_dir)
+    names = unit_names(unit_name)
+    instances = timer_instances(unit_name)
+    reject_different_deployment(repo_dir, installed_dir, unit_name)
     for name in UNIT_NAMES:
         template = repo_unit_dir(repo_dir) / name
         if not template.is_file():
@@ -374,21 +396,22 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
                 "templates are the single source of truth)"
             )
     installed_dir.mkdir(parents=True, exist_ok=True)
-    migrate_legacy_units(installed_dir, run_command=run_command)
-    for name in UNIT_NAMES:
+    if unit_name is None:
+        migrate_legacy_units(installed_dir, run_command=run_command)
+    for template_name, name in zip(UNIT_NAMES, names):
         # Issue #262: render the template (substitute the deployment
         # checkout path for the {{ORBI_REPO_DIR}} placeholder) so the
         # installed unit points at THIS checkout regardless of where it
         # lives. A template without the placeholder is written unchanged.
         template_text = (
-            repo_unit_dir(repo_dir) / name
+            repo_unit_dir(repo_dir) / template_name
         ).read_text(encoding="utf-8")
         rendered = render_unit_template(template_text, repo_dir)
         (installed_dir / name).write_bytes(rendered.encode("utf-8"))
     run_command(["systemctl", "--user", "daemon-reload"])
-    for instance in TIMER_INSTANCES[:max_concurrency]:
+    for instance in instances[:max_concurrency]:
         run_command(["systemctl", "--user", "enable", "--now", instance])
-    for instance in TIMER_INSTANCES[max_concurrency:]:
+    for instance in instances[max_concurrency:]:
         run_command(["systemctl", "--user", "disable", "--now", instance])
     commit = run_command(["git", "rev-parse", "HEAD"], cwd=repo_dir)
     units = {
@@ -396,13 +419,13 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
             "installed_path": installed_dir / name,
             "sha256": sha256_hex(installed_dir / name),
         }
-        for name in UNIT_NAMES
+        for name in names
     }
     LOGGER.info(
         "units_installed commit=%s installed_dir=%s units=%s "
         "instances=%s",
-        commit, installed_dir, ",".join(UNIT_NAMES),
-        ",".join(TIMER_INSTANCES[:max_concurrency]),
+        commit, installed_dir, ",".join(names),
+        ",".join(instances[:max_concurrency]),
     )
     return {
         "commit": commit,

--- a/src/orbi/systemd_deploy.py
+++ b/src/orbi/systemd_deploy.py
@@ -156,18 +156,17 @@ def sha256_hex(path: Path) -> str:
     return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
 
-def render_unit_template(template_text: str, repo_dir: Path) -> str:
-    """Substitute the deployment checkout path into a unit template.
-
-    The repo templates are machine-independent: the single
-    machine-specific value (the deployment checkout path) is carried as
-    the ``{{ORBI_REPO_DIR}}`` placeholder and replaced here with the
-    checkout's resolved absolute path. A template without the placeholder
-    is returned unchanged.
-    """
-    return template_text.replace(
+def render_unit_template(template_text: str, repo_dir: Path,
+                         unit_name: str | None = None) -> str:
+    """Render a template for the deployment's installed unit name."""
+    rendered = template_text.replace(
         REPO_DIR_PLACEHOLDER, str(Path(repo_dir).resolve()),
     )
+    if unit_name is not None:
+        rendered = rendered.replace(
+            "orbi@%i.service", f"orbi-{unit_name}@%i.service",
+        )
+    return rendered
 
 
 def unit_status(repo_dir: Path, installed_dir: Path,
@@ -192,7 +191,7 @@ def unit_status(repo_dir: Path, installed_dir: Path,
             # compare against the rendered form — otherwise a clean
             # install would always look drifted.
             rendered = render_unit_template(
-                repo_path.read_text(encoding="utf-8"), repo_dir,
+                repo_path.read_text(encoding="utf-8"), repo_dir, unit_name,
             )
             repo_sha = hashlib.sha256(
                 rendered.encode("utf-8"),
@@ -406,7 +405,7 @@ def install_units(repo_dir: Path, installed_dir: Path | None = None,
         template_text = (
             repo_unit_dir(repo_dir) / template_name
         ).read_text(encoding="utf-8")
-        rendered = render_unit_template(template_text, repo_dir)
+        rendered = render_unit_template(template_text, repo_dir, unit_name)
         (installed_dir / name).write_bytes(rendered.encode("utf-8"))
     run_command(["systemctl", "--user", "daemon-reload"])
     for instance in instances[:max_concurrency]:

--- a/tests/test_issue_461.py
+++ b/tests/test_issue_461.py
@@ -51,6 +51,10 @@ def test_unit_name_is_optional_and_validated(tmp_path):
         runner.load_config(config)
 
 
+def test_runner_runtime_excludes_cover_worktrees():
+    assert ".worktrees/" in runner.RUNNER_RUNTIME_EXCLUDES
+
+
 def test_setup_excludes_runner_worktrees_and_reports_structured_change(tmp_path):
     repo = tmp_path / "checkout"
     repo.mkdir()

--- a/tests/test_issue_461.py
+++ b/tests/test_issue_461.py
@@ -13,7 +13,9 @@ def test_named_units_are_distinct_and_install_without_touching_default(tmp_path)
     (systemd / "orbi@.service").write_text(
         '[Service]\nEnvironment="ORBI_CONFIG={{ORBI_REPO_DIR}}/orbi.toml"\n'
     )
-    (systemd / "orbi@.timer").write_text("[Timer]\nOnCalendar=hourly\n")
+    (systemd / "orbi@.timer").write_text(
+        "[Timer]\nOnCalendar=hourly\nUnit=orbi@%i.service\n"
+    )
     installed = tmp_path / "units"
     calls = []
 
@@ -26,6 +28,9 @@ def test_named_units_are_distinct_and_install_without_touching_default(tmp_path)
     assert (installed / "orbi-website@.timer").is_file()
     assert not (installed / "orbi@.service").exists()
     assert ["systemctl", "--user", "enable", "--now", "orbi-website@1.timer"] in calls
+    assert "Unit=orbi-website@%i.service" in (
+        installed / "orbi-website@.timer"
+    ).read_text()
     systemd_deploy.check_unit_drift(repo, installed, "website")
 
 

--- a/tests/test_issue_461.py
+++ b/tests/test_issue_461.py
@@ -1,0 +1,95 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from orbi import pilot_setup, runner, systemd_deploy
+
+
+def test_named_units_are_distinct_and_install_without_touching_default(tmp_path):
+    repo = tmp_path / "repo"
+    systemd = repo / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "orbi@.service").write_text(
+        '[Service]\nEnvironment="ORBI_CONFIG={{ORBI_REPO_DIR}}/orbi.toml"\n'
+    )
+    (systemd / "orbi@.timer").write_text("[Timer]\nOnCalendar=hourly\n")
+    installed = tmp_path / "units"
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return "deadbeef" if command[:3] == ["git", "rev-parse", "HEAD"] else ""
+
+    systemd_deploy.install_units(repo, installed, unit_name="website", run_command=run)
+    assert (installed / "orbi-website@.service").is_file()
+    assert (installed / "orbi-website@.timer").is_file()
+    assert not (installed / "orbi@.service").exists()
+    assert ["systemctl", "--user", "enable", "--now", "orbi-website@1.timer"] in calls
+    systemd_deploy.check_unit_drift(repo, installed, "website")
+
+
+def test_named_setup_unit_step_passes_instance_name(tmp_path):
+    repo = tmp_path / "repo"
+    systemd = repo / "systemd"
+    systemd.mkdir(parents=True)
+    (systemd / "orbi@.service").write_text("[Service]\n")
+    (systemd / "orbi@.timer").write_text("[Timer]\n")
+    result = pilot_setup.install_units_step(
+        repo, tmp_path / "units", unit_name="web",
+        run_command=lambda command, **kwargs: "active" if command[:3] == ["systemctl", "--user", "show"] else "",
+    )
+    assert "orbi-web@1.timer" in result["timer"]["instances"]
+
+
+def test_unit_name_is_optional_and_validated(tmp_path):
+    config = tmp_path / "orbi.toml"
+    config.write_text('source_repos=["owner/repo"]\n')
+    assert runner.load_config(config)["unit_name"] is None
+    config.write_text('source_repos=["owner/repo"]\nunit_name="web site"\n')
+    with pytest.raises(ValueError, match="unit_name"):
+        runner.load_config(config)
+
+
+def test_setup_excludes_runner_worktrees_and_reports_structured_change(tmp_path):
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    (repo / ".worktrees").mkdir()
+    info = repo / "git" / "info"
+    info.mkdir(parents=True)
+    exclude = info / "exclude"
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if command[:3] == ["git", "check-ignore", "--quiet"]:
+            raise subprocess.CalledProcessError(1, command)
+        if command[:4] == ["git", "rev-parse", "--git-path", "info/exclude"]:
+            return "git/info/exclude"
+        return ""
+
+    assert pilot_setup.ensure_worktrees_ignored(repo, run_command=run) is True
+    assert exclude.read_text() == ".worktrees/\n"
+    assert run(["noop"]) == ""
+
+
+def test_setup_does_not_duplicate_a_local_exclude_entry(tmp_path):
+    repo = tmp_path / "checkout"
+    (repo / ".worktrees").mkdir(parents=True)
+    exclude = repo / "git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True)
+    exclude.write_text(".worktrees/\n")
+    def run(command, **kwargs):
+        if command[:3] == ["git", "check-ignore", "--quiet"]:
+            raise subprocess.CalledProcessError(1, command)
+        return str(exclude)
+    assert pilot_setup.ensure_worktrees_ignored(repo, run_command=run) is True
+    assert exclude.read_text() == ".worktrees/\n"
+
+
+def test_setup_keeps_an_already_ignored_worktrees_directory(tmp_path):
+    repo = tmp_path / "checkout"
+    (repo / ".worktrees").mkdir(parents=True)
+    assert pilot_setup.ensure_worktrees_ignored(
+        repo, run_command=lambda command, **kwargs: "ignored",
+    ) is False

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1190,24 +1190,28 @@ def test_install_units_command_uses_deploy_home(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     config["deploy_home"] = home
+    config["unit_name"] = "website"
     installed = tmp_path / "elsewhere"
     captured = {}
 
-    def fake_install(repo_dir, installed_dir, *, max_concurrency, run_command):
+    def fake_install(repo_dir, installed_dir, *, max_concurrency, run_command,
+                     unit_name=None):
         captured["repo_dir"] = Path(repo_dir)
+        captured["unit_name"] = unit_name
         return {
             "commit": "0123456789abcdef0123456789abcdef01234567",
             "installed_dir": installed_dir,
             "units": {
                 name: {"installed_path": installed_dir / name,
                        "sha256": f"hash-{name}"}
-                for name in systemd_deploy.UNIT_NAMES
+                for name in systemd_deploy.unit_names(unit_name)
             },
         }
 
     monkeypatch.setattr(systemd_deploy, "install_units", fake_install)
     orbi.install_units_command(config, installed)
     assert captured["repo_dir"] == home
+    assert captured["unit_name"] == "website"
     assert captured["repo_dir"] != config["repo_dir"]
 
 
@@ -1223,12 +1227,14 @@ def test_doctor_report_routes_home_checks_to_deploy_home(
     home = tmp_path / "home"
     home.mkdir()
     config["deploy_home"] = home
+    config["unit_name"] = "website"
     _fake_doctor_commands(monkeypatch)
     monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
     seen = {}
 
-    def spy_unit_status(repo_dir, installed_dir):
+    def spy_unit_status(repo_dir, installed_dir, unit_name=None):
         seen["units"] = Path(repo_dir)
+        seen["unit_name"] = unit_name
         return []
 
     def spy_cli_source(expected_repo_dir):
@@ -1242,6 +1248,7 @@ def test_doctor_report_routes_home_checks_to_deploy_home(
     monkeypatch.setattr(cli_source, "drift_line", lambda source: None)
     report = orbi.doctor_report(config, installed)
     assert seen["units"] == home
+    assert seen["unit_name"] == "website"
     assert seen["cli"] == home
     assert home != config["repo_dir"]
     assert "unit_drift: clean" in report.splitlines()

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -1155,8 +1155,9 @@ def test_run_setup_capacity_two_enables_both_timers(tmp_path):
     repo, installed, state = make_run_state(tmp_path)
     fake_run, calls = fake_run_factory(state)
     config = runner.load_config(make_config(tmp_path, repo, max_concurrency=2))
+    config["unit_name"] = "website"
     result = pilot_setup.run_setup(config, installed, run_command=fake_run)
-    for instance in systemd_deploy.TIMER_INSTANCES:
+    for instance in systemd_deploy.timer_instances("website"):
         assert result["timer"]["instances"][instance]["enabled"] is True
         assert result["timer"]["instances"][instance]["active"] is True
         assert ["systemctl", "--user", "enable", "--now", instance] in calls


### PR DESCRIPTION
<!-- orbi:run=09989cda -->

Fixes #461

多实例部署缺口：setup/install-units 无每实例单元命名（第二个引擎实例要手搓 systemd 单元）；setup 干净门禁会被引擎自建的 .worktrees/ 绊倒 (run_id=09989cda)
