### PR TITLE
Bug：release 测试步非中性执行器——硬编码 /usr/bin/python3 coverage gate（Python 锁死+依赖系统工具链）——runner 原样执行仓库自有测试入口，契约归客户仓库

### DIFF
--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -174,7 +174,11 @@ DAG, no priority numbers, no separate queues:
   1. Strictly parse the `## Release` declaration from the Issue body:
      `version`, `base_branch`, `test_command`, `scope` (a list of `#N`
      items), and optional `version_file` (`pyproject.toml` by default,
-     `package.json`, or `none`). Missing, duplicated or unknown fields fail fast.
+     `package.json`, or `none`). `test_command` is the self-contained
+     command a contributor runs from a clean checkout; the Runner executes
+     it unchanged. Optional `test_timeout_seconds` sets its positive integer
+     timeout (default 1800 seconds). Missing, duplicated or unknown fields
+     fail fast.
   2. Freeze the base — the release commit is exactly
      `origin/<base_branch>` (fetched under the base-sync lock).
   3. Enforce the pre-release gates: no leftover open `ai-in-progress` /
@@ -190,8 +194,9 @@ DAG, no priority numbers, no separate queues:
   4. Verify the scope item by item: `gh pr view` must report `MERGED`,
      otherwise `gh issue view` must report `CLOSED`. Checkbox parsing
      is forbidden — every scope item is checked against the live API.
