### PR TITLE
Enhancement: release 状态机 version_file 支持多生态版本载体（gradle/maven/go/rust/composer/pubspec）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -40,6 +40,7 @@ import tempfile
 import threading
 import time
 import tomllib
+import xml.etree.ElementTree as ET
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -1726,8 +1727,8 @@ def parse_release_declaration(body: str) -> dict:
     branch the release commit is frozen from, `test_command` the
     shell command that must pass in a clean worktree at the release
     commit, and `scope` the Issue/PR numbers verified one by one.
-    Optional `version_file` selects `pyproject.toml` (the default),
-    `package.json`, or `none` to skip version metadata changes.
+    Optional `version_file` selects a supported ecosystem metadata file
+    (the default is `pyproject.toml`) or `none` to skip version metadata changes.
     Exactly one of `scope` / `scope_from_milestone` must be present:
     both (conflict) or neither fails fast. `scope_from_milestone` is
     the Milestone TITLE (no spaces); its scope is derived later by
@@ -1862,10 +1863,13 @@ def parse_release_declaration(body: str) -> dict:
                 "not contain spaces"
             )
     version_file = fields.get("version_file", "pyproject.toml")
-    if version_file not in ("pyproject.toml", "package.json", "none"):
+    if version_file not in (
+        "pyproject.toml", "package.json", "pom.xml", "build.gradle",
+        "build.gradle.kts", "gradle.properties", "Cargo.toml",
+        "composer.json", "pubspec.yaml", "none",
+    ):
         raise ValueError(
-            "release declaration field `version_file` must be one of "
-            "`pyproject.toml`, `package.json` or `none`"
+            "release declaration field `version_file` is not supported"
         )
     return {
         "version": fields["version"],
@@ -2398,26 +2402,28 @@ def prepare_release_version(worktree: Path, tag: str,
             f"release version {tag!r} must be a v-prefixed numeric tag"
         )
     version = match.group(1)
-    if version_file not in ("pyproject.toml", "package.json", "none"):
-        raise ValueError(
-            "release version_file must be one of `pyproject.toml`, "
-            "`package.json` or `none`"
-        )
+    supported_files = {
+        "pyproject.toml", "package.json", "pom.xml", "build.gradle",
+        "build.gradle.kts", "gradle.properties", "Cargo.toml",
+        "composer.json", "pubspec.yaml", "none",
+    }
+    if version_file not in supported_files:
+        raise ValueError("release version_file is not supported")
     if version_file == "none":
         return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
-    if version_file == "package.json":
+    if version_file in ("package.json", "composer.json"):
         package_json = worktree / version_file
         try:
             package_data = json.loads(package_json.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(
-                "release version source package.json is not valid JSON"
+                f"release version source {version_file} is not valid JSON"
             ) from exc
         if not isinstance(package_data, dict) or not isinstance(
             package_data.get("version"), str
         ) or not package_data["version"]:
             raise RuntimeError(
-                "release version source package.json must contain a non-empty "
+                f"release version source {version_file} must contain a non-empty "
                 "version field"
             )
         if package_data["version"] != version:
@@ -2425,6 +2431,72 @@ def prepare_release_version(worktree: Path, tag: str,
             package_json.write_text(
                 json.dumps(package_data, indent=2) + "\n", encoding="utf-8",
             )
+            run_command(["git", "add", version_file], cwd=worktree)
+            run_command([
+                "git", "commit", "-m", f"chore: prepare release {tag}",
+            ], cwd=worktree)
+            run_command([
+                "git", "push", "origin", f"HEAD:refs/heads/{base_branch}",
+            ], cwd=worktree)
+        return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
+    if version_file not in ("pyproject.toml", "package.json", "composer.json"):
+        source = worktree / version_file
+        try:
+            text = source.read_text(encoding="utf-8")
+            if version_file == "pom.xml":
+                ET.fromstring(text)
+                matches = list(re.finditer(
+                    r"<version>\s*([^<\s]+)\s*</version>", text,
+                ))
+                parents = [m.span() for m in re.finditer(
+                    r"<parent\b.*?</parent>", text, re.DOTALL,
+                )]
+                matches = [m for m in matches if not any(
+                    start <= m.start() < end for start, end in parents
+                )]
+                pattern = matches[0] if len(matches) == 1 else None
+                replacement = rf"<version>{version}</version>"
+            elif version_file == "Cargo.toml":
+                data = tomllib.loads(text)
+                current = data.get("package", {}).get("version")
+                if not isinstance(current, str) or not current:
+                    raise ValueError("missing [package].version")
+                pattern = re.search(
+                    r"(?ms)^(\[package\][^\[]*?^version\s*=\s*)"
+                    r"([\"'])[^\n]+?\2\s*$",
+                    text,
+                )
+                replacement = None
+            elif version_file == "pubspec.yaml":
+                matches = list(re.finditer(
+                    r"(?m)^version\s*:\s*([^#\s]+)", text,
+                ))
+                pattern = matches[0] if len(matches) == 1 else None
+                replacement = f"version: {version}"
+            elif version_file == "gradle.properties":
+                matches = list(re.finditer(
+                    r"(?m)^version\s*=\s*([^#\s]+)", text,
+                ))
+                pattern = matches[0] if len(matches) == 1 else None
+                replacement = f"version={version}"
+            else:
+                matches = list(re.finditer(
+                    r"(?m)^[ \t]*version\s*=\s*(['\"])([^'\"]+)\1[ \t]*$",
+                    text,
+                ))
+                pattern = matches[0] if len(matches) == 1 else None
+                replacement = f"version = '" + version + "'"
+            if pattern is None:
+                raise ValueError("version declaration is not uniquely parseable")
+            if version_file == "Cargo.toml":
+                replacement = pattern.group(1) + f'"{version}"'
+            updated = text[:pattern.start()] + replacement + text[pattern.end():]
+        except (OSError, ET.ParseError, tomllib.TOMLDecodeError, ValueError) as exc:
+            raise RuntimeError(
+                f"release version source {version_file} has no parseable version"
+            ) from exc
+        if updated != text:
+            source.write_text(updated, encoding="utf-8")
             run_command(["git", "add", version_file], cwd=worktree)
             run_command([
                 "git", "commit", "-m", f"chore: prepare release {tag}",

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2454,7 +2454,11 @@ def prepare_release_version(worktree: Path, tag: str,
                 matches = [m for m in matches if not any(
                     start <= m.start() < end for start, end in parents
                 )]
-                pattern = matches[0] if len(matches) == 1 else None
+                # Maven projects normally contain additional dependency
+                # versions.  The declaration contract selects the first
+                # version outside the parent block, not a uniquely occurring
+                # version in the whole document.
+                pattern = matches[0] if matches else None
                 replacement = rf"<version>{version}</version>"
             elif version_file == "Cargo.toml":
                 data = tomllib.loads(text)
@@ -2481,11 +2485,17 @@ def prepare_release_version(worktree: Path, tag: str,
                 replacement = f"version={version}"
             else:
                 matches = list(re.finditer(
-                    r"(?m)^[ \t]*version\s*=\s*(['\"])([^'\"]+)\1[ \t]*$",
+                    r"(?m)^([ \t]*version\s*=\s*)(['\"])([^'\"]+)\2[ \t]*$",
                     text,
                 ))
                 pattern = matches[0] if len(matches) == 1 else None
-                replacement = f"version = '" + version + "'"
+                # Groovy accepts either quote style, while Kotlin DSL only
+                # accepts double quotes. Preserve the source syntax.
+                replacement = (
+                    pattern.group(1) + pattern.group(2) + version
+                    + pattern.group(2)
+                    if pattern is not None else ""
+                )
             if pattern is None:
                 raise ValueError("version declaration is not uniquely parseable")
             if version_file == "Cargo.toml":

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -12837,6 +12837,19 @@ def test_parse_release_declaration_accepts_none_version_file():
     assert runner.parse_release_declaration(body)["version_file"] == "none"
 
 
+@pytest.mark.parametrize(
+    "version_file",
+    ["pom.xml", "build.gradle", "build.gradle.kts", "gradle.properties",
+     "Cargo.toml", "composer.json", "pubspec.yaml"],
+)
+def test_parse_release_declaration_accepts_ecosystem_version_file(version_file):
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n",
+        f"- version: v0.3.0\n- version_file: {version_file}\n",
+    )
+    assert runner.parse_release_declaration(body)["version_file"] == version_file
+
+
 def test_parse_release_declaration_rejects_invalid_version_file():
     body = RELEASE_DECLARATION_BODY.replace(
         "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: version.txt\n",
@@ -13828,6 +13841,97 @@ def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
         (["git", "push", "origin", "HEAD:refs/heads/main"], {"cwd": work}),
         (["git", "rev-parse", "HEAD"], {"cwd": work}),
     ]
+
+
+@pytest.mark.parametrize(
+    ("version_file", "source", "expected"),
+    [
+        (
+            "pom.xml",
+            "<project><parent><version>9.9.9</version></parent>"
+            "<version>0.2.0</version></project>",
+            "<version>0.3.0</version>",
+        ),
+        ("build.gradle", "version = '0.2.0'\n", "version = '0.3.0'"),
+        ("build.gradle.kts", "version = '0.2.0'\n", "version = '0.3.0'"),
+        ("gradle.properties", "version=0.2.0\n", "version=0.3.0"),
+        (
+            "Cargo.toml",
+            "[package]\nname = \"demo\"\nversion = \"0.2.0\"\n",
+            'version = "0.3.0"',
+        ),
+        ("composer.json", '{"name":"demo","version":"0.2.0"}\n',
+         '"version": "0.3.0"'),
+        ("pubspec.yaml", "name: demo\nversion: 0.2.0\n", "version: 0.3.0"),
+    ],
+)
+def test_prepare_release_version_updates_ecosystem_file(
+    tmp_path, monkeypatch, version_file, source, expected,
+):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / version_file).write_text(source, encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
+    )
+
+    assert runner.prepare_release_version(
+        work, "v0.3.0", "main", version_file,
+    ) == "newsha"
+    updated = (work / version_file).read_text(encoding="utf-8")
+    assert expected in updated
+    if version_file == "Cargo.toml":
+        assert "[package]" in updated
+    assert calls[0] == (["git", "add", version_file], {"cwd": work})
+    assert calls[-1] == (["git", "rev-parse", "HEAD"], {"cwd": work})
+
+
+def test_prepare_release_version_ecosystem_file_is_idempotent(tmp_path, monkeypatch):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "gradle.properties").write_text("version=0.3.0\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "head",
+    )
+    assert runner.prepare_release_version(
+        work, "v0.3.0", "main", "gradle.properties",
+    ) == "head"
+    assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": work})]
+
+
+def test_prepare_release_version_rejects_unparseable_ecosystem_file(tmp_path):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "build.gradle").write_text("plugins {}\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="build.gradle"):
+        runner.prepare_release_version(work, "v0.3.0", "main", "build.gradle")
+
+
+def test_prepare_release_version_rejects_cargo_without_package_version(tmp_path):
+    work = tmp_path / "release"
+    work.mkdir()
+    (work / "Cargo.toml").write_text("[package]\nname = \"demo\"\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="Cargo.toml"):
+        runner.prepare_release_version(work, "v0.3.0", "main", "Cargo.toml")
+
+
+def test_prepare_release_version_none_does_not_require_a_file(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "head",
+    )
+    assert runner.prepare_release_version(tmp_path, "v0.3.0", "main", "none") == "head"
+    assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": tmp_path})]
+
+
+def test_prepare_release_version_rejects_unrecognized_file(tmp_path):
+    with pytest.raises(ValueError, match="version_file"):
+        runner.prepare_release_version(tmp_path, "v0.3.0", "main", "VERSION")
 
 
 def test_prepare_release_version_package_json_is_idempotent(tmp_path, monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13849,11 +13849,13 @@ def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
         (
             "pom.xml",
             "<project><parent><version>9.9.9</version></parent>"
-            "<version>0.2.0</version></project>",
+            "<version>0.2.0</version><dependencies>"
+            "<dependency><version>8.8.8</version></dependency>"
+            "</dependencies></project>",
             "<version>0.3.0</version>",
         ),
         ("build.gradle", "version = '0.2.0'\n", "version = '0.3.0'"),
-        ("build.gradle.kts", "version = '0.2.0'\n", "version = '0.3.0'"),
+        ("build.gradle.kts", "version = \"0.2.0\"\n", "version = \"0.3.0\""),
         ("gradle.properties", "version=0.2.0\n", "version=0.3.0"),
         (
             "Cargo.toml",


### PR DESCRIPTION
<!-- orbi:run=567091e5 -->

Fixes #468

Enhancement: release 状态机 version_file 支持多生态版本载体（gradle/maven/go/rust/composer/pubspec） (run_id=567091e5)
