### PR TITLE
Bug：交付分支身份含 run_id 导致重复/滞留 PR 阻塞 release——分支改为按 issue 命名，claim 时接管已有交付

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4304,7 +4304,7 @@ def stable_branch_exists(repo_dir: Path, branch: str) -> bool:
     """Return whether the stable delivery branch exists on origin."""
     raw = run_command(
         ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
-        cwd=repo_dir,
+        cwd=repo_dir, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
     )
     return bool(raw.strip())
 
@@ -4315,7 +4315,7 @@ def open_pr_for_branch(repo_dir: Path, branch: str) -> dict | None:
         "gh", "pr", "list", "--state", "open", "--head", branch,
         "--json", "number,url,baseRefName,headRefName,headRefOid",
         "--limit", "2",
-    ], cwd=repo_dir)
+    ], cwd=repo_dir, timeout=RESUME_PR_STATE_TIMEOUT_SECONDS)
     prs = json.loads(raw) if raw.strip() else []
     if not isinstance(prs, list):
         raise RuntimeError("open PR query must return an array")
@@ -4856,7 +4856,9 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
     if existing_branch:
         # The branch is the delivery identity.  Fetch it, then create the
         # run-isolated worktree from its remote HEAD rather than the base.
-        run_command(["git", "fetch", "origin", branch], cwd=repo_dir)
+        run_git_network_command(
+            ["git", "fetch", "origin", branch], cwd=repo_dir,
+        )
         local = run_command(
             ["git", "branch", "--list", branch], cwd=repo_dir,
         )

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -9090,6 +9090,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
     # label, so re-claiming an issue always starts a fresh run.
     existing_worktree: Path | None = None
     takeover_pr: dict | None = None
+    stable_branch_present = False
     claim_labels = {
         label.get("name") for label in issue.get("labels", [])
         if isinstance(label, dict) and isinstance(label.get("name"), str)
@@ -9098,9 +9099,12 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
     if not in_progress and READY_LABEL in claim_labels:
         stable_branch = task_branch(source_repo, number)
         takeover_pr = open_pr_for_branch(config["repo_dir"], stable_branch)
+        stable_branch_present = stable_branch_exists(
+            config["repo_dir"], stable_branch,
+        )
         route = claim_route(
             claim_labels,
-            branch_exists=stable_branch_exists(config["repo_dir"], stable_branch),
+            branch_exists=stable_branch_present,
             open_pr=takeover_pr is not None,
         )
         LOGGER.info(
@@ -9206,7 +9210,10 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, base_sha,
             existing=existing_worktree,
-            existing_branch=takeover_pr is not None,
+            # A stable branch without an open PR is the interrupted push/
+            # create gap: continue from that branch rather than trying to
+            # create a second local branch with the same name.
+            existing_branch=stable_branch_present or takeover_pr is not None,
         )
         # Issue #219: the run state file is the same-run marker —
         # written for EVERY run (a fresh one included, so a later

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4273,10 +4273,57 @@ def freeze_base(repo_dir: Path, base_branch: str) -> str:
     )
 
 
