### PR TITLE
fix: 指纹归一化覆盖浮动时长，streak 打断时清除该 issue 的告警键

### DIFF
--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -60,10 +60,15 @@ HEALTH_MARKER_PREFIX = "orbi-health-fingerprint:"
 CRASH_EXIT_RE = re.compile(r"\.service: (Main process exited, code=|Failed with result)")
 
 # Volatile tokens stripped before fingerprinting: 8-40 hex runs (run ids,
-# SHAs) and ISO-ish timestamps. Only errors whose normalized text is IDENTICAL
-# share a fingerprint — the conservative "same pit" rule of Issue #266.
+# SHAs), ISO-ish timestamps, and duration shapes ("30m", "6s", "1h5m",
+# "200ms" — the format_duration output the model_wait / idle-recovery
+# failures embed; the duration drifts by one poll interval for the same
+# pit). Only errors whose normalized text is IDENTICAL share a
+# fingerprint — the conservative "same pit" rule of Issue #266.
 VOLATILE_TOKEN_RE = re.compile(
-    r"\b[0-9a-f]{8,40}\b|\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}",
+    r"\b[0-9a-f]{8,40}\b"
+    r"|\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    r"|\b(?:\d+(?:ms|[smh]))+(?![0-9a-z])",
 )
 
 # Fail-fast validation errors a HUMAN must fix in the config (Issue #345):
@@ -154,6 +159,16 @@ def record_run_attempt(
 ) -> None:
     """Append one run attempt to the bounded health history."""
     state = load_health_state(state_path)
+    if outcome != "failed":
+        # A non-failure outcome breaks the repeated-failure streak. The
+        # issue's alert history must turn a fresh page with it: a later
+        # NEW streak on the same issue alerts again instead of staying
+        # silent forever behind the key recorded for the old streak.
+        prefix = f"{repo}#{issue}:"
+        state["alerted"] = [
+            key for key in state["alerted"]
+            if not key.startswith(prefix)
+        ]
     state["runs"].append({
         "repo": repo, "issue": issue, "run_id": run_id,
         "outcome": outcome, "fingerprint": fingerprint,

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -149,6 +149,29 @@ def test_failure_fingerprint_uses_first_line_only():
         runner_health.failure_fingerprint(exc_b)
 
 
+def test_failure_fingerprint_normalizes_drifting_durations():
+    # model_wait / idle-recovery failures embed format_duration output
+    # ("30m", "1h5m") that drifts by one poll interval for the SAME pit;
+    # the fingerprint must not change with it.
+    assert runner_health.failure_fingerprint(
+        RuntimeError("model_wait dead: frozen session for 30m"),
+    ) == runner_health.failure_fingerprint(
+        RuntimeError("model_wait dead: frozen session for 31m"),
+    )
+    assert runner_health.failure_fingerprint(
+        RuntimeError("pi stayed idle for 1h5m"),
+    ) == runner_health.failure_fingerprint(
+        RuntimeError("pi stayed idle for 1h40m"),
+    )
+    # Plain integers stay meaningful: a different retry count is a
+    # different failure, not the same pit with a drifting duration.
+    assert runner_health.failure_fingerprint(
+        RuntimeError("attempt 3 failed"),
+    ) != runner_health.failure_fingerprint(
+        RuntimeError("attempt 4 failed"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # State file (the lightweight file in the existing state dir)
 # ---------------------------------------------------------------------------
@@ -429,6 +452,65 @@ def test_repeated_failure_alerts_once_with_the_latest_run_marker(tmp_path):
     )
     assert alerts == []
     assert len(fake.commands("gh issue comment")) == 1
+
+
+def test_record_run_attempt_clears_alerted_keys_on_a_streak_break(tmp_path):
+    path = write_state(tmp_path, {
+        "runs": [], "last_pickup_ts": time.time(),
+        "alerted": [f"{REPO}#41:fp1", f"{REPO}#42:fp9"],
+    })
+    runner_health.record_run_attempt(
+        path, repo=REPO, issue=41, run_id="00000009",
+        outcome="pr_opened", fingerprint="",
+    )
+    state = runner_health.load_health_state(path)
+    # A success on the issue breaks the streak: the issue's alert history
+    # must turn a fresh page so a NEW 3-failure streak can alert again.
+    assert state["alerted"] == [f"{REPO}#42:fp9"]
+
+
+def test_repeated_failure_alerts_again_after_drifting_failures_and_a_break(
+    tmp_path,
+):
+    """同一坑的浮动时长失败必须累计成 streak；被成功打断后再次累计
+    必须再次告警——修复前时长漂移让 streak 反复清零、alerted 只增不
+    清让第二次累计永静默。"""
+    path = write_state(tmp_path, {
+        "runs": [], "last_pickup_ts": time.time(), "alerted": [],
+    })
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi@1.service": "",
+        "journalctl --user -u orbi@2.service": "",
+    })
+
+    def fail(run_id, stale_text):
+        runner_health.record_run_attempt(
+            path, repo=REPO, issue=41, run_id=run_id, outcome="failed",
+            fingerprint=runner_health.failure_fingerprint(
+                RuntimeError(f"model_wait dead: frozen session {stale_text}"),
+            ),
+        )
+
+    fail("00000001", "for 30m")
+    fail("00000002", "for 31m")
+    fail("00000003", "for 45m")
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path), run_command=fake,
+    )
+    assert alerts == [f"repeated_failure:{REPO}#41"]
+
+    runner_health.record_run_attempt(
+        path, repo=REPO, issue=41, run_id="00000004",
+        outcome="pr_opened", fingerprint="",
+    )
+    fail("00000005", "for 30m")
+    fail("00000006", "for 32m")
+    fail("00000007", "for 44m")
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path), run_command=fake,
+    )
+    assert alerts == [f"repeated_failure:{REPO}#41"]
+    assert len(fake.commands("gh issue comment")) == 2
 
 
 def test_crash_loop_creates_one_deduplicated_bug_issue(tmp_path):


