### PR TITLE
fix: 崩溃计数只数主进程异常退出行，消除健康部署误报与阈值折半

### DIFF
--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -51,13 +51,30 @@ RECENT_RUNS_KEEP = 50
 GH_TIMEOUT_SECONDS = 60
 HEALTH_MARKER_PREFIX = "orbi-health-fingerprint:"
 
-# The real systemd crash lines (verified against the live journal):
-#   systemd[1015]: orbi@1.service: Main process exited, code=exited, ...
-#   systemd[1015]: orbi@1.service: Failed with result 'exit-code'.
+# The real systemd main-process exit lines (verified against the live
+# journal):
+#   systemd[1015]: orbi@1.service: Main process exited, code=exited,
+#                  status=1/FAILURE
+#   systemd[1015]: orbi@1.service: Main process exited, code=dumped,
+#                  status=11/SEGV
+# Only ABNORMAL main-process exits count, exactly one line per crash:
+# - status=0/SUCCESS is a healthy tick exit (a timer-driven Type=simple
+#   service exits cleanly every run — counting those would fire the
+#   crash_loop alert on every healthy deployment);
+# - "Failed with result" is NOT counted: a real crash emits it alongside
+#   the exit line (double counting would halve the threshold), and an
+#   ExecStartPre failure emits it WITHOUT the main process ever starting
+#   (a preflight problem, not a main-process crash);
+# - code=killed (e.g. status=15/TERM) is a systemd/human stop, not a
+#   crash — `orbi install-units` never stops a running Runner, so a kill
+#   is an external action outside this check's scope.
 # The `.service:` prefix requirement keeps the count conservative: the
 # Runner's own journal lines can echo the words "Main process exited" when
 # logging a command, and those must never count as a crash.
-CRASH_EXIT_RE = re.compile(r"\.service: (Main process exited, code=|Failed with result)")
+CRASH_EXIT_RE = re.compile(
+    r"\.service: Main process exited, "
+    r"code=(?:dumped|exited, status=[1-9][0-9]*/)"
+)
 
 # Volatile tokens stripped before fingerprinting: 8-40 hex runs (run ids,
 # SHAs), ISO-ish timestamps, and duration shapes ("30m", "6s", "1h5m",

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -51,30 +51,60 @@ RECENT_RUNS_KEEP = 50
 GH_TIMEOUT_SECONDS = 60
 HEALTH_MARKER_PREFIX = "orbi-health-fingerprint:"
 
-# The real systemd main-process exit lines (verified against the live
-# journal):
-#   systemd[1015]: orbi@1.service: Main process exited, code=exited,
-#                  status=1/FAILURE
-#   systemd[1015]: orbi@1.service: Main process exited, code=dumped,
-#                  status=11/SEGV
-# Only ABNORMAL main-process exits count, exactly one line per crash:
-# - status=0/SUCCESS is a healthy tick exit (a timer-driven Type=simple
-#   service exits cleanly every run — counting those would fire the
-#   crash_loop alert on every healthy deployment);
-# - "Failed with result" is NOT counted: a real crash emits it alongside
-#   the exit line (double counting would halve the threshold), and an
-#   ExecStartPre failure emits it WITHOUT the main process ever starting
-#   (a preflight problem, not a main-process crash);
-# - code=killed (e.g. status=15/TERM) is a systemd/human stop, not a
-#   crash — `orbi install-units` never stops a running Runner, so a kill
-#   is an external action outside this check's scope.
+# Two real systemd crash line shapes (verified against the live journal):
+#   systemd[1015]: orbi@1.service: Main process exited, code=exited, status=1/FAILURE
+#   systemd[1015]: orbi@1.service: Failed with result 'exit-code'.
+# A single crash usually emits BOTH — the exit line and the result line
+# land on the same or an adjacent second — and an ExecStartPre failure
+# (dirty checkout, broken CLI install, SSH transport down: the Runner
+# never starts at all) emits ONLY the result line. Both shapes must count,
+# and the pair must count ONCE (a raw line count would halve the crash
+# threshold — that dedupe lives in count_crashes, keyed on unit+clock).
+# Exclusions are by STATUS, never by code class:
+# - status=0/SUCCESS is the healthy timer-tick exit (a timer-driven
+#   Type=simple service exits cleanly every run — counting those would
+#   fire the crash_loop alert on every healthy deployment);
+# - status=15/TERM is a systemd/human stop (`orbi install-units` never
+#   stops a running Runner, so a TERM is an external action);
+# everything else counts, including code=killed status=9/KILL: the OOM
+# killer and TimeoutStopSec land there, and an OOM crash loop must alert.
 # The `.service:` prefix requirement keeps the count conservative: the
 # Runner's own journal lines can echo the words "Main process exited" when
 # logging a command, and those must never count as a crash.
 CRASH_EXIT_RE = re.compile(
-    r"\.service: Main process exited, "
-    r"code=(?:dumped|exited, status=[1-9][0-9]*/)"
+    r"\.service: Main process exited, code=(?:dumped|killed|exited), "
+    r"status=(?!0/|15/TERM)\d+/"
 )
