### PR TITLE
resume PR 校验失败时 Runner 不应未处理退出进程

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -5963,7 +5963,8 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     if current_branch != branch:
         error_type = ResumeVerificationError if expected_url is not None else RuntimeError
         raise error_type(
-            f"resume PR validation: open_pr_count=unknown open_prs=[] "
+            f"resume PR validation: run_id={run_id} branch={branch} "
+            f"open_pr_count=unknown open_prs=[] "
             f"scene_pr={expected_url or '-'} scene_pr_state=unknown; "
             f"Pi changed branch: expected={branch} actual={current_branch}"
         )
@@ -6022,7 +6023,8 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
             except Exception:
                 LOGGER.exception("resume_scene_pr_state_lookup_failed")
             raise ResumeVerificationError(
-                f"resume PR validation: open_pr_count={len(prs)} "
+                f"resume PR validation: run_id={run_id} branch={branch} "
+                f"open_pr_count={len(prs)} "
                 f"open_prs={json.dumps(prs, sort_keys=True)} "
                 f"scene_pr={expected_url} scene_pr_state={scene_state}; "
                 "the scene PR is not uniquely open and must not be replaced"
@@ -6040,7 +6042,8 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
             )
             error_type = ResumeVerificationError if expected_url is not None else RuntimeError
             raise error_type(
-                f"resume PR validation: open_pr_count=1 open_prs={[url]} "
+                f"resume PR validation: run_id={run_id} branch={branch} "
+                f"open_pr_count=1 open_prs={[url]} "
                 f"scene_pr={expected_url or '-'} scene_pr_state=OPEN; "
                 f"PR head repo is {head_repo}, expected {pr_repo}; the "
                 "resume must keep the PR of the configured source repo"
@@ -6053,7 +6056,8 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
         )
         error_type = ResumeVerificationError if expected_url is not None else RuntimeError
         raise error_type(
-            f"resume PR validation: open_pr_count=1 open_prs={[url]} "
+            f"resume PR validation: run_id={run_id} branch={branch} "
+            f"open_pr_count=1 open_prs={[url]} "
             f"scene_pr={expected_url or '-'} scene_pr_state=OPEN; "
             f"PR base is {base_ref}, expected {base_branch}; recreate the "
             "PR against the configured base branch"
@@ -6127,9 +6131,10 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
             expected_url, url, branch,
         )
         raise ResumeVerificationError(
-            f"resume PR validation: open_pr_count=1 "
-            f"open_prs={[url]} scene_pr_state=OPEN; PR URL {url} "
-            f"is not the recovered original PR {expected_url}; the "
+            f"resume PR validation: run_id={run_id} branch={branch} "
+            f"open_pr_count=1 open_prs={[url]} scene_pr_state=OPEN; "
+            f"scene_pr={expected_url}; PR URL {url} is not the "
+            f"recovered original PR {expected_url}; the "
             "resume must keep the same PR number"
         )
     return url

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -345,6 +345,15 @@ class UnrecoverableDeliveryError(RuntimeError):
     """
 
 
+class ResumeVerificationError(UnrecoverableDeliveryError):
+    """A resume precondition was handled and reported for this tick.
+
+    The verification handler has already written the label and failure
+    evidence. Keeping a distinct type lets the tick boundary end normally
+    without swallowing unrelated Runner bugs.
+    """
+
+
 class PreExistingCIFailure(UnrecoverableDeliveryError):
     """A failed delivery check is already failing on the PR's base.
 
@@ -5952,7 +5961,10 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
         ["git", "branch", "--show-current"], cwd=worktree,
     )
     if current_branch != branch:
-        raise RuntimeError(
+        error_type = ResumeVerificationError if expected_url is not None else RuntimeError
+        raise error_type(
+            f"resume PR validation: open_pr_count=unknown open_prs=[] "
+            f"scene_pr={expected_url or '-'} scene_pr_state=unknown; "
             f"Pi changed branch: expected={branch} actual={current_branch}"
         )
     if require_latest_base:
@@ -5986,10 +5998,35 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
         "--json",
         "url,baseRefName,headRefName,headRefOid,"
         "headRepository,headRepositoryOwner,body",
-        "--limit", "2",
+        "--limit", "100" if expected_url is not None else "2",
     ], cwd=worktree)
     prs = json.loads(raw)
