### PR TITLE
Bug：release 状态机硬编码 pyproject.toml——非 Python 仓库发布必炸（orbi-cloud v0.5.0 发布实测，#21 ai-blocked）

### DIFF
--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -168,7 +168,8 @@ DAG, no priority numbers, no separate queues:
 
   1. Strictly parse the `## Release` declaration from the Issue body:
      `version`, `base_branch`, `test_command`, `scope` (a list of `#N`
-     items). Missing, duplicated or unknown fields fail fast.
+     items), and optional `version_file` (`pyproject.toml` by default,
+     `package.json`, or `none`). Missing, duplicated or unknown fields fail fast.
   2. Freeze the base — the release commit is exactly
      `origin/<base_branch>` (fetched under the base-sync lock).
   3. Enforce the pre-release gates: no leftover open `ai-in-progress` /

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -143,8 +143,9 @@ PR 验收时校验该关键词，缺失即 fail fast。
   run id/worktree），按顺序执行这些步骤：
 
   1. 严格解析 Issue 正文的 `## Release` 声明：`version`、
-     `base_branch`、`test_command`、`scope`（`#N` 列表）。字段缺失、
-     重复或未知都 fail fast。
+     `base_branch`、`test_command`、`scope`（`#N` 列表），以及可选的
+     `version_file`（默认 `pyproject.toml`，也可为 `package.json` 或 `none`）。
+     字段缺失、重复或未知都 fail fast。
   2. 冻结 base——release commit 就是 `origin/<base_branch>`（在
      base-sync 锁下 fetch）。
   3. 执行发布前门禁：无遗留 open 的 `ai-in-progress` /

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -1726,6 +1726,8 @@ def parse_release_declaration(body: str) -> dict:
     branch the release commit is frozen from, `test_command` the
     shell command that must pass in a clean worktree at the release
     commit, and `scope` the Issue/PR numbers verified one by one.
+    Optional `version_file` selects `pyproject.toml` (the default),
+    `package.json`, or `none` to skip version metadata changes.
     Exactly one of `scope` / `scope_from_milestone` must be present:
     both (conflict) or neither fails fast. `scope_from_milestone` is
     the Milestone TITLE (no spaces); its scope is derived later by
@@ -1800,13 +1802,13 @@ def parse_release_declaration(body: str) -> dict:
                 scope_open = True
                 fields["scope"] = ""
             elif key in ("version", "base_branch", "test_command",
-                         "scope_from_milestone"):
+                         "scope_from_milestone", "version_file"):
                 fields[key] = value
             else:
                 raise ValueError(
                     f"release declaration has the unknown field {key!r} "
                     "(expected version, base_branch, test_command, "
-                    "scope or scope_from_milestone)"
+                    "scope, scope_from_milestone or version_file)"
                 )
         elif scope_open:
             raise ValueError(
@@ -1859,12 +1861,19 @@ def parse_release_declaration(body: str) -> dict:
                 "release declaration field `scope_from_milestone` must "
                 "not contain spaces"
             )
+    version_file = fields.get("version_file", "pyproject.toml")
+    if version_file not in ("pyproject.toml", "package.json", "none"):
+        raise ValueError(
+            "release declaration field `version_file` must be one of "
+            "`pyproject.toml`, `package.json` or `none`"
+        )
     return {
         "version": fields["version"],
         "base_branch": fields["base_branch"],
         "test_command": fields["test_command"],
         "scope": scope,
         "scope_from_milestone": fields.get("scope_from_milestone"),
+        "version_file": version_file,
     }
 
 
@@ -2374,14 +2383,14 @@ def release_test_evidence(exc: subprocess.CalledProcessError) -> str | None:
 
 
 def prepare_release_version(worktree: Path, tag: str,
-                            base_branch: str) -> str:
-    """Commit the tag's version into both runtime metadata sources.
+                            base_branch: str,
+                            version_file: str = "pyproject.toml") -> str:
+    """Commit the tag's version into the declared metadata source.
 
     The release tag is the public identity (for example ``v0.3.0``), while
