### PR TITLE
bug: release 声明的 test_command 非自包含（系统 python 无测试工具链）+ 全量套件依赖未声明——建立自包含测试入口并更新 #551/#563

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install requirements and the test toolchain
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install pytest coverage pyyaml
+      - name: Run the repository-owned test entry point
+        run: scripts/test
 
       # CLI packaging (Issue #140, #152): the console script must
       # install in a clean environment and the entry must work
@@ -98,22 +95,6 @@ jobs:
               exit 1
               ;;
           esac
-
-      - name: Run the full test suite with branch coverage (contract)
-        run: python3 -m coverage run --branch -m pytest tests/ -q
-
-      # Tiered coverage gate (Issue #234): the whole repository keeps
-      # line >= 95% AND branch >= 95% (tools/coverage_gate.py checks the two
-      # tiers SEPARATELY from the coverage JSON totals — never a merged
-      # single percentage), and the Python lines/branches changed in
-      # this PR keep 100% (tools/diff_coverage_gate.py against origin/main;
-      # a doc-only PR has no changed Python and passes). The report
-      # keeps showing both real numbers as evidence.
-      - name: Enforce the tiered coverage gate (contract, Issue #234)
-        run: |
-          python3 -m coverage report --show-missing
-          python3 tools/coverage_gate.py
-          python3 tools/diff_coverage_gate.py origin/main
 
       # Mintlify docs build smoke (Issue #116): the official `mint` CLI
       # validates the docs/ build (docs.json config, pages, links) in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Run the repository-owned test entry point
-        run: scripts/test
-
       # CLI packaging (Issue #140, #152): the console script must
       # install in a clean environment and the entry must work
       # (`orbi --help` and `orbi --version`, exit 0).
@@ -95,6 +92,9 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Run the repository-owned test entry point
+        run: scripts/test
 
       # Mintlify docs build smoke (Issue #116): the official `mint` CLI
       # validates the docs/ build (docs.json config, pages, links) in

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -101,13 +101,11 @@ first.
    refactor. External interfaces (CLI flags, HTTP paths, config fields)
    are asserted against the official docs or one real call — never
    against a guessed shape.
-4. Run the full contract locally:
+4. Run the full contract locally with the repository-owned, self-contained
+   entry point (it installs the declared test extra in an isolated virtual environment):
 
    ```bash
-   /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-   /usr/bin/python3 -m coverage report --show-missing
-   /usr/bin/python3 tools/coverage_gate.py
-   /usr/bin/python3 tools/diff_coverage_gate.py origin/main
+   scripts/test
    ```
 
 5. Open one PR per Issue. The PR description must contain

--- a/docs/testing.mdx
+++ b/docs/testing.mdx
@@ -18,21 +18,15 @@ the coverage report. Unjustified `# pragma: no cover` is a contract
 violation (a static test pins the few justified sites: the `__main__`
 entry guards and one defensive `except` guard in a test).
 
-## Local contract commands
+## The repository-owned test entry point
 
-Run them from the repository root (production interpreter
-`/usr/bin/python3`, Python 3.14). `COVERAGE_FILE` (the official
-coverage.py environment variable) points the coverage data into the
-excluded run dir `.orbi/` (Issue #302): the worktree root never
-receives a coverage artifact, so the dirty-worktree gate never trips
-over one:
-
-```bash
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/coverage_gate.py .orbi/.coverage
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/diff_coverage_gate.py origin/main
-```
+Run `scripts/test` from the repository root. It creates or reuses the
+Python virtual environment outside the checkout, installs the `[test]` extra declared
+in `pyproject.toml`, and runs the full suite with branch coverage,
+`coverage report --show-missing`, and both tiered gates. Coverage data is
+stored in the excluded `.orbi/` run directory (Issue #302), so a clean
+checkout needs no pre-installed pytest, coverage, or YAML tooling. CI and
+Release tasks use this same command.
 
 The report shows both real numbers (line and branch) per file. The two
 gate scripts are the gate, not a report: `tools/coverage_gate.py` exits
@@ -49,11 +43,11 @@ changed since the base ref is not 100% covered.
 and every push to `main`: one job, Python 3.14 pinned via
 `actions/setup-python` (GitHub-hosted runners do not have the production
 interpreter at the production path, so the workflow pins the same minor
-version and runs the identical commands through `python3` on PATH),
-`requirements.txt` installed, then the contract commands above — the
-report, `tools/coverage_gate.py`, and `tools/diff_coverage_gate.py origin/main`
-(the changed-code tier against the PR base; a doc-only PR has no
-changed Python and passes). No lint, no matrix, no cache.
+version), then runs the repository-owned `scripts/test` entry point. That
+entry point installs the `pyproject.toml` `[test]` extra and runs the report
+and tiered gates (the changed-code tier uses the PR base; a doc-only PR has
+no changed Python and passes). No inline dependency injection, lint, matrix,
+or cache.
 
 The checkout uses `fetch-depth: 0` (full history + all tags): the release
 reconciliation tests (`tests/test_release_v01.py`) verify the REAL annotated

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -176,7 +176,8 @@ DAG, no priority numbers, no separate queues:
      items), and optional `version_file` (`pyproject.toml` by default,
      `package.json`, or `none`). `test_command` is the self-contained
      command a contributor runs from a clean checkout; the Runner executes
-     it unchanged. Optional `test_timeout_seconds` sets its positive integer
+     it unchanged. For this repository, use `scripts/test`, which owns the
+     declared test environment and coverage gates. Optional `test_timeout_seconds` sets its positive integer
      timeout (default 1800 seconds). Missing, duplicated or unknown fields
      fail fast.
   2. Freeze the base — the release commit is exactly

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -87,13 +87,10 @@ journal、Issue/PR 或 UI 中，不为形式上的 E2E 增加基础设施。
 3. 先写失败测试，再写最小实现，再重构。外部接口（CLI flag、HTTP
    path、配置字段）对照官方文档或一次真实调用断言——从不对照猜出来的
    形状。
-4. 本地跑完整契约：
+4. 使用仓库自有的自包含入口运行完整契约（它会在隔离的虚拟环境安装声明的测试依赖）：
 
    ```bash
-   /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-   /usr/bin/python3 -m coverage report --show-missing
-   /usr/bin/python3 tools/coverage_gate.py
-   /usr/bin/python3 tools/diff_coverage_gate.py origin/main
+   scripts/test
    ```
 
 5. 一个 Issue 一个 PR。PR 描述必须包含 `Fixes #<issue-number>`，

--- a/docs/zh/testing.mdx
+++ b/docs/zh/testing.mdx
@@ -17,19 +17,13 @@ GitHub 远端运行。
 （静态测试钉住少数正当位置：`__main__` 入口守卫和测试里一个防御性
 `except` 守卫）。
 
-## 本地契约命令
+## 仓库自有的测试入口
 
-从仓库根目录运行（生产解释器 `/usr/bin/python3`，Python 3.14）。`COVERAGE_FILE`
-（coverage.py 官方环境变量）把覆盖率数据指到已排除的运行目录 `.orbi/`
-（Issue #302）：worktree 根不会出现任何覆盖率产物，dirty-worktree 门禁
-也就不会被它绊住：
-
-```bash
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/coverage_gate.py .orbi/.coverage
-COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/diff_coverage_gate.py origin/main
-```
+从仓库根目录运行 `scripts/test`。它在 checkout 外创建或复用 Python 虚拟环境，
+安装 `pyproject.toml` 声明的 `[test]` 依赖，然后运行完整套件、分支覆盖率、
+`coverage report --show-missing` 和两个分层门禁。覆盖率数据存放在排除的
+`.orbi/` 运行目录（Issue #302），clean checkout 不需要系统预装 pytest、coverage
+或 YAML 工具。CI 和 Release task 使用同一条命令。
 
 报告逐文件给出两个真实数字（行和分支）。两个门禁脚本才是门禁，不是
 报告：`tools/coverage_gate.py` 在行层级或分支层级任一低于 95% 时退出非零
@@ -44,9 +38,9 @@ Python 行或分支未达 100% 覆盖时退出非零。
 `main` 时运行同一契约：单个 job，`actions/setup-python` 固定 Python
 3.14（GitHub-hosted runner 没有生产路径上的生产解释器，所以 workflow
 固定同一 minor 版本，通过 PATH 上的 `python3` 运行相同命令），安装
-`requirements.txt`，然后运行上面的契约命令——报告、`tools/coverage_gate.py`
-和 `tools/diff_coverage_gate.py origin/main`（变更代码层级对照 PR base；纯
-文档 PR 没有变更的 Python，直接通过）。没有 lint、没有矩阵、没有缓存。
+仓库自有的 `scripts/test` 入口；它安装 `pyproject.toml` 的 `[test]` 依赖，
+并运行相同的报告和分层门禁（变更代码层级对照 PR base；纯文档 PR 没有变更
+的 Python，直接通过）。没有内联依赖注入、没有 lint、没有矩阵、没有缓存。
 
 Checkout 用 `fetch-depth: 0`（完整历史 + 全部 tags）：发布对账测试
 （`tests/test_release_v01.py`）用 `git cat-file` / `git rev-parse` 对

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -148,7 +148,8 @@ PR 验收时校验该关键词，缺失即 fail fast。
   1. 严格解析 Issue 正文的 `## Release` 声明：`version`、
      `base_branch`、`test_command`、`scope`（`#N` 列表），以及可选的
      `version_file`（默认 `pyproject.toml`，也可为 `package.json` 或 `none`）。
-     `test_command` 是贡献者从 clean checkout 执行的自包含命令，Runner 原样执行；
+     `test_command` 是贡献者从 clean checkout 执行的自包含命令，Runner 原样执行；本仓库使用
+     `scripts/test`，由它负责声明的测试环境和覆盖率门禁；
      可选的 `test_timeout_seconds` 设置正整数超时（默认 1800 秒）。字段缺失、
      重复或未知都 fail fast。
   2. 冻结 base——release commit 就是 `origin/<base_branch>`（在

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ license = { file = "LICENSE.md" }
 authors = [{ name = "xqliu" }]
 dependencies = []
 
+[project.optional-dependencies]
+test = [
+    "coverage",
+    "pytest",
+    "pyyaml",
+]
+
 [project.scripts]
 orbi = "orbi.cli:main"
 
@@ -54,9 +61,8 @@ orbi = "orbi.cli:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
-# The contract test command (`python3 -m coverage run --branch -m pytest
-# tests/ -q`) runs WITHOUT installing the package: pytest puts `src/` on
-# sys.path so the suite imports `orbi.*` straight from the
-# checkout (Issue #168).
+# The repository-owned `scripts/test` entry point installs this test extra and
+# runs the full suite with coverage in an isolated virtual environment outside
+# the checkout.
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Repository-owned test entry point: dependencies come from pyproject.toml.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT"
+
+# Keep installed third-party sources outside the checkout: repository tests
+# intentionally scan every checkout Python file for coverage directives.
+VENV="${TMPDIR:-/tmp}/orbi-test-venv-$(basename "$ROOT")"
+"${PYTHON:-python3}" -m venv "$VENV"
+"$VENV/bin/python" -m pip install --editable '.[test]'
+
+mkdir -p .orbi
+export COVERAGE_FILE=.orbi/.coverage
+"$VENV/bin/python" -m coverage run --branch -m pytest tests/ -q
+"$VENV/bin/python" -m coverage report --show-missing
+"$VENV/bin/python" tools/coverage_gate.py .orbi/.coverage
+"$VENV/bin/python" tools/diff_coverage_gate.py origin/main

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -17,17 +17,20 @@ plus the link, Issue #241) must keep documenting what the remote CI is
 and when it runs.
 """
 import re
+import tomllib
 from pathlib import Path
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+TEST_ENTRY = REPO_ROOT / "scripts" / "test"
+PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 
-# The contract commands (AGENTS.md) run through the pinned interpreter on
-# PATH in CI; the local machine uses the same commands with /usr/bin/python3.
-CONTRACT_RUN = "python3 -m coverage run --branch -m pytest tests/ -q"
-CONTRACT_REPORT = "python3 -m coverage report"
+# CI delegates the contract to the repository-owned self-contained entry
+# point, which installs the pyproject test extra and runs these commands.
+CONTRACT_RUN = "scripts/test"
+CONTRACT_REPORT = "coverage report"
 
 
 def load_workflow() -> dict:
@@ -63,6 +66,23 @@ def step_commands(steps: list[dict]) -> list[str]:
         for step in steps
         if step.get("run")
     ]
+
+
+def test_repository_test_entry_owns_declared_dependencies_and_coverage():
+    assert TEST_ENTRY.is_file(), f"missing test entry point: {TEST_ENTRY}"
+    assert TEST_ENTRY.stat().st_mode & 0o111, "test entry point must be executable"
+    script = TEST_ENTRY.read_text(encoding="utf-8")
+    assert "-m venv" in script
+    assert "pip install --editable '.[test]'" in script
+    assert "coverage run --branch -m pytest tests/ -q" in script
+    assert "coverage report --show-missing" in script
+    assert "tools/coverage_gate.py" in script
+    assert "tools/diff_coverage_gate.py origin/main" in script
+
+    project = tomllib.loads(PYPROJECT_FILE.read_text(encoding="utf-8"))
+    assert set(project["project"]["optional-dependencies"]["test"]) == {
+        "coverage", "pytest", "pyyaml",
+    }
 
 
 def test_ci_workflow_exists_at_repository_root():
@@ -149,11 +169,14 @@ def test_ci_workflow_pins_python_3_14_like_production():
     )
 
 
-def test_ci_workflow_installs_requirements_txt():
+def test_ci_workflow_uses_the_repository_owned_test_entry_point():
     commands = step_commands(steps_of(load_workflow()))
-    assert any(
-        "pip install -r requirements.txt" in command for command in commands
-    ), f"CI must install requirements.txt, steps run: {commands!r}"
+    assert any(command == CONTRACT_RUN for command in commands), (
+        f"CI must run {CONTRACT_RUN!r}, steps run: {commands!r}"
+    )
+    assert not any("pip install pytest coverage pyyaml" in command for command in commands), (
+        "CI must not inject undeclared test dependencies"
+    )
 
 
 def test_ci_workflow_installs_the_cli_and_verifies_the_entry():
@@ -284,9 +307,9 @@ def test_ci_workflow_installs_the_cli_editable_and_verifies_the_import_source():
 
 def test_ci_workflow_runs_the_contract_test_command():
     commands = step_commands(steps_of(load_workflow()))
-    assert any(
-        CONTRACT_RUN in command for command in commands
-    ), f"CI must run the contract test command {CONTRACT_RUN!r}, steps run: {commands!r}"
+    assert any(CONTRACT_RUN in command for command in commands), (
+        f"CI must run the contract test command {CONTRACT_RUN!r}, steps run: {commands!r}"
+    )
 
 
 def test_ci_workflow_enforces_the_tiered_coverage_gate():
@@ -298,8 +321,9 @@ def test_ci_workflow_enforces_the_tiered_coverage_gate():
     changed Python and passes). The old --fail-under=100 gate checked
     only the merged percentage and is gone."""
     commands = step_commands(steps_of(load_workflow()))
+    contract = commands + [TEST_ENTRY.read_text(encoding="utf-8")]
     global_gate = [
-        command for command in commands
+        command for command in contract
         if "tools/coverage_gate.py" in command
     ]
     assert global_gate, (
@@ -308,7 +332,7 @@ def test_ci_workflow_enforces_the_tiered_coverage_gate():
         f"{commands!r}"
     )
     diff_gate = [
-        command for command in commands
+        command for command in contract
         if "tools/diff_coverage_gate.py origin/main" in command
     ]
     assert diff_gate, (
@@ -316,13 +340,13 @@ def test_ci_workflow_enforces_the_tiered_coverage_gate():
         f"origin/main: changed Python at 100% line/branch), steps run: "
         f"{commands!r}"
     )
-    assert not any("--fail-under" in command for command in commands), (
+    assert not any("--fail-under" in command for command in contract), (
         "CI must not keep the old --fail-under merged-percentage gate "
         f"(Issue #234), steps run: {commands!r}"
     )
     assert any(
         CONTRACT_REPORT in command and "--show-missing" in command
-        for command in commands
+        for command in contract
     ), (
         "CI must keep the coverage report with --show-missing as "
         f"evidence (both real numbers), steps run: {commands!r}"

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -408,8 +408,8 @@ def test_chinese_testing_documents_the_contract_commands():
     contract commands and the remote CI gate — same facts and numbers as
     the English page."""
     text = zh_page_text("testing")
-    assert "coverage run --branch -m pytest tests/" in text, (
-        "testing must show the contract coverage-run command"
+    assert "scripts/test" in text, (
+        "testing must show the repository-owned test entry point"
     )
     assert "coverage report" in text, "testing must show the coverage report command"
     assert "tools/coverage_gate.py" in text, (

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -555,8 +555,8 @@ def test_docs_document_tests_and_coverage_commands():
     (full pytest with branch coverage, the report, and the two gate
     scripts) and the remote CI gate."""
     text = page_text("testing")
-    assert "coverage run --branch -m pytest tests/" in text, (
-        "testing must show the contract coverage-run command"
+    assert "scripts/test" in text, (
+        "testing must show the repository-owned test entry point"
     )
     assert "coverage report" in text, "testing must show the coverage report command"
     assert "tools/coverage_gate.py" in text, (

--- a/tests/test_src_layout.py
+++ b/tests/test_src_layout.py
@@ -202,7 +202,7 @@ def test_direct_execution_entry_fails_fast_without_the_package(tmp_path):
     env = os.environ.copy()
     env.pop("PYTHONPATH", None)
     result = _run(
-        [sys.executable, "-m", "orbi.cli", "--help"],
+        ["/usr/bin/python3", "-m", "orbi.cli", "--help"],
         cwd="/", env=env,
     )
     assert result.returncode != 0


### PR DESCRIPTION
<!-- orbi:run=4da22020 -->

Fixes #567

bug: release 声明的 test_command 非自包含（系统 python 无测试工具链）+ 全量套件依赖未声明——建立自包含测试入口并更新 #551/#563 (run_id=4da22020)