-    if not isinstance(prs, list) or len(prs) != 1:
+    if not isinstance(prs, list):
+        raise RuntimeError("expected exactly one open PR for the task branch")
+    if len(prs) != 1:
+        # A resume cannot safely select a replacement PR. Include the full
+        # query result in the exception: it is the audit record used by the
+        # resume failure transition (Issue #495).
+        if expected_url is not None:
+            scene_state = "unknown"
+            try:
+                scene_pr = run_command([
+                    "gh", "pr", "view", str(_pr_number(expected_url)),
+                    "--repo", pr_repo or "", "--json", "state,mergedAt",
+                ], cwd=worktree)
+                state = json.loads(scene_pr)
+                if isinstance(state, dict):
+                    scene_state = str(state.get("state", "unknown"))
+                    if state.get("mergedAt"):
+                        scene_state = "MERGED"
+            except Exception:
+                LOGGER.exception("resume_scene_pr_state_lookup_failed")
+            raise ResumeVerificationError(
+                f"resume PR validation: open_pr_count={len(prs)} "
+                f"open_prs={json.dumps(prs, sort_keys=True)} "
+                f"scene_pr={expected_url} scene_pr_state={scene_state}; "
+                "the scene PR is not uniquely open and must not be replaced"
+            )
         raise RuntimeError("expected exactly one open PR for the task branch")
     url = prs[0].get("url")
     if not url:
@@ -6001,7 +6038,10 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
                 "pr_repo_mismatch expected=%s actual=%s branch=%s",
                 pr_repo, head_repo, branch,
             )
-            raise RuntimeError(
+            error_type = ResumeVerificationError if expected_url is not None else RuntimeError
+            raise error_type(
+                f"resume PR validation: open_pr_count=1 open_prs={[url]} "
+                f"scene_pr={expected_url or '-'} scene_pr_state=OPEN; "
                 f"PR head repo is {head_repo}, expected {pr_repo}; the "
                 "resume must keep the PR of the configured source repo"
             )
@@ -6011,7 +6051,10 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
             "pr_base_mismatch expected=%s actual=%s branch=%s",
             base_branch, base_ref, branch,
         )
-        raise RuntimeError(
+        error_type = ResumeVerificationError if expected_url is not None else RuntimeError
+        raise error_type(
+            f"resume PR validation: open_pr_count=1 open_prs={[url]} "
+            f"scene_pr={expected_url or '-'} scene_pr_state=OPEN; "
             f"PR base is {base_ref}, expected {base_branch}; recreate the "
             "PR against the configured base branch"
         )
@@ -6083,9 +6126,11 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
             "pr_url_mismatch expected=%s actual=%s branch=%s",
             expected_url, url, branch,
         )
