### PR TITLE
开发契约：将用户视角的端到端验收内化到 Issue、Agent 和 Review 流程

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-outcome.md
+++ b/.github/ISSUE_TEMPLATE/user-outcome.md
@@ -1,0 +1,28 @@
+---
+name: User outcome
+about: Describe one user-visible outcome and its evidence
+title: ""
+labels: ""
+---
+
+## User outcome
+When [user/context], the user should [observable result].
+
+## Preconditions
+- User has [installation/configuration/provider/access prerequisite].
+- User runs: `[real command or interaction]`.
+
+## Acceptance
+### Success path
+- System action: [what the system actually does].
+- User sees: [specific result and where it appears].
+
+### Failure path
+- Trigger: [failure condition].
+- User sees: [specific error/journal/Issue/PR/UI evidence].
+- Repair action: [concrete fix the user can take].
+
+## Evidence
+- Real entry point: [CLI, setup, provider, concurrency scenario, UI, or public caller].
+- Test/log/journal/Issue/PR/UI evidence: [link or command and expected output].
+- Verification depth matches the impact; unit tests alone do not replace the user path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,11 @@ replace a real user path through the affected entry point. Evidence belongs in
 the test output, journal, Issue/PR, or UI as appropriate.
 
 Match verification depth to impact rather than running an unrelated full business
-journey: provider changes use a real provider/configuration check, concurrency
-changes use a contention scenario, setup changes use the install/setup entry
-point, UI changes use a real browser flow, and pure internal refactors use the
-existing public caller and regression tests. Both success and failure paths need
+journey: documentation changes use the rendered docs page/preview and link checks,
+provider changes use a real provider/configuration check, concurrency changes use
+contention, setup changes use the install/setup entry point, UI changes use a real
+browser flow, and pure internal refactors use the existing public caller and
+regression tests. Both success and failure paths need
 observable acceptance evidence. Do not add a database, queue, daemon, or state
 system merely to make an end-to-end claim.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,24 @@ each section points at the owning page instead of restating it.
 - Read the GitHub Issue (body and comments) first. Then, in priority order: the repository `AGENTS.md`, the files you will change plus their callers, and the related tests.
 - `README.md`, the configured context files, build files and history are read only when the task is actually about them — a normal Issue never requires a full repository scan, and re-reading the same large files triggers pointless compactions.
 
