### PR TITLE
fix: 发布 scope 与 milestone 分页查询改用 --slurp 展平多页结果

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2205,9 +2205,10 @@ def derive_release_scope_from_milestone(repo: str,
     release, never a guessed one.
     """
     raw = run_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all", "--paginate",
+        "gh", "api", f"repos/{repo}/milestones?state=all",
+        "--paginate", "--slurp",
     ])
-    milestones = parse_issue_array(raw)
+    milestones = parse_paginated_issue_array(raw)
     matches = [
         m for m in milestones
         if isinstance(m, dict) and m.get("title") == milestone_title
@@ -2230,9 +2231,9 @@ def derive_release_scope_from_milestone(repo: str,
         raw = run_command([
             "gh", "api",
             f"repos/{repo}/issues?state={state}&milestone={number}",
-            "--paginate",
+            "--paginate", "--slurp",
         ])
-        return [item for item in parse_issue_array(raw)
+        return [item for item in parse_paginated_issue_array(raw)
                 if isinstance(item, dict)]
 
     closed_issues = [item for item in issues("closed")
@@ -2982,9 +2983,10 @@ def close_release_milestone(repo: str, version: str, *, run_id: str | None = Non
     is a failed check.
     """
     raw = run_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all", "--paginate",
+        "gh", "api", f"repos/{repo}/milestones?state=all",
+        "--paginate", "--slurp",
     ])
-    milestones = parse_issue_array(raw)
+    milestones = parse_paginated_issue_array(raw)
     matches = [
         m for m in milestones
         if isinstance(m, dict) and m.get("title") == version
@@ -4562,9 +4564,10 @@ def advance_active_milestone_on_idle(
 ) -> tuple[str, str | None]:
     """Check and advance a configured milestone after no_ready_issue."""
     raw = run_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all", "--paginate",
+        "gh", "api", f"repos/{repo}/milestones?state=all",
+        "--paginate", "--slurp",
     ], timeout=30)
