### PR TITLE
release 后置路径仍错误地从 Node source repo 查找 pyproject.toml

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3495,11 +3495,14 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             on_delivery_wait=on_delivery_wait,
         )
         # The release version changed the packaging inputs after the tick's
-        # preflight refresh. Install the release worktree before validating
-        # it, so installed-CLI assertions exercise the version being released
-        # on this first run rather than waiting for the next tick.
+        # preflight refresh. Refresh Orbi from its deployment checkout, not
+        # the published source worktree: a foreign release (for example a
+        # Node-only repo) is not required to carry Orbi's pyproject.toml.
+        # The fallback keeps direct callers with legacy hand-built configs
+        # compatible; load_config always supplies deploy_home.
+        deployment_home = config.get("deploy_home", config["repo_dir"])
         refresh_cli_install(
-            worktree, lock_repo_dir=config["repo_dir"],
+            deployment_home, lock_repo_dir=deployment_home,
             run_command=run_command,
         )
         try:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14580,31 +14580,48 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert state["run_ids"][0] == "a1b2c3d4"
 
 
-def test_process_release_refreshes_cli_before_release_tests(monkeypatch):
-    state = make_release_process_env(monkeypatch)
+def test_process_release_refreshes_deployment_cli_before_release_tests(
+    monkeypatch, tmp_path,
+):
+    """Issue #490: a foreign Node source worktree is not Orbi's install input."""
+    make_release_process_env(monkeypatch)
+    source = tmp_path / "node-source"
+    deployment = tmp_path / "orbi-deployment"
+    source.mkdir()
+    (source / "package.json").write_text("{}", encoding="utf-8")
+    deployment.mkdir()
+    (deployment / "pyproject.toml").write_text(
+        "[project]\nname = 'orbi'\n", encoding="utf-8",
+    )
     order = []
     monkeypatch.setattr(
         runner, "prepare_release_version",
         lambda worktree, tag, base_branch: order.append("version") or "abc123",
     )
 
-    def refresh(worktree, **kwargs):
+    def refresh(repo_dir, **kwargs):
         order.append("cli")
-        assert Path(worktree) == Path("/wt")
+        assert Path(repo_dir) == deployment
+        assert kwargs["lock_repo_dir"] == deployment
         assert kwargs["run_command"] is runner.run_command
         return "installed"
 
     monkeypatch.setattr(runner, "refresh_cli_install", refresh)
-    monkeypatch.setattr(
-        runner, "run_release_tests",
-        lambda worktree, command, timeout: order.append("tests"),
-    )
+    def run_tests(worktree, command, timeout):
+        order.append("tests")
+        assert Path(worktree) == Path("/wt")
+
+    monkeypatch.setattr(runner, "run_release_tests", run_tests)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
 
     assert runner.process_release(
-        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+        issue,
+        {"repo_dir": source,
+         "deploy_home": deployment,
+         "base_branch": "main"},
+        "o/r",
     ) == "https://github.com/o/r/releases/tag/v0.3.0"
     assert order == ["version", "cli", "tests"]
 


### PR DESCRIPTION
<!-- orbi:run=42511ecd -->

Fixes #490

release 后置路径仍错误地从 Node source repo 查找 pyproject.toml (run_id=42511ecd)
