### PR TITLE
Runner Python exception：resume 校验对已关闭 PR 抛 expected exactly one open PR 并死循环重试

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -6289,9 +6289,9 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
     if not isinstance(prs, list):
         raise RuntimeError("expected exactly one open PR for the task branch")
     if len(prs) != 1:
-        # A resume cannot safely select a replacement PR. Include the full
-        # query result in the exception: it is the audit record used by the
-        # resume failure transition (Issue #495).
+        # A resume cannot safely select a replacement PR. Query the scene PR
+        # separately so zero open PRs (a closed/merged or missing scene PR)
+        # have a different outcome from an ambiguous branch (Issue #494).
         if expected_url is not None:
             scene_state = "unknown"
             try:
@@ -6306,14 +6306,44 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
                         scene_state = "MERGED"
             except Exception:
                 LOGGER.exception("resume_scene_pr_state_lookup_failed")
-            raise ResumeVerificationError(
-                f"resume PR validation: run_id={run_id} branch={branch} "
+            evidence = (
+                f"run_id={run_id} branch={branch} "
                 f"open_pr_count={len(prs)} "
                 f"open_prs={json.dumps(prs, sort_keys=True)} "
-                f"scene_pr={expected_url} scene_pr_state={scene_state}; "
-                "the scene PR is not uniquely open and must not be replaced"
+                f"scene_pr={expected_url} scene_pr_state={scene_state}"
             )
-        raise RuntimeError("expected exactly one open PR for the task branch")
+            if len(prs) == 0:
+                if scene_state in ("CLOSED", "MERGED"):
+                    LOGGER.error(
+                        "resume_pr_closed issue=%s branch=%s pr=%s state=%s",
+                        issue, branch, expected_url, scene_state,
+                    )
+                    raise UnrecoverableDeliveryError(
+                        f"resume PR is {scene_state.lower()} and cannot be "
+                        f"resumed or replaced: {evidence}; a human must "
+                        "decide whether to reopen or create a new delivery"
+                    )
+                LOGGER.error(
+                    "resume_pr_missing issue=%s branch=%s pr=%s state=%s",
+                    issue, branch, expected_url, scene_state,
+                )
+                raise ResumeVerificationError(
+                    f"resume PR is not open and was not found as closed or "
+                    f"merged: {evidence}; the scene must be repaired"
+                )
+            LOGGER.error(
+                "resume_pr_multiple_open issue=%s branch=%s count=%s",
+                issue, branch, len(prs),
+            )
+            raise ResumeVerificationError(
+                f"resume has multiple open PRs for the task branch: {evidence}; "
+                "the runner will not choose one"
+            )
+        if len(prs) == 0:
+            raise RuntimeError(
+                "no open PR for the task branch (expected exactly one open PR)"
+            )
+        raise RuntimeError("multiple open PRs for the task branch")
     url = prs[0].get("url")
     if not url:
         raise RuntimeError("open PR has no URL")

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -1642,6 +1642,7 @@ def run_command(command: list[str], *, cwd: Path | None = None,
 
 GIT_NETWORK_MAX_ATTEMPTS = 3
 GIT_NETWORK_TIMEOUT_SECONDS = 30
+RESUME_PR_STATE_TIMEOUT_SECONDS = 30
 GIT_NETWORK_BACKOFF_SECONDS = 1
 GIT_TRANSIENT_ERROR_MARKERS = (
     "connection timed out",
@@ -6298,7 +6299,7 @@ def verify_pr(worktree: Path, branch: str, base_branch: str,
                 scene_pr = run_command([
                     "gh", "pr", "view", str(_pr_number(expected_url)),
                     "--repo", pr_repo or "", "--json", "state,mergedAt",
-                ], cwd=worktree)
+                ], cwd=worktree, timeout=RESUME_PR_STATE_TIMEOUT_SECONDS)
                 state = json.loads(scene_pr)
                 if isinstance(state, dict):
                     scene_state = str(state.get("state", "unknown"))

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1062,6 +1062,29 @@ def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
     assert any(command[:3] == ["gh", "pr", "view"] for command in commands)
 
 
+def test_verify_pr_non_resume_rejects_multiple_open_prs(
+    monkeypatch, tmp_path,
+):
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return FAKE_BRANCH
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return "head"
+        if command[:3] == ["gh", "pr", "list"]:
+            return json.dumps([{"url": FAKE_PR_URL}, {"url": FAKE_PR_URL}])
+        raise AssertionError(command)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(RuntimeError, match="multiple open PRs"):
+        runner.verify_pr(
+            worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
+            repo_dir=tmp_path, require_latest_base=False,
+        )
+
+
 def test_verify_pr_resume_keeps_unknown_state_for_non_object_scene_lookup(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1077,6 +1077,8 @@ def test_verify_pr_non_resume_rejects_multiple_open_prs(
             return json.dumps([{"url": FAKE_PR_URL}, {"url": FAKE_PR_URL}])
         raise AssertionError(command)
 
+    with pytest.raises(AssertionError):
+        fake_run(["unexpected"])
     monkeypatch.setattr(runner, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="multiple open PRs"):
         runner.verify_pr(

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -1016,19 +1016,19 @@ def expected_resume_worktree(tmp_path) -> Path:
 
 
 @pytest.mark.parametrize(
-    ("open_prs", "scene_state", "expected"),
+    ("open_prs", "scene_state", "expected", "error_type"),
     [
-        ([], "CLOSED", "scene_pr_state=CLOSED"),
-        ([], "MERGED", "scene_pr_state=MERGED"),
+        ([], "CLOSED", "scene_pr_state=CLOSED", runner.UnrecoverableDeliveryError),
+        ([], "MERGED", "scene_pr_state=MERGED", runner.UnrecoverableDeliveryError),
         ([{"url": "https://github.com/owner/repo/pull/10"},
          {"url": "https://github.com/owner/repo/pull/11"}],
-         "OPEN", "open_pr_count=2"),
+         "OPEN", "open_pr_count=2", runner.ResumeVerificationError),
     ],
 )
 def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
-    monkeypatch, tmp_path, open_prs, scene_state, expected,
+    monkeypatch, tmp_path, open_prs, scene_state, expected, error_type,
 ):
-    """Issue #495: resume never guesses among zero or multiple open PRs."""
+    """Issue #494: resume classifies closed and ambiguous PR scenes."""
     worktree = tmp_path / "worktree"
     worktree.mkdir()
     commands = []
@@ -1049,7 +1049,7 @@ def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
     monkeypatch.setattr(runner, "run_command", fake_run)
-    with pytest.raises(runner.ResumeVerificationError) as excinfo:
+    with pytest.raises(error_type) as excinfo:
         runner.verify_pr(
             worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
             repo_dir=tmp_path, pr_repo="owner/repo",


### PR DESCRIPTION
<!-- orbi:run=d8dbc4ac -->

Fixes #494

Runner Python exception：resume 校验对已关闭 PR 抛 expected exactly one open PR 并死循环重试 (run_id=d8dbc4ac)
