### PR TITLE
fix: docs 同步无暂存时检验远端可达，补推遗留提交

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3327,6 +3327,33 @@ def sync_release_docs(*, source_repo: str, repo_dir: Path,
             if exc.returncode != 1:
                 raise
         else:
+            # Nothing staged has TWO possible worlds: the docs commit
+            # already reached origin/<base> (genuinely in sync), or the
+            # previous run committed locally and its push failed — then
+            # this no-op would be a FALSE success (the release notes
+            # never landed remotely while the release is declared done,
+            # with Milestone closed and a success comment posted).
+            # HEAD reachable from origin/<base> is the evidence that
+            # separates the worlds; unreachable → push the recovery.
+            try:
+                run_command(
+                    ["git", "merge-base", "--is-ancestor",
+                     "HEAD", f"origin/{base_branch}"],
+                    cwd=worktree,
+                )
+            except subprocess.CalledProcessError as merge_exc:
+                if merge_exc.returncode != 1:
+                    raise
+                run_git_network_command(
+                    ["git", "push", "origin",
+                     f"HEAD:refs/heads/{base_branch}"],
+                    cwd=worktree,
+                )
+                return (
+                    f"docs release notes for {tag} recovered — the "
+                    "previous local commit had not been pushed; pushed "
+                    f"to {base_branch} now"
+                )
             return (
                 f"docs release notes for {tag} already in sync — "
                 "idempotent no-op, nothing committed"

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16292,6 +16292,49 @@ def test_sync_release_docs_is_idempotent_on_rerun(tmp_path, monkeypatch):
     assert (work / "docs" / "release-v0.4.0.mdx").read_text(encoding="utf-8") == en_before
 
 
+def test_sync_release_docs_pushes_the_local_commit_a_failed_push_left_behind(
+    tmp_path, monkeypatch,
+):
+    """上次运行 commit 成功但 push 瞬时失败的续跑现场：工作区无可暂存
+    内容 ≠ 已同步——"无暂存"有两种世界，其一（本地提交从未到达远端）
+    返回 already in sync 就是假成功：release 宣告完成而远端永远拿不到
+    release notes。无暂存时必须用 merge-base 检验 HEAD 是否真的可达
+    origin/<base>，未达则补推。"""
+    work = make_release_docs_repo(tmp_path)
+    head = git_out(work, "rev-parse", "HEAD")
+    subprocess.run(["git", "-C", str(work), "tag", "-a", "v0.4.0",
+                    "-m", "rel", head], check=True, capture_output=True)
+    fake_gh_release_view(monkeypatch, body=RELEASE_DOCS_BODY_V040)
+    original = runner.run_git_network_command
+
+    def failing_push(command, **kwargs):
+        if command[:3] == ["git", "push", "origin"]:
+            raise subprocess.CalledProcessError(1, command, stderr="boom")
+        return original(command, **kwargs)
+
+    monkeypatch.setattr(runner, "run_git_network_command", failing_push)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.sync_release_docs(
+            source_repo="o/r", repo_dir=work, worktree=work,
+            base_branch="main", tag="v0.4.0", release_commit=head,
+            issue_number=77,
+        )
+    remote_before = git_out(work, "rev-parse", "origin/main")
+    # 续跑：网络恢复。修复前这里假成功（already in sync），远端仍停在
+    # 旧提交；修复后补推本地 docs 提交。
+    monkeypatch.setattr(runner, "run_git_network_command", original)
+    evidence = runner.sync_release_docs(
+        source_repo="o/r", repo_dir=work, worktree=work,
+        base_branch="main", tag="v0.4.0", release_commit=head,
+        issue_number=77,
+    )
+    assert "pushed" in evidence
+    assert git_out(work, "rev-parse", "origin/main") != remote_before
+    assert git_out(work, "rev-parse", "origin/main") == git_out(
+        work, "rev-parse", "HEAD",
+    )
+
+
 def test_sync_release_docs_resumes_after_a_partial_step(tmp_path, monkeypatch):
     """Resume after a partial step: the pages are written and the marker
     moved, but the navigation was never updated (a crash mid-step). The


### PR DESCRIPTION
Fixes #587

Fixes 587

## 改动文件
- `src/orbi/runner.py`：`sync_release_docs` 的幂等 no-op 分支增加远端可达性检验——无暂存内容时先 `git merge-base --is-ancestor HEAD origin/<base>`：可达才是真"already in sync"；不可达说明上次提交从未推送，补推 `HEAD:refs/heads/<base>` 并返回 "recovered" 证据。
- `tests/test_bootstrap_runner.py`：新增 1 个测试。

## 做了哪些测试
- 新增 `test_sync_release_docs_pushes_the_local_commit_a_failed_push_left_behind`（真实 bare 远端 + clone）：第一次注入 push 失败（commit 已落地），续跑必须补推——断言返回证据含 "pushed" 且 origin/main 前进到与 HEAD 一致。

## 测试情况
- 修复前该测试红（返回 already in sync 假成功，远端不动），修复后绿。
- `sync_release_docs` 组 13 个测试全部通过——关键的既有"幂等重跑 = no-op"测试（真已同步场景）行为不变。
