### PR TITLE
fix: treat slots schema drift as inconclusive, never idle

### DIFF
--- a/src/orbi/pi_recovery.py
+++ b/src/orbi/pi_recovery.py
@@ -396,8 +396,12 @@ def slots_idle(url: str, timeout: float = SLOTS_PROBE_TIMEOUT) -> bool | None:
       generating (a slow model, NOT a swallow).
     - `None`  — inconclusive: a probe error (network / non-200 / timeout),
       invalid JSON, or a payload that is not a non-empty list of slot
-      objects. The caller treats `None` as "no evidence" — the probe is a
-      pure bypass (Issue #79) and never fails the delivery.
+      objects — INCLUDING slots whose `is_processing` is missing or not
+      a bool (schema drift): a vacuous "every slot is false" over slots
+      that carry no flag would fabricate the swallow evidence and send
+      the #231 recovery after a model that is in fact generating. The
+      caller treats `None` as "no evidence" — the probe is a pure
+      bypass (Issue #79) and never fails the delivery.
     """
     try:
         # urlopen raises HTTPError for a non-2xx status (caught below),
@@ -413,8 +417,11 @@ def slots_idle(url: str, timeout: float = SLOTS_PROBE_TIMEOUT) -> bool | None:
     for slot in payload:
         if not isinstance(slot, dict):
             return None
-        if slot.get("is_processing") is True:
+        flag = slot.get("is_processing")
+        if flag is True:
             return False
+        if flag is not False:
+            return None
     return True
 
 

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -890,6 +890,49 @@ def test_slots_idle_uses_the_given_timeout(monkeypatch):
     assert calls["url"] == "http://x/slots"
 
 
+def test_slots_idle_none_when_no_slot_carries_the_flag(monkeypatch):
+    # Schema drift (a proxy that drops the key): no slot carries a real
+    # `is_processing` bool, so "every slot is false" is vacuously true —
+    # but a vacuous True is FABRICATED swallow evidence, and the #231
+    # recovery would kill a session whose model is in fact generating.
+    # Missing evidence is inconclusive (None), like every other
+    # unparseable payload.
+    _patch_urlopen(
+        monkeypatch, result=_FakeSlotsResponse(200, b'[{"id": 0}, {"id": 1}]'),
+    )
+    assert pi_recovery.slots_idle("http://x/slots") is None
+
+
+def test_slots_idle_none_when_flag_is_not_a_bool(monkeypatch):
+    # A non-bool `is_processing` (the string "true", the int 1) is not
+    # the documented contract (`is_processing` bool): inconclusive, not
+    # idle. `is True` on such a value answers False for BUSY and falls
+    # through to "idle" — the fail-open direction.
+    _patch_urlopen(
+        monkeypatch,
+        result=_FakeSlotsResponse(200, b'[{"is_processing": "true"}]'),
+    )
+    assert pi_recovery.slots_idle("http://x/slots") is None
+    _patch_urlopen(
+        monkeypatch,
+        result=_FakeSlotsResponse(200, b'[{"is_processing": 1}]'),
+    )
+    assert pi_recovery.slots_idle("http://x/slots") is None
+
+
+def test_slots_idle_none_when_any_slot_lacks_the_flag(monkeypatch):
+    # `True` means EVERY slot is idle (the documented contract). One slot
+    # without the flag is one slot of unknown state: the whole payload is
+    # inconclusive.
+    _patch_urlopen(
+        monkeypatch,
+        result=_FakeSlotsResponse(
+            200, b'[{"is_processing": false}, {"id": 1}]',
+        ),
+    )
+    assert pi_recovery.slots_idle("http://x/slots") is None
+
+
 def test_upstream_alive_false_for_live_state_without_remote_ip(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION

Fixes #571

## What

`slots_idle` answered `True` ("every slot idle — swallow evidence")
vacuously whenever a slot carried no `is_processing` flag or a non-bool
one: the `is True` busy-check answers False for a missing key, a `"true"`
string, or a `1` int, and the loop fell through to `return True`. Schema
drift in front of `/slots` (a proxy dropping or retyping the key) thus
fabricated the #231 swallow evidence and could send the `model_wait`
recovery after a model that was in fact generating.

A slot whose `is_processing` is missing or not a bool is now an unknown
slot: the payload is inconclusive (`None`), exactly like the other
unparseable payload shapes (non-list, empty list, non-dict slot). The
pure-bypass contract (Issue #79) is unchanged.

## Evidence

- Red first: `test_slots_idle_none_when_no_slot_carries_the_flag`,
  `test_slots_idle_none_when_flag_is_not_a_bool`,
  `test_slots_idle_none_when_any_slot_lacks_the_flag` (commit 1) fail on
  main.
- Green: all `slots_idle` tests (11 existing + 3 new) pass; the genuine
  all-idle payload (the real llama-server body from #231) still returns
  `True`, a genuinely busy slot still returns `False`.

## Verification note

Unit suite `tests/test_pi_recovery.py` green locally on Python 3.14
(mocked-urlopen pattern; no `/proc` dependency).