-  5. Run the declared `test_command` in a clean worktree at the release
-     commit (`timeout`-wrapped, Issue #95).
+  5. Run the declared self-contained `test_command` unchanged in a clean
+     worktree at the release commit (`timeout`-wrapped, Issue #95; the
+     optional `test_timeout_seconds` overrides the 1800-second default).
   6. Tag: when the remote tag is absent, create an annotated tag at the
      release commit and push it with a plain push (never `--force`).
      When it exists it must point EXACTLY at the release commit — a

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -148,7 +148,9 @@ PR 验收时校验该关键词，缺失即 fail fast。
   1. 严格解析 Issue 正文的 `## Release` 声明：`version`、
      `base_branch`、`test_command`、`scope`（`#N` 列表），以及可选的
      `version_file`（默认 `pyproject.toml`，也可为 `package.json` 或 `none`）。
-     字段缺失、重复或未知都 fail fast。
+     `test_command` 是贡献者从 clean checkout 执行的自包含命令，Runner 原样执行；
+     可选的 `test_timeout_seconds` 设置正整数超时（默认 1800 秒）。字段缺失、
+     重复或未知都 fail fast。
   2. 冻结 base——release commit 就是 `origin/<base_branch>`（在
      base-sync 锁下 fetch）。
   3. 执行发布前门禁：无遗留 open 的 `ai-in-progress` /
@@ -162,8 +164,9 @@ PR 验收时校验该关键词，缺失即 fail fast。
   4. 逐项验证 scope：`gh pr view` 必须报告 `MERGED`，否则
      `gh issue view` 必须报告 `CLOSED`。禁止解析复选框——每个 scope
      项都对照 live API 检查。
-  5. 在 release commit 的干净 worktree 里跑声明的 `test_command`
-     （`timeout` 包裹，Issue #95）。
+  5. 在 release commit 的干净 worktree 里原样执行自包含的 `test_command`
+     （`timeout` 包裹，Issue #95；可选的 `test_timeout_seconds` 覆盖默认的
+     1800 秒）。
   6. 打 tag：远端 tag 不存在时，在 release commit 上创建 annotated
      tag 并普通 push（绝不 `--force`）。已存在时必须精确指向 release
      commit——不匹配 fail fast。已存在的 tag 绝不移动、覆盖或

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -230,10 +230,9 @@ _CURRENT_RUN_ID: str | None = None
 # `- scope:` with `  - #N` items. Parsed strictly — a missing or
 # malformed declaration fails fast, never guessed.
 RELEASE_SECTION = "## Release"
-# The declared `test_command` runs in a clean worktree at the release
-# commit wrapped in `timeout <seconds> bash -c ...` (Issue #95): a test
-# that does not terminate within the deadline is a broken path, never
-# ignorable noise.
+# The repository-owned test entry point runs in a clean worktree wrapped
+# in `timeout <seconds> bash -c ...` (Issue #95). The runner is deliberately
+# stack-neutral: the command owns its tools and test policy.
 RELEASE_TEST_TIMEOUT_SECONDS = 1800
 # Release CI wait (Issue #268): the release commit is born from the last
 # delivery PR merge, so its CI is almost always still running when the
@@ -1949,9 +1948,12 @@ def parse_release_declaration(body: str) -> dict:
     ```
 
     `version` is the exact tag name (no spaces), `base_branch` the
-    branch the release commit is frozen from, `test_command` the
-    shell command that must pass in a clean worktree at the release
-    commit, and `scope` the Issue/PR numbers verified one by one.
+    branch the release commit is frozen from, and `test_command` the
+    self-contained command a new contributor runs from a clean checkout
+    to test the repository. The runner executes that command unchanged;
+    the repository owns its toolchain and test policy. Optional
+    `test_timeout_seconds` sets the positive integer timeout (default
+    1800 seconds). `scope` lists the Issue/PR numbers verified one by one.
     Optional `version_file` selects a supported ecosystem metadata file
     (the default is `pyproject.toml`) or `none` to skip version metadata changes.
     Exactly one of `scope` / `scope_from_milestone` must be present:
@@ -2028,13 +2030,15 @@ def parse_release_declaration(body: str) -> dict:
                 scope_open = True
                 fields["scope"] = ""
             elif key in ("version", "base_branch", "test_command",
-                         "scope_from_milestone", "version_file"):
+                         "scope_from_milestone", "version_file",
+                         "test_timeout_seconds"):
                 fields[key] = value
             else:
                 raise ValueError(
                     f"release declaration has the unknown field {key!r} "
                     "(expected version, base_branch, test_command, "
-                    "scope, scope_from_milestone or version_file)"
+                    "test_timeout_seconds, scope, scope_from_milestone "
+                    "or version_file)"
                 )
         elif scope_open:
             raise ValueError(
@@ -2087,6 +2091,16 @@ def parse_release_declaration(body: str) -> dict:
                 "release declaration field `scope_from_milestone` must "
                 "not contain spaces"
             )
+    timeout_value = fields.get("test_timeout_seconds")
+    if timeout_value is None:
+        test_timeout_seconds = RELEASE_TEST_TIMEOUT_SECONDS
+    elif not re.fullmatch(r"[1-9][0-9]*", timeout_value):
+        raise ValueError(
+            "release declaration field `test_timeout_seconds` must be a "
+            "positive integer"
+        )
+    else:
+        test_timeout_seconds = int(timeout_value)
     version_file = fields.get("version_file", "pyproject.toml")
     if version_file not in (
         "pyproject.toml", "package.json", "pom.xml", "build.gradle",
@@ -2100,6 +2114,7 @@ def parse_release_declaration(body: str) -> dict:
         "version": fields["version"],
         "base_branch": fields["base_branch"],
         "test_command": fields["test_command"],
+        "test_timeout_seconds": test_timeout_seconds,
         "scope": scope,
         "scope_from_milestone": fields.get("scope_from_milestone"),
         "version_file": version_file,
@@ -2518,22 +2533,14 @@ def run_release_tests(worktree: Path, test_command: str,
     """Run the declared release test command in the release worktree.
 
     The command is a shell string (it may chain steps with `&&`), so
-    it runs through `bash -c` wrapped in `timeout <seconds>` (Issue
-    #95). Its success is followed by the repository's tiered coverage
-    gate (Issue #234: the report shows both real numbers, and
-    tools/coverage_gate.py enforces line >= 95% and branch >= 95% checked
-    separately): a declaration such as `true` or a bare `pytest` must
-    not let a release claim the coverage contract. A test that does not
-    terminate within the deadline fails fast with `timeout`'s exit 124
-    — never ignorable noise or a second unbounded attempt.
+    it runs unchanged through `bash -c` wrapped in `timeout <seconds>`
+    (Issue #95). The repository owns its test tools and coverage policy;
+    the runner must not append stack-specific commands. A test that does
+    not terminate within the deadline fails fast with `timeout`'s exit
+    124 — never ignorable noise or a second unbounded attempt.
     """
-    coverage_gate = (
-        "/usr/bin/python3 -m coverage report --show-missing && "
-        "/usr/bin/python3 tools/coverage_gate.py"
-    )
     run_command(
-        ["timeout", str(timeout_seconds), "bash", "-c",
-         f"{test_command} && {coverage_gate}"],
+        ["timeout", str(timeout_seconds), "bash", "-c", test_command],
         cwd=worktree,
     )
 
@@ -3804,7 +3811,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         try:
             run_release_tests(
                 worktree, declaration["test_command"],
-                RELEASE_TEST_TIMEOUT_SECONDS,
+                declaration["test_timeout_seconds"],
             )
         except subprocess.CalledProcessError as exc:
             release_test_error = exc
@@ -3813,7 +3820,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             f"declared test command and tiered coverage gate "
             f"(line/branch >= 95%, Issue #234) passed in a clean "
             f"worktree at {release_commit} "
-            f"(timeout {RELEASE_TEST_TIMEOUT_SECONDS}s)"
+            f"(timeout {declaration['test_timeout_seconds']}s)"
         )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13006,10 +13006,26 @@ def test_parse_release_declaration_returns_all_fields():
             "/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q "
             "&& /usr/bin/python3 -m coverage report --show-missing"
         ),
+        "test_timeout_seconds": 1800,
         "scope": [123, 124],
         "scope_from_milestone": None,
         "version_file": "pyproject.toml",
     }
+
+
+def test_parse_release_declaration_accepts_custom_test_timeout():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- test_command:", "- test_timeout_seconds: 42\n- test_command:",
+    )
+    assert runner.parse_release_declaration(body)["test_timeout_seconds"] == 42
+
+
+def test_parse_release_declaration_rejects_invalid_test_timeout():
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- test_command:", "- test_timeout_seconds: 0\n- test_command:",
+    )
+    with pytest.raises(ValueError, match="test_timeout_seconds"):
+        runner.parse_release_declaration(body)
 
 
 def test_parse_release_declaration_accepts_package_json_version_file():
@@ -13155,6 +13171,7 @@ def test_parse_release_declaration_scope_from_milestone():
         "version": "v0.3.0",
         "base_branch": "main",
         "test_command": "/usr/bin/python3 -m pytest tests/ -q",
+        "test_timeout_seconds": 1800,
         "scope": [],
         "scope_from_milestone": "v0.3.0",
         "version_file": "pyproject.toml",
@@ -13912,10 +13929,18 @@ def test_run_release_tests_wraps_the_command_in_timeout_bash(monkeypatch):
     runner.run_release_tests(Path("/wt"), "pytest -q", 120)
     (command, kwargs), = calls
     assert command == [
-        "timeout", "120", "bash", "-c",
-        "pytest -q && /usr/bin/python3 -m coverage report "
-        "--show-missing && /usr/bin/python3 tools/coverage_gate.py",
+        "timeout", "120", "bash", "-c", "pytest -q",
     ]
+    assert kwargs == {"cwd": Path("/wt")}
+
+
+def test_run_release_tests_keeps_node_command_stack_neutral(monkeypatch):
+    calls = []
+    monkeypatch.setattr(runner, "run_command",
+                        lambda c, **k: calls.append((c, k)) or "")
+    runner.run_release_tests(Path("/wt"), "npm ci && npm test", 300)
+    (command, kwargs), = calls
+    assert command == ["timeout", "300", "bash", "-c", "npm ci && npm test"]
     assert kwargs == {"cwd": Path("/wt")}
 
 
@@ -14725,9 +14750,7 @@ def test_process_release_success_end_to_end(monkeypatch):
     assert (["timeout", str(runner.RELEASE_TEST_TIMEOUT_SECONDS),
              "bash", "-c",
              "/usr/bin/python3 -m coverage run --branch -m pytest tests/ -q "
-             "&& /usr/bin/python3 -m coverage report --show-missing && "
-             "/usr/bin/python3 -m coverage report --show-missing && "
-             "/usr/bin/python3 tools/coverage_gate.py"],
+             "&& /usr/bin/python3 -m coverage report --show-missing"],
             {"cwd": Path("/wt")}) in state["commands"]
     # Issue #275: the docs sync step runs once, after the GitHub Release
     # is published and before the Milestone is closed, with the release

--- a/tools/release_test.sh
+++ b/tools/release_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The release test command is the repository's contributor-facing contract.
+# Keep its toolchain setup here rather than making the Orbi runner Python-only.
+venv_dir="${TMPDIR:-/tmp}/orbi-release-test.$$"
+trap 'rm -rf "$venv_dir"' EXIT
+uv venv "$venv_dir"
+uv pip install --python "$venv_dir/bin/python" pytest coverage pyyaml
+mkdir -p .orbi
+COVERAGE_FILE=.orbi/.coverage "$venv_dir/bin/python" -m coverage run --branch -m pytest tests/ -q
+COVERAGE_FILE=.orbi/.coverage "$venv_dir/bin/python" -m coverage report --show-missing
+COVERAGE_FILE=.orbi/.coverage "$venv_dir/bin/python" tools/coverage_gate.py .orbi/.coverage


### PR DESCRIPTION
<!-- orbi:run=c6d01a8b -->

Fixes #556

Bug：release 测试步非中性执行器——硬编码 /usr/bin/python3 coverage gate（Python 锁死+依赖系统工具链）——runner 原样执行仓库自有测试入口，契约归客户仓库 (run_id=c6d01a8b)