+## User-centered acceptance
+
+Every Issue and delivery describes one **User outcome**, its **Preconditions**, the
+**Acceptance** path, and the **Evidence** that a user can inspect. The acceptance
+follows the user journey: user command and configuration, the system action, the
+success result the user sees in the success path, and the failure path (the concrete error the user
+sees plus the repair action). Unit tests prove local logic only; they do not
+replace a real user path through the affected entry point. Evidence belongs in
+the test output, journal, Issue/PR, or UI as appropriate.
+
+Match verification depth to impact rather than running an unrelated full business
+journey: provider changes use a real provider/configuration check, concurrency
+changes use a contention scenario, setup changes use the install/setup entry
+point, UI changes use a real browser flow, and pure internal refactors use the
+existing public caller and regression tests. Both success and failure paths need
+observable acceptance evidence. Do not add a database, queue, daemon, or state
+system merely to make an end-to-end claim.
+
 ## TDD and coverage
 
 - TDD: write a failing test first, then the smallest implementation, then refactor.

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -56,6 +56,22 @@ reads the Issue, the repository's `AGENTS.md`, the files it will change
 plus their callers, and the related tests — the README and the rest of
 the repository only when the task is actually about them (Issue #180).
 
+## User-centered acceptance
+
+Use the same four sections for every new Issue: **User outcome** (what the user
+can accomplish), **Preconditions** (the configuration and command),
+**Acceptance** (the system action and the success result the user sees), and
+**Evidence** (a real entry point plus inspectable output). Include both a success
+path and a failure path: name the concrete error the user sees and the repair
+action. Unit tests are necessary local evidence, but do not replace the user
+path.
+
+Match depth to impact: provider changes need a real provider/configuration check;
+concurrency changes need contention; setup changes need the setup entry point; UI
+changes need a real browser flow; and pure internal refactors need the existing
+public caller and regression tests. Record evidence in tests, journal, Issue/PR,
+or UI without adding infrastructure just for E2E.
+
 ## Reporting a bug
 
 Open an Issue with the `bug` label and include:

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -66,7 +66,8 @@ path and a failure path: name the concrete error the user sees and the repair
 action. Unit tests are necessary local evidence, but do not replace the user
 path.
 
-Match depth to impact: provider changes need a real provider/configuration check;
+Match depth to impact: documentation changes need the rendered docs page/preview
+and link checks; provider changes need a real provider/configuration check;
 concurrency changes need contention; setup changes need the setup entry point; UI
 changes need a real browser flow; and pure internal refactors need the existing
 public caller and regression tests. Record evidence in tests, journal, Issue/PR,

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -48,6 +48,19 @@ gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 改任何东西之前会读 Issue、仓库的 `AGENTS.md`、要改的文件及其调用方和
 相关测试——README 和仓库其余部分只在任务确实相关时才读（Issue #180）。
 
+## 面向用户的验收（User-centered acceptance）
+
+每个新 Issue 使用同一组四个部分：**User outcome（用户结果）**、
+**Preconditions（前置条件）**、**Acceptance（验收）** 和 **Evidence（证据）**。
+写清用户执行的命令和配置、系统实际动作、用户看到的成功结果。必须同时
+写 success path 和 failure path：说明用户看到的具体错误以及 repair action
+（修复动作）。单元测试只是局部证据，不能替代真实用户路径。
+
+验收深度按影响面匹配：provider 变更做真实 provider/configuration 检查，
+concurrency 变更做竞争场景，setup 变更走 setup 入口，UI 变更走真实浏览器
+流程，纯内部 refactor 使用现有 public caller 和回归测试。证据记录在测试、
+journal、Issue/PR 或 UI 中，不为形式上的 E2E 增加基础设施。
+
 ## 报告 bug
 
 开一个带 `bug` 标签的 Issue，包含：

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -56,9 +56,10 @@ gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 写 success path 和 failure path：说明用户看到的具体错误以及 repair action
 （修复动作）。单元测试只是局部证据，不能替代真实用户路径。
 
-验收深度按影响面匹配：provider 变更做真实 provider/configuration 检查，
-concurrency 变更做竞争场景，setup 变更走 setup 入口，UI 变更走真实浏览器
-流程，纯内部 refactor 使用现有 public caller 和回归测试。证据记录在测试、
+验收深度按影响面匹配：文档变更检查渲染后的文档页面/预览和链接，provider
+变更做真实 provider/configuration 检查，concurrency 变更做竞争场景，setup
+变更走 setup 入口，UI 变更走真实浏览器流程，纯内部 refactor 使用现有
+public caller 和回归测试。证据记录在测试、
 journal、Issue/PR 或 UI 中，不为形式上的 E2E 增加基础设施。
 
 ## 报告 bug

--- a/prompts/prompt.md
+++ b/prompts/prompt.md
@@ -40,6 +40,17 @@ read only when the task is actually about them — a normal Issue never
 requires a full repository scan, and re-reading the same large files is
 what triggers the pointless compactions of long sessions.
 
+User-centered acceptance (Issue #173) is part of every delivery: before coding,
+define the User Journey with User outcome, Preconditions, Acceptance, and Evidence.
+Trace the real user command/configuration through the system action to the success
+result the user sees. Include a failure path with the concrete error the user sees
+and the repair action. Unit tests are local evidence, not a substitute for the
+real user path. Match depth to impact: provider/config changes use a real provider
+check, concurrency uses contention, setup uses the setup entry point, UI uses a
+real Playwright flow, and internal refactors verify the existing public caller.
+Record the applicable success and failure evidence in tests, journal, Issue/PR, or
+UI; do not invent a database, queue, daemon, or state system for this.
+
 This project is intentionally an MVP. Do not invent a task platform, database,
 queue framework, policy engine, risk model, multi-agent DAG, daemon loop, or fallback path.
 Use the existing GitHub Issue task pool and fail fast with useful logs.
@@ -132,7 +143,7 @@ Work through this exact loop:
 1. Read the GitHub Issue and inspect the relevant repository under the configured workspace root. The runner supplies the source repository and its context.
 2. Write `.orbi/plan.md` with the goal, inspected context, repository decision, tasks, and verification commands.
 3. Implement the smallest complete change.
-4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts.
+4. Add or update tests. For UI work, use Playwright against the real running application, assert the changed flow, check browser errors, and save screenshots under the run artifacts. Verify the defined User Journey at the matching real entry point; pytest alone is not completion evidence.
 5. Run the real project tests/build/smoke checks and record the commands and results in `.orbi/test.log` inside the task worktree (the automatic `tests passed/failed` milestone and the progress comment's tests field read that file).
 6. Verify the result yourself.
 7. Commit the change on the task branch. Your job ends at the committed delivery: you do not fetch the base, push, or create the PR. The Runner then completes the deterministic closeout (Issue #186): it re-fetches the base under the shared base-sync lock, absorbs a base advance with a plain merge, pushes the task branch, and opens exactly one PR for this Issue whose body contains the run marker and `Fixes #{{ISSUE_NUMBER}}` (it may be on the first line) so GitHub natively closes the source Issue when the PR merges into the default branch. After the PR is open, the Runner runs an independent review/fix loop and merges it itself; you do not review, fix, or merge.

--- a/prompts/prompt.md
+++ b/prompts/prompt.md
@@ -45,9 +45,10 @@ define the User Journey with User outcome, Preconditions, Acceptance, and Eviden
 Trace the real user command/configuration through the system action to the success
 result the user sees. Include a failure path with the concrete error the user sees
 and the repair action. Unit tests are local evidence, not a substitute for the
-real user path. Match depth to impact: provider/config changes use a real provider
-check, concurrency uses contention, setup uses the setup entry point, UI uses a
-real Playwright flow, and internal refactors verify the existing public caller.
+real user path. Match depth to impact: documentation changes use the rendered
+page/preview and link checks, provider/config changes use a real provider check,
+concurrency uses contention, setup uses the setup entry point, UI uses a real
+Playwright flow, and internal refactors verify the existing public caller.
 Record the applicable success and failure evidence in tests, journal, Issue/PR, or
 UI; do not invent a database, queue, daemon, or state system for this.
 

--- a/prompts/prompt_review.md
+++ b/prompts/prompt_review.md
@@ -38,8 +38,9 @@ Review the same User Journey as the implementer: User outcome, Preconditions,
 Acceptance, and Evidence. Confirm the real user path reaches the success result
 the user sees, and that the failure path names the concrete error and repair
 action. Pytest alone is not proof. Check verification depth against impact:
-provider/config, concurrency contention, setup entry point, real Playwright UI
-flow, or the existing public caller for an internal refactor. Require observable
+documentation rendered page/preview and link checks, provider/config,
+concurrency contention, setup entry point, real Playwright UI flow, or the
+existing public caller for an internal refactor. Require observable
 success and failure evidence in tests, journal, Issue/PR, or UI.
 
 ## Context recovery after compaction (Issue #180)

--- a/prompts/prompt_review.md
+++ b/prompts/prompt_review.md
@@ -32,6 +32,16 @@ task is actually about them — a normal Issue never requires a full
 repository scan, and re-reading the same large files is what triggers the
 pointless compactions of long sessions.
 
+## User-centered acceptance review (Issue #173)
+
+Review the same User Journey as the implementer: User outcome, Preconditions,
+Acceptance, and Evidence. Confirm the real user path reaches the success result
+the user sees, and that the failure path names the concrete error and repair
+action. Pytest alone is not proof. Check verification depth against impact:
+provider/config, concurrency contention, setup entry point, real Playwright UI
+flow, or the existing public caller for an internal refactor. Require observable
+success and failure evidence in tests, journal, Issue/PR, or UI.
+
 ## Context recovery after compaction (Issue #180)
 
 When the session context is compacted, recover from the run artifacts —

--- a/tests/test_user_acceptance_contract.py
+++ b/tests/test_user_acceptance_contract.py
@@ -1,0 +1,64 @@
+"""Contract tests for Issue #173's user-centered acceptance workflow."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENTS = ROOT / "AGENTS.md"
+PROMPT = ROOT / "prompts" / "prompt.md"
+REVIEW = ROOT / "prompts" / "prompt_review.md"
+TEMPLATE = ROOT / ".github" / "ISSUE_TEMPLATE" / "user-outcome.md"
+DOCS = (ROOT / "docs" / "contributing.mdx", ROOT / "docs" / "zh" / "contributing.mdx")
+
+
+REQUIRED_CONTRACT = (
+    "User-centered acceptance",
+    "User outcome",
+    "Preconditions",
+    "Acceptance",
+    "Evidence",
+    "success path",
+    "failure path",
+    "user sees",
+    "repair action",
+)
+
+
+def text(path: Path) -> str:
+    assert path.is_file(), f"missing contract file: {path}"
+    return path.read_text(encoding="utf-8").lower()
+
+
+def test_agents_defines_user_centered_acceptance_contract():
+    content = text(AGENTS)
+    missing = [item for item in REQUIRED_CONTRACT if item.lower() not in content]
+    assert not missing, f"AGENTS.md misses user acceptance rules: {missing}"
+
+
+def test_prompts_make_implementer_and_reviewer_follow_the_user_journey():
+    for path in (PROMPT, REVIEW):
+        content = text(path)
+        for item in ("user journey", "real user path", "evidence", "failure path"):
+            assert item in content, f"{path.name} misses {item!r}"
+    assert "define" in text(PROMPT)
+    assert "review the same" in text(REVIEW)
+
+
+def test_issue_template_has_the_unified_user_facing_shape():
+    content = text(TEMPLATE)
+    for heading in ("user outcome", "preconditions", "acceptance", "evidence"):
+        assert f"## {heading}" in content
+    for item in ("success", "failure", "repair"):
+        assert item in content
+
+
+def test_bilingual_guidance_has_matching_contract_and_impact_examples():
+    english, chinese = (text(path) for path in DOCS)
+    for content in (english, chinese):
+        for item in ("user outcome", "preconditions", "acceptance", "evidence"):
+            assert item in content
+        for item in ("provider", "concurrency", "setup", "ui", "refactor"):
+            assert item in content
+        assert "success" in content and "failure" in content
+    # The same impact categories must be present in both languages; this
+    # prevents the translated page from silently weakening the contract.
+    for item in ("provider", "concurrency", "setup", "ui", "refactor"):
+        assert item in english and item in chinese

--- a/tests/test_user_acceptance_contract.py
+++ b/tests/test_user_acceptance_contract.py
@@ -58,6 +58,7 @@ def test_bilingual_guidance_has_matching_contract_and_impact_examples():
         for item in ("provider", "concurrency", "setup", "ui", "refactor"):
             assert item in content
         assert "success" in content and "failure" in content
+    assert "documentation" in english and "文档" in chinese
     # The same impact categories must be present in both languages; this
     # prevents the translated page from silently weakening the contract.
     for item in ("provider", "concurrency", "setup", "ui", "refactor"):


### PR DESCRIPTION
<!-- orbi:run=5d52fe15 -->

Fixes #173

开发契约：将用户视角的端到端验收内化到 Issue、Agent 和 Review 流程 (run_id=5d52fe15)
