### PR TITLE
CI failure: tests on branch main (push)

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -64,6 +64,7 @@ from orbi.pi_recovery import (
     clk_tck,
     find_idle_descendants,
     pid_alive,
+    process_ppid,
     process_start_monotonic,
     signal_pid,
     slots_idle,
@@ -4796,13 +4797,37 @@ def _pending_timeout_targets(targets: list[dict]) -> list[tuple[dict, float]]:
     hz = clk_tck()
     now_mono = time.monotonic()
     now = time.time()
+    starts = {
+        target["pid"]: process_start_monotonic(target["pid"], hz=hz)
+        for target in targets
+    }
+    durations = {
+        target["pid"]: timeout_duration(target["cmdline"] or "")
+        for target in targets
+    }
+    # coreutils timeout forks the actual tool. The child has no `timeout`
+    # token in its command line, but it is still governed by the wrapper's
+    # deadline and must not be mistaken for a hung tool.
+    wrapper_deadlines = {
+        pid: (start, durations[pid])
+        for pid, start in starts.items()
+        if start is not None and durations[pid] is not None
+    }
     pending: list[tuple[dict, float]] = []
     for target in targets:
-        start_mono = process_start_monotonic(target["pid"], hz=hz)
-        if start_mono is None:
-            continue
-        duration = timeout_duration(target["cmdline"] or "")
+        pid = target["pid"]
+        start_mono = starts[pid]
+        duration = durations[pid]
         if duration is None:
+            parent = process_ppid(pid)
+            if parent not in wrapper_deadlines:
+                continue
+            # The wrapper itself is the single wait record. Keeping the
+            # delegated child out of the result avoids duplicate evidence;
+            # the non-empty wrapper result also protects the child from
+            # escalation while its wrapper is inside the deadline.
+            continue
+        if start_mono is None:
             continue
         remaining = duration - (now_mono - start_mono)
         if remaining > 0:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7873,6 +7873,7 @@ def test_pending_timeout_targets_unit(tmp_path, monkeypatch):
         return now_mono - 9.0  # started 9 s ago, timeout 5 s (passed)
 
     monkeypatch.setattr(runner, "process_start_monotonic", fake_start)
+    monkeypatch.setattr(runner, "process_ppid", lambda pid: None)
     targets = [
         {"pid": 1, "cmdline": "timeout 5 pytest"},
         {"pid": 2, "cmdline": "timeout 5 pytest"},
@@ -7885,6 +7886,22 @@ def test_pending_timeout_targets_unit(tmp_path, monkeypatch):
     (target, deadline) = pending[0]
     assert target["pid"] == 2
     assert time.time() + 3.0 < deadline < time.time() + 5.0
+    # A child process delegated to the timeout wrapper inherits its
+    # wrapper's deadline, even though its own command line has no
+    # `timeout` token.
+    monkeypatch.setattr(
+        runner, "process_ppid", lambda pid: 10 if pid == 11 else None,
+    )
+    monkeypatch.setattr(
+        runner, "process_start_monotonic",
+        lambda pid, *, hz: now_mono - 1.0,
+    )
+    pending = runner._pending_timeout_targets([
+        {"pid": 10, "cmdline": "timeout 5 sleep 300"},
+        {"pid": 11, "cmdline": "sleep 300"},
+    ])
+    assert [target["pid"] for target, _ in pending] == [10]
+
     # An empty target list is a no-op.
     assert runner._pending_timeout_targets([]) == []
 


### PR DESCRIPTION
<!-- orbi:run=f1acb1ea -->

Fixes #471

CI failure: tests on branch main (push) (run_id=f1acb1ea)
