### PR TITLE
CI failure: tests on branch fix/release-tag-retry-lock (pull_request)

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2681,35 +2681,76 @@ def prepare_release_version(worktree: Path, tag: str,
 def release_tag_commit(repo_dir: Path, tag: str) -> str | None:
     """Return the commit the tag points to on the remote, or None.
 
-    (Issue #98) The tag is fetched under the base-sync lock — a task
-    worktree shares the checkout's common dir, so an unlocked
-    concurrent fetch would race on `refs/tags/<tag>` exactly like the
-    shared remote-tracking ref of Issue #171. When the remote has no
-    such tag the fetch exits 128 (verified against the real CLI) and
-    None is returned; after a successful fetch the tag is resolved to
-    the commit it points to locally (annotated tags are peeled with
-    `^{commit}`). Any other fetch failure fails fast.
+    (Issue #98) `git ls-remote` keeps the existence probe read-only and
+    its exit semantics unambiguous: exit 0 with empty output means the
+    remote has no such tag (None); ANY non-zero exit is a real failure
+    (network/auth) and propagates. The previous `git fetch` probe read
+    exit 128 as "missing", but a network failure also exits 128 — a
+    transient outage would read as "no tag on the remote", the retry
+    would re-create the tag, and a local residue from the failed push
+    deadlocked the release ticket (Issue #585). Annotated tags are
+    peeled with the `^{}` line ls-remote reports alongside the tag
+    object.
+
+    The base-sync lock is kept: `ls-remote` does not write refs, but
+    the sibling steps around it do, and the lock orders them against
+    task worktrees sharing the checkout's common dir.
     """
     fd = acquire_base_sync_lock(repo_dir, 300.0)
     try:
-        try:
-            run_git_network_command(
-                ["git", "fetch", "origin",
-                 f"refs/tags/{tag}:refs/tags/{tag}"],
-                cwd=repo_dir,
-            )
-        except subprocess.CalledProcessError as exc:
-            if exc.returncode != 128:
-                raise
-            return None
-        return run_command(
-            ["git", "rev-parse", "-q", "--verify",
-             f"refs/tags/{tag}^{{commit}}"],
+        output = run_git_network_command(
+            ["git", "ls-remote", "origin",
+             f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"],
             cwd=repo_dir,
         )
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
+    refs: dict[str, str] = {}
+    for line in output.splitlines():
+        oid, _, ref = line.partition("\t")
+        refs[ref.strip()] = oid.strip()
+    peeled = refs.get(f"refs/tags/{tag}^{{}}")
+    if peeled:
+        return peeled
+    return refs.get(f"refs/tags/{tag}")
+
+
+def ensure_release_tag_pushed(repo_dir: Path, tag: str,
+                              release_commit: str) -> None:
+    """Create the annotated release tag and push it — idempotently.
+
+    本地残留收敛：上次 `git tag` 成功但 push 失败会留下本地 tag，重试
+    时远端仍无此 tag，不处理残留的话 `git tag -a` 永远 fatal: tag
+    already exists（发布票死锁，Issue #585）。残留指向本次发布提交 →
+    跳过重建直接重推；指向别的提交 → fail fast——已有的 tag 永不移动
+    或覆盖（与 `release_tag_commit` 的远端侧同一不变量）。
+    """
+    try:
+        local_tag_commit = run_command(
+            ["git", "rev-parse", "-q", "--verify",
+             f"refs/tags/{tag}^{{commit}}"],
+            cwd=repo_dir,
+        ).strip()
+    except subprocess.CalledProcessError:
+        local_tag_commit = None
+    if local_tag_commit is None:
+        run_command(
+            ["git", "tag", "-a", tag, "-m", f"Release {tag}",
+             release_commit],
+            cwd=repo_dir,
+        )
+    elif local_tag_commit != release_commit:
+        raise RuntimeError(
+            f"local tag {tag} already exists and points at "
+            f"{local_tag_commit}, not the release commit "
+            f"{release_commit} — an existing tag is never moved or "
+            "overwritten"
+        )
+    run_git_network_command(
+        ["git", "push", "origin", f"refs/tags/{tag}"],
+        cwd=repo_dir,
+    )
 
 
 def tag_commit_is_ancestor_of_base(tag_commit: str, base_commit: str,
@@ -3782,14 +3823,8 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
                     "tag is never moved or overwritten"
                 )
         else:
-            run_command(
-                ["git", "tag", "-a", tag, "-m", f"Release {tag}",
-                 release_commit],
-                cwd=config["repo_dir"],
-            )
-            run_git_network_command(
-                ["git", "push", "origin", f"refs/tags/{tag}"],
-                cwd=config["repo_dir"],
+            ensure_release_tag_pushed(
+                config["repo_dir"], tag, release_commit,
             )
             LOGGER.info(
                 "issue=%s release_tag_pushed tag=%s commit=%s",

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14708,6 +14708,84 @@ def test_release_tag_commit_reraises_real_fetch_failure(tmp_path, monkeypatch):
         runner.release_tag_commit(work, "v0.1.0")
 
 
+def test_release_tag_commit_never_reads_a_network_failure_as_missing_tag(
+    tmp_path, monkeypatch,
+):
+    """fetch 的 exit 128 分不清"远端没有这个 tag"和"网络/鉴权故障"（对
+    真实 CLI 实测两种都是 128）：把网络故障读成"缺失"会让流程走到重打
+    tag 的分支，叠加本地残留就是发布票死锁（Issue #585）。改用 ls-remote
+    后二者语义分离——exit 0 且空输出才是真缺失，任何非零退出原样抛出。"""
+    work, _ = make_local_remote_pair(tmp_path)
+
+    def fail_ls_remote(command, **kwargs):
+        assert command[1] == "ls-remote"
+        raise subprocess.CalledProcessError(128, command, stderr="boom")
+
+    monkeypatch.setattr(runner, "run_git_network_command", fail_ls_remote)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.release_tag_commit(work, "v0.1.0")
+
+
+def test_ensure_release_tag_pushed_creates_and_pushes_when_no_local_tag(
+    tmp_path, monkeypatch,
+):
+    work, head = make_local_remote_pair(tmp_path)
+    pushed = []
+
+    def fake_push(command, **kwargs):
+        pushed.append(command)
+
+    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    runner.ensure_release_tag_pushed(work, "v0.1.0", head)
+    tag_type = subprocess.run(
+        ["git", "-C", str(work), "cat-file", "-t", "v0.1.0"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert tag_type == "tag"  # annotated, same as before
+    assert pushed == [["git", "push", "origin", "refs/tags/v0.1.0"]]
+
+
+def test_ensure_release_tag_pushed_repushes_local_residue(tmp_path, monkeypatch):
+    """上次 `git tag` 成功但 push 失败会留下本地残留 tag：重试时远端
+    仍无此 tag，不处理残留的话 `git tag -a` 永远 fatal: tag already
+    exists（发布票死锁，Issue #585）。残留指向本次发布提交 → 直接重推
+    收敛。"""
+    work, head = make_local_remote_pair(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(work), "tag", "-a", "v0.1.0", "-m", "rel", head],
+        check=True, capture_output=True,
+    )
+    pushed = []
+
+    def fake_push(command, **kwargs):
+        pushed.append(command)
+
+    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    runner.ensure_release_tag_pushed(work, "v0.1.0", head)
+    assert pushed == [["git", "push", "origin", "refs/tags/v0.1.0"]]
+
+
+def test_ensure_release_tag_pushed_fails_fast_on_residue_pointing_elsewhere(
+    tmp_path,
+):
+    work, head = make_local_remote_pair(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(work), "commit", "--allow-empty",
+         "-m", "other", "--quiet"],
+        check=True, capture_output=True,
+    )
+    other = subprocess.run(
+        ["git", "-C", str(work), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(work), "tag", "-a", "v0.1.0", "-m", "rel", other],
+        check=True, capture_output=True,
+    )
+    with pytest.raises(RuntimeError, match="never moved or overwritten"):
+        runner.ensure_release_tag_pushed(work, "v0.1.0", head)
+
+
 def make_release_gh(monkeypatch, *, release_exists=False,
                     release_body="## Changelog"):
     """Answer `gh release view` / `gh release create` / `gh release edit`."""
@@ -15015,6 +15093,10 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             return ""
         if command[:2] == ["git", "push"]:
             return ""
+        if command[:2] == ["git", "rev-parse"]:
+            # ensure_release_tag_pushed 的本地残留探测：env 假环境没有
+            # 本地 tag——按"不存在"失败（走创建分支）。
+            raise subprocess.CalledProcessError(1, command)
         if command[0] == "timeout":
             return ""
         if command[:3] == ["gh", "issue", "close"]:
@@ -17163,22 +17245,24 @@ def test_release_process_env_fake_rejects_unexpected_command(monkeypatch):
         runner.run_command(["gh", "label", "list"])
 
 
-def test_release_process_env_fake_answers_the_real_tag_fetch(tmp_path,
+def test_release_process_env_fake_answers_the_real_tag_probe(tmp_path,
                                                              monkeypatch):
-    # The env fake answers the `git fetch` of the REAL
+    # The env fake answers the `git ls-remote` of the REAL
     # `release_tag_commit` (the lock is taken for real on tmp_path).
     real_release_tag_commit = runner.release_tag_commit
     make_release_process_env(monkeypatch)
     monkeypatch.setattr(runner, "release_tag_commit",
                         real_release_tag_commit)
-    env_fake = runner.run_command
 
     def fake(command, **kwargs):
-        if command[:2] == ["git", "rev-parse"]:
-            return "abc123"
-        return env_fake(command, **kwargs)
+        if command[:2] == ["git", "ls-remote"]:
+            return ("abc123\trefs/tags/v0.3.0\n"
+                    "abc123\trefs/tags/v0.3.0^{}\n")
+        raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake)
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake(["git", "fetch", "origin"])
     assert runner.release_tag_commit(tmp_path, "v0.3.0") == "abc123"
 
 


### PR DESCRIPTION
<!-- orbi:run=eb21ccd6 -->

Fixes #600

CI failure: tests on branch fix/release-tag-retry-lock (pull_request) (run_id=eb21ccd6)
