### PR TITLE
可观测性：Orbi progress/blocked/failed 评论携带 runner 版本指纹，旧代码执行一眼可见

### DIFF
--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -18,18 +18,64 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
+from importlib import metadata
+from pathlib import Path
 from typing import Callable
 
 # One marker per run: hidden in the rendered comment, exact for lookup.
 RUN_ID_PATTERN = re.compile(r"[0-9a-f]{8}")
 RUN_MARKER_PATTERN = re.compile(r"<!-- orbi:run=([0-9a-f]{8}) -->")
 RUN_MARKER_TEMPLATE = "<!-- orbi:run={run_id} -->"
+RUNNER_MARKER_TEMPLATE = "<!-- runner={fingerprint} -->"
+_RUNNER_MARKER_PATTERN = re.compile(r"<!-- runner=[^>]+ -->")
 # Standalone milestone comments share this prefix so they are recognizable.
 MILESTONE_PREFIX = "Orbi:"
 # The live progress comment carries this header; together with the run
 # marker it identifies the run's progress comment among the run's other
 # marker-carrying comments (started Pi / opened PR scenes, milestones).
 PROGRESS_HEADER = "**Orbi progress**"
+
+
+def _checkout_root(path: Path) -> Path | None:
+    """Return the nearest checkout containing a Git marker."""
+    for parent in (path, *path.parents):
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def runner_fingerprint() -> str:
+    """Identify the code executing the Runner without fabricating a value.
+
+    An editable install points at a package inside its checkout, whose HEAD
+    is the useful deployment identity. A copied/non-editable package has no
+    checkout, so its distribution version is the only available identity.
+    Any probe failure is deliberately reported as ``unknown``.
+    """
+    try:
+        checkout = _checkout_root(Path(__file__).resolve().parent)
+        if checkout is not None:
+            result = subprocess.run(
+                ["git", "rev-parse", "--short=8", "HEAD"],
+                cwd=checkout, check=True, capture_output=True,
+                text=True, timeout=5,
+            )
+            fingerprint = result.stdout.strip()
+            if re.fullmatch(r"[0-9a-fA-F]{7,40}", fingerprint):
+                return fingerprint
+            return "unknown"
+        version = metadata.version("orbi")
+        return version if isinstance(version, str) and version else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _with_runner_marker(body: str) -> str:
+    """Append the runner identity as a hidden, machine-readable marker."""
+    body = _RUNNER_MARKER_PATTERN.sub("", body).rstrip()
+    marker = RUNNER_MARKER_TEMPLATE.format(fingerprint=runner_fingerprint())
+    return body + "\n\n" + marker
 
 
 def field_block(run_id: str, headline: str, fields: dict[str, object]) -> str:
@@ -39,7 +85,7 @@ def field_block(run_id: str, headline: str, fields: dict[str, object]) -> str:
         f"- {key}={value}" if key == "run_id"
         else f"- {key}: {value}" for key, value in fields.items()
     )
-    return "\n".join(lines)
+    return _with_runner_marker("\n".join(lines))
 
 
 def format_status_comment(body: str) -> str:
@@ -55,7 +101,7 @@ def format_status_comment(body: str) -> str:
         "Orbi release failed", "Orbi release waiting",
     )
     if not first.startswith(prefixes):
-        return (marker + "\n" + body) if marker else body
+        return _with_runner_marker((marker + "\n" + body) if marker else body)
     fields: dict[str, object] = {}
     for key, value in re.findall(r"([A-Za-z_][\w-]*)=([^\s)]+)", first):
         fields[key] = value
@@ -69,8 +115,11 @@ def format_status_comment(body: str) -> str:
         rendered = field_block(run_id, detail, fields)
         if remainder:
             rendered += "\n" + remainder
-        return (marker + "\n" + rendered.split("\n", 1)[1]) if marker else rendered
-    return (marker + "\n" + body) if marker else body
+        return _with_runner_marker(
+            (marker + "\n" + rendered.split("\n", 1)[1])
+            if marker else rendered
+        )
+    return _with_runner_marker((marker + "\n" + body) if marker else body)
 
 
 def validate_run_id(run_id: object) -> str:

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -37,7 +37,7 @@ import time
 from pathlib import Path
 
 from orbi.delivery_labels import READY_LABEL
-from orbi.progress import run_marker
+from orbi.progress import format_status_comment, run_marker
 from orbi.systemd_deploy import SERVICE_INSTANCES
 
 LOGGER = logging.getLogger("orbi.health")
