### PR TITLE
bug: release 路径裸调 create_worktree——上次尝试的稳定分支/worktree 残留使 retry 必然 255（交付路径已处理，release 漏了）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3764,7 +3764,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
                 f"{'; '.join(scope_evidence)}",
             ),
         )
-        worktree = create_worktree(
+        worktree = create_release_worktree(
             config["repo_dir"], source_repo, number, run_id, release_commit,
         )
         # Version metadata is part of the release commit, not a post-release
@@ -4883,6 +4883,48 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
             "git", "worktree", "add", "-b", branch, str(path), base_sha,
         ], cwd=repo_dir)
     return path
+
+
+def create_release_worktree(repo_dir: Path, source_repo: str, number: int,
+                            run_id: str, release_commit: str) -> Path:
+    """Prepare the release worktree at this attempt's verified commit.
+
+    Release worktrees have no resumable session semantics.  A failed release
+    may leave the stable branch checked out in an older, run-specific
+    worktree, so reusing ``create_worktree(..., existing_branch=True)`` would
+    incorrectly preserve that old position.  Find that worktree when it is
+    registered, otherwise create one from the local stable branch (or the
+    release commit), then hard-reset it to the commit whose gates just passed.
+    """
+    branch = task_branch(source_repo, number, run_id)
+    listing = run_command(
+        ["git", "worktree", "list", "--porcelain"], cwd=repo_dir,
+    )
+    current_path: Path | None = None
+    current_branch = f"branch refs/heads/{branch}"
+    for block in listing.split("\n\n"):
+        lines = block.splitlines()
+        if current_branch in lines and lines:
+            current_path = Path(lines[0].removeprefix("worktree "))
+            break
+    if current_path is None:
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            current_path = worktree_path(
+                repo_dir, source_repo, number, run_id,
+            )
+            run_command([
+                "git", "worktree", "add", "--force", str(current_path),
+                branch,
+            ], cwd=repo_dir)
+        else:
+            current_path = create_worktree(
+                repo_dir, source_repo, number, run_id, release_commit,
+            )
+    run_command(["git", "reset", "--hard", release_commit], cwd=current_path)
+    return current_path
 
 
 def run_state_path(worktree: Path) -> Path:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2647,6 +2647,83 @@ def test_create_worktree_reuses_existing_remote_branch(monkeypatch, tmp_path):
     ]
 
 
+def test_create_release_worktree_resets_leftover_worktree_to_current_commit(
+    monkeypatch, tmp_path,
+):
+    old_worktree = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-oldrun"
+    branch = "orbi/owner-repo-issue-3"
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command == ["git", "worktree", "list", "--porcelain"]:
+            return f"worktree {old_worktree}\nHEAD old\nbranch refs/heads/{branch}\n"
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.create_release_worktree(
+        tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
+    ) == old_worktree
+    assert calls[-1] == (
+        ["git", "reset", "--hard", "new-release-commit"],
+        {"cwd": old_worktree},
+    )
+    assert not any(command[:3] == ["git", "worktree", "add"]
+                   for command, _ in calls)
+
+
+def test_create_release_worktree_handles_leftover_local_branch(
+    monkeypatch, tmp_path,
+):
+    path = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-newrun"
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command == ["git", "worktree", "list", "--porcelain"]:
+            return ""
+        if command == ["git", "branch", "--list", "orbi/owner-repo-issue-3"]:
+            return "  orbi/owner-repo-issue-3"
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.create_release_worktree(
+        tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
+    ) == path
+    assert calls[-2:] == [
+        (["git", "worktree", "add", "--force", str(path),
+          "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "reset", "--hard", "new-release-commit"],
+         {"cwd": path}),
+    ]
+
+
+def test_create_release_worktree_creates_from_release_commit_when_branch_is_new(
+    monkeypatch, tmp_path,
+):
+    calls = []
+    expected = tmp_path / "created"
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command == ["git", "worktree", "list", "--porcelain"]:
+            return ""
+        if command == ["git", "branch", "--list", "orbi/owner-repo-issue-3"]:
+            return ""
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(runner, "create_worktree",
+                        lambda *args: expected)
+    assert runner.create_release_worktree(
+        tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
+    ) == expected
+    assert calls[-1] == (
+        ["git", "reset", "--hard", "new-release-commit"],
+        {"cwd": expected},
+    )
+
+
 def test_latest_run_id_returns_none_without_task_worktrees(tmp_path):
     assert runner.latest_run_id(tmp_path, "owner/repo", 3) is None
     # Unrelated directories are not task worktrees.
@@ -14613,6 +14690,8 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
     monkeypatch.setattr(runner, "comment_issue",
                         lambda n, **k: state["comments"].append((n, k)))
     monkeypatch.setattr(runner, "create_worktree",
+                        lambda *a: Path("/wt"))
+    monkeypatch.setattr(runner, "create_release_worktree",
                         lambda *a: Path("/wt"))
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
     monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)


### PR DESCRIPTION
<!-- orbi:run=03f62435 -->

Fixes #565

bug: release 路径裸调 create_worktree——上次尝试的稳定分支/worktree 残留使 retry 必然 255（交付路径已处理，release 漏了） (run_id=03f62435)