-        raise RuntimeError(
-            f"PR URL {url} is not the recovered original PR "
-            f"{expected_url}; the resume must keep the same PR number"
+        raise ResumeVerificationError(
+            f"resume PR validation: open_pr_count=1 "
+            f"open_prs={[url]} scene_pr_state=OPEN; PR URL {url} "
+            f"is not the recovered original PR {expected_url}; the "
+            "resume must keep the same PR number"
         )
     return url
 
@@ -6423,9 +6468,10 @@ def verify_resumed_pr(scene: dict, issue: dict, config: dict,
     config change) is terminal: the Issue is marked `ai-blocked` ALONE
     (the opened-PR state label is removed, and a leftover
     `ai-fix-needed` too) with the explicit reason why automatic
-    recovery is impossible. Either way the error is re-raised so the
-    tick stops — no review Pi is started, nothing is merged, and the
-    PR, branch and worktree stay intact.
+    recovery is impossible. The error is re-raised after reporting so
+    the tick boundary can distinguish this handled external scene from
+    an unhandled Runner bug; no review Pi is started, nothing is merged,
+    and the PR, branch and worktree stay intact.
     """
     number = int(issue["number"])
     run_id = scene["run_id"]
@@ -9541,7 +9587,19 @@ def main(argv: list[str] | None = None) -> int:
             # string, so a comment can never steer the runner into the
             # wrong PR (Issue #45). A mismatch is terminal: the Issue
             # is marked ai-blocked and the tick stops.
-            pr_url = verify_resumed_pr(scene, issue, config, source_repo)
+            try:
+                pr_url = verify_resumed_pr(
+                    scene, issue, config, source_repo,
+                )
+            except UnrecoverableDeliveryError as exc:
+                # Resume verification has already performed the audited
+                # label/comment transition. This is an expected external
+                # scene condition, not a failed Runner tick (Issue #495).
+                LOGGER.error(
+                    "resume_pr_handled issue=%s scene_pr=%s reason=%s",
+                    issue["number"], scene["pr_url"], exc,
+                )
+                return 0
         else:
             result = process_issue(issue, config, source_repo)
             # `process_issue` owns task dispatch and reports its outcome;

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1041,6 +1041,8 @@ def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
                                "mergedAt": "2024-01-01" if scene_state == "MERGED" else None})
         raise AssertionError(command)
 
+    with pytest.raises(AssertionError):
+        fake_run(["unexpected"])
     monkeypatch.setattr(runner, "run_command", fake_run)
     with pytest.raises(runner.ResumeVerificationError) as excinfo:
         runner.verify_pr(
@@ -1053,6 +1055,60 @@ def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
     assert "open_prs=" in message
     assert FAKE_PR_URL in message
     assert any(command[:3] == ["gh", "pr", "view"] for command in commands)
+
+
+def test_verify_pr_resume_keeps_unknown_state_for_non_object_scene_lookup(
+    monkeypatch, tmp_path,
+):
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return FAKE_BRANCH
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "head"
+        if command[:3] == ["gh", "pr", "list"]:
+            return "[]"
+        if command[:3] == ["gh", "pr", "view"]:
+            return "[]"
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
+        runner.verify_pr(
+            worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
+            repo_dir=tmp_path, pr_repo="owner/repo",
+            expected_url=FAKE_PR_URL, require_latest_base=False,
+        )
+
+
+def test_verify_pr_resume_keeps_failure_evidence_when_scene_lookup_fails(
+    monkeypatch, tmp_path, caplog,
+):
+    """A failed scene lookup is logged without replacing PR evidence."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return FAKE_BRANCH
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "head"
+        if command[:3] == ["gh", "pr", "list"]:
+            return "[]"
+        if command[:3] == ["gh", "pr", "view"]:
+            raise RuntimeError("lookup unavailable")
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
+        runner.verify_pr(
+            worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
+            repo_dir=tmp_path, pr_repo="owner/repo",
+            expected_url=FAKE_PR_URL, require_latest_base=False,
+        )
+    assert "resume_scene_pr_state_lookup_failed" in caplog.text
 
 
 def test_verify_resumed_pr_verifies_scene_pr_and_returns_verified_url(

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -943,6 +943,47 @@ def test_main_still_claims_new_issue_when_no_resumable(monkeypatch, tmp_path):
 # --------------------------- resume PR verification (Issue #89)
 
 
+def test_main_ends_cleanly_after_handled_resume_scene_failure(
+    monkeypatch, tmp_path,
+):
+    """Issue #495: an audited stale scene does not kill the Runner tick."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "prompt.md").write_text("prompt", encoding="utf-8")
+    (prompts / "prompt_review.md").write_text("review", encoding="utf-8")
+    config_path = tmp_path / "orbi.toml"
+    config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
+    issue = {"number": 9, "title": "ship", "body": ""}
+    released = []
+
+    monkeypatch.setattr(runner, "sync_active_milestone_variable", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "refresh_cli_install", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "check_transport", lambda *a, **k: {})
+    monkeypatch.setattr(runner.runner_health, "run_health_check", lambda *a, **k: None)
+    monkeypatch.setattr(runner, "acquire_slot", lambda *a, **k: type(
+        "Slot", (), {"release": lambda self: released.append(True)},
+    )())
+    monkeypatch.setattr(
+        runner, "pick_next_delivery",
+        lambda *a, **k: ("owner/repo", issue, make_resume_scene()),
+    )
+    monkeypatch.setattr(
+        runner, "verify_resumed_pr",
+        lambda *a, **k: (_ for _ in ()).throw(
+            runner.ResumeVerificationError(
+                "open_pr_count=0 open_prs=[] scene_pr=" + FAKE_PR_URL
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        runner, "wait_for_delivery",
+        lambda *a, **k: pytest.fail("stale resume must not enter delivery wait"),
+    )
+    assert runner.main(["--config", str(config_path)]) == 0
+    assert released == [True]
+
+
 def make_resume_config(tmp_path) -> dict:
     return {
         "repo_dir": tmp_path,
@@ -967,6 +1008,51 @@ def expected_resume_worktree(tmp_path) -> Path:
     return runner.worktree_path(
         tmp_path, "owner/repo", 9, FAKE_RUN_ID,
     )
+
+
+@pytest.mark.parametrize(
+    ("open_prs", "scene_state", "expected"),
+    [
+        ([], "CLOSED", "scene_pr_state=CLOSED"),
+        ([], "MERGED", "scene_pr_state=MERGED"),
+        ([{"url": "https://github.com/owner/repo/pull/10"},
+         {"url": "https://github.com/owner/repo/pull/11"}],
+         "OPEN", "open_pr_count=2"),
+    ],
+)
+def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
+    monkeypatch, tmp_path, open_prs, scene_state, expected,
+):
+    """Issue #495: resume never guesses among zero or multiple open PRs."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return FAKE_BRANCH
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "head"
+        if command[:3] == ["gh", "pr", "list"]:
+            return json.dumps(open_prs)
+        if command[:3] == ["gh", "pr", "view"]:
+            return json.dumps({"state": scene_state,
+                               "mergedAt": "2024-01-01" if scene_state == "MERGED" else None})
+        raise AssertionError(command)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(runner.ResumeVerificationError) as excinfo:
+        runner.verify_pr(
+            worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
+            repo_dir=tmp_path, pr_repo="owner/repo",
+            expected_url=FAKE_PR_URL, require_latest_base=False,
+        )
+    message = str(excinfo.value)
+    assert expected in message
+    assert "open_prs=" in message
+    assert FAKE_PR_URL in message
+    assert any(command[:3] == ["gh", "pr", "view"] for command in commands)
 
 
 def test_verify_resumed_pr_verifies_scene_pr_and_returns_verified_url(

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1072,8 +1072,10 @@ def test_verify_pr_resume_keeps_unknown_state_for_non_object_scene_lookup(
             return "[]"
         if command[:3] == ["gh", "pr", "view"]:
             return "[]"
-        return ""
+        raise AssertionError(command)
 
+    with pytest.raises(AssertionError):
+        fake_run(["unexpected"])
     monkeypatch.setattr(runner, "run_command", fake_run)
     with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
         runner.verify_pr(
@@ -1099,8 +1101,10 @@ def test_verify_pr_resume_keeps_failure_evidence_when_scene_lookup_fails(
             return "[]"
         if command[:3] == ["gh", "pr", "view"]:
             raise RuntimeError("lookup unavailable")
-        return ""
+        raise AssertionError(command)
 
+    with pytest.raises(AssertionError):
+        fake_run(["unexpected"])
     monkeypatch.setattr(runner, "run_command", fake_run)
     with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
         runner.verify_pr(


### PR DESCRIPTION
<!-- orbi:run=7422a8fe -->

Fixes #495

resume PR 校验失败时 Runner 不应未处理退出进程 (run_id=7422a8fe)