### PR DESCRIPTION
Fixes 618

## 改动文件
- `src/orbi/runner_health.py`：
  - `VOLATILE_TOKEN_RE` 新增时长形状 `\b(?:\d+(?:ms|[smh]))+(?![0-9a-z])`——"30m"/"6s"/"1h5m"/"200ms"（format_duration 家族输出，含连写段如 "1h5m" 整体归一）与 hex、时间戳一并剥为 `<x>`；后顾断言确保只吃完整时长 token、不腐蚀普通词（如 "123host" 不受影响）。
  - `record_run_attempt` 在 `outcome != "failed"`（streak 被 pr_opened 等成功结局打断）时，按 `repo#issue:` 前缀清除 `state["alerted"]` 中该 issue 的告警键——翻篇语义，新 streak 可再次告警；其他 issue 的键不动。
- `tests/test_runner_health.py`：新增三个测试——时长漂移同指纹（30m/31m、1h5m/1h40m）+ 普通整数仍有区分度（attempt 3 ≠ attempt 4）；打断清键单元测试（同 issue 键清、他 issue 键留）；端到端集成（3 次漂移失败→告警 1→pr_opened 打断→3 次漂移失败→告警 2）。

## 做了哪些测试
- 修复前三个测试全红：漂移时长指纹不同（streak 无法累计）、打断后 alerted 键残留、集成场景第二次告警被吞。
- 既有指纹测试（时间戳/长 SHA 剥离、首行语义、异常类区分）与告警去重测试（同 streak 只告警一次）原样通过——保守"同坑"规则未放松。

## 测试情况
- `tests/test_runner_health.py` 全量 54 通过。
- 全量回归 `pytest tests/ -k 'not stream_pi_timeout_tool'`（stream_pi 族为本机 macOS 限制跳过，Linux CI 权威验证）通过。
- 覆盖门：`coverage_gate` 与 `diff_coverage_gate`（本 PR 改动行/分支 100%）均通过。

## 行为对照
- model_wait 挂死反复发生（时长随轮询周期漂移）：旧=指纹漂移→streak 清零→永不告警；新=同指纹累计→第 3 次告警。
- 连败被成功打断后同坑复发：旧=alerted 终身静默；新=清键后再凑 3 连败再次告警。