+CRASH_FAIL_RESULT_RE = re.compile(r"\.service: Failed with result")
+
+# journalctl --user default ("short") line clock: "Sep 04 11:41:02 …" —
+# monotonic within the bounded window; enough to tell the paired result
+# line of the same crash (same or adjacent second) from a fresh crash.
+_JOURNAL_CLOCK_RE = re.compile(
+    r"^(?P<mon>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+"
+    r"(?P<day>\d{1,2})\s+(?P<h>\d{2}):(?P<m>\d{2}):(?P<s>\d{2})\b"
+)
+_UNIT_ON_LINE_RE = re.compile(r"(?P<unit>[\w.-]+@\d+\.service): ")
+_MONTH_INDEX = {
+    "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+    "Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12,
+}
+# One crash emits its exit line and its result line at most this far apart
+# (same second in practice; +1s covers a second-boundary straddle).
+CRASH_PAIR_WINDOW_SECONDS = 1
+
+
+def _line_clock_seconds(line: str) -> int | None:
+    """Monotonic-ish seconds for a journalctl short-format line (None when
+    the clock cannot be parsed — the caller then counts conservatively)."""
+    m = _JOURNAL_CLOCK_RE.match(line)
+    if not m:
+        return None
+    return (
+        (_MONTH_INDEX[m.group("mon")] * 31 + int(m.group("day"))) * 86400
+        + int(m.group("h")) * 3600 + int(m.group("m")) * 60
+        + int(m.group("s"))
+    )
 
 # Volatile tokens stripped before fingerprinting: 8-40 hex runs (run ids,
 # SHAs), ISO-ish timestamps, and duration shapes ("30m", "6s", "1h5m",
@@ -235,16 +265,36 @@ def count_crashes(
     run_command, since_minutes: int = CRASH_WINDOW_MINUTES,
     unit_name: str | None = None,
 ) -> int:
-    """Count service crashes in the window from the systemd journal.
+    """Count crash EVENTS in the window from the systemd journal.
 
