### PR TITLE
可观测性：Orbi progress/blocked/failed 评论携带 runner 版本指纹，旧代码执行一眼可见

### DIFF
--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -237,7 +237,10 @@ def progress_body(state: dict) -> str:
     # pre-#94 body shape exactly.
     if state.get("recovery"):
         lines.append(f"- recovery: {state['recovery']}")
-    return "\n".join(lines)
+    # Issue #526: the progress comment (and the blocked / fix-needed
+    # scene it becomes) carries the runner fingerprint like every other
+    # Orbi comment.
+    return _with_runner_marker("\n".join(lines))
 
 
 class ProgressPublisher:

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -8306,10 +8306,15 @@ def review_and_merge_if_clean(worktree: Path, branch: str, base_branch: str,
 
 
 def comment_pr(number: int, *, repo: str, body: str) -> None:
-    """Comment on a PR in the configured source repository."""
+    """Comment on a PR in the configured source repository.
+
+    The same `format_status_comment` rendering as `comment_issue`: the
+    PR-side copy of a round / finding / blocked comment carries the run
+    marker and the runner fingerprint like its Issue twin (Issue #526).
+    """
     run_command([
         "gh", "pr", "comment", str(number), "--repo", repo,
-        "--body", body,
+        "--body", format_status_comment(body),
     ])
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -10386,6 +10386,7 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
     # The fake rejects anything that is not a pr/issue view or the
     # progress API.
     with pytest.raises(AssertionError, match="unexpected command"):
@@ -10437,8 +10438,10 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
     assert "branch=None" not in body
     assert "delivery_review_failed" in caplog.text
     # The failure comment is written to the Issue AND the PR
-    # (Issue #50).
-    assert pr_comments == [body]
+    # (Issue #50); the PR copy is the same formatted comment and
+    # additionally carries the hidden runner fingerprint (Issue #526).
+    assert pr_comments[0].startswith("<!-- orbi:run=a1b2c3d4 -->")
+    assert pr_comments[0].endswith("<!-- runner=8a12fb1c -->")
     # The recoverable failure posts the fix-needed milestone (Issue
     # #18) AND the tracked progress comment becomes the fix-needed
     # scene.

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -109,6 +109,53 @@ def test_legacy_comment_places_runner_marker_at_end(monkeypatch):
     assert body.endswith("<!-- runner=8a12fb1c -->")
 
 
+def test_progress_body_places_runner_marker_at_end(monkeypatch):
+    # The live progress comment (and the blocked / fix-needed scenes it
+    # becomes) is the run's main observability surface, so it carries the
+    # runner fingerprint like every other Orbi comment (Issue #526).
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
+    body = progress.progress_body({
+        "run_id": "abc12345",
+        "issue": 18,
+        "issue_title": "Publish progress",
+        "role": "implement",
+        "phase": "test",
+        "elapsed": "3m 12s",
+        "last_activity": None,
+        "last_action": None,
+        "tests": None,
+        "review_round": 0,
+        "branch": "b",
+        "pr": None,
+        "session": None,
+    })
+    assert body.endswith("\n\n<!-- runner=8a12fb1c -->")
+    assert body.count("runner=") == 1
+
+
+def test_comment_rendering_degrades_to_runner_unknown(monkeypatch):
+    # Issue #526 acceptance: when the fingerprint probe fails, every
+    # Orbi comment still renders — with `runner=unknown`, never a
+    # fabricated value, and never a publishing failure (Issue #79).
+    # The probe's own catch-all owns the degradation (runner_fingerprint
+    # returns ``unknown``), so the failure is injected one layer below.
+    def _raise(*args, **kwargs):
+        raise RuntimeError("git unavailable")
+    monkeypatch.setattr(progress.subprocess, "run", _raise)
+    for body in (
+        progress.progress_body({
+            "run_id": "abc12345", "issue": 18,
+            "issue_title": "Publish progress", "role": "implement",
+            "phase": "test", "elapsed": "1s", "last_activity": None,
+            "last_action": None, "tests": None, "review_round": 0,
+            "branch": "b", "pr": None, "session": None,
+        }),
+        progress.field_block("abc12345", "Orbi: tests passed", {}),
+        progress.format_status_comment("Orbi failed: boom"),
+    ):
+        assert body.endswith("<!-- runner=unknown -->")
+
+
 def test_run_marker_rejects_missing_or_invalid_run_id():
     for bad in ("", "run1", None):
         with pytest.raises(ValueError, match="invalid run id"):
@@ -423,10 +470,12 @@ def test_progress_body_shows_recovery_field_only_when_active():
     assert "- recovery" not in body
     body = progress.progress_body({**state, "recovery": "term"})
     assert "- recovery: term" in body
-    # The recovery line is the last line of the body.
-    assert body.splitlines()[-1] == "- recovery: term"
+    # The recovery line is the last field line; the hidden runner
+    # fingerprint marker (Issue #526) closes the body.
+    assert body.splitlines()[-3] == "- recovery: term"
+    assert body.splitlines()[-1].startswith("<!-- runner=")
     body = progress.progress_body({**state, "recovery": "kill"})
-    assert body.splitlines()[-1] == "- recovery: kill"
+    assert body.splitlines()[-3] == "- recovery: kill"
 
 
 def make_publisher(run_command=None, comments=None, posted=None,

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1210,6 +1210,9 @@ def make_resume_failure_fake(monkeypatch, *, progress_comments=None,
         progress_comments = []
     if labels is None:
         labels = ["ai-pr-opened"]
+    # The PR-side failure comment carries the hidden runner marker
+    # (Issue #526); pin the fingerprint for a deterministic assertion.
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
     captured = {"api": [], "edits": [], "comments": [], "pr_comments": []}
 
     def fake_run(command, **kwargs):
@@ -1442,9 +1445,12 @@ def test_verify_resumed_pr_backfill_label_api_failure_fails_fast(
     assert "Orbi needs a fix:" in body
     assert run_marker_body() in body
     assert "rate limited" in body
-    # ... written to the Issue AND the PR (Issue #50) ...
+    # ... written to the Issue AND the PR (Issue #50); the PR copy is
+    # the same formatted comment and additionally carries the hidden
+    # runner fingerprint (Issue #526) ...
     assert len(captured["pr_comments"]) == 1
-    assert captured["pr_comments"][0] == body
+    assert captured["pr_comments"][0].startswith(run_marker_body())
+    assert captured["pr_comments"][0].endswith("<!-- runner=8a12fb1c -->")
     # ... and the fix-needed milestone.
     posted = [
         command[command.index("--field") + 1][len("body="):]
@@ -1514,9 +1520,12 @@ def test_verify_resumed_pr_pr_url_mismatch_stays_fix_needed(
     assert "Orbi needs a fix:" in body
     assert run_marker_body() in body
     assert "not the recovered original PR" in body
-    # ... written to the Issue AND the PR (Issue #50) ...
+    # ... written to the Issue AND the PR (Issue #50); the PR copy is
+    # the same formatted comment and additionally carries the hidden
+    # runner fingerprint (Issue #526) ...
     assert len(captured["pr_comments"]) == 1
-    assert captured["pr_comments"][0] == body
+    assert captured["pr_comments"][0].startswith(run_marker_body())
+    assert captured["pr_comments"][0].endswith("<!-- runner=8a12fb1c -->")
     # ... and the fix-needed milestone.
     posted = [
         command[command.index("--field") + 1][len("body="):]

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 import pytest
 
 import orbi.runner as runner
-from orbi import cli_install
+from orbi import cli_install, progress
 from tests.test_progress_wiring import make_fake_gh
 
 
@@ -844,15 +844,27 @@ def test_comment_pr_runs_gh_pr_comment_from_unrelated_cwd(
 ):
     calls = []
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
     monkeypatch.setattr(
         runner, "run_command",
         lambda command, **kwargs: calls.append(command),
     )
-    runner.comment_pr(4, repo="owner/repo", body="round 1 findings")
-    assert calls == [[
-        "gh", "pr", "comment", "4", "--repo", "owner/repo",
-        "--body", "round 1 findings",
-    ]]
+    runner.comment_pr(
+        4, repo="owner/repo",
+        body=(
+            "<!-- orbi:run=abc12345 -->\n"
+            "Orbi review round 1 for PR #4: findings"
+        ),
+    )
+    assert calls[0][:7] == [
+        "gh", "pr", "comment", "4", "--repo", "owner/repo", "--body",
+    ]
+    body = calls[0][7]
+    # The PR-side copy of a round/finding comment carries the same
+    # markers as its Issue twin (Issue #526): run marker first, the
+    # hidden runner fingerprint last.
+    assert body.startswith("<!-- orbi:run=abc12345 -->\n")
+    assert body.endswith("<!-- runner=8a12fb1c -->")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- orbi:run=688aaaa2 -->

Fixes #526

可观测性：Orbi progress/blocked/failed 评论携带 runner 版本指纹，旧代码执行一眼可见 (run_id=688aaaa2)
