### PR TITLE
fix: 发布后收尾改为旁路语义，绝不改写已发布终态

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3791,13 +3791,25 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
                 f"**Orbi release docs synced**: {docs_evidence}",
             ),
         )
-        apply_label_patch(
-            number, repo=source_repo, event=EVENT_MERGED,
-            current_labels={IN_PROGRESS_LABEL},
-        )
-        run_command(
-            ["gh", "issue", "close", str(number), "--repo", source_repo],
-        )
+        try:
+            apply_label_patch(
+                number, repo=source_repo, event=EVENT_MERGED,
+                current_labels={IN_PROGRESS_LABEL},
+            )
+            run_command(
+                ["gh", "issue", "close", str(number), "--repo", source_repo],
+            )
+        except Exception:
+            # The tag and GitHub Release are already published at this
+            # point. The ai-merged transition and the Issue close are
+            # bookkeeping of that irreversible fact — a transient failure
+            # here must not fall through to the generic handler and
+            # rewrite the published result as ai-blocked (Issue #79:
+            # bypass, never a terminal rewrite; same rule as the
+            # milestone evidence below).
+            LOGGER.exception(
+                "issue=%s release_publish_closeout_failed", number,
+            )
         try:
             milestone_evidence = close_release_milestone(
                 source_repo, tag, run_id=run_id,
@@ -3812,14 +3824,19 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             milestone_evidence = (
                 "milestone evidence unavailable: " + str(exc)
             )
-        comment_issue(
-            number, repo=source_repo,
-            body=release_success_comment_body(
-                run_id, run_info, release_url, tag, release_commit,
-                scope_evidence, gate_evidence, test_evidence,
-                docs_evidence, milestone_evidence,
-            ),
-        )
+        try:
+            comment_issue(
+                number, repo=source_repo,
+                body=release_success_comment_body(
+                    run_id, run_info, release_url, tag, release_commit,
+                    scope_evidence, gate_evidence, test_evidence,
+                    docs_evidence, milestone_evidence,
+                ),
+            )
+        except Exception:
+            LOGGER.exception(
+                "issue=%s release_success_comment_failed", number,
+            )
         _safe_publish(
             run_id=run_id, issue=number, source_repo=source_repo,
             role=ROLE_RELEASE,

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -15326,6 +15326,34 @@ def test_process_release_gate_failure_blocks_and_returns_cleanly(monkeypatch):
     )
 
 
+def test_process_release_publish_closeout_failure_keeps_release_result(
+    monkeypatch,
+):
+    """tag 和 GitHub Release 已发布之后，ai-merged 转移/关票/成功评论
+    都是既成事实的记账（Issue #79 旁路语义）：任何一步瞬时失败只记日志，
+    绝不允许掉进通用异常处理器把已发布结果改写成 ai-blocked（仓库里
+    同时挂 ai-merged 与 ai-blocked 双终态）。"""
+    state = make_release_process_env(monkeypatch)
+    real_edit = runner.edit_issue
+
+    def failing_edit(number, **kwargs):
+        if kwargs.get("add") == "ai-merged":
+            raise RuntimeError("GitHub unavailable")
+        return real_edit(number, **kwargs)
+
+    monkeypatch.setattr(runner, "edit_issue", failing_edit)
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    url = runner.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    # The published release result stands; the closeout failure never
+    # rewrote it as blocked.
+    assert url == "https://github.com/o/r/releases/tag/v0.3.0"
+    assert not any(k.get("add") == "ai-blocked" for _, k in state["edits"])
+
+
 def test_process_release_milestone_failure_keeps_release_successful(monkeypatch):
     state = make_release_process_env(monkeypatch)
     real = runner.run_command


### PR DESCRIPTION
Fixes #586

Fixes 586

## 改动文件
- `src/orbi/runner.py`：`process_release` 发布成功后的三步收尾（ai-merged 标签转移、`gh issue close`、成功评论）分别包进旁路 try/except，失败记 `release_publish_closeout_failed` / `release_success_comment_failed` 结构化日志，交付结果保持 `return release_url`——与同函数中 milestone 收尾已有的旁路语义完全一致（Issue #79）。
- `tests/test_bootstrap_runner.py`：新增 1 个测试。

## 做了哪些测试
- 新增 `test_process_release_publish_closeout_failure_keeps_release_result`：ai-merged 转移注入瞬时失败，断言返回值仍是发布 URL、终态不出现 ai-blocked。

## 测试情况
- 修复前该测试红（返回空串且 ai-blocked 被打上），修复后绿。
- `process_release or closeout` 组 27 个测试全部通过。