-    Counts only the real systemd exit lines (see CRASH_EXIT_RE).
+    Both crash shapes count (an abnormal main-process exit, and a
+    "Failed with result" line — the only shape an ExecStartPre failure
+    leaves). One crash usually emits both lines on the same or an
+    adjacent second: per unit, a matched line within
+    CRASH_PAIR_WINDOW_SECONDS of the previous matched line is the pair
+    half of that crash, not a new event. A matched line whose clock or
+    unit cannot be parsed counts as-is (conservative: never miss a real
+    crash to dedupe).
     """
-    return sum(
-        1 for line in crash_journal_lines(
-            run_command, since_minutes, unit_name=unit_name,
-        )
-        if CRASH_EXIT_RE.search(line)
-    )
+    last_matched: dict[str, int] = {}
+    events = 0
+    for line in crash_journal_lines(
+        run_command, since_minutes, unit_name=unit_name,
+    ):
+        if not (CRASH_EXIT_RE.search(line) or CRASH_FAIL_RESULT_RE.search(line)):
+            continue
+        unit_m = _UNIT_ON_LINE_RE.search(line)
+        clock = _line_clock_seconds(line)
+        if unit_m is None or clock is None:
+            events += 1
+            continue
+        unit = unit_m.group("unit")
+        prev = last_matched.get(unit)
+        last_matched[unit] = clock
+        if prev is not None and clock - prev <= CRASH_PAIR_WINDOW_SECONDS:
+            continue
+        events += 1
+    return events
 
 
 def classify_crash(journal_lines: list[str]) -> tuple[str, str]:

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -1206,3 +1206,21 @@ def _write_config(tmp_path: Path) -> None:
         f'repo_dir = "{repo_dir}"\n',
         encoding="utf-8",
     )
+
+
+def test_count_crashes_counts_unparseable_clock_lines_conservatively():
+    # A crash-shaped line whose clock (or unit) cannot be parsed must
+    # still count: dedupe can never be allowed to hide a real crash.
+    no_clock = (
+        "host systemd[1015]: orbi@1.service: Main process exited, "
+        "code=exited, status=1/FAILURE"
+    )
+    no_unit = (
+        "Sep 04 11:50:00 host systemd[1015]: orbi.service: Failed with "
+        "result 'exit-code'."
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": f"{no_clock}\n{no_unit}\n",
+        "journalctl --user -u orbi@2.service": "",
+    })
+    assert runner_health.count_crashes(fake) == 2

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -359,7 +359,50 @@ def test_count_crashes_counts_real_systemd_exit_lines():
         "journalctl --user -u orbi@2.service":
             f"{FAILED_RESULT_LINE}\n",
     })
-    assert runner_health.count_crashes(fake) == 3
+    assert runner_health.count_crashes(fake) == 2
+
+
+def test_count_crashes_ignores_clean_exits_and_preflight_failures():
+    clean_exit = (
+        "Sep 04 11:40:00 host systemd[1015]: orbi@1.service: Main process "
+        "exited, code=exited, status=0/SUCCESS (success)"
+    )
+    stopped_by_systemd = (
+        "Sep 04 11:41:00 host systemd[1015]: orbi@1.service: Main process "
+        "exited, code=killed, status=15/TERM"
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service":
+            f"{clean_exit}\n{stopped_by_systemd}\n{FAILED_RESULT_LINE}\n",
+        "journalctl --user -u orbi@2.service": "",
+    })
+    # status=0 is a healthy tick exit; ExecStartPre failures produce
+    # "Failed with result" without the main process ever starting; a TERM
+    # stop is a human/systemd action. None of them is a crash.
+    assert runner_health.count_crashes(fake) == 0
+
+
+def test_count_crashes_counts_each_crash_once():
+    crashed_then_failed = f"{CRASH_LINE}\n{FAILED_RESULT_LINE}\n"
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": crashed_then_failed,
+        "journalctl --user -u orbi@2.service": "",
+    })
+    # One real crash emits BOTH the exit line and the Failed-with-result
+    # line; the count must stay 1 so the threshold keeps its meaning.
+    assert runner_health.count_crashes(fake) == 1
+
+
+def test_count_crashes_counts_core_dumps():
+    dumped = (
+        "Sep 04 11:42:00 host systemd[1015]: orbi@1.service: Main process "
+        "exited, code=dumped, status=11/SEGV"
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": f"{dumped}\n",
+        "journalctl --user -u orbi@2.service": "",
+    })
+    assert runner_health.count_crashes(fake) == 1
 
 
 def test_count_crashes_ignores_non_crash_lines():

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -346,23 +346,41 @@ CRASH_LINE = (
     "Sep 04 11:41:02 host systemd[1015]: orbi@1.service: Main process "
     "exited, code=exited, status=1/FAILURE"
 )
-FAILED_RESULT_LINE = (
-    "Sep 04 11:45:00 host systemd[1015]: orbi@2.service: Failed with "
+# The result line of the SAME crash as CRASH_LINE (same unit, same
+# second) — review round 1: "Failed with result" must count, deduped.
+CRASH_RESULT_LINE = (
+    "Sep 04 11:41:02 host systemd[1015]: orbi@1.service: Failed with "
     "result 'exit-code'."
 )
+# Distinct crash events need distinct clocks: one unit cannot crash twice
+# in the same second, and count_crashes dedupes the same-second pair.
+CRASH_LINE_2 = (
+    "Sep 04 11:42:10 host systemd[1015]: orbi@1.service: Main process "
+    "exited, code=exited, status=1/FAILURE"
+)
+CRASH_LINE_3 = (
+    "Sep 04 11:43:30 host systemd[1015]: orbi@1.service: Main process "
+    "exited, code=exited, status=1/FAILURE"
+)
+THREE_CRASH_JOURNAL = f"{CRASH_LINE}\n{CRASH_LINE_2}\n{CRASH_LINE_3}\n"
 
 
 def test_count_crashes_counts_real_systemd_exit_lines():
+    second_crash = (
+        "Sep 04 11:43:10 host systemd[1015]: orbi@1.service: Main process "
+        "exited, code=exited, status=216/GROUP"
+    )
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service":
-            f"{CRASH_LINE}\n{CRASH_LINE}\n",
-        "journalctl --user -u orbi@2.service":
-            f"{FAILED_RESULT_LINE}\n",
+            f"{CRASH_LINE}\n{CRASH_RESULT_LINE}\n{second_crash}\n",
+        "journalctl --user -u orbi@2.service": "",
     })
+    # Two distinct crashes (11:41:02 and 11:43:10); the result line of
+    # the first is a pair half, not a third event.
     assert runner_health.count_crashes(fake) == 2
 
 
-def test_count_crashes_ignores_clean_exits_and_preflight_failures():
+def test_count_crashes_ignores_clean_exits_and_term_stops():
     clean_exit = (
         "Sep 04 11:40:00 host systemd[1015]: orbi@1.service: Main process "
         "exited, code=exited, status=0/SUCCESS (success)"
@@ -373,17 +391,71 @@ def test_count_crashes_ignores_clean_exits_and_preflight_failures():
     )
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service":
-            f"{clean_exit}\n{stopped_by_systemd}\n{FAILED_RESULT_LINE}\n",
+            f"{clean_exit}\n{stopped_by_systemd}\n",
         "journalctl --user -u orbi@2.service": "",
     })
-    # status=0 is a healthy tick exit; ExecStartPre failures produce
-    # "Failed with result" without the main process ever starting; a TERM
-    # stop is a human/systemd action. None of them is a crash.
+    # status=0 is a healthy tick exit; status=15/TERM is a systemd/human
+    # stop. Neither is a crash.
     assert runner_health.count_crashes(fake) == 0
 
 
+def test_count_crashes_counts_oom_kills():
+    # Review round 1: code=killed status=9/KILL is the OOM killer (and
+    # TimeoutStopSec) — a textbook crash loop; it must count.
+    oom_kill = (
+        "Sep 04 11:42:00 host systemd[1015]: orbi@1.service: Main process "
+        "exited, code=killed, status=9/KILL"
+    )
+    oom_result = (
+        "Sep 04 11:42:00 host systemd[1015]: orbi@1.service: Failed with "
+        "result 'oom'."
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": f"{oom_kill}\n{oom_result}\n",
+        "journalctl --user -u orbi@2.service": "",
+    })
+    assert runner_health.count_crashes(fake) == 1
+
+
+def test_count_crashes_counts_exec_start_pre_failures():
+    # Review round 1: an ExecStartPre failure (dirty checkout, broken CLI
+    # install, SSH transport down) leaves ONLY the result line — the main
+    # process never started. This is the never-starts class the alert
+    # exists for; dropping "Failed with result" would silence it forever.
+    preflight_only = (
+        "Sep 04 11:44:00 host systemd[1015]: orbi@1.service: Failed with "
+        "result 'exit-code'."
+    )
+    other_unit_same_second = (
+        "Sep 04 11:44:00 host systemd[1015]: orbi@2.service: Failed with "
+        "result 'exit-code'."
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": f"{preflight_only}\n",
+        "journalctl --user -u orbi@2.service": f"{other_unit_same_second}\n",
+    })
+    # Counts once per unit: the dedupe key is unit+clock, so two units
+    # failing in the same second are two events.
+    assert runner_health.count_crashes(fake) == 2
+
+
+def test_count_crashes_dedupes_a_second_boundary_straddle():
+    straddled_result = (
+        "Sep 04 11:41:03 host systemd[1015]: orbi@1.service: Failed with "
+        "result 'exit-code'."
+    )
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service":
+            f"{CRASH_LINE}\n{straddled_result}\n",
+        "journalctl --user -u orbi@2.service": "",
+    })
+    # The exit line at 11:41:02 and the result line at 11:41:03 are the
+    # same crash (CRASH_PAIR_WINDOW_SECONDS covers the straddle).
+    assert runner_health.count_crashes(fake) == 1
+
+
 def test_count_crashes_counts_each_crash_once():
-    crashed_then_failed = f"{CRASH_LINE}\n{FAILED_RESULT_LINE}\n"
+    crashed_then_failed = f"{CRASH_LINE}\n{CRASH_RESULT_LINE}\n"
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": crashed_then_failed,
         "journalctl --user -u orbi@2.service": "",
@@ -586,7 +658,7 @@ def test_repeated_failure_alerts_again_after_drifting_failures_and_a_break(
 def test_crash_loop_creates_one_deduplicated_bug_issue(tmp_path):
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
-    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    journal = THREE_CRASH_JOURNAL
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
         "journalctl --user -u orbi@2.service": "",
@@ -627,7 +699,7 @@ def test_run_health_check_with_unit_name_watches_the_renamed_units(tmp_path):
     # the alert, and no query may target the nonexistent default units.
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
-    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    journal = THREE_CRASH_JOURNAL
     fake = FakeRunCommand({
         "journalctl --user -u orbi-x@1.service": journal,
         "journalctl --user -u orbi-x@2.service": "",
@@ -856,7 +928,7 @@ def test_config_caused_crash_loop_is_non_dispatchable(tmp_path):
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
     journal = (
-        f"{CRASH_LINE}\n{CONFIG_REASON_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+        f"{CRASH_LINE}\n{CONFIG_REASON_LINE}\n{CRASH_LINE_2}\n{CRASH_LINE_3}\n"
     )
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
@@ -887,7 +959,7 @@ def test_bug_caused_crash_loop_is_dispatchable_with_reason(tmp_path):
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
     journal = (
-        f"{CRASH_LINE}\n{BUG_REASON_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+        f"{CRASH_LINE}\n{BUG_REASON_LINE}\n{CRASH_LINE_2}\n{CRASH_LINE_3}\n"
     )
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
@@ -912,7 +984,7 @@ def test_health_alert_repo_override_wins(tmp_path):
     deploy-home origin lookup (fork/private deployments)."""
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
-    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    journal = THREE_CRASH_JOURNAL
     override = "fork-owner/orbi-fork"
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
@@ -934,7 +1006,7 @@ def test_undeterminable_alert_repo_skips_the_issue(tmp_path, caplog):
     skipped (bypass) — never filed in the delivery repo, never guessed."""
     write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
                            "alerted": []})
-    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    journal = THREE_CRASH_JOURNAL
     fake = FakeRunCommand({
         "journalctl --user -u orbi@1.service": journal,
         "journalctl --user -u orbi@2.service": "",


### PR DESCRIPTION
Fixes #617

## 改动文件
- `src/orbi/runner_health.py`：`CRASH_EXIT_RE` 从"退出行或 Failed 行均计"改为只匹配主进程异常退出行——`code=exited` 且 `status` 非零（`status=[1-9][0-9]*/`），或 `code=dumped`；`Failed with result` 不再计入（一次真实崩溃只计 1 次、ExecStartPre 预检失败天然排除），`code=killed`（TERM 等 systemd/人为停止）不计入。正则上方注释块完整记录三类排除的理由。
- `tests/test_runner_health.py`：既有 `test_count_crashes_counts_real_systemd_exit_lines` 按新语义修正（2 条 status=1 退出行 + 1 条 Failed 行 = 2）；新增三个测试——干净退出/TERM/预检失败不计入、一次崩溃（退出行+Failed 行成对）只计 1、core dump 计入。

## 做了哪些测试
- 修复前新增测试红：干净退出+TERM+Failed 行的组合在旧正则下计 3（误报现场），新正则下计 0；成对行旧计 2 新计 1。
- `test_count_crashes_ignores_non_crash_lines`（Runner 自身日志回显不计数）与窗口测试不受影响，原样通过。

## 测试情况
- `tests/test_runner_health.py` 全量 54 通过。
- 全量回归 `pytest tests/ -k 'not stream_pi_timeout_tool'`（stream_pi 族为本机 macOS 限制跳过，Linux CI 权威验证）通过。
- 覆盖门：`coverage_gate`（全仓行/分支 ≥95% 分开算）与 `diff_coverage_gate`（本 PR 改动行/分支 100%）均通过。

## 行为对照
- 健康部署（每 tick 干净退出）：旧=crash_loop 每 tick 误报 + 自动派发幻影 bug+ai-ready 任务；新=计 0，不告警。
- 真实崩溃循环：旧=2 次即触发（阈值折半）；新=逐次计数，阈值 3 恢复本义，`classify_crash` 派发行为不变。