### PR TITLE
Release 验证首跑必挂：版本 bump 先 push、CLI 刷新在后，installed-CLI 版本断言确定性失败

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3274,6 +3274,11 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             on_wait=on_ci_wait,
             on_delivery_wait=on_delivery_wait,
         )
+        # The release version changed the packaging inputs after the tick's
+        # preflight refresh. Install the release worktree before validating
+        # it, so installed-CLI assertions exercise the version being released
+        # on this first run rather than waiting for the next tick.
+        refresh_cli_install(worktree, run_command=run_command)
         try:
             run_release_tests(
                 worktree, declaration["test_command"],

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3278,7 +3278,10 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         # preflight refresh. Install the release worktree before validating
         # it, so installed-CLI assertions exercise the version being released
         # on this first run rather than waiting for the next tick.
-        refresh_cli_install(worktree, run_command=run_command)
+        refresh_cli_install(
+            worktree, lock_repo_dir=config["repo_dir"],
+            run_command=run_command,
+        )
         try:
             run_release_tests(
                 worktree, declaration["test_command"],
@@ -7136,9 +7139,13 @@ def write_install_state(repo_dir: Path, fingerprint: str) -> None:
 def refresh_cli_install(
     repo_dir: Path, *, run_command,
     lock_timeout_seconds: float = 300.0,
+    lock_repo_dir: Path | None = None,
 ) -> str:
     """Refresh the editable CLI install when the packaging inputs
-    changed; return `"unchanged"` or `"installed"`.
+    changed; return `"unchanged"` or `"installed"`. ``repo_dir`` is
+    the checkout to install; ``lock_repo_dir`` optionally names the
+    shared deployment checkout whose base-sync lock also protects the
+    tool environment.
 
     The pre-start gate (called by the Runner tick before any slot or
     claim):
@@ -7162,6 +7169,9 @@ def refresh_cli_install(
     failure).
     """
     repo_dir = Path(repo_dir)
+    lock_repo_dir = (
+        Path(lock_repo_dir) if lock_repo_dir is not None else repo_dir
+    )
     fingerprint = packaging_fingerprint(repo_dir)
     if read_install_state(repo_dir) == fingerprint:
         CLI_INSTALL_LOGGER.info(
@@ -7169,7 +7179,7 @@ def refresh_cli_install(
             repo_dir, fingerprint,
         )
         return "unchanged"
-    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    fd = acquire_base_sync_lock(lock_repo_dir, lock_timeout_seconds)
     try:
         # Re-check UNDER the lock: a concurrent instance may have
         # refreshed the tool env while we waited for the flock —

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14191,6 +14191,10 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                         lambda r, t: tag_commit)
     monkeypatch.setattr(runner, "prepare_release_version",
                         lambda worktree, tag, base_branch: "abc123")
+    monkeypatch.setattr(
+        runner, "refresh_cli_install",
+        lambda worktree, **kwargs: "installed",
+    )
     monkeypatch.setattr(runner, "publish_release", lambda **k: release_url)
     # Issue #275: the docs sync step is covered by its own unit tests
     # (real git repos); here it is stubbed so the orchestration order is
@@ -14321,6 +14325,35 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert "docs release notes for v0.3.0 synced to base" \
         in comment_kwargs["body"]
     assert state["run_ids"][0] == "a1b2c3d4"
+
+
+def test_process_release_refreshes_cli_before_release_tests(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    order = []
+    monkeypatch.setattr(
+        runner, "prepare_release_version",
+        lambda worktree, tag, base_branch: order.append("version") or "abc123",
+    )
+
+    def refresh(worktree, **kwargs):
+        order.append("cli")
+        assert Path(worktree) == Path("/wt")
+        assert kwargs["run_command"] is runner.run_command
+        return "installed"
+
+    monkeypatch.setattr(runner, "refresh_cli_install", refresh)
+    monkeypatch.setattr(
+        runner, "run_release_tests",
+        lambda worktree, command, timeout: order.append("tests"),
+    )
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+
+    assert runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    ) == "https://github.com/o/r/releases/tag/v0.3.0"
+    assert order == ["version", "cli", "tests"]
 
 
 def test_process_release_derives_scope_from_milestone(monkeypatch):

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -462,6 +462,25 @@ def test_base_sync_lock_path_is_the_shared_state_dir_file(tmp_path):
     )
 
 
+def test_refresh_can_install_one_checkout_while_locking_shared_checkout(
+    tmp_path,
+):
+    release_worktree = tmp_path / "release-worktree"
+    deployment_checkout = tmp_path / "deployment-checkout"
+    _write_pyproject(release_worktree, '[project]\nname = "release"\n')
+    calls = []
+
+    cli_install.refresh_cli_install(
+        release_worktree,
+        lock_repo_dir=deployment_checkout,
+        run_command=_recorder(calls),
+    )
+
+    assert cli_install.base_sync_lock_path(deployment_checkout).is_file()
+    assert not cli_install.base_sync_lock_path(release_worktree).exists()
+    assert calls[0][0] == cli_source.reinstall_args(release_worktree)
+
+
 def test_reinstall_argv_is_the_verified_editable_force_reinstall(tmp_path):
     """The refresh runs the EXACT verified argv (Issue #152 contract,
     asserted against the real `uv tool install --help` in


### PR DESCRIPTION
<!-- orbi:run=bfa797cf -->

Fixes #462

Release 验证首跑必挂：版本 bump 先 push、CLI 刷新在后，installed-CLI 版本断言确定性失败 (run_id=bfa797cf)
