### PR TITLE
fix: read the timeout deadline off the wrapped command only

### DIFF
--- a/src/orbi/pi_recovery.py
+++ b/src/orbi/pi_recovery.py
@@ -209,21 +209,33 @@ def timeout_duration(cmdline: str) -> float | None:
     wrapper in the command line, or None when the command has no clear
     timeout (Issue #169).
 
-    The wrapper word must stand alone (`timeout`, or an absolute path
-    to it) and the duration must be the IMMEDIATE next token — the
-    prompt contract form `timeout <seconds> ...`. Anything else
-    (options in between, a missing/unparseable duration, the word
-    inside a longer token) is not a clear timeout: the existing
-    recovery behavior applies (fail-safe, never a fabricated deadline).
+    The wrapper must BE the command: the prompt contract form
+    `timeout <seconds> ...`, or the `bash -c` payload form the Pi bash
+    tool actually spawns (`bash -c timeout <seconds> ...`). Anywhere
+    else the `timeout <number>` pair is data, not a deadline — a commit
+    message (`git commit -m "fix timeout 300 regression"` joins to
+    `... -m fix timeout 300 regression` on the real cmdline), an echo
+    argument, a pytest -k expression — and reading a deadline off it
+    would make the runner WAIT for a wrapper that does not exist.
+    Anything not matching the contract (options in between, a
+    missing/unparseable duration, a wrapper buried deeper in a compound
+    command) is not a clear timeout: the existing recovery behavior
+    applies (fail-safe, never a fabricated deadline).
     """
     tokens = cmdline.split()
-    for index, token in enumerate(tokens):
-        if token.rsplit("/", 1)[-1] != "timeout":
-            continue
-        if index + 1 >= len(tokens):
-            return None
-        return _parse_duration(tokens[index + 1])
-    return None
+    wrapper_index: int | None = None
+    if tokens and tokens[0].rsplit("/", 1)[-1] == "timeout":
+        wrapper_index = 0
+    elif (
+        len(tokens) >= 3
+        and tokens[0].rsplit("/", 1)[-1] == "bash"
+        and tokens[1] == "-c"
+        and tokens[2].rsplit("/", 1)[-1] == "timeout"
+    ):
+        wrapper_index = 2
+    if wrapper_index is None or wrapper_index + 1 >= len(tokens):
+        return None
+    return _parse_duration(tokens[wrapper_index + 1])
 
 
 # /proc/net/tcp socket states that still hold a live connection to a

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -570,6 +570,32 @@ def test_timeout_duration_edge_tokens(tmp_path):
     assert pi_recovery.timeout_duration("timeout . x") is None
 
 
+def test_timeout_duration_none_when_wrapper_is_not_the_command():
+    # A `timeout <number>` pair that is NOT the wrapped command itself is
+    # data, not a deadline: a commit message, an echo argument, a pytest
+    # -k expression. (/proc cmdline carries no quotes, so `git commit -m
+    # "fix timeout 300 regression"` joins to the tokens below.) A deadline
+    # read off the message text would make the runner WAIT for a wrapper
+    # that does not exist (the fabricated-deadline scene).
+    assert pi_recovery.timeout_duration(
+        "git commit -m fix timeout 300 regression",
+    ) is None
+    assert pi_recovery.timeout_duration("echo timeout 300 done") is None
+    assert pi_recovery.timeout_duration("pytest -k timeout 300 tests/") is None
+
+
+def test_timeout_duration_none_when_wrapper_sits_deeper_than_bash_c():
+    # The contract form is `timeout <seconds> ...` as THE command, either
+    # directly or as the `bash -c` payload. A wrapper buried deeper in a
+    # compound command (after `cd ... &&`, inside another tool's argv) is
+    # not the contract form: no clear timeout, the existing recovery
+    # behavior applies (fail-safe — never a fabricated deadline).
+    assert pi_recovery.timeout_duration(
+        "bash -c cd /x && timeout 300 pytest",
+    ) is None
+    assert pi_recovery.timeout_duration("sh -c timeout 300 pytest") is None
+
+
 def test_upstream_alive_true_for_established_tcp_socket(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION

Fixes #570

## What

`timeout_duration` recognized a `timeout <number>` pair **anywhere** in a
process's command line, so command *data* could fabricate a deadline:
`git commit -m "fix timeout 300 regression"` (which `/proc/<pid>/cmdline`
joins to `... -m fix timeout 300 regression`) produced a 300 s deadline,
`_pending_timeout_targets` classified the tool as a legitimately-running
wrapper, and the runner entered `pi_idle_wait` — waiting on a wrapper that
does not exist.

The wrapper is now recognized only when it **is** the command: `timeout
<duration> ...` at argv[0], or the `bash -c` payload form `bash -c timeout
<duration> ...` (the Pi bash tool's spawn shape, pinned by the existing
contract test). A physical `timeout` process always carries the wrapper at
its own argv[0], so every real wrapped tool is still recognized; only
data-position matches are gone.

## Evidence

- Red first: `test_timeout_duration_none_when_wrapper_is_not_the_command`
  and `test_timeout_duration_none_when_wrapper_sits_deeper_than_bash_c`
  (commit 1) fail on main.
- Green: all `timeout_duration` tests (7 existing + 2 new) pass.
- Repro on main: `timeout_duration('git commit -m "fix timeout 300 regression"') == 300.0` → `None` with this PR.

## Verification note

Unit suite `tests/test_pi_recovery.py` green locally on Python 3.14.
The runner-side `pi_idle_wait` scenes read the real `/proc` (Linux-only;
this machine is macOS, where those tests fail on pristine main too) — CI
(ubuntu) is the authority for that path.