### PR TITLE
fix: guard process_state against an empty field list

### DIFF
--- a/src/orbi/pi_recovery.py
+++ b/src/orbi/pi_recovery.py
@@ -95,7 +95,7 @@ def process_state(pid: int) -> str | None:
     if raw is None:
         return None
     fields = _stat_fields(raw)
-    if fields is None or not fields[0]:
+    if fields is None or not fields:
         return None
     return fields[0]
 

--- a/tests/test_pi_recovery.py
+++ b/tests/test_pi_recovery.py
@@ -486,6 +486,22 @@ def test_process_state_none_for_malformed_stat(tmp_path, monkeypatch):
     assert pi_recovery.process_state(5) is None
 
 
+def test_process_state_none_for_paren_terminated_stat(
+    tmp_path, monkeypatch,
+):
+    # A line that ENDS at the comm parentheses has no state field at
+    # all: `_stat_fields` returns [] and the None contract of the
+    # sibling parsers applies — never an IndexError out of a
+    # fail-safe module (`not fields[0]` indexes before checking
+    # emptiness, and its empty-string intent can never fire: split()
+    # never yields empty tokens).
+    proc = make_procfs(tmp_path, [])
+    (proc / "5").mkdir()
+    (proc / "5" / "stat").write_text("5 (bash)", encoding="utf-8")
+    monkeypatch.setattr(pi_recovery, "PROC", proc)
+    assert pi_recovery.process_state(5) is None
+
+
 def test_process_start_monotonic_reads_field_22(tmp_path, monkeypatch):
     # stat field 22 (starttime) in ticks since boot, converted with the
     # given hz: 100 ticks at hz=100 -> 1.0 s since boot. The value stays


### PR DESCRIPTION

Fixes #573

## What

`process_state`'s malformed-line guard `not fields[0]` indexes before
checking emptiness: a stat line that ends at the comm parentheses
(`"5 (bash)"` — no fields after the last `)`) makes `_stat_fields`
return `[]` and the guard raise `IndexError` instead of returning `None`
like every sibling parser (`process_ppid`, `process_start_epoch`). The
guard's empty-string intent can never fire — `str.split()` never yields
empty tokens — so as written it defends a shape that cannot exist and
misses the shape that can. One-line fix: `if fields is None or not
fields:`.

Honest scope: a real Linux kernel emits complete `/proc/<pid>/stat`
lines, so this is a defensive-contract inconsistency (fail-safe module
raising), not a production crash path — the issue says so explicitly.

## Evidence

- Red first: `test_process_state_none_for_paren_terminated_stat`
  (commit 1) fails on main with `IndexError: list index out of range`.
- Green: all `process_state` tests (3 existing + 1 new) pass.

## Verification note

Unit suite `tests/test_pi_recovery.py` green locally on Python 3.14
(fake-procfs pattern; no `/proc` dependency).