### PR TITLE
fix: recheck pid identity before the recovery signal

### DIFF
--- a/src/orbi/pi_recovery.py
+++ b/src/orbi/pi_recovery.py
@@ -338,7 +338,10 @@ def find_idle_descendants(root_pid: int, idle_start_epoch: float,
     no later than `idle_start_epoch` — the hung tools of the stalled
     scene.
 
-    Each result is `{"pid": int, "cmdline": str}`. A process spawned
+    Each result is `{"pid": int, "cmdline": str, "start_epoch": float}`.
+    The start time rides along as the process identity: the signal path
+    re-checks it before delivering, so a pid reused inside the
+    discovery-to-signal gap is never signaled. A process spawned
     after the idle window began (a new tool call) is never a target, and
     a process that is not a descendant (checked by the ppid chain) is
     never a target. `btime`/`hz` default to the real clock constants.
@@ -358,7 +361,11 @@ def find_idle_descendants(root_pid: int, idle_start_epoch: float,
         if start is None:
             continue
         if start <= idle_start_epoch:
-            targets.append({"pid": pid, "cmdline": cmdline_of(pid)})
+            targets.append({
+                "pid": pid,
+                "cmdline": cmdline_of(pid),
+                "start_epoch": start,
+            })
     return targets
 
 
@@ -418,13 +425,34 @@ def slots_idle(url: str, timeout: float = SLOTS_PROBE_TIMEOUT) -> bool | None:
     return True
 
 
-def signal_pid(pid: int, sig: int) -> str:
+def signal_pid(pid: int, sig: int, *, expected_start_epoch: float | None = None,
+               btime: float | None = None, hz: float | None = None) -> str:
     """Send `sig` to `pid`; return the outcome for the journal.
 
+    With `expected_start_epoch` (the target's start time from
+    `find_idle_descendants`) the identity is re-checked on the stat
+    line right before the delivery: the discovery-to-signal gap can
+    span a full idle window, and a pid the kernel reused in the gap
+    belongs to an innocent process that must never be signaled
+    (TOCTOU).
+
     `sent` (delivered), `already_dead` (ESRCH: it exited between the
-    discovery and the signal) or `failed: <error>` (any other OS error —
-    logged, never raised: the recovery must not take the delivery down).
+    discovery and the signal — or the start-time recheck finds the
+    stat line gone), `pid_reused` (the recheck finds a different start
+    time on the pid: not the discovered process, nothing signaled) or
+    `failed: <error>` (any other OS error — logged, never raised: the
+    recovery must not take the delivery down).
     """
+    if expected_start_epoch is not None:
+        current = process_start_epoch(
+            pid,
+            btime=boot_time() if btime is None else btime,
+            hz=clk_tck() if hz is None else hz,
+        )
+        if current is None:
+            return "already_dead"
+        if current != expected_start_epoch:
+            return "pid_reused"
     try:
         os.kill(pid, sig)
         return "sent"

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -5793,6 +5793,7 @@ def stream_pi(
                             for target in flipped:
                                 result = signal_pid(
                                     target["pid"], signal.SIGTERM,
+                                    expected_start_epoch=target["start_epoch"],
                                 )
                                 LOGGER.warning(
                                     "pi_idle_term run=%s issue=%s "
@@ -5856,7 +5857,10 @@ def stream_pi(
                                 quote_value(target["cmdline"] or "-"),
                             )
                             continue
-                        result = signal_pid(target["pid"], signal.SIGKILL)
+                        result = signal_pid(
+                            target["pid"], signal.SIGKILL,
+                            expected_start_epoch=target["start_epoch"],
+                        )
                         LOGGER.warning(
                             "pi_idle_kill run=%s issue=%s role=%s "
                             "pid=%s cmdline=%s result=%s",

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -298,8 +298,71 @@ def test_find_idle_descendants_selects_pre_idle_start_descendants_only(
         100, idle_start, btime=FAKE_BTIME, hz=FAKE_HZ,
     )
     assert targets == [
-        {"pid": 200, "cmdline": "/bin/bash -c pytest"},
+        {
+            "pid": 200, "cmdline": "/bin/bash -c pytest",
+            "start_epoch": start_epoch(100),
+        },
     ]
+
+
+def test_signal_pid_rechecks_identity_and_refuses_a_reused_pid(
+    tmp_path, monkeypatch,
+):
+    # The discovery-to-signal gap can span a full idle window: a target
+    # that exits in the gap and whose pid the kernel hands to an
+    # innocent process must NEVER be signaled. The start time (stat
+    # field 22) is the identity: a different start on the same pid is a
+    # reused pid (`pid_reused`, nothing signaled); the same start is
+    # the discovered process (`sent`).
+    proc = make_procfs(tmp_path, [(42, "innocent", 1, 200, b"other")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+
+    def refuse(pid, sig):
+        raise AssertionError(f"signaled the reused pid {pid}")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", refuse)
+    assert pi_recovery.signal_pid(
+        42, signal.SIGTERM,
+        expected_start_epoch=start_epoch(100), btime=FAKE_BTIME,
+        hz=FAKE_HZ,
+    ) == "pid_reused"
+
+
+def test_signal_pid_identity_recheck_confirms_the_discovered_process(
+    tmp_path, monkeypatch,
+):
+    proc = make_procfs(tmp_path, [(42, "bash", 1, 100, b"bash")])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.signal_pid(
+        42, 0,
+        expected_start_epoch=start_epoch(100), btime=FAKE_BTIME,
+        hz=FAKE_HZ,
+    ) == "sent"
+
+
+def test_signal_pid_identity_recheck_reports_a_gone_process(
+    tmp_path, monkeypatch,
+):
+    # The target exited between the discovery and the signal (its stat
+    # is gone): already_dead, like the ESRCH path — no signal, no error.
+    proc = make_procfs(tmp_path, [])
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+
+    def refuse(pid, sig):
+        raise AssertionError(f"signaled the gone pid {pid}")
+
+    monkeypatch.setattr(pi_recovery.os, "kill", refuse)
+    assert pi_recovery.signal_pid(
+        42, signal.SIGTERM,
+        expected_start_epoch=start_epoch(100), btime=FAKE_BTIME,
+        hz=FAKE_HZ,
+    ) == "already_dead"
+
+
+def test_signal_pid_without_expected_start_keeps_the_legacy_behavior():
+    # No identity given (callers outside the idle recovery): the signal
+    # path is exactly as before.
+    assert pi_recovery.signal_pid(os.getpid(), 0) == "sent"
 
 
 def test_find_idle_descendants_includes_process_started_at_idle_start(

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -333,8 +333,11 @@ def test_signal_pid_identity_recheck_confirms_the_discovered_process(
 ):
     proc = make_procfs(tmp_path, [(42, "bash", 1, 100, b"bash")])
     monkeypatch.setattr(pi_recovery, "PROC", proc)
+    # The identity recheck reads the fake stat line; the delivery itself
+    # is faked (pid 42 is not a real process to signal).
+    monkeypatch.setattr(pi_recovery.os, "kill", lambda pid, sig: None)
     assert pi_recovery.signal_pid(
-        42, 0,
+        42, signal.SIGTERM,
         expected_start_epoch=start_epoch(100), btime=FAKE_BTIME,
         hz=FAKE_HZ,
     ) == "sent"


### PR DESCRIPTION

Fixes #572

## What

The idle-recovery TERM/KILL delivered to a **bare pid**. The
discovery-to-signal gap spans a full idle window by design (the #181
grace), so a discovered process that exits in the gap and whose pid the
kernel reuses turns the signal into a kill of an innocent, never-Pi-descendant
process — journaled as `result=sent`, indistinguishable from a
legitimate kill. The module's own contract ("ONLY [pre-idle descendants]
may be signaled") was enforced at discovery but not at delivery.

`find_idle_descendants` now carries each target's start time (stat field
22 — the same identity that made it a target) as `start_epoch` in the
result, and `signal_pid` re-reads the stat line immediately before
delivering: same start → `sent`; different start → `pid_reused`,
nothing signaled; stat gone → `already_dead` (same as the ESRCH path).
Both runner call sites (TERM at the flip window, KILL at the next
window) pass the identity. Callers outside the recovery keep the legacy
single-argument form, unchanged.

## Contract note

`find_idle_descendants`' result dict gains a `start_epoch` field; the
one test that asserts the exact dict shape
(`test_find_idle_descendants_selects_pre_idle_start_descendants_only`)
is updated accordingly.

## Evidence

- Red first: `test_signal_pid_rechecks_identity_and_refuses_a_reused_pid`
  (a refusing `os.kill` fake asserts nothing is ever delivered for a
  reused pid), plus confirm/gone/legacy-form tests (commit 1) fail on
  main.
- Green: all 74 tests in `tests/test_pi_recovery.py` pass, including the
  3 pre-existing `signal_pid` tests.

## Verification note

Unit suite green locally on Python 3.14 (fake-procfs pattern; no real
process is signaled in tests). The runner-side TERM/KILL scenes read the
real `/proc` (Linux-only; those tests fail on pristine main on this
macOS machine too) — CI (ubuntu) is the authority for that path.