### PR TITLE
fix: swallow 探针窗口在事件到达时重启，杜绝跨轮误杀

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -5816,6 +5816,16 @@ def stream_pi(
                 model_wait_probe_url is not None
                 and activity["model_wait"]
             ):
+                if activity["changed"]:
+                    # Events arrived since the last poll — a turn may
+                    # have completed entirely inside the poll gap. The
+                    # sustained-idle window must RESTART: a window
+                    # carried across a completed turn killed healthy
+                    # sessions (the journal showed idle_seconds far
+                    # below the probe grace). This is the "never fires
+                    # while events keep arriving" contract enforced
+                    # across poll gaps, not just within one poll.
+                    probe_first_idle = None
                 idle = slots_idle(model_wait_probe_url)
                 if idle is True:
                     if probe_first_idle is None:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7942,6 +7942,48 @@ def test_stream_pi_swallow_not_fired_while_a_slot_is_processing(
     assert "reason=model_wait_dead_stale_" in failures[0]
 
 
+def test_stream_pi_swallow_window_restarts_when_events_arrive(
+    tmp_path, caplog, monkeypatch,
+):
+    """事件持续到达的会话绝不能判 swallow（本函数自身的契约："Never
+    fires while events keep arriving"）。turn 完整落在两次 poll 之间
+    时，持续空闲窗口此前不重置——跨轮携带的窗口把"刚完成一轮健康
+    请求"的活会话误杀（复现日志里 idle_seconds 远小于 probe_seconds）。
+    事件每 0.4s 到达一次（< probe_seconds=0.6），窗口必须在每次事件
+    后重启，探测永不触发，会话自然跑完。"""
+    monkeypatch.setattr(runner, "slots_idle", lambda url: True)
+    records = [
+        (0.0, {"type": "session", "id": "sess-live",
+               "timestamp": fresh_timestamp(), "cwd": "/w"}),
+        (0.4, {"type": "message", "id": "r1",
+               "timestamp": fresh_timestamp(1),
+               "message": {"role": "toolResult", "toolCallId": "t1",
+                           "toolName": "bash",
+                           "content": [{"type": "text", "text": "ok"}]}}),
+        (0.8, {"type": "message", "id": "r2",
+               "timestamp": fresh_timestamp(2),
+               "message": {"role": "toolResult", "toolCallId": "t2",
+                           "toolName": "bash",
+                           "content": [{"type": "text", "text": "ok"}]}}),
+        (1.2, {"type": "message", "id": "r3",
+               "timestamp": fresh_timestamp(3),
+               "message": {"role": "toolResult", "toolCallId": "t3",
+                           "toolName": "bash",
+                           "content": [{"type": "text", "text": "ok"}]}}),
+    ]
+    command = make_fake_pi(tmp_path, session_records=records, sleep=1.4)
+    runner.stream_pi(
+        command, cwd=tmp_path, poll_interval=0.1,
+        model_wait_dead_seconds=10.0,
+        model_wait_probe_url="http://127.0.0.1:18082/slots",
+        model_wait_probe_seconds=0.6,
+        run_id="deadbeef", issue=233, source_repo="xqliu/orbi",
+        branch="b",
+    )
+    assert " model_wait_swallowed " not in caplog.text
+    assert " run_failed " not in caplog.text
+
+
 def test_stream_pi_swallow_probe_failure_is_inconclusive(
     tmp_path, caplog, monkeypatch,
 ):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7952,26 +7952,26 @@ def test_stream_pi_swallow_window_restarts_when_events_arrive(
     事件每 0.4s 到达一次（< probe_seconds=0.6），窗口必须在每次事件
     后重启，探测永不触发，会话自然跑完。"""
     monkeypatch.setattr(runner, "slots_idle", lambda url: True)
+
+    def tool_result(n):
+        return {"type": "message", "id": f"r{n}",
+                "timestamp": fresh_timestamp(n),
+                "message": {"role": "toolResult", "toolCallId": f"t{n}",
+                            "toolName": "bash",
+                            "content": [{"type": "text", "text": "ok"}]}}
+    # make_fake_pi 的 delay 是逐条累加的 sleep：0.3s 间隔的事件流
+    # （< probe_seconds=0.6），结尾 0.4s 收尾——任何无事件间隙都小于
+    # 探针宽限，窗口在每次事件后重启，永不触发。
     records = [
         (0.0, {"type": "session", "id": "sess-live",
                "timestamp": fresh_timestamp(), "cwd": "/w"}),
-        (0.4, {"type": "message", "id": "r1",
-               "timestamp": fresh_timestamp(1),
-               "message": {"role": "toolResult", "toolCallId": "t1",
-                           "toolName": "bash",
-                           "content": [{"type": "text", "text": "ok"}]}}),
-        (0.8, {"type": "message", "id": "r2",
-               "timestamp": fresh_timestamp(2),
-               "message": {"role": "toolResult", "toolCallId": "t2",
-                           "toolName": "bash",
-                           "content": [{"type": "text", "text": "ok"}]}}),
-        (1.2, {"type": "message", "id": "r3",
-               "timestamp": fresh_timestamp(3),
-               "message": {"role": "toolResult", "toolCallId": "t3",
-                           "toolName": "bash",
-                           "content": [{"type": "text", "text": "ok"}]}}),
+        (0.3, tool_result(1)),
+        (0.3, tool_result(2)),
+        (0.3, tool_result(3)),
+        (0.3, tool_result(4)),
+        (0.3, tool_result(5)),
     ]
-    command = make_fake_pi(tmp_path, session_records=records, sleep=1.4)
+    command = make_fake_pi(tmp_path, session_records=records, sleep=0.4)
     runner.stream_pi(
         command, cwd=tmp_path, poll_interval=0.1,
         model_wait_dead_seconds=10.0,


### PR DESCRIPTION
Fixes #590

Fixes 590

## 改动文件
- `src/orbi/runner.py`：`stream_pi` 的 swallow 探测块——处于 model_wait 且 `activity["changed"]`（本次 poll 读到新会话事件）时，把 `probe_first_idle` 重置为 None。真吞请求场景（事件冻结 + slot 持续空闲）的触发路径不变。
- `tests/test_bootstrap_runner.py`：新增 1 个测试。

## 做了哪些测试
- 新增 `test_stream_pi_swallow_window_restarts_when_events_arrive`（真实子进程假 Pi + 真时钟）：事件每 0.3s 到达一次（小于 0.6s 探针宽限）的活会话必须自然跑完，断言不出现 `model_wait_swallowed` 与 `run_failed`。覆盖"turn 完整落在两次 poll 之间"的序列——既有 5 个 swallow 测试全是单次冻结窗口，均未覆盖此形态。

## 测试情况
- 修复前该测试红：误杀日志 `reason=model_wait_swallowed_idle_0.2s`（会话新鲜度仅 0.2s 也照杀，实锤窗口跨轮携带）；修复后绿。
- `swallow or model_wait` 组 48 个测试全部通过，原有触发路径（冻结窗口、slot 处理中、探针不可达）行为不变。