-    Python package metadata omits the leading ``v``.  Both existing sources
-    must be structurally recognizable and agree before either is changed;
-    otherwise a release stops before creating a tag.  The commit is pushed
-    directly to the release base, matching the release docs-sync step.
+    metadata version fields omit the leading ``v``.  The selected source
+    must be structurally recognizable before it is changed; the commit is
+    pushed directly to the release base, matching the release docs-sync step.
     """
     match = re.fullmatch(r"v([0-9]+(?:\.[0-9]+)+)", tag)
     if match is None:
@@ -2389,7 +2398,41 @@ def prepare_release_version(worktree: Path, tag: str,
             f"release version {tag!r} must be a v-prefixed numeric tag"
         )
     version = match.group(1)
-    pyproject = worktree / "pyproject.toml"
+    if version_file not in ("pyproject.toml", "package.json", "none"):
+        raise ValueError(
+            "release version_file must be one of `pyproject.toml`, "
+            "`package.json` or `none`"
+        )
+    if version_file == "none":
+        return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
+    if version_file == "package.json":
+        package_json = worktree / version_file
+        try:
+            package_data = json.loads(package_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                "release version source package.json is not valid JSON"
+            ) from exc
+        if not isinstance(package_data, dict) or not isinstance(
+            package_data.get("version"), str
+        ) or not package_data["version"]:
+            raise RuntimeError(
+                "release version source package.json must contain a non-empty "
+                "version field"
+            )
+        package_data["version"] = version
+        package_json.write_text(
+            json.dumps(package_data, indent=2) + "\n", encoding="utf-8",
+        )
+        run_command(["git", "add", version_file], cwd=worktree)
+        run_command([
+            "git", "commit", "-m", f"chore: prepare release {tag}",
+        ], cwd=worktree)
+        run_command([
+            "git", "push", "origin", f"HEAD:refs/heads/{base_branch}",
+        ], cwd=worktree)
+        return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
+    pyproject = worktree / version_file
     init_file = worktree / "src" / "orbi" / "__init__.py"
     pyproject_text = pyproject.read_text(encoding="utf-8")
     init_text = init_file.read_text(encoding="utf-8")
@@ -2420,7 +2463,7 @@ def prepare_release_version(worktree: Path, tag: str,
         pyproject.write_text(updated_pyproject, encoding="utf-8")
         init_file.write_text(updated_init, encoding="utf-8")
         run_command([
-            "git", "add", "pyproject.toml", "src/orbi/__init__.py",
+            "git", "add", version_file, "src/orbi/__init__.py",
         ], cwd=worktree)
         run_command([
             "git", "commit", "-m", f"chore: prepare release {tag}",
@@ -3030,10 +3073,10 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        Issues + merged PRs; open items are surfaced as evidence, never
        released. Then verify the scope item by item
        (`verify_release_scope`).
-    Before step 5, prepare the release version in the clean worktree:
-       update both `pyproject.toml` and `src/orbi/__init__.py`, commit, and
-       push the new release commit to the base branch; mismatched sources
-       fail fast. The subsequent steps run against that commit.
+    Before step 5, prepare the release version in the clean worktree using
+       the declared `version_file` (`pyproject.toml` by default,
+       `package.json`, or `none`), commit and push when metadata changes.
+       The subsequent steps run against that commit.
     5. Run the declared test command in that release worktree
        (`timeout`-wrapped, Issue #95).
     6. Tag: the remote tag must not exist or must point EXACTLY at
@@ -3254,9 +3297,17 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         )
         # Version metadata is part of the release commit, not a post-release
         # fix: tests and the tag must identify the exact same commit.
-        release_commit = prepare_release_version(
-            worktree, declaration["version"], base_branch,
-        )
+        if declaration["version_file"] == "pyproject.toml":
+            # Keep the default invocation compatible with existing callers;
+            # the omitted field is the unchanged Python release path.
+            release_commit = prepare_release_version(
+                worktree, declaration["version"], base_branch,
+            )
+        else:
+            release_commit = prepare_release_version(
+                worktree, declaration["version"], base_branch,
+                declaration["version_file"],
+            )
         # Version preparation creates the commit that will be tagged. Re-run
         # the commit-specific gates so the recorded CI result and final
         # no-open-PR check cover that exact release commit, not the frozen

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2420,17 +2420,18 @@ def prepare_release_version(worktree: Path, tag: str,
                 "release version source package.json must contain a non-empty "
                 "version field"
             )
-        package_data["version"] = version
-        package_json.write_text(
-            json.dumps(package_data, indent=2) + "\n", encoding="utf-8",
-        )
-        run_command(["git", "add", version_file], cwd=worktree)
-        run_command([
-            "git", "commit", "-m", f"chore: prepare release {tag}",
-        ], cwd=worktree)
-        run_command([
-            "git", "push", "origin", f"HEAD:refs/heads/{base_branch}",
-        ], cwd=worktree)
+        if package_data["version"] != version:
+            package_data["version"] = version
+            package_json.write_text(
+                json.dumps(package_data, indent=2) + "\n", encoding="utf-8",
+            )
+            run_command(["git", "add", version_file], cwd=worktree)
+            run_command([
+                "git", "commit", "-m", f"chore: prepare release {tag}",
+            ], cwd=worktree)
+            run_command([
+                "git", "push", "origin", f"HEAD:refs/heads/{base_branch}",
+            ], cwd=worktree)
         return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
     pyproject = worktree / version_file
     init_file = worktree / "src" / "orbi" / "__init__.py"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13830,6 +13830,24 @@ def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
     ]
 
 
+def test_prepare_release_version_package_json_is_idempotent(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "package.json").write_text(
+        '{"name": "cloud", "version": "0.3.0"}\n', encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "head",
+    )
+
+    assert runner.prepare_release_version(
+        work, "v0.3.0", "main", "package.json",
+    ) == "head"
+    assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": work})]
+
+
 def test_prepare_release_version_rejects_invalid_version_file(tmp_path):
     with pytest.raises(ValueError, match="version_file"):
         runner.prepare_release_version(tmp_path, "v0.3.0", "main", "version.txt")

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -12819,7 +12819,30 @@ def test_parse_release_declaration_returns_all_fields():
         ),
         "scope": [123, 124],
         "scope_from_milestone": None,
+        "version_file": "pyproject.toml",
     }
+
+
+def test_parse_release_declaration_accepts_package_json_version_file():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: package.json\n",
+    )
+    assert runner.parse_release_declaration(body)["version_file"] == "package.json"
+
+
+def test_parse_release_declaration_accepts_none_version_file():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: none\n",
+    )
+    assert runner.parse_release_declaration(body)["version_file"] == "none"
+
+
+def test_parse_release_declaration_rejects_invalid_version_file():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: version.txt\n",
+    )
+    with pytest.raises(ValueError, match="version_file"):
+        runner.parse_release_declaration(body)
 
 
 def test_parse_release_declaration_requires_the_release_section():
@@ -12932,6 +12955,7 @@ def test_parse_release_declaration_scope_from_milestone():
         "test_command": "/usr/bin/python3 -m pytest tests/ -q",
         "scope": [],
         "scope_from_milestone": "v0.3.0",
+        "version_file": "pyproject.toml",
     }
 
 
@@ -13781,6 +13805,68 @@ def test_prepare_release_version_updates_sources_and_commits(tmp_path, monkeypat
     ]
 
 
+def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "package.json").write_text(
+        '{\n  "name": "cloud",\n  "version": "0.2.0"\n}\n', encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
+    )
+
+    assert runner.prepare_release_version(
+        work, "v0.3.0", "main", "package.json",
+    ) == "newsha"
+    assert '"version": "0.3.0"' in (work / "package.json").read_text()
+    assert calls == [
+        (["git", "add", "package.json"], {"cwd": work}),
+        (["git", "commit", "-m", "chore: prepare release v0.3.0"],
+         {"cwd": work}),
+        (["git", "push", "origin", "HEAD:refs/heads/main"], {"cwd": work}),
+        (["git", "rev-parse", "HEAD"], {"cwd": work}),
+    ]
+
+
+def test_prepare_release_version_rejects_invalid_version_file(tmp_path):
+    with pytest.raises(ValueError, match="version_file"):
+        runner.prepare_release_version(tmp_path, "v0.3.0", "main", "version.txt")
+
+
+def test_prepare_release_version_rejects_invalid_package_json(tmp_path):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "package.json").write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        runner.prepare_release_version(work, "v0.3.0", "main", "package.json")
+
+
+def test_prepare_release_version_rejects_package_without_version(tmp_path):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "package.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="version field"):
+        runner.prepare_release_version(work, "v0.3.0", "main", "package.json")
+
+
+def test_prepare_release_version_none_does_not_change_files(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    work.mkdir()
+    marker = work / "README.md"
+    marker.write_text("unchanged\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "head",
+    )
+
+    assert runner.prepare_release_version(work, "v0.3.0", "main", "none") == "head"
+    assert marker.read_text() == "unchanged\n"
+    assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": work})]
+
+
 def test_prepare_release_version_rejects_non_tag_version(tmp_path):
     with pytest.raises(ValueError, match="release version"):
         runner.prepare_release_version(tmp_path, "0.3.0", "main")
@@ -14260,6 +14346,22 @@ def test_process_release_wait_timeout_uses_persisted_wait_start(monkeypatch):
     )
     assert result == ""
     assert state["edits"][-1][1]["add"] == "ai-blocked"
+
+
+def test_process_release_uses_declared_package_version_file(monkeypatch):
+    state = make_release_process_env(monkeypatch)
+    seen = []
+    monkeypatch.setattr(
+        runner, "prepare_release_version",
+        lambda *args: seen.append(args) or "abc123",
+    )
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: package.json\n",
+    )
+    issue = {"number": 99, "title": "Release v0.3.0", "body": body,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    runner.process_release(issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r")
+    assert seen == [(Path("/wt"), "v0.3.0", "main", "package.json")]
 
 
 def test_process_release_success_end_to_end(monkeypatch):


### PR DESCRIPTION
<!-- orbi:run=f6e6febd -->

Fixes #466

Bug：release 状态机硬编码 pyproject.toml——非 Python 仓库发布必炸（orbi-cloud v0.5.0 发布实测，#21 ai-blocked） (run_id=f6e6febd)
