### PR TITLE
P0：review 测试门禁改为以 PR CI 为准（CI-as-gate），取代 PR #511 的本地包装方案（关联 #500）

### DIFF
--- a/prompts/prompt_review.md
+++ b/prompts/prompt_review.md
@@ -102,34 +102,11 @@ real pytest output (the summary line), never a self-declared "tests
 passed": the Runner reads it for the progress comment and the `tests
 passed/failed` milestone, and it must stay consistent with CI.
 
-Issue #500: run the review test gate with explicit exit-code aggregation.
-Do not use `&&` to hide which gate failed, and do not run the gates through
-`tail`. Use this exact shape (with the repository's actual test command):
-
-```bash
-set +e
-: > .orbi/test.log
-timeout 1800 bash -c 'COVERAGE_FILE=.orbi/.coverage python3 -m coverage run --branch -m pytest tests/ -q' >> .orbi/test.log 2>&1
-test_exit=$?
-timeout 1800 bash -c 'COVERAGE_FILE=.orbi/.coverage python3 -m coverage report --show-missing' >> .orbi/test.log 2>&1
-report_exit=$?
-timeout 1800 bash -c 'COVERAGE_FILE=.orbi/.coverage python3 tools/coverage_gate.py .orbi/.coverage' >> .orbi/test.log 2>&1
-full_gate_exit=$?
-timeout 1800 bash -c 'COVERAGE_FILE=.orbi/.coverage python3 tools/diff_coverage_gate.py origin/main' >> .orbi/test.log 2>&1
-diff_gate_exit=$?
-final_exit=0
-for exit_code in "$test_exit" "$report_exit" "$full_gate_exit" "$diff_gate_exit"; do
-  if [ "$exit_code" -ne 0 ] && [ "$final_exit" -eq 0 ]; then final_exit="$exit_code"; fi
-done
-printf '\ntest_exit=%s report_exit=%s full_gate_exit=%s diff_gate_exit=%s final_exit=%s\n' "$test_exit" "$report_exit" "$full_gate_exit" "$diff_gate_exit" "$final_exit" >> .orbi/test.log
-exit "$final_exit"
-```
-
-The diff gate runs even when the full gate fails, preserves every command's
-complete output and makes any failed subcommand non-zero overall.
-If `final_exit` is non-zero, do not emit a passing review verdict or continue
-toward merge: fix the failure, or end with `findings` so the Runner enters its
-deterministic `ai-fix-needed` path and releases the slot after terminal failure.
+Local test commands in this ladder are advisory debugging only. The Runner
+accepts a clean review only after the PR's current-head GitHub Actions checks
+pass; do not invent or copy a repository-specific gate command into this
+shared prompt. Keep local test output in `.orbi/test.log` as evidence and
+preserve real exit codes: do not use `&&` to hide which command failed.
 
 1. CI first: when the PR has CI failures, read the CI failure logs
    BEFORE running any local test — `gh pr checks {{PR_NUMBER}}` (the

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -7139,6 +7139,67 @@ def _raise_if_preexisting_ci_failure(
         )
 
 
+def check_review_ci(repo: str, commit: str, *, wait_seconds: float) -> str:
+    """Gate a clean review on the PR head's current GitHub check runs.
+
+    Review-local tests are advisory; the repository's own CI is the only
+    acceptance gate. An absent check list is intentionally fail-open, matching
+    the release gate, while pending checks are polled with the shared release
+    wait configuration and cadence.
+    """
+    def fetch() -> list[dict]:
+        return json.loads(run_command([
+            "gh", "api", f"repos/{repo}/commits/{commit}/check-runs",
+            "--jq", ".check_runs",
+        ]))
+
+    waited = 0.0
+    check_runs = fetch()
+    while True:
+        pending = [
+            f"check '{check.get('name')}' is {check.get('status')}/"
+            f"{check.get('conclusion')}"
+            for check in check_runs if check.get("status") != "completed"
+        ]
+        if not pending:
+            break
+        detail = ", ".join(pending)
+        LOGGER.info(
+            "review_waiting_ci head=%s pending=%s waited=%ds limit=%ds",
+            commit, detail, int(waited), int(wait_seconds),
+        )
+        if waited >= wait_seconds:
+            raise RuntimeError(
+                f"review gate: waiting for CI on PR head {commit} timed out "
+                f"after {int(wait_seconds)}s (still pending: {detail})"
+            )
+        step = min(RELEASE_CI_POLL_INTERVAL, wait_seconds - waited)
+        time.sleep(step)
+        waited += step
+        check_runs = fetch()
+
+    failed = [
+        check for check in check_runs
+        if check.get("conclusion") not in ("success", "neutral", "skipped")
+    ]
+    if failed:
+        check = failed[0]
+        reference = check.get("html_url") or check.get("details_url") or "no run URL"
+        raise RuntimeError(
+            f"review gate: CI check '{check.get('name')}' failed on PR head "
+            f"{commit} ({reference})"
+        )
+    if not check_runs:
+        evidence = f"CI on review head {commit}: no check runs (nothing to gate)"
+    else:
+        evidence = (
+            f"CI on review head {commit}: {len(check_runs)} check(s) all "
+            "success/neutral/skipped"
+        )
+    LOGGER.info("%s", evidence)
+    return evidence
+
+
 def check_delivery_ci(repo: str, commit: str, *, wait_seconds: float,
                        base_commit: str | None = None) -> None:
     """Require delivery checks to pass, identifying failures inherited from base."""
@@ -8049,6 +8110,19 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
             current_labels=issue_labels(number, source_repo),
         )
 
+    try:
+        ci_evidence = check_review_ci(
+            source_repo, refrozen["head_oid"], wait_seconds=config.get(
+                "release_ci_wait_seconds", RELEASE_CI_WAIT_SECONDS,
+            ),
+        )
+        LOGGER.info(
+            "review_ci_gate_passed pr=%s head=%s evidence=%s",
+            refrozen["number"], refrozen["head_oid"], ci_evidence,
+        )
+    except RuntimeError as exc:
+        handle_gate_failure(str(exc), ci_failure=True)
+        return False
     try:
         merged = merge_gate(
             worktree,

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -1394,6 +1394,9 @@ def _run_review_and_merge(monkeypatch, tmp_path, *, verdict,
         "head_ref": "h", "head_oid": "h1",
     })
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: verdict)
+    # CI-as-gate is exercised in test_review_merge; keep this fixture focused
+    # on ProgressPublisher's bypass behavior.
+    monkeypatch.setattr(runner, "check_review_ci", lambda *a, **k: "ci ok")
     edits = []
     monkeypatch.setattr(
         runner, "edit_issue",

--- a/tests/test_prompt_contract.py
+++ b/tests/test_prompt_contract.py
@@ -30,10 +30,7 @@ review session, and the real pytest exit code as the only test result.
 The key wording is locked here so it cannot be silently deleted or
 weakened.
 """
-import os
 from pathlib import Path
-import re
-import subprocess
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROMPT = REPO_ROOT / "prompts" / "prompt.md"
@@ -50,75 +47,6 @@ def _text(path: Path) -> str:
 
 def _missing(text: str, items: tuple) -> list:
     return [name for name, needle in items if needle.lower() not in text]
-
-
-# --- Issue #500: review gate exit-code propagation ---------------------------
-
-REVIEW_GATE_ITEMS = (
-    ("gate-set-e", "set +e"),
-    ("gate-test-status", "test_exit=$?"),
-    ("gate-full-status", "full_gate_exit=$?"),
-    ("gate-diff-status", "diff_gate_exit=$?"),
-    ("gate-final-status", "final_exit"),
-    ("gate-diff-no-short-circuit", "diff gate runs even when the full gate fails"),
-    ("gate-log-append", ">> .orbi/test.log 2>&1"),
-    ("gate-log-status", "printf"),
-    ("gate-nonzero", "exit \"$final_exit\""),
-)
-
-
-def test_review_prompt_aggregates_all_gate_exit_codes():
-    missing = _missing(_text(PROMPT_REVIEW), REVIEW_GATE_ITEMS)
-    assert not missing, (
-        f"prompt_review.md is missing the Issue #500 gate contract: {missing}"
-    )
-
-
-def test_review_gate_returns_nonzero_for_each_failed_gate(tmp_path):
-    """Execute the prescribed wrapper, rather than only checking its prose."""
-    prompt = PROMPT_REVIEW.read_text(encoding="utf-8")
-    script = re.search(r"```bash\n(.*?)\n```", prompt, re.DOTALL).group(1)
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    (fake_bin / "timeout").write_text(
-        "#!/bin/sh\nshift\nexec \"$@\"\n", encoding="utf-8"
-    )
-    (fake_bin / "python3").write_text(
-        "#!/bin/sh\n"
-        "case \"$*\" in\n"
-        "  *'coverage run'*) gate=test;;\n"
-        "  *'coverage report'*) gate=report;;\n"
-        "  *'tools/coverage_gate.py'*) gate=full;;\n"
-        "  *'tools/diff_coverage_gate.py'*) gate=diff;;\n"
-        "esac\n"
-        "printf '%s output\\n' \"$gate\"\n"
-        "case \"$gate\" in\n"
-        "  test) status=${GATE_TEST_EXIT:-0};;\n"
-        "  report) status=${GATE_REPORT_EXIT:-0};;\n"
-        "  full) status=${GATE_FULL_EXIT:-0};;\n"
-        "  diff) status=${GATE_DIFF_EXIT:-0};;\n"
-        "esac\n"
-        "exit \"$status\"\n",
-        encoding="utf-8",
-    )
-    for executable in fake_bin.iterdir():
-        executable.chmod(0o755)
-    (tmp_path / ".orbi").mkdir()
-    expected = {
-        "success": (0, {}),
-        "full": (7, {"GATE_FULL_EXIT": "7"}),
-        "diff": (9, {"GATE_DIFF_EXIT": "9"}),
-    }
-    for name, (status, overrides) in expected.items():
-        env = {**os.environ, "PATH": f"{fake_bin}:/usr/bin:/bin", **overrides}
-        result = subprocess.run(
-            ["/usr/bin/bash", "-c", script], cwd=tmp_path, env=env,
-            capture_output=True, text=True,
-        )
-        assert result.returncode == status, name
-        log = (tmp_path / ".orbi/test.log").read_text(encoding="utf-8")
-        assert "test output" in log and "diff output" in log
-        assert f"final_exit={status}" in log
 
 
 # --- prompt.md (implementer) -------------------------------------------------

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -363,6 +363,85 @@ def test_merge_gate_rejects_failed_status_context(monkeypatch, tmp_path):
         )
 
 
+def test_review_ci_gate_passes_success_neutral_and_skipped(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append(command) or json.dumps([
+            {"name": "tests", "status": "completed", "conclusion": "success"},
+            {"name": "docs", "status": "completed", "conclusion": "neutral"},
+            {"name": "deploy", "status": "completed", "conclusion": "skipped"},
+        ]),
+    )
+    assert runner.check_review_ci("owner/repo", "head-green", wait_seconds=10) == (
+        "CI on review head head-green: 3 check(s) all success/neutral/skipped"
+    )
+    assert calls[0][2] == "repos/owner/repo/commits/head-green/check-runs"
+
+
+def test_review_ci_gate_fails_with_run_reference(monkeypatch):
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([{
+            "name": "tests", "status": "completed", "conclusion": "failure",
+            "html_url": "https://github.com/owner/repo/actions/runs/42",
+        }]),
+    )
+    with pytest.raises(RuntimeError, match="actions/runs/42"):
+        runner.check_review_ci("owner/repo", "head-red", wait_seconds=10)
+
+
+@pytest.mark.parametrize("reference", [
+    {"details_url": "https://github.com/owner/repo/actions/runs/43"},
+    {},
+])
+def test_review_ci_gate_reports_any_failure_reference(monkeypatch, reference):
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([{
+            "name": "tests", "status": "completed", "conclusion": "failure",
+            **reference,
+        }]),
+    )
+    with pytest.raises(RuntimeError) as error:
+        runner.check_review_ci("owner/repo", "head-red", wait_seconds=10)
+    assert (reference.get("details_url") or "no run URL") in str(error.value)
+
+
+def test_review_ci_gate_times_out_pending_checks(monkeypatch):
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps([{
+            "name": "tests", "status": "in_progress", "conclusion": None,
+        }]),
+    )
+    monkeypatch.setattr(runner, "time", Mock(sleep=Mock()))
+    with pytest.raises(RuntimeError, match="timed out"):
+        runner.check_review_ci("owner/repo", "head-pending", wait_seconds=0)
+
+
+def test_review_ci_gate_allows_no_checks_with_evidence(monkeypatch):
+    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "[]")
+    assert runner.check_review_ci("owner/repo", "head-none", wait_seconds=10) == (
+        "CI on review head head-none: no check runs (nothing to gate)"
+    )
+
+
+def test_review_ci_gate_polls_the_current_head(monkeypatch):
+    heads = iter([
+        [{"name": "tests", "status": "in_progress", "conclusion": None}],
+        [{"name": "tests", "status": "completed", "conclusion": "success"}],
+    ])
+    seen = []
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: seen.append(command) or json.dumps(next(heads)),
+    )
+    monkeypatch.setattr(runner.time, "sleep", lambda seconds: None)
+    runner.check_review_ci("owner/repo", "new-head", wait_seconds=30)
+    assert all(any("new-head" in item for item in command) for command in seen)
+
+
 def test_check_delivery_ci_distinguishes_pr_failure_from_base(
         monkeypatch):
     responses = {
@@ -1573,9 +1652,12 @@ def test_review_and_merge_ci_failure_labels_fix_needed(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
-        runner, "merge_gate",
+        runner, "check_review_ci",
         lambda *a, **k: (_ for _ in ()).throw(
-            RuntimeError("delivery gate: CI check 'tests' failed"),
+            RuntimeError(
+                "review gate: CI check 'tests' failed "
+                "(https://github.com/owner/repo/actions/runs/42)"
+            ),
         ),
     )
     monkeypatch.setattr(
@@ -1594,6 +1676,7 @@ def test_review_and_merge_ci_failure_labels_fix_needed(monkeypatch, tmp_path):
         "owner/repo", 4, title="Review task", priority="normal",
     ) is False
     assert "CI merge gate blocked" in calls[0][1]
+    assert "actions/runs/42" in calls[0][1]
     assert calls[2] == ("edit", {"repo": "owner/repo", "add": "ai-fix-needed",
                                  "remove": "ai-pr-opened"})
 


### PR DESCRIPTION
<!-- orbi:run=f3f0db93 -->

Fixes #513

P0：review 测试门禁改为以 PR CI 为准（CI-as-gate），取代 PR #511 的本地包装方案（关联 #500） (run_id=f3f0db93)