-    milestones = parse_issue_array(raw)
+    milestones = parse_paginated_issue_array(raw)
     matches = [
         milestone for milestone in milestones
         if isinstance(milestone, dict)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -13926,6 +13926,43 @@ def test_verify_release_scope_reraises_real_gh_failure(monkeypatch):
         runner.verify_release_scope("o/r", [123], Path("/repo"), "release123")
 
 
+def test_derive_release_scope_flattens_multi_page_results(monkeypatch):
+    """`gh api --paginate` 不带 `--slurp` 时把每页 JSON 首尾拼接输出：
+    Milestone 的 issue 超过一页（REST 默认每页 30 条）后按单页
+    `json.loads` 解析必崩，发布 scope 推导对该 Milestone 永久失败。
+    修复与 `milestone_open_issues` 同款：`--slurp` 收拢各页 +
+    `parse_paginated_issue_array` 展平，多页 scope 完整保留。"""
+    milestones = [{
+        "number": 5, "title": "v0.9.0", "state": "closed",
+        "open_issues": 0, "closed_issues": 35,
+        "url": "https://api.github.com/repos/o/r/milestones/5",
+        "html_url": "https://github.com/o/r/milestone/5",
+    }]
+    page_one = [{"number": n, "title": f"issue {n}", "state": "closed"}
+                for n in range(1, 31)]
+    page_two = [{"number": n, "title": f"issue {n}", "state": "closed"}
+                for n in range(31, 36)]
+
+    def fake_run(command, **kwargs):
+        # 忠实模拟 gh 的两种输出形态：带 --slurp 收拢进外层数组；
+        # 不带则各页 JSON 首尾相接（这正是修复前的崩溃输入）。
+        path = command[2]
+        if "--slurp" in command:
+            if path.startswith("repos/o/r/milestones?"):
+                return json.dumps([milestones])
+            return json.dumps([page_one, page_two])
+        if path.startswith("repos/o/r/milestones?"):
+            return json.dumps(milestones)
+        return json.dumps(page_one) + json.dumps(page_two)
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    scope, open_evidence = runner.derive_release_scope_from_milestone(
+        "o/r", "v0.9.0",
+    )
+    assert scope == list(range(1, 36))
+    assert open_evidence == []
+
+
 def make_milestone_gh(monkeypatch, *, milestones=None, items_by_milestone=None):
     """Answer the gh API calls used for milestone issue scope derivation.
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -5407,7 +5407,7 @@ def test_advance_active_milestone_pending_creates_one_p0_ready_issue(
         calls.append(command)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
-        return json.dumps(milestones)
+        return json.dumps([milestones])
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     with caplog.at_level("INFO"):
@@ -5432,10 +5432,10 @@ def test_advance_active_milestone_manual_notification_is_not_pickupable(
     monkeypatch.setattr(
         runner, "run_command",
         lambda command, **kwargs: calls.append(command) or (
-            "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([
+            "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([[
                 {"title": "v0.3.0", "state": "closed"},
                 {"title": "v0.4.0", "state": "open"},
-            ])
+            ]])
         ),
     )
 
@@ -5465,7 +5465,7 @@ def test_advance_active_milestone_closes_old_manual_notification_after_manual_mo
                     "body": "orbi-milestone-advance old=v0.3.0 candidates=v0.4.0",
                 },
             ])
-        return json.dumps([{"title": "v0.4.0", "state": "open"}])
+        return json.dumps([[{"title": "v0.4.0", "state": "open"}]])
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.advance_active_milestone_on_idle(
@@ -5486,7 +5486,7 @@ def test_advance_active_milestone_close_failure_is_bypassed(
 
     def fail_close(command, **kwargs):
         if command[:2] == ["gh", "api"]:
-            return json.dumps([{"title": "v0.4.0", "state": "open"}])
+            return json.dumps([[{"title": "v0.4.0", "state": "open"}]])
         raise RuntimeError("GitHub unavailable")
 
     monkeypatch.setattr(runner, "run_command", fail_close)
@@ -5506,9 +5506,9 @@ def test_advance_active_milestone_closure_is_idempotent_on_repeated_tick(
     monkeypatch.setattr(
         runner, "run_command",
         lambda command, **kwargs: calls.append(command) or (
-            "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([
+            "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([[
                 {"title": "v0.4.0", "state": "open"},
-            ])
+            ]])
         ),
     )
 
@@ -5529,10 +5529,10 @@ def test_advance_active_milestone_pending_issue_failure_is_bypassed(
             return "[]"
         if command[:3] == ["gh", "issue", "create"]:
             raise RuntimeError("GitHub unavailable")
-        return json.dumps([
+        return json.dumps([[
             {"title": "v0.3.0", "state": "closed"},
             {"title": "v0.3.1", "state": "open", "open_issues": 2},
-        ])
+        ]])
 
     monkeypatch.setattr(runner, "run_command", fail_pending)
     with caplog.at_level("ERROR"):
@@ -5550,10 +5550,10 @@ def test_advance_active_milestone_pending_is_idempotent(
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     calls = []
     responses = [
-        json.dumps([
+        json.dumps([[
             {"title": "v0.3.0", "state": "closed"},
             {"title": "v0.3.1", "state": "open", "open_issues": 2},
-        ]),
+        ]]),
         '[{"number": 436}]',
     ]
     monkeypatch.setattr(
@@ -5572,11 +5572,11 @@ def test_advance_active_milestone_sorts_double_digit_versions_numerically(
     config.write_text('active_milestone = "v0.9.0"\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps([
+        lambda command, **kwargs: json.dumps([[
             {"title": "v0.9.0", "state": "closed"},
             {"title": "v0.10.0", "state": "open"},
             {"title": "v0.11.0", "state": "open"},
-        ]),
+        ]]),
     )
 
     assert runner.advance_active_milestone_on_idle(
@@ -5597,7 +5597,7 @@ def test_advance_active_milestone_selects_smallest_higher_open(
     ]
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps(milestones),
+        lambda command, **kwargs: json.dumps([milestones]),
     )
     with caplog.at_level("INFO"):
         assert runner.advance_active_milestone_on_idle(
@@ -5615,9 +5615,9 @@ def test_advance_active_milestone_open_reconciles_notifications_without_write(
     calls = []
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: calls.append(command) or json.dumps([
+        lambda command, **kwargs: calls.append(command) or json.dumps([[
             {"title": "v0.3.0", "state": "open"},
-        ]),
+        ]]),
     )
     assert runner.advance_active_milestone_on_idle("owner/repo", "v0.3.0", config) == ("open", None)
     assert len(calls) == 2
@@ -5632,11 +5632,11 @@ def test_advance_active_milestone_closed_without_candidate_logs_and_keeps_value(
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps([
+        lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.0", "state": "closed"},
             {"title": "v0.2.0", "state": "open", "open_issues": 1},
             {"title": "future", "state": "open", "open_issues": 2},
-        ]),
+        ]]),
     )
     with caplog.at_level("INFO"):
         assert runner.advance_active_milestone_on_idle(
@@ -5651,9 +5651,9 @@ def test_advance_active_milestone_missing_lists_open_milestones(monkeypatch, tmp
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps([
+        lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.1", "state": "open", "open_issues": 8},
-        ]),
+        ]]),
     )
     with pytest.raises(RuntimeError, match=r"active_milestone_missing current=v0.3.0; open milestones: v0.3.1\(8\)"):
         runner.advance_active_milestone_on_idle("owner/repo", "v0.3.0", config)
@@ -5664,10 +5664,10 @@ def test_advance_active_milestone_rejects_duplicate_title(monkeypatch, tmp_path)
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps([
+        lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.0", "state": "closed", "number": 1},
             {"title": "v0.3.0", "state": "closed", "number": 2},
-        ]),
+        ]]),
     )
     with pytest.raises(RuntimeError, match="ambiguous"):
         runner.advance_active_milestone_on_idle("owner/repo", "v0.3.0", config)
@@ -13950,9 +13950,13 @@ def test_derive_release_scope_flattens_multi_page_results(monkeypatch):
         if "--slurp" in command:
             if path.startswith("repos/o/r/milestones?"):
                 return json.dumps([milestones])
+            if "state=open" in path:
+                return json.dumps([[]])
             return json.dumps([page_one, page_two])
         if path.startswith("repos/o/r/milestones?"):
             return json.dumps(milestones)
+        if "state=open" in path:
+            return "[]"
         return json.dumps(page_one) + json.dumps(page_two)
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -13979,7 +13983,7 @@ def make_milestone_gh(monkeypatch, *, milestones=None, items_by_milestone=None):
         calls.append(command)
         path = command[2] if len(command) > 2 else ""
         if path == "repos/o/r/milestones?state=all":
-            return json.dumps(milestones)
+            return json.dumps([milestones])
         if "/pulls?" in path:
             raise AssertionError(
                 "milestone scope must not query /pulls: milestone is ignored"
@@ -13990,7 +13994,7 @@ def make_milestone_gh(monkeypatch, *, milestones=None, items_by_milestone=None):
         if match:
             state, number = match.groups()
             bucket = items_by_milestone.get(int(number), {})
-            return json.dumps(bucket.get(f"issues_{state}", []))
+            return json.dumps([bucket.get(f"issues_{state}", [])])
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
@@ -14908,9 +14912,9 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
         if command[:3] == ["gh", "issue", "list"]:
             label = command[command.index("--label") + 1]
             return json.dumps([{"number": n} for n in leftover_labels.get(label, [])])
-        if command == ["gh", "api",
-                       "repos/o/r/milestones?state=all", "--paginate"]:
-            return json.dumps([
+        if command == ["gh", "api", "repos/o/r/milestones?state=all",
+                       "--paginate", "--slurp"]:
+            return json.dumps([[
                 {"number": 1, "title": "v0.2.0", "state": "closed",
                  "open_issues": 0, "closed_issues": 28,
                  "url": "https://api.github.com/repos/o/r/milestones/1",
@@ -14919,7 +14923,7 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                  "open_issues": 0, "closed_issues": 2,
                  "url": "https://api.github.com/repos/o/r/milestones/5",
                  "html_url": "https://github.com/o/r/milestone/5"},
-            ])
+            ]])
         if command == ["gh", "api", "repos/o/r/issues?milestone=5&state=open&per_page=100",
                        "--paginate", "--slurp"]:
             return json.dumps([[]])
@@ -14936,7 +14940,7 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                 if match:
                     kind, item_state, number = match.groups()
                     bucket = milestone_items.get(int(number), {})
-                    return json.dumps(bucket.get(f"{kind}_{item_state}", []))
+                    return json.dumps([bucket.get(f"{kind}_{item_state}", [])])
             if check_run_pages:
                 page = check_run_pages.pop(0)
                 if not check_run_pages:
@@ -15205,7 +15209,8 @@ def test_process_release_derives_scope_from_milestone(monkeypatch):
     commands = [c for c, _ in state["commands"]]
     # The scope was derived from the milestone, not hand-listed.
     assert ["gh", "api",
-            "repos/o/r/issues?state=closed&milestone=5", "--paginate"] \
+            "repos/o/r/issues?state=closed&milestone=5",
+            "--paginate", "--slurp"] \
         in commands
     # The derived scope went through the existing item-by-item verify.
     (comment_number, comment_kwargs), = state["comments"]
@@ -15371,12 +15376,12 @@ def test_process_release_milestone_failure_keeps_release_successful(monkeypatch)
         # The v0.3.0 Milestone still has an open Issue: the close must
         # fail fast, but the already-published release remains successful.
         if command[:2] == ["gh", "api"] and "?state=all" in command[2]:
-            return json.dumps([
+            return json.dumps([[
                 {"number": 5, "title": "v0.3.0", "state": "open",
                  "open_issues": 1, "closed_issues": 2,
                  "url": "https://api.github.com/repos/o/r/milestones/5",
                  "html_url": "https://github.com/o/r/milestone/5"},
-            ])
+            ]])
         if command[:2] == ["gh", "api"] and "issues?milestone=5&state=open" in command[2]:
             return json.dumps([[{"number": 101, "title": "leftover"}]])
         return real(command, **kwargs)
@@ -15588,7 +15593,8 @@ def test_process_release_fails_on_scope_violation(monkeypatch):
 
 
 MILESTONE_LIST_COMMAND = [
-    "gh", "api", "repos/o/r/milestones?state=all", "--paginate",
+    "gh", "api", "repos/o/r/milestones?state=all",
+    "--paginate", "--slurp",
 ]
 MILESTONE_ISSUES_COMMAND = [
     "gh", "api", "repos/o/r/issues?milestone=5&state=open&per_page=100",
@@ -15611,11 +15617,11 @@ def test_close_release_milestone_closes_an_open_empty_milestone(monkeypatch):
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([
+            return json.dumps([[
                 _milestone(4, "v0.2.0", "closed", 0),
                 _milestone(5, "v0.3.0", "open", 0),
                 _milestone(6, "v0.4.0", "open", 3),
-            ])
+            ]])
         if command == MILESTONE_ISSUES_COMMAND:
             return json.dumps([[]])
         if command == ["gh", "api", "repos/o/r/milestones/5",
@@ -15644,10 +15650,10 @@ def test_close_release_milestone_is_idempotent_when_already_closed(monkeypatch):
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([
+            return json.dumps([[
                 _milestone(1, "v0.2.0", "closed", 0),
                 _milestone(2, "v0.3.0", "closed", 0),
-            ])
+            ]])
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -15665,10 +15671,10 @@ def test_close_release_milestone_fails_fast_without_a_matching_title(monkeypatch
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([
+            return json.dumps([[
                 _milestone(1, "v0.2.0", "closed", 0),
                 _milestone(3, "v0.4.0", "open", 7),
-            ])
+            ]])
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -15686,9 +15692,9 @@ def test_close_release_milestone_fails_fast_when_open_issues_remain(monkeypatch)
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([
+            return json.dumps([[
                 _milestone(5, "v0.3.0", "open", 2),
-            ])
+            ]])
         if command == MILESTONE_ISSUES_COMMAND:
             return json.dumps([[{"number": 101, "title": "leftover one"},
                                 {"number": 102, "title": "leftover two"}]])
@@ -15715,10 +15721,10 @@ def test_close_release_milestone_fails_fast_on_duplicate_titles(monkeypatch):
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([
+            return json.dumps([[
                 _milestone(5, "v0.3.0", "open", 0),
                 _milestone(7, "v0.3.0", "open", 0),
-            ])
+            ]])
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -15931,7 +15937,7 @@ def test_close_release_milestone_reconciles_epics_when_summary_lags(monkeypatch)
     def fake_run(command, **kwargs):
         calls.append(command)
         if command == MILESTONE_LIST_COMMAND:
-            return json.dumps([_milestone(5, "v0.4.0", "open", 1)])
+            return json.dumps([[_milestone(5, "v0.4.0", "open", 1)]])
         if command == MILESTONE_ISSUES_COMMAND:
             return json.dumps([[{"number": 20}]]) if calls.count(command) == 1 else json.dumps([[]])
         if command[-1:] == ["state=closed"]:
@@ -16776,7 +16782,7 @@ def test_close_release_milestone_rejects_a_non_array_milestone_list(monkeypatch)
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
-    with pytest.raises(ValueError, match="must be a JSON array"):
+    with pytest.raises(ValueError, match="must be an array of arrays"):
         runner.close_release_milestone("o/r", "v0.3.0")
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["unexpected"])


### PR DESCRIPTION
Fixes #584

Fixes 584

## 改动文件
- `src/orbi/runner.py`：四处 `gh api --paginate` 查询（derive_release_scope_from_milestone 的 milestones 与 issues 两处、close_release_milestone、advance_active_milestone_on_idle）全部补上 `--slurp`，解析从 `parse_issue_array` 切换为已合入的 `parse_paginated_issue_array`——与 `milestone_open_issues` 现行写法完全同款。
- `tests/test_bootstrap_runner.py`：新增多页红色测试；受新输出契约影响的既有夹具（make_milestone_gh、make_release_process_env、MILESTONE_LIST_COMMAND 及若干内联假体）从单页扁平形更新为收拢形。

## 做了哪些测试
- 新增 `test_derive_release_scope_flattens_multi_page_results`：假体忠实模拟 gh 的两种分页输出形态（带 --slurp 收拢进外层数组；不带则各页 JSON 首尾相接），35 条跨页 scope 必须完整保留。
- 修复前该测试红（JSONDecodeError: Extra data），修复后绿。

## 测试情况
- 目标组：`milestone or scope or derive or release` 共 237 个测试全部通过（含既有 close_release_milestone / advance_active_milestone / process_release 全家族）。
- 全量回归：`test_bootstrap_runner(-k 'not stream_pi')` + test_runner_health + test_pi_recovery + test_run_id_e2e 共 838 通过（stream_pi 族为 /proc Linux 专属，本机 macOS 无法运行，由 CI 权威验证）。