@@ -480,7 +480,9 @@ def run_health_check(config: dict, *, run_command) -> list[str]:
             run_command([
                 "timeout", str(GH_TIMEOUT_SECONDS), "gh", "issue",
                 "comment", str(finding["issue"]), "--repo", finding["repo"],
-                "--body", repeat_failure_comment(finding),
+                "--body", format_status_comment(
+                    repeat_failure_comment(finding),
+                ),
             ])
             alerts.append(f"repeated_failure:{finding['repo']}#{finding['issue']}")
         # 3. Stale pickup: system stuck vs queue idle.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3520,7 +3520,8 @@ def test_comment_issue_runs_gh_comment(monkeypatch):
     runner.comment_issue(3, repo="xqliu/orbi-backlog", body="done")
     assert calls == [[
         "gh", "issue", "comment", "3", "--repo", "xqliu/orbi-backlog",
-        "--body", "done",
+        "--body", "done\n\n<!-- runner="
+        + progress.runner_fingerprint() + " -->",
     ]]
 
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -6,6 +6,7 @@ finds the same comment and keeps PATCHing it — no database. Milestones are
 short standalone comments so GitHub Mobile pushes a notification.
 """
 import json
+import subprocess
 
 import pytest
 
@@ -35,6 +36,77 @@ def test_run_marker_pattern_extracts_the_run_id():
     )
     assert match is not None
     assert match.group(1) == "abc12345"
+
+
+def test_runner_fingerprint_uses_editable_checkout_head(monkeypatch, tmp_path):
+    package = tmp_path / "checkout" / "src" / "orbi"
+    package.mkdir(parents=True)
+    (tmp_path / "checkout" / ".git").mkdir()
+    monkeypatch.setattr(progress, "__file__", str(package / "progress.py"))
+    monkeypatch.setattr(
+        progress.subprocess, "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, stdout="8a12fb1c\n", stderr="",
+        ),
+    )
+    assert progress.runner_fingerprint() == "8a12fb1c"
+
+
+def test_runner_fingerprint_uses_package_version_when_not_editable(
+    monkeypatch, tmp_path,
+):
+    package = tmp_path / "site-packages" / "orbi"
+    package.mkdir(parents=True)
+    monkeypatch.setattr(progress, "__file__", str(package / "progress.py"))
+    monkeypatch.setattr(progress.metadata, "version", lambda name: "0.3.4")
+    assert progress.runner_fingerprint() == "0.3.4"
+
+
+def test_runner_fingerprint_returns_unknown_for_invalid_git_output(
+    monkeypatch, tmp_path,
+):
+    package = tmp_path / "checkout" / "src" / "orbi"
+    package.mkdir(parents=True)
+    (tmp_path / "checkout" / ".git").mkdir()
+    monkeypatch.setattr(progress, "__file__", str(package / "progress.py"))
+    monkeypatch.setattr(
+        progress.subprocess, "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, stdout="not-a-sha\n", stderr="",
+        ),
+    )
+    assert progress.runner_fingerprint() == "unknown"
+
+
+def test_runner_fingerprint_returns_unknown_when_detection_fails(
+    monkeypatch, tmp_path,
+):
+    package = tmp_path / "checkout" / "src" / "orbi"
+    package.mkdir(parents=True)
+    (tmp_path / "checkout" / ".git").mkdir()
+    monkeypatch.setattr(progress, "__file__", str(package / "progress.py"))
+    monkeypatch.setattr(
+        progress.subprocess, "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(128, args[0]),
+        ),
+    )
+    assert progress.runner_fingerprint() == "unknown"
+
+
+def test_structured_comment_places_runner_marker_at_end(monkeypatch):
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
+    body = progress.field_block("abc12345", "Orbi: started", {"run_id": "abc12345"})
+    assert body.endswith("<!-- runner=8a12fb1c -->")
+    assert body.count("runner=") == 1
+
+
+def test_legacy_comment_places_runner_marker_at_end(monkeypatch):
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
+    body = progress.format_status_comment(
+        "<!-- orbi:run=abc12345 -->\nOrbi failed: boom (run_id=abc12345)",
+    )
+    assert body.endswith("<!-- runner=8a12fb1c -->")
 
 
 def test_run_marker_rejects_missing_or_invalid_run_id():
@@ -589,7 +661,8 @@ def test_publisher_milestone_posts_multiline_field_block():
             "body=<!-- orbi:run=abc12345 -->\n"
             "Orbi: tests passed\n"
             "- result: 156 passed in 4.43s\n"
-            "- run_id=abc12345",
+            "- run_id=abc12345\n"
+            "\n<!-- runner=0531f7da -->",
         ],
     ]
     assert publisher.comment_id is None

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+from orbi import progress
 from tests.test_progress_wiring import make_fake_gh
 
 
@@ -74,6 +75,8 @@ def test_parse_pr_comment_returns_scene_for_multiline_opened_pr_comment():
         "- base_branch: main",
         "- base_sha: abc123def456",
         f"- run_id={FAKE_RUN_ID}",
+        "",
+        f"<!-- runner={progress.runner_fingerprint()} -->",
     ]
 
 
@@ -104,7 +107,9 @@ def test_started_pi_comment_uses_multiline_field_block():
         f"- run_id={FAKE_RUN_ID}\n"
         "- priority: normal\n"
         f"- branch: {FAKE_BRANCH}\n"
-        f"- worktree: {FAKE_WORKTREE}"
+        f"- worktree: {FAKE_WORKTREE}\n"
+        "\n"
+        f"<!-- runner={progress.runner_fingerprint()} -->"
     )
 
 

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 import pytest
 
 import orbi.runner as runner
-from orbi import cli_install
+from orbi import cli_install, progress
 from tests.test_progress_wiring import make_fake_gh
 
 


### PR DESCRIPTION
<!-- orbi:run=7d9a98f7 -->

Fixes #526

可观测性：Orbi progress/blocked/failed 评论携带 runner 版本指纹，旧代码执行一眼可见 (run_id=7d9a98f7)