-def task_branch(source_repo: str, number: int, run_id: str) -> str:
-    return (
-        f"orbi/{source_repo.replace('/', '-')}-issue-{number}-{run_id}"
+def task_branch(source_repo: str, number: int, run_id: str | None = None) -> str:
+    """Return the stable remote delivery identity for one Issue.
+
+    ``run_id`` remains accepted for callers and compatibility, but is not
+    part of the branch identity: retries must converge on one GitHub branch
+    and therefore one open PR.
+    """
+    return f"orbi/{source_repo.replace('/', '-')}-issue-{number}"
+
+
+def claim_route(labels: set[str], *, branch_exists: bool,
+                open_pr: bool) -> str:
+    """Choose the fresh-claim action from the physical GitHub scene.
+
+    This is deliberately pure: labels are the event and branch/PR existence
+    is the observed physical state.  The existing review loop handles the
+    returned ``review`` route.
+    """
+    if open_pr and READY_LABEL in labels:
+        return "review"
+    if open_pr and (PR_OPENED_LABEL in labels or FIX_NEEDED_LABEL in labels):
+        return "review"
+    # An existing branch without an open PR is resumed by implementation;
+    # a missing branch is the same implementation path.
+    return "implement"
+
+
+def stable_branch_exists(repo_dir: Path, branch: str) -> bool:
+    """Return whether the stable delivery branch exists on origin."""
+    raw = run_command(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        cwd=repo_dir,
     )
+    return bool(raw.strip())
+
+
+def open_pr_for_branch(repo_dir: Path, branch: str) -> dict | None:
+    """Return the sole open PR for a branch, or None when absent."""
+    raw = run_command([
+        "gh", "pr", "list", "--state", "open", "--head", branch,
+        "--json", "number,url,baseRefName,headRefName,headRefOid",
+        "--limit", "2",
+    ], cwd=repo_dir)
+    prs = json.loads(raw) if raw.strip() else []
+    if not isinstance(prs, list):
+        raise RuntimeError("open PR query must return an array")
+    if len(prs) > 1:
+        raise RuntimeError(
+            f"multiple open PRs for stable delivery branch {branch}"
+        )
+    return prs[0] if prs else None
 
 
 def _run_info_fields(run_info: str) -> dict[str, str]:
@@ -4789,7 +4836,8 @@ def worktree_path(repo_dir: Path, source_repo: str, number: int,
 
 def create_worktree(repo_dir: Path, source_repo: str, number: int,
                     run_id: str, base_sha: str,
-                    existing: Path | None = None) -> Path:
+                    existing: Path | None = None,
+                    existing_branch: bool = False) -> Path:
     """Create the task worktree from the frozen base SHA, never HEAD.
 
     An existing path is reused: only a resumed run (same run id after a
@@ -4805,9 +4853,26 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
     if path.exists():
         return path
     branch = task_branch(source_repo, number, run_id)
-    run_command([
-        "git", "worktree", "add", "-b", branch, str(path), base_sha,
-    ], cwd=repo_dir)
+    if existing_branch:
+        # The branch is the delivery identity.  Fetch it, then create the
+        # run-isolated worktree from its remote HEAD rather than the base.
+        run_command(["git", "fetch", "origin", branch], cwd=repo_dir)
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            run_command([
+                "git", "worktree", "add", "--force", str(path), branch,
+            ], cwd=repo_dir)
+        else:
+            run_command([
+                "git", "worktree", "add", "-b", branch, str(path),
+                f"origin/{branch}",
+            ], cwd=repo_dir)
+    else:
+        run_command([
+            "git", "worktree", "add", "-b", branch, str(path), base_sha,
+        ], cwd=repo_dir)
     return path
 
 
@@ -9024,7 +9089,28 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
     # Completed runs keep their worktrees as evidence but lose the
     # label, so re-claiming an issue always starts a fresh run.
     existing_worktree: Path | None = None
-    if has_in_progress_label(number, source_repo):
+    takeover_pr: dict | None = None
+    claim_labels = {
+        label.get("name") for label in issue.get("labels", [])
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+    in_progress = has_in_progress_label(number, source_repo)
+    if not in_progress and READY_LABEL in claim_labels:
+        stable_branch = task_branch(source_repo, number)
+        takeover_pr = open_pr_for_branch(config["repo_dir"], stable_branch)
+        route = claim_route(
+            claim_labels,
+            branch_exists=stable_branch_exists(config["repo_dir"], stable_branch),
+            open_pr=takeover_pr is not None,
+        )
+        LOGGER.info(
+            "fresh_claim_route issue=%s branch=%s route=%s open_pr=%s",
+            number, stable_branch, route, takeover_pr is not None,
+        )
+        if route == "review":
+            LOGGER.info("delivery_takeover issue=%s branch=%s pr=%s",
+                        number, stable_branch, takeover_pr.get("url"))
+    if in_progress:
         try:
             scene = worktree_resume_scene(
                 config["repo_dir"], source_repo, number,
@@ -9120,6 +9206,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
         worktree = create_worktree(
             config["repo_dir"], source_repo, number, run_id, base_sha,
             existing=existing_worktree,
+            existing_branch=takeover_pr is not None,
         )
         # Issue #219: the run state file is the same-run marker —
         # written for EVERY run (a fresh one included, so a later
@@ -9170,16 +9257,17 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
                 ),
             )),
         )
-        run_pi(
-            issue, worktree, config, source_repo, branch=branch,
-            resume_context=resume_ctx,
-            progress=LiveProgressThrottle(
-                publisher, issue=number, title=title, run_id=run_id,
-                role=ROLE_IMPLEMENT, branch=branch, worktree=worktree,
-                started=started, pr_url=None, review_round=0,
-                priority=priority,
-            ),
-        )
+        if takeover_pr is None:
+            run_pi(
+                issue, worktree, config, source_repo, branch=branch,
+                resume_context=resume_ctx,
+                progress=LiveProgressThrottle(
+                    publisher, issue=number, title=title, run_id=run_id,
+                    role=ROLE_IMPLEMENT, branch=branch, worktree=worktree,
+                    started=started, pr_url=None, review_round=0,
+                    priority=priority,
+                ),
+            )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_IMPLEMENT,
@@ -9194,10 +9282,12 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
         # freshness + absorb, plain push, PR creation, PR verification)
         # is the Runner's job — the agent stopped at the committed
         # delivery.
-        pr_url = deliver_pr(
-            worktree, branch, base_branch, base_sha, run_id,
-            issue=number, issue_title=title,
-            repo_dir=config["repo_dir"],
+        pr_url = (
+            takeover_pr["url"] if takeover_pr is not None else deliver_pr(
+                worktree, branch, base_branch, base_sha, run_id,
+                issue=number, issue_title=title,
+                repo_dir=config["repo_dir"],
+            )
         )
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,
@@ -9208,7 +9298,7 @@ def process_issue(issue: dict, config: dict, source_repo: str) -> IssueResult:
         # review session, which records its own round comments.)
         apply_label_patch(
             number, repo=source_repo, event=EVENT_PR_OPENED,
-            current_labels=(),
+            current_labels={IN_PROGRESS_LABEL},
         )
         pr_opened = True
         # The scene comment is NOT a bypass (Issue #79): the next

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2641,7 +2641,7 @@ def test_create_worktree_reuses_existing_remote_branch(monkeypatch, tmp_path):
         tmp_path, "owner/repo", 3, "run1", "base", existing_branch=True,
     ) == path
     assert calls == [
-        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path, "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS}),
         (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
         (["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "origin/orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
     ]

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2621,7 +2621,7 @@ def test_create_worktree_adds_branch_from_frozen_base_sha(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)))
     assert runner.create_worktree(tmp_path, "owner/repo", 3, "run1", "abc123def456") == path
     assert calls == [(
-        ["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3-run1", str(path), "abc123def456"],
+        ["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "abc123def456"],
         {"cwd": tmp_path},
     )]
 
@@ -3505,13 +3505,21 @@ def test_worktree_path_and_task_branch_differ_per_run_for_same_issue():
     first_path = runner.worktree_path(repo_dir, "owner/repo", 3, "run1")
     retry_path = runner.worktree_path(repo_dir, "owner/repo", 3, "run2")
     assert first_path != retry_path
-    assert runner.task_branch("owner/repo", 3, "run1") != runner.task_branch("owner/repo", 3, "run2")
-    assert runner.task_branch("owner/repo", 3, "run1") == "orbi/owner-repo-issue-3-run1"
+    assert runner.task_branch("owner/repo", 3, "run1") == "orbi/owner-repo-issue-3"
+    assert runner.task_branch("owner/repo", 3, "run2") == runner.task_branch("owner/repo", 3, "run1")
 
 
 def test_task_branch_includes_source_repo_to_avoid_same_number_collision():
-    assert runner.task_branch("owner/pilot", 1, "run1") == "orbi/owner-pilot-issue-1-run1"
+    assert runner.task_branch("owner/pilot", 1, "run1") == "orbi/owner-pilot-issue-1"
     assert runner.task_branch("owner/pilot", 1, "run1") != runner.task_branch("owner/ceo", 1, "run1")
+
+
+def test_claim_route_decision_table():
+    assert runner.claim_route({runner.READY_LABEL}, branch_exists=False, open_pr=False) == "implement"
+    assert runner.claim_route({runner.READY_LABEL}, branch_exists=True, open_pr=False) == "implement"
+    assert runner.claim_route({runner.READY_LABEL}, branch_exists=True, open_pr=True) == "review"
+    assert runner.claim_route({runner.PR_OPENED_LABEL}, branch_exists=True, open_pr=True) == "review"
+    assert runner.claim_route({runner.FIX_NEEDED_LABEL}, branch_exists=True, open_pr=True) == "review"
 
 
 def test_comment_issue_runs_gh_comment(monkeypatch):
@@ -4409,7 +4417,7 @@ def test_verify_pr_skips_latest_base_check_when_not_required(
 def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_path):
     calls = []
     gh_calls, posted = make_fake_gh(monkeypatch)
-    branch = "orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4"
+    branch = "orbi/xqliu-orbi-backlog-issue-4"
     head = "0123456789abcdef0123456789abcdef01234567"
 
     def fake_run(command, **kwargs):
@@ -4461,7 +4469,7 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
         if "**Orbi progress**" in body
     ]
     assert len(progress_posts) == 1
-    assert "- branch: orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4" in progress_posts[0]
+    assert "- branch: orbi/xqliu-orbi-backlog-issue-4" in progress_posts[0]
     # The PR URL is only known after verify_pr: the initial POST shows
     # `- PR: -`, the final delivery PATCH carries the URL.
     assert "- PR: -" in progress_posts[0]
@@ -4476,7 +4484,7 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
     assert "- base_branch: main" in start_body
     assert "- base_sha: abc123def456" in start_body
     assert "run_id=a1b2c3d4" in start_body
-    assert "- branch: orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4" in start_body
+    assert "- branch: orbi/xqliu-orbi-backlog-issue-4" in start_body
     assert "- worktree: " + str(tmp_path / "wt") in start_body
     assert "<!-- orbi:run=a1b2c3d4 -->" in start_body
     opened_body = scene_comments[1][-1]
@@ -5779,7 +5787,7 @@ def test_process_issue_failure_without_session_still_carries_scene(
     # No session file yet: the scene still carries the full debug entry
     # (worktree, branch) with '-' session fields.
     assert f"worktree={tmp_path / 'wt'}" in failure_body
-    assert "branch=orbi/xqliu-orbi-backlog-issue-8-a1b2c3d4" in failure_body
+    assert "branch=orbi/xqliu-orbi-backlog-issue-8" in failure_body
     assert "session=-" in failure_body
     assert "session_file=-" in failure_body
 
@@ -5878,7 +5886,7 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     assert "1 failed" in failure_body
     # The full scene on the failure comment carries the debug entry.
     assert f"worktree={tmp_path / 'wt'}" in failure_body
-    assert "branch=orbi/xqliu-orbi-backlog-issue-8-a1b2c3d4" in failure_body
+    assert "branch=orbi/xqliu-orbi-backlog-issue-8" in failure_body
 
 
 def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, caplog):
@@ -9870,7 +9878,7 @@ def test_wait_for_delivery_keeps_waiting_while_pr_open(
     assert len(reviews) == 2
     # The review ran on the derived worktree/branch of the same run.
     worktree, branch, base_branch, review_config, repo, number = reviews[0][0]
-    assert branch == "orbi/owner-repo-issue-39-a1b2c3d4"
+    assert branch == "orbi/owner-repo-issue-39"
     assert base_branch == "main"
     assert review_config["run_id"] == "a1b2c3d4"
     assert review_config["base_sha"] == "abc123def456"
@@ -10441,7 +10449,7 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
     assert "orbi-owner-repo-issue-39-a1b2c3d4" in body
     # The full scene carries the ACTUAL branch (derived before the
     # worktree check, Issue #50) — never a `branch=None` placeholder.
-    assert "branch=orbi/owner-repo-issue-39-a1b2c3d4" in body
+    assert "branch=orbi/owner-repo-issue-39" in body
     assert "branch=None" not in body
     assert "delivery_review_failed" in caplog.text
     # The failure comment is written to the Issue AND the PR
@@ -10627,7 +10635,7 @@ def test_wait_for_delivery_runs_review_when_fix_needed(
     # No fixer: the review ran on the derived worktree/branch of the
     # same run.
     worktree, branch, base_branch, review_config, repo, number = reviews[0][0]
-    assert branch == "orbi/owner-repo-issue-39-a1b2c3d4"
+    assert branch == "orbi/owner-repo-issue-39"
     assert base_branch == "main"
     assert review_config["run_id"] == "a1b2c3d4"
     assert review_config["base_sha"] == "abc123def456"
@@ -16598,7 +16606,7 @@ def test_process_release_publishes_the_release_role_progress_body(
     assert "<!-- orbi:run=a1b2c3d4 -->" in body
     assert "- role: release" in body
     assert "- priority: normal" in body
-    assert "- branch: orbi/o-r-issue-99-a1b2c3d4" in body
+    assert "- branch: orbi/o-r-issue-99" in body
 
 
 def test_process_release_fails_on_scope_item_that_is_neither(monkeypatch):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2626,6 +2626,27 @@ def test_create_worktree_adds_branch_from_frozen_base_sha(monkeypatch, tmp_path)
     )]
 
 
+def test_create_worktree_reuses_existing_remote_branch(monkeypatch, tmp_path):
+    path = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-run1"
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[:3] == ["git", "branch", "--list"]:
+            return ""
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.create_worktree(
+        tmp_path, "owner/repo", 3, "run1", "base", existing_branch=True,
+    ) == path
+    assert calls == [
+        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "origin/orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+    ]
+
+
 def test_latest_run_id_returns_none_without_task_worktrees(tmp_path):
     assert runner.latest_run_id(tmp_path, "owner/repo", 3) is None
     # Unrelated directories are not task worktrees.
@@ -2671,13 +2692,13 @@ def test_write_run_state_writes_the_run_identity(tmp_path):
     worktree.mkdir()
     runner.write_run_state(
         worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
-        branch="orbi/owner-repo-issue-3-a1b2c3d4",
+        branch="orbi/owner-repo-issue-3",
     )
     state = json.loads(runner.run_state_path(worktree).read_text())
     assert state["run_id"] == "a1b2c3d4"
     assert state["issue"] == 3
     assert state["repo"] == "owner/repo"
-    assert state["branch"] == "orbi/owner-repo-issue-3-a1b2c3d4"
+    assert state["branch"] == "orbi/owner-repo-issue-3"
     assert state["worktree"] == str(worktree)
     assert isinstance(state["created_at"], str) and state["created_at"]
 
@@ -2689,11 +2710,11 @@ def test_write_run_state_is_idempotent_for_a_resumed_run(tmp_path):
     worktree.mkdir()
     runner.write_run_state(
         worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
-        branch="orbi/owner-repo-issue-3-a1b2c3d4",
+        branch="orbi/owner-repo-issue-3",
     )
     runner.write_run_state(
         worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
-        branch="orbi/owner-repo-issue-3-a1b2c3d4",
+        branch="orbi/owner-repo-issue-3",
     )
     state = json.loads(runner.run_state_path(worktree).read_text())
     assert state["run_id"] == "a1b2c3d4"
@@ -2708,7 +2729,7 @@ def test_read_run_state_round_trips_the_written_state(tmp_path):
     worktree.mkdir()
     runner.write_run_state(
         worktree, run_id="a1b2c3d4", issue=3, source_repo="owner/repo",
-        branch="orbi/owner-repo-issue-3-a1b2c3d4",
+        branch="orbi/owner-repo-issue-3",
     )
     state = runner.read_run_state(worktree)
     assert state["run_id"] == "a1b2c3d4"
@@ -2852,7 +2873,7 @@ def test_resume_run_id_matches_by_issue_and_repo_name_across_a_rename(
     old.mkdir(parents=True)
     runner.write_run_state(
         old, run_id="aaaa1111", issue=42, source_repo="xqliu/orbi",
-        branch="orbi/xqliu-orbi-issue-42-aaaa1111",
+        branch="orbi/xqliu-orbi-issue-42",
     )
     assert runner.resume_run_id(
         tmp_path, "orbi-build/orbi", 42,
@@ -2987,7 +3008,7 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
     gh_calls, posted = make_fake_gh(
         monkeypatch, comments=[existing_comment], in_progress=True,
     )
-    branch = "orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4"
+    branch = "orbi/xqliu-orbi-backlog-issue-4"
     head = "0123456789abcdef0123456789abcdef01234567"
 
     def fake_run(command, **kwargs):
@@ -3075,7 +3096,7 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
     assert patches, "the existing progress comment was not updated"
     last_body = patches[-1][patches[-1].index("--field") + 1][len("body="):]
     assert "Orbi delivered" in last_body
-    assert "- branch: orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4" in last_body
+    assert "- branch: orbi/xqliu-orbi-backlog-issue-4" in last_body
 
 
 def test_process_issue_binds_run_id_before_the_resume_scan(
@@ -3087,7 +3108,7 @@ def test_process_issue_binds_run_id_before_the_resume_scan(
     which run before the resume decision (review round 3, PR #42)."""
     gh_calls, posted = make_fake_gh(monkeypatch, in_progress=True)
     head = "0123456789abcdef0123456789abcdef01234567"
-    branch = "orbi/xqliu-orbi-backlog-issue-4-a1b2c3d4"
+    branch = "orbi/xqliu-orbi-backlog-issue-4"
 
     def fake_run(command, **kwargs):
         gh_calls.append(command)
@@ -3172,7 +3193,7 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
             return json.dumps([{
                 "url": "https://github.com/orbi-build/orbi/pull/4",
                 "baseRefName": "main",
-                "headRefName": "orbi/xqliu-orbi-backlog-issue-4-ffffeeee",
+                "headRefName": "orbi/xqliu-orbi-backlog-issue-4",
                 "headRefOid": head,
                 "headRepository": {"name": "orbi"},
                 "headRepositoryOwner": {"login": "orbi-build"},
@@ -3182,7 +3203,7 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
                 ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
-            return "orbi/xqliu-orbi-backlog-issue-4-ffffeeee"
+            return "orbi/xqliu-orbi-backlog-issue-4"
         if command[:2] == ["git", "rev-parse"]:
             return head
         return ""
@@ -3239,7 +3260,7 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
             return json.dumps([{
                 "url": "https://github.com/orbi-build/orbi/pull/4",
                 "baseRefName": "main",
-                "headRefName": "orbi/xqliu-orbi-backlog-issue-4-ffffeeee",
+                "headRefName": "orbi/xqliu-orbi-backlog-issue-4",
                 "headRefOid": head,
                 "headRepository": {"name": "orbi"},
                 "headRepositoryOwner": {"login": "orbi-build"},
@@ -3249,7 +3270,7 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
                 ),
             }])
         if command[:3] == ["git", "branch", "--show-current"]:
-            return "orbi/xqliu-orbi-backlog-issue-4-ffffeeee"
+            return "orbi/xqliu-orbi-backlog-issue-4"
         if command[:2] == ["git", "rev-parse"]:
             return head
         return ""
@@ -3298,7 +3319,7 @@ def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
     # resumed one (label on + a worktree to resume) or the fresh one.
     run_id = ("a1b2c3d4"
               if in_progress and latest_run_id_result else "ffffeeee")
-    branch = f"orbi/xqliu-orbi-backlog-issue-4-{run_id}"
+    branch = f"orbi/xqliu-orbi-backlog-issue-4"
     comment_bodies = []
 
     def fake_run(command, **kwargs):
@@ -3564,7 +3585,7 @@ def test_run_pi_renders_base_sync_lock_into_prompt(monkeypatch, tmp_path):
     }
     runner.run_pi(
         issue, tmp_path, config, "owner/repo",
-        branch="orbi/owner-repo-issue-4-run1",
+        branch="orbi/owner-repo-issue-4",
     )
     command = calls[0]
     assert command[command.index("--system-prompt") + 1] == "SYSTEM " + str(
@@ -3598,7 +3619,7 @@ def test_run_pi_logs_provider_config_loaded_with_selection(
     with caplog.at_level("INFO"):
         runner.run_pi(
             issue, tmp_path, config, "owner/repo",
-            branch="orbi/owner-repo-issue-4-run1",
+            branch="orbi/owner-repo-issue-4",
         )
     lines = [line for line in caplog.text.splitlines()
              if " provider_config_loaded " in line]
@@ -3731,7 +3752,7 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
     }
     assert runner.run_pi(
         issue, tmp_path, config, "owner/repo",
-        branch="orbi/owner-repo-issue-4-run1",
+        branch="orbi/owner-repo-issue-4",
     ) == "done"
     command, kwargs = calls[0]
     assert command[:5] == ["pi", "--no-extensions", "--skill", "skill.md", "--print"]
@@ -3751,7 +3772,7 @@ def test_run_pi_injects_base_branch_sha_and_run_id_into_prompt(monkeypatch, tmp_
     assert kwargs["run_id"] == "run1"
     assert kwargs["issue"] == 4
     assert kwargs["source_repo"] == "owner/repo"
-    assert kwargs["branch"] == "orbi/owner-repo-issue-4-run1"
+    assert kwargs["branch"] == "orbi/owner-repo-issue-4"
     assert kwargs["log_command"][-2:] == ["<redacted>", "<issue-context-redacted>"]
 
 
@@ -3774,9 +3795,9 @@ def test_run_pi_passes_task_branch_to_stream_pi(monkeypatch, tmp_path):
     }
     runner.run_pi(
         issue, tmp_path, config, "owner/repo",
-        timeout=7, branch="orbi/owner-repo-issue-5-run1",
+        timeout=7, branch="orbi/owner-repo-issue-5",
     )
-    assert calls[0]["branch"] == "orbi/owner-repo-issue-5-run1"
+    assert calls[0]["branch"] == "orbi/owner-repo-issue-5"
     assert calls[0]["timeout"] == 7
 
 
@@ -3788,7 +3809,7 @@ def test_run_pi_redacts_prompt_and_issue_from_command_log(monkeypatch, tmp_path)
     runner.run_pi(
         {"number": 5, "title": "secret", "body": "token"}, tmp_path,
         {"prompt": prompt_path, "repo_dir": tmp_path, "source_repos": ["owner/repo"], "workspace_root": tmp_path, "context_files": [], "skills": [], "base_branch": "main", "base_sha": "abc123def456", "run_id": "run1"},
-        "owner/repo", branch="orbi/owner-repo-issue-5-run1",
+        "owner/repo", branch="orbi/owner-repo-issue-5",
     )
     command, kwargs = calls[0]
     assert "PRIVATE SYSTEM" in command[6]
@@ -3820,7 +3841,7 @@ def test_run_pi_keeps_the_fresh_context_without_a_resume_context(
     }
     runner.run_pi(
         {"number": 5, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-5-run1",
+        "owner/repo", branch="orbi/owner-repo-issue-5",
     )
     command = calls[0]
     assert command[-1] == (
@@ -3860,7 +3881,7 @@ def test_run_pi_appends_the_resume_context_to_the_context_argument(
     )
     runner.run_pi(
         {"number": 5, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-5-run1",
+        "owner/repo", branch="orbi/owner-repo-issue-5",
         resume_context=resume,
     )
     command = calls[0]
@@ -6007,7 +6028,7 @@ def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
         result = runner.stream_pi(
             command, cwd=tmp_path, poll_interval=0.1,
             run_id="deadbeef", issue=24, source_repo="xqliu/orbi",
-            branch="orbi/xqliu-orbi-issue-24-run1",
+            branch="orbi/xqliu-orbi-issue-24",
         )
     assert result == "final answer"
     # Without an explicit log_command the raw command is never logged.
@@ -6019,7 +6040,7 @@ def test_stream_pi_logs_run_start_once_with_full_scene(tmp_path, caplog):
     assert "run=deadbeef" in start
     assert "issue=xqliu/orbi#24" in start
     assert "role=implement" in start
-    assert "branch=orbi/xqliu-orbi-issue-24-run1" in start
+    assert "branch=orbi/xqliu-orbi-issue-24" in start
     assert f"worktree={tmp_path}" in start
     # The session fields are part of the scene; before Pi writes its first
     # record they are '-' (the full entry reappears on run_failed).
@@ -8786,7 +8807,7 @@ def test_run_pi_keeps_tdd_dev_and_code_review_drops_review_fix_loop(
     )
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     skills = _command_skills(calls[0])
     assert any("tdd-dev" in skill for skill in skills)
@@ -8835,7 +8856,7 @@ def test_run_pi_and_run_review_skill_lists_differ(monkeypatch, tmp_path):
     )
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     runner.run_review(
         tmp_path,
@@ -11111,7 +11132,7 @@ def test_run_pi_passes_configured_model_args(monkeypatch, tmp_path):
     )
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     command, kwargs = calls[0]
     assert _command_model_args(command) == [
@@ -11140,7 +11161,7 @@ def test_run_pi_passes_partial_model_args(monkeypatch, tmp_path):
     config = _model_config(tmp_path, pi_provider="openai")
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     command, kwargs = calls[0]
     assert _command_model_args(command) == [("--provider", "openai")]
@@ -11161,7 +11182,7 @@ def test_run_pi_omits_model_args_when_not_configured(monkeypatch, tmp_path):
     config = _model_config(tmp_path)
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     command, kwargs = calls[0]
     assert "--provider" not in command
@@ -12123,7 +12144,7 @@ def test_run_pi_materializes_provider_dir_and_env(monkeypatch, tmp_path):
     )
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     kwargs = calls[0]
     agent_dir = tmp_path / ".orbi" / "pi-agent"
@@ -12147,7 +12168,7 @@ def test_run_pi_without_providers_keeps_pre_157_env(monkeypatch, tmp_path):
     config = _model_config(tmp_path)
     runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     kwargs = calls[0]
     assert "pi_env" not in kwargs
@@ -12465,7 +12486,7 @@ def test_e2e_provider_endpoint_reaches_pi_process(monkeypatch, tmp_path):
     )
     result = runner.run_pi(
         {"number": 4, "title": "t", "body": "b"}, tmp_path, config,
-        "owner/repo", branch="orbi/owner-repo-issue-4-a1b2c3d4",
+        "owner/repo", branch="orbi/owner-repo-issue-4",
     )
     assert result == "https://api.groq.com/openai/v1"
 
@@ -12553,7 +12574,7 @@ def test_stop_handler_active_run_logs_stopping_then_stopped_and_exits(
     monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
     monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.set_active_run(
-        48, "Log the stop scene", "orbi/owner-repo-issue-48-a1b2c3d4",
+        48, "Log the stop scene", "orbi/owner-repo-issue-48",
         str(worktree),
     )
     child = subprocess.Popen(
@@ -12583,7 +12604,7 @@ def test_stop_handler_active_run_logs_stopping_then_stopped_and_exits(
     # No session file yet: the snapshot fields are '-' (never invented).
     assert "phase=-" in line
     assert "session=-" in line
-    assert "branch=orbi/owner-repo-issue-48-a1b2c3d4" in line
+    assert "branch=orbi/owner-repo-issue-48" in line
     assert f"worktree={worktree}" in line
     assert stopped[0].endswith("run_stopped issue=48 result=interrupted")
     # The live Pi child was shut down: no orphan survives the stop.
@@ -12764,7 +12785,7 @@ signal.signal(signal.SIGTERM, runner._handle_stop)
 runner.set_run_id("a1b2c3d4")
 runner.set_active_run(
     48, "Log the stop scene",
-    "orbi/owner-repo-issue-48-a1b2c3d4", {worktree!r},
+    "orbi/owner-repo-issue-48", {worktree!r},
 )
 # The real Pi-like child: a real long-running process (what stream_pi
 # tracks via set_active_pi). It lingers briefly on SIGTERM before
@@ -12871,7 +12892,7 @@ def test_real_subprocess_sigterm_logs_stop_scene_and_shuts_down_pi(
     # worktree's .pi-session.
     assert "phase=test" in line
     assert "session=sess-48" in line
-    assert "branch=orbi/owner-repo-issue-48-a1b2c3d4" in line
+    assert "branch=orbi/owner-repo-issue-48" in line
     assert f"worktree={worktree}" in line
     assert stopped[0].endswith("run_stopped issue=48 result=interrupted")
     # No orphan Pi: the stop handler waited for the child to exit

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3543,6 +3543,20 @@ def test_claim_route_decision_table():
     assert runner.claim_route({runner.FIX_NEEDED_LABEL}, branch_exists=True, open_pr=True) == "review"
 
 
+def test_open_pr_for_branch_rejects_malformed_and_ambiguous_results(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: "{}")
+    with pytest.raises(RuntimeError, match="must return an array"):
+        runner.open_pr_for_branch(tmp_path, "orbi/owner-repo-issue-3")
+
+    monkeypatch.setattr(
+        runner, "run_command", lambda *args, **kwargs: "[{}, {}]",
+    )
+    with pytest.raises(RuntimeError, match="multiple open PRs"):
+        runner.open_pr_for_branch(tmp_path, "orbi/owner-repo-issue-3")
+
+
 def test_comment_issue_runs_gh_comment(monkeypatch):
     calls = []
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append(command))

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -146,9 +146,10 @@ elif args[:2] == ["issue", "view"]:
 elif args[:2] == ["pr", "list"]:
     branch = args[args.index("--head") + 1]
     head = git("rev-parse", "HEAD")
-    # Branch shape: orbi-owner-repo-issue-<n>-<run_id>.
-    issue_num = branch.rsplit("-", 2)[1]
-    run_id = branch.rsplit("-", 1)[1]
+    # Stable delivery branch shape: orbi-owner-repo-issue-<n>.
+    issue_num = branch.split("-issue-", 1)[1]
+    with open(os.path.join(os.getcwd(), ".orbi", "run-state.json"), encoding="utf-8") as f:
+        run_id = json.load(f)["run_id"]
     print(json.dumps([{
         "number": 99,
         "url": "https://github.com/owner/repo/pull/99",
@@ -964,7 +965,7 @@ def _run_ref_hammer(
     worktree = clone / ".worktrees" / \
         "orbi-owner-repo-issue-9-01234567"
     git(clone, "worktree", "add", "-b",
-        "orbi/owner-repo-issue-9-01234567", str(worktree), "HEAD")
+        "orbi/owner-repo-issue-9", str(worktree), "HEAD")
     if base_sha is None:
         base_sha = git(clone, "rev-parse", "HEAD")
 
@@ -1011,7 +1012,7 @@ def _run_ref_hammer(
                     clone, "owner/repo", number, "01234567", base_sha,
                 )
                 runner.verify_pr(
-                    worktree, "orbi/owner-repo-issue-9-01234567",
+                    worktree, "orbi/owner-repo-issue-9",
                     "main", "01234567", repo_dir=clone, issue=9,
                     require_latest_base=False,
                 )

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -148,8 +148,15 @@ elif args[:2] == ["pr", "list"]:
     head = git("rev-parse", "HEAD")
     # Stable delivery branch shape: orbi-owner-repo-issue-<n>.
     issue_num = branch.split("-issue-", 1)[1]
-    with open(os.path.join(os.getcwd(), ".orbi", "run-state.json"), encoding="utf-8") as f:
-        run_id = json.load(f)["run_id"]
+    # Standalone verification may run before the delivery path writes its
+    # state file; normal delivery calls still provide their real run id.
+    state_path = os.path.join(os.getcwd(), ".orbi", "run-state.json")
+    try:
+        with open(state_path, encoding="utf-8") as f:
+            run_id = json.load(f)["run_id"]
+    except FileNotFoundError:
+        # The ref hammer supplies this fixed id to verify_pr.
+        run_id = "01234567"
     print(json.dumps([{
         "number": 99,
         "url": "https://github.com/owner/repo/pull/99",

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -21,7 +21,7 @@ PR_URL = "https://github.com/owner/repo/pull/46"
 RUN_ID = "a1b2c3d4"
 MARKER = f"<!-- orbi:run={RUN_ID} -->"
 WORKTREE = "/srv/repo/.worktrees/orbi-owner-repo-issue-39-a1b2c3d4"
-BRANCH = "orbi/owner-repo-issue-39-a1b2c3d4"
+BRANCH = "orbi/owner-repo-issue-39"
 
 
 @pytest.fixture(autouse=True)
@@ -616,7 +616,7 @@ def test_verify_resumed_pr_diverged_pr_head_stays_fix_needed(
     assert "Orbi needs a fix:" in body
     assert f"<!-- orbi:run={FAKE_RUN_ID} -->" in body
     assert FAKE_PR_URL in body
-    assert "orbi/owner-repo-issue-9-a1b2c3d4" in body
+    assert "orbi/owner-repo-issue-9" in body
     assert str(expected_resume_worktree(tmp_path)) in body
     assert "the branch diverged" in body
     # ... and the fix-needed milestone (not the blocked one).
@@ -648,7 +648,7 @@ def test_verify_resumed_pr_local_ahead_of_pr_head_continues_to_review(
 
     worktree = expected_resume_worktree(tmp_path)
     worktree.mkdir(parents=True)
-    branch = f"orbi/owner-repo-issue-9-{FAKE_RUN_ID}"
+    branch = f"orbi/owner-repo-issue-9"
     local_head = "18c78a2" * 5 + "18c78a2"
     pr_head = "ed72915" * 5 + "ed72915"
 

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -89,7 +89,7 @@ def test_task_created_from_latest_origin_base_when_main_worktree_on_side_branch(
     assert path.exists()
     # The worktree HEAD is the frozen origin/main, not the side-branch HEAD.
     assert git(path, "rev-parse", "HEAD") == origin_main
-    assert git(path, "branch", "--show-current") == "orbi/owner-repo-issue-3-run1"
+    assert git(path, "branch", "--show-current") == "orbi/owner-repo-issue-3"
 
 
 def test_retry_of_same_issue_gets_new_independent_run(clone):
@@ -106,7 +106,7 @@ def test_retry_of_same_issue_gets_new_independent_run(clone):
 
 def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
     # Delivery branch is based on the first commit only.
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3-a1b2c3d4",
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3",
         git(clone, "rev-parse", "origin/main~1"))
     commit_file(clone, "delivery.txt", "delivery")
     # Remote main advances after the delivery was created.
@@ -114,20 +114,20 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):
     commit_file(clone, "advance.txt", "main advanced")
     git(clone, "push", "origin", "main")
     # The delivery worktree stays on the task branch.
-    git(clone, "checkout", "orbi/owner-repo-issue-3-a1b2c3d4")
+    git(clone, "checkout", "orbi/owner-repo-issue-3")
 
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
         runner.verify_pr(
-            clone, "orbi/owner-repo-issue-3-a1b2c3d4", "main",
+            clone, "orbi/owner-repo-issue-3", "main",
             "a1b2c3d4", issue=3, repo_dir=clone,
         )
     assert "base_branch=main" in caplog.text
 
 
 def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monkeypatch):
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3-a1b2c3d4")
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3")
     commit_file(clone, "delivery.txt", "delivery")
     # Remote main is unchanged, so the delivery contains it.
     local_head = git(clone, "rev-parse", "HEAD")
@@ -144,7 +144,7 @@ def test_verify_pr_accepts_delivery_that_contains_latest_remote_base(clone, monk
         }]),
     )
     assert runner.verify_pr(
-        clone, "orbi/owner-repo-issue-3-a1b2c3d4", "main",
+        clone, "orbi/owner-repo-issue-3", "main",
         "a1b2c3d4", issue=3, repo_dir=clone,
     ) == "https://github.com/owner/repo/pull/3"
 
@@ -158,7 +158,7 @@ def test_verify_pr_passes_through_when_local_head_ahead_of_pr_head(
     the exact heads (local ahead of the PR head) and returns the PR URL
     so the next review session can push the task branch on the same
     PR (no replacement PR, no discarded commit, no force push)."""
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3-a1b2c3d4")
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-3")
     commit_file(clone, "delivery-a.txt", "commit A")
     pushed_head = git(clone, "rev-parse", "HEAD")
     commit_file(clone, "delivery-b.txt", "commit B")
@@ -178,7 +178,7 @@ def test_verify_pr_passes_through_when_local_head_ahead_of_pr_head(
     )
     with caplog.at_level("INFO"):
         url = runner.verify_pr(
-            clone, "orbi/owner-repo-issue-3-a1b2c3d4", "main",
+            clone, "orbi/owner-repo-issue-3", "main",
             "a1b2c3d4", issue=3, repo_dir=clone,
         )
     assert url == "https://github.com/owner/repo/pull/3"

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -92,16 +92,13 @@ def test_task_created_from_latest_origin_base_when_main_worktree_on_side_branch(
     assert git(path, "branch", "--show-current") == "orbi/owner-repo-issue-3"
 
 
-def test_retry_of_same_issue_gets_new_independent_run(clone):
-    base_sha = runner.freeze_base(clone, "main")
-    first = runner.create_worktree(clone, "owner/repo", 3, "run1", base_sha)
-    commit_file(first, "first-run.txt", "first run work")
-    second = runner.create_worktree(clone, "owner/repo", 3, "run2", base_sha)
-    assert second != first
-    assert git(second, "rev-parse", "HEAD") == base_sha
-    # The old scene is preserved untouched.
-    assert git(first, "rev-parse", "HEAD") != base_sha
-    assert (first / "first-run.txt").is_file()
+def test_retries_share_the_stable_delivery_branch(clone):
+    assert runner.task_branch("owner/repo", 3, "run1") == (
+        "orbi/owner-repo-issue-3"
+    )
+    assert runner.task_branch("owner/repo", 3, "run2") == (
+        "orbi/owner-repo-issue-3"
+    )
 
 
 def test_verify_pr_rejects_delivery_behind_latest_remote_base(clone, caplog):

--- a/tests/test_git_merge_smoke.py
+++ b/tests/test_git_merge_smoke.py
@@ -101,11 +101,11 @@ def install_fake_gh(monkeypatch, clone: Path, pr_json: str) -> list:
 
 
 def test_merge_gate_merges_head_containing_latest_base(clone, monkeypatch):
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4-run1")
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4")
     head_oid = commit_file(clone, "delivery.txt", "delivery")
     pr = {"number": 4, "url": "u", "base_ref": "main",
           "base_oid": git(clone, "rev-parse", "origin/main"),
-          "head_ref": "orbi/owner-repo-issue-4-run1",
+          "head_ref": "orbi/owner-repo-issue-4",
           "head_oid": head_oid}
     commands = install_fake_gh(monkeypatch, clone, make_pr(head_oid))
     merged = runner.merge_gate(clone, pr, "main", repo_dir=clone)
@@ -136,14 +136,14 @@ def test_merge_gate_merges_head_containing_latest_base(clone, monkeypatch):
 
 def test_merge_gate_rejects_head_behind_latest_base(clone, monkeypatch, caplog):
     # Delivery branch is based on the first commit only.
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4-run1",
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4",
         git(clone, "rev-parse", "origin/main~1"))
     head_oid = commit_file(clone, "delivery.txt", "delivery")
     # Remote main advances after the delivery was created.
     git(clone, "checkout", "main")
     commit_file(clone, "advance.txt", "main advanced")
     git(clone, "push", "origin", "main")
-    git(clone, "checkout", "orbi/owner-repo-issue-4-run1")
+    git(clone, "checkout", "orbi/owner-repo-issue-4")
 
     real_run = runner.run_command
     commands: list = []
@@ -157,7 +157,7 @@ def test_merge_gate_rejects_head_behind_latest_base(clone, monkeypatch, caplog):
     monkeypatch.setattr(runner, "run_command", fake_run)
     pr = {"number": 4, "url": "u", "base_ref": "main",
           "base_oid": git(clone, "rev-parse", "origin/main~1"),
-          "head_ref": "orbi/owner-repo-issue-4-run1",
+          "head_ref": "orbi/owner-repo-issue-4",
           "head_oid": head_oid}
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
@@ -194,11 +194,11 @@ def test_deployment_checkout_fast_forwards_after_independent_merge(
 
     # Delivery branch in the worktree clone; the fake `gh pr merge`
     # (the independent merge actor) lands the merge on origin/main.
-    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4-run1")
+    git(clone, "checkout", "-b", "orbi/owner-repo-issue-4")
     head_oid = commit_file(clone, "delivery.txt", "delivery")
     pr = {"number": 4, "url": "u", "base_ref": "main",
           "base_oid": git(clone, "rev-parse", "origin/main"),
-          "head_ref": "orbi/owner-repo-issue-4-run1",
+          "head_ref": "orbi/owner-repo-issue-4",
           "head_oid": head_oid}
     install_fake_gh(monkeypatch, clone, make_pr(head_oid))
     merged = runner.merge_gate(clone, pr, "main", repo_dir=clone)

--- a/tests/test_orbi_exporter.py
+++ b/tests/test_orbi_exporter.py
@@ -445,7 +445,7 @@ def test_build_metrics_labels_stay_within_allowlist():
     entries = [
         entry(100, "1",
               "INFO [eeee5555] run_start run=eeee5555 issue=xqliu/orbi#162 "
-              "role=implement branch=orbi/xqliu-orbi-issue-162-eeee5555 "
+              "role=implement branch=orbi/xqliu-orbi-issue-162 "
               "worktree=/home/x/w session=- session_file=- phase=starting "
               "last_activity=- action=- result=-"),
         entry(200, "1",

--- a/tests/test_pi_activity.py
+++ b/tests/test_pi_activity.py
@@ -920,12 +920,12 @@ def test_format_run_scene_is_the_full_scene_logged_once():
     scene = pi_activity.format_run_scene(
         snapshot, run_id="e07383c2",
         issue="xqliu/orbi#18", role="implement",
-        branch="orbi/xqliu-orbi-issue-18-e07383c2",
+        branch="orbi/xqliu-orbi-issue-18",
         worktree="/w",
     )
     assert scene == (
         "run=e07383c2 issue=xqliu/orbi#18 role=implement "
-        "branch=orbi/xqliu-orbi-issue-18-e07383c2 worktree=/w "
+        "branch=orbi/xqliu-orbi-issue-18 worktree=/w "
         "session=sess-1 session_file=/w/.pi-session/sess-1.jsonl phase=test "
         "last_activity=2026-01-01T00:00:02Z action=\"bash pytest tests/\" "
         "result=ok"
@@ -1037,14 +1037,14 @@ def test_parse_scene_round_trips_run_scene():
     scene = pi_activity.format_run_scene(
         snapshot, run_id="e07383c2",
         issue="xqliu/orbi#18", role="implement",
-        branch="orbi/xqliu-orbi-issue-18-e07383c2",
+        branch="orbi/xqliu-orbi-issue-18",
         worktree="/w",
     )
     fields = pi_activity.parse_scene(scene)
     assert fields["run"] == "e07383c2"
     assert fields["issue"] == "xqliu/orbi#18"
     assert fields["branch"] == (
-        "orbi/xqliu-orbi-issue-18-e07383c2"
+        "orbi/xqliu-orbi-issue-18"
     )
     assert fields["session_file"] == "/w/.pi-session/sess-1.jsonl"
     assert fields["action"] == "bash pytest tests/"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -353,7 +353,7 @@ def test_progress_body_starts_with_hidden_run_marker():
         "last_action": "bash pytest tests/",
         "tests": "156 passed",
         "review_round": 0,
-        "branch": "orbi/xqliu-orbi-issue-18-abc12345",
+        "branch": "orbi/xqliu-orbi-issue-18",
         "pr": None,
         "session": "sess-1",
     })
@@ -368,7 +368,7 @@ def test_progress_body_starts_with_hidden_run_marker():
     assert "- last action: bash pytest tests/" in body
     assert "- tests: 156 passed" in body
     assert "- review/fix round: 0" in body
-    assert "- branch: orbi/xqliu-orbi-issue-18-abc12345" in body
+    assert "- branch: orbi/xqliu-orbi-issue-18" in body
     assert "- PR: -" in body
     assert "- session: sess-1" in body
 

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -427,7 +427,7 @@ def test_process_issue_creates_progress_comment_with_marker(monkeypatch, tmp_pat
     # Issue #100: the issue line shows the number AND the title.
     assert "- issue: #18 Publish progress" in body
     assert "- role: implement" in body
-    assert "- branch: orbi/xqliu-orbi-issue-18-a1b2c3d4" in body
+    assert "- branch: orbi/xqliu-orbi-issue-18" in body
     assert "- PR: -" in body
 
 

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -368,7 +368,7 @@ def test_e2e_restart_continues_on_the_uncommitted_work(
     assert not worktree_for(clone, REPO, "b2c3d4e5").exists()
     assert git(
         worktree, "branch", "--show-current",
-    ) == f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-a1b2c3d4"
+    ) == f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
 
     # The new session RECEIVED the resume context (the existing work),
     # and the agent continued it: the committed work.txt carries BOTH
@@ -432,7 +432,7 @@ def test_e2e_repo_rename_finds_the_old_worktree_by_issue_and_name(
     # continues, never a second one.
     assert git(
         worktree, "branch", "--show-current",
-    ) == f"orbi/{RENAME_OLD.replace('/', '-')}-issue-{ISSUE_NUMBER}-a1b2c3d4"
+    ) == f"orbi/{RENAME_OLD.replace('/', '-')}-issue-{ISSUE_NUMBER}"
     # The continued work landed on the ORIGINAL branch.
     committed = git(worktree, "show", "HEAD:work.txt")
     assert committed == "part-1\npart-2"

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -320,7 +320,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
                     pr["merged_head"] = head
                     return ""
                 branch = command[command.index("--head") + 1]
-                run_id = branch.rsplit("-", 1)[1]
+                run_id = runner.current_run_id() or "a1b2c3d4"
                 head = real_run(
                     ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
                 )
@@ -452,7 +452,7 @@ def test_e2e_base_advances_and_review_fixes_the_same_pr_in_session(
     assert result.url == PR_URL
     run_id = runner.current_run_id()
     assert re.fullmatch(r"[0-9a-f]{8}", run_id)
-    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
     worktree = worktree_for(clone, run_id)
     assert worktree.is_dir()
     # The started Pi scene comment is posted first; the live progress
@@ -654,7 +654,7 @@ def test_e2e_pr_opened_without_fix_needed_never_starts_a_fixer(
             if "--head" not in command:
                 raise AssertionError(f"unexpected command: {command}")
             branch = command[command.index("--head") + 1]
-            run_id = branch.rsplit("-", 1)[1]
+            run_id = runner.current_run_id() or "a1b2c3d4"
             head = subprocess.run(
                 ["git", "rev-parse", "HEAD"], cwd=kwargs["cwd"],
                 capture_output=True, text=True, check=True,
@@ -793,7 +793,7 @@ def test_e2e_review_failure_keeps_pr_and_stays_fix_needed(
     result = runner.process_issue(issue(), config, REPO)
     assert result.url == PR_URL
     run_id = runner.current_run_id()
-    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
     worktree = worktree_for(clone, run_id)
 
     # The review session cannot finish (the Pi fails): the delivery

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -22,7 +22,7 @@ from tests.test_progress_wiring import make_fake_gh
 
 
 FAKE_RUN_ID = "a1b2c3d4"
-FAKE_BRANCH = f"orbi/owner-repo-issue-9-{FAKE_RUN_ID}"
+FAKE_BRANCH = f"orbi/owner-repo-issue-9"
 FAKE_WORKTREE = "/srv/repo/.worktrees/orbi-owner-repo-issue-9-a1b2c3d4"
 FAKE_PR_URL = "https://github.com/owner/repo/pull/9"
 

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -168,7 +168,7 @@ def _pr_json(number=4, base="main", base_oid="b1", head="h1"):
         "url": f"https://github.com/owner/repo/pull/{number}",
         "baseRefName": base,
         "baseRefOid": base_oid,
-        "headRefName": "orbi/owner-repo-issue-4-run1",
+        "headRefName": "orbi/owner-repo-issue-4",
         "headRefOid": head,
     }])
 
@@ -182,7 +182,7 @@ def test_freeze_pr_returns_frozen_base_and_head(monkeypatch, tmp_path):
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     pr = runner.freeze_pr(
-        tmp_path, "orbi/owner-repo-issue-4-run1", "main",
+        tmp_path, "orbi/owner-repo-issue-4", "main",
     )
     assert pr["number"] == 4
     assert pr["base_ref"] == "main"
@@ -191,7 +191,7 @@ def test_freeze_pr_returns_frozen_base_and_head(monkeypatch, tmp_path):
     assert pr["url"].endswith("/pull/4")
     assert calls == [[
         "gh", "pr", "list", "--state", "open", "--head",
-        "orbi/owner-repo-issue-4-run1",
+        "orbi/owner-repo-issue-4",
         "--json", "number,url,baseRefName,baseRefOid,headRefName,headRefOid",
         "--limit", "2",
     ]]
@@ -202,13 +202,13 @@ def test_freeze_pr_rejects_wrong_base(monkeypatch, tmp_path):
         runner, "run_command", lambda command, **kwargs: _pr_json(base="develop"),
     )
     with pytest.raises(RuntimeError, match="PR base is develop, expected main"):
-        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4-run1", "main")
+        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
 
 def test_freeze_pr_rejects_no_open_pr(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4-run1", "main")
+        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
 
 def test_freeze_pr_rejects_multiple_open_prs(monkeypatch, tmp_path):
@@ -220,7 +220,7 @@ def test_freeze_pr_rejects_multiple_open_prs(monkeypatch, tmp_path):
     ])
     monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: two)
     with pytest.raises(RuntimeError, match="exactly one open PR"):
-        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4-run1", "main")
+        runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +253,7 @@ def test_run_review_launches_independent_readonly_pi_session(monkeypatch, tmp_pa
     pr = {"number": 4, "url": "u", "base_ref": "main", "base_oid": "b1",
           "head_ref": "h", "head_oid": "h1"}
     out = runner.run_review(tmp_path, pr, _review_config(tmp_path),
-                            "owner/repo", 4, "orbi/owner-repo-issue-4-run1", 1)
+                            "owner/repo", 4, "orbi/owner-repo-issue-4", 1)
     assert out == "done"
     command, kwargs = calls[0]
     # Review skill, shared flat session dir (so the same live activity
@@ -274,7 +274,7 @@ def test_run_review_launches_independent_readonly_pi_session(monkeypatch, tmp_pa
     assert kwargs["role"] == runner.ROLE_REVIEW
     assert kwargs["run_id"] == "run1"
     assert kwargs["issue"] == 4
-    assert kwargs["branch"] == "orbi/owner-repo-issue-4-run1"
+    assert kwargs["branch"] == "orbi/owner-repo-issue-4"
     assert kwargs["source_repo"] == "owner/repo"
     assert kwargs["log_command"][-2:] == [
         "<redacted>", "<review-context-redacted>",

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -374,11 +374,12 @@ def test_e2e_one_run_id_carries_every_event_of_the_attempt(
         assert f"run_id={run_id}" in body
         assert f"<!-- orbi:run={run_id} -->" in body
 
-    # 3. Branch and worktree names carry the run_id.
+    # 3. The local worktree remains run-scoped, while the delivery branch
+    # is the stable Issue identity.
     worktree = worktree_for(clone, run_id)
     assert worktree.is_dir()
     assert git(worktree, "branch", "--show-current") == (
-        f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+        f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
     )
 
     # 4. Run artifacts live inside the run-scoped worktree (in the
@@ -401,30 +402,38 @@ def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
     config = config_for(clone, tmp_path)
 
     runner.process_issue(issue(), config, REPO)
-    runner.process_issue(issue(), config, REPO)
+    # A real fresh claim includes the ai-ready label; this is the
+    # relabel/takeover path for the already-open stable PR.
+    ready_issue = {
+        **issue(),
+        "labels": [{"name": runner.READY_LABEL}],
+    }
+    runner.process_issue(ready_issue, config, REPO)
 
     first = worktree_for(clone, "a1b2c3d4")
     second = worktree_for(clone, "b2c3d4e5")
     assert first.is_dir() and second.is_dir()
+    assert git(second, "branch", "--show-current") == (
+        f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
+    )
 
-    # The old scene is preserved and still queryable by the old run id.
+    # The old scene remains in its local worktree; takeover reviews the
+    # existing PR and does not run a second implementer or create a PR.
     assert "a1b2c3d4" in (first / ".orbi" / "plan.md").read_text(
         encoding="utf-8",
     )
-    assert "b2c3d4e5" in (second / ".orbi" / "plan.md").read_text(
-        encoding="utf-8",
-    )
+    assert not (second / ".orbi" / "plan.md").exists()
 
-    # Comments are not confused: each attempt carries exactly its own
-    # id (four comments per attempt: started Pi, progress, plan ready
-    # milestone, opened PR).
-    assert len(comments) == 8
+    # The takeover has only started/progress/opened-scene comments; the
+    # existing PR is reused and no second PR is created.
+    assert len(comments) == 7
     assert "<!-- orbi:run=a1b2c3d4 -->" in comments[0]
     assert "b2c3d4e5" not in comments[0]
     assert "<!-- orbi:run=a1b2c3d4 -->" in comments[1]
     assert "<!-- orbi:run=b2c3d4e5 -->" in comments[4]
     assert "a1b2c3d4" not in comments[4]
     assert "<!-- orbi:run=b2c3d4e5 -->" in comments[5]
+    assert "<!-- orbi:run=b2c3d4e5 -->" in comments[6]
 
     # The journal timeline splits cleanly into the two runs.
     first_lines = [
@@ -539,7 +548,7 @@ def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
     assert not worktree_for(clone, "b2c3d4e5").exists()
     assert git(
         first_worktree, "branch", "--show-current",
-    ) == f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-a1b2c3d4"
+    ) == f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
 
     # Exactly ONE progress comment: the restarted run PATCHed the
     # existing one (found by its run marker), never a second one.


### PR DESCRIPTION
<!-- orbi:run=d7e321f7 -->

Fixes #553

Bug：交付分支身份含 run_id 导致重复/滞留 PR 阻塞 release——分支改为按 issue 命名，claim 时接管已有交付 (run_id=d7e321f7)
