### PR TITLE
P0 Bug：runner_health 是唯一漏传 unit_name 的消费方——改名部署（cloud 托管沙箱方向）崩溃告警恒不触发，系统静默死亡

### DIFF
--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -38,7 +38,7 @@ from pathlib import Path
 
 from orbi.delivery_labels import READY_LABEL
 from orbi.progress import format_status_comment, run_marker
-from orbi.systemd_deploy import SERVICE_INSTANCES
+from orbi.systemd_deploy import service_instances
 
 LOGGER = logging.getLogger("orbi.health")
 
@@ -173,17 +173,20 @@ def record_pickup(repo_dir: Path) -> None:
 
 def crash_journal_lines(
     run_command, since_minutes: int = CRASH_WINDOW_MINUTES,
+    unit_name: str | None = None,
 ) -> list[str]:
     """Return the systemd journal lines for every service instance in the
     window.
 
-    One bounded `journalctl` query per service instance (the verified shape
-    from `orbi doctor`). The lines are the raw scene the crash-loop alert
+    One bounded `journalctl` query per service instance of THIS deployment
+    (Issue #616: a `unit_name` deployment installs `orbi-<name>@N.service`,
+    so the query must follow the same naming — `None` keeps the default
+    `orbi@N.service`). The lines are the raw scene the crash-loop alert
     needs (Issue #345): the exit lines plus the structured fail-fast reason
     the Runner logged before each crash.
     """
     lines: list[str] = []
-    for unit in SERVICE_INSTANCES:
+    for unit in service_instances(unit_name):
         output = run_command([
             "timeout", "30", "journalctl", "--user", "-u", unit,
             "--since", f"-{since_minutes}min", "--no-pager", "-q",
@@ -192,13 +195,18 @@ def crash_journal_lines(
     return lines
 
 
-def count_crashes(run_command, since_minutes: int = CRASH_WINDOW_MINUTES) -> int:
+def count_crashes(
+    run_command, since_minutes: int = CRASH_WINDOW_MINUTES,
+    unit_name: str | None = None,
+) -> int:
     """Count service crashes in the window from the systemd journal.
 
     Counts only the real systemd exit lines (see CRASH_EXIT_RE).
     """
     return sum(
-        1 for line in crash_journal_lines(run_command, since_minutes)
+        1 for line in crash_journal_lines(
+            run_command, since_minutes, unit_name=unit_name,
+        )
         if CRASH_EXIT_RE.search(line)
     )
 
@@ -430,9 +438,13 @@ def run_health_check(config: dict, *, run_command) -> list[str]:
             )
         # 1. Crash loop (#262 scene: repeated service exits, including the
         #    unit self-heal death loop — each iteration exits non-zero).
-        crashes = count_crashes(run_command)
+        #    Issue #616: watch THIS deployment's units (unit_name-aware).
+        unit_name = config.get("unit_name")
+        crashes = count_crashes(run_command, unit_name=unit_name)
         if crashes >= CRASH_THRESHOLD:
-            journal_lines = crash_journal_lines(run_command)
+            journal_lines = crash_journal_lines(
+                run_command, unit_name=unit_name,
+            )
             kind, reason_line = classify_crash(journal_lines)
             LOGGER.info(
                 "health_degraded check=crash_loop crashes=%s "

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -66,12 +66,14 @@ REPO = "owner/repo"
 ORBI_REPO = "orbi-build/orbi"
 
 
-def make_config(tmp_path: Path, *, health_alert_repo=None) -> dict:
+def make_config(tmp_path: Path, *, health_alert_repo=None,
+                unit_name: str | None = None) -> dict:
     return {
         "repo_dir": tmp_path,
         "source_repos": [REPO],
         "deploy_home": tmp_path,
         "health_alert_repo": health_alert_repo,
+        "unit_name": unit_name,
     }
 
 
@@ -363,6 +365,31 @@ def test_count_crashes_uses_a_bounded_window():
         assert "-60min" in call
 
 
+def journal_units(fake: FakeRunCommand) -> list[str]:
+    """The unit each journalctl call received (the `-u` argument)."""
+    return [
+        call[call.index("-u") + 1] for call in fake.commands("journalctl")
+    ]
+
+
+def test_count_crashes_queries_the_configured_unit_name():
+    # Issue #616: a deployment with unit_name installs orbi-x@*.service;
+    # the health check must query THOSE units (the old hardcode queried
+    # nonexistent orbi@*.service and never saw a crash).
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi-x@1.service": "",
+        "journalctl --user -u orbi-x@2.service": "",
+    })
+    runner_health.count_crashes(fake, unit_name="x")
+    assert journal_units(fake) == ["orbi-x@1.service", "orbi-x@2.service"]
+
+
+def test_count_crashes_default_unit_name_unchanged():
+    fake = FakeRunCommand()
+    runner_health.count_crashes(fake)
+    assert journal_units(fake) == ["orbi@1.service", "orbi@2.service"]
+
+
 # ---------------------------------------------------------------------------
 # Stale pickup (queue idle vs system stuck)
 # ---------------------------------------------------------------------------
@@ -467,6 +494,27 @@ def test_crash_loop_creates_one_deduplicated_bug_issue(tmp_path):
     )
     assert alerts == ["crash_loop"]
     assert len(fake.commands("gh issue create")) == 1
+
+
+def test_run_health_check_with_unit_name_watches_the_renamed_units(tmp_path):
+    # Issue #616: with unit_name="x" the installed units are
+    # orbi-x@{1,2}.service — a crash loop seen in THEIR journal must fire
+    # the alert, and no query may target the nonexistent default units.
+    write_state(tmp_path, {"runs": [], "last_pickup_ts": time.time(),
+                           "alerted": []})
+    journal = f"{CRASH_LINE}\n{CRASH_LINE}\n{CRASH_LINE}\n"
+    fake = FakeRunCommand({
+        "journalctl --user -u orbi-x@1.service": journal,
+        "journalctl --user -u orbi-x@2.service": "",
+        **origin_route(),
+        # No health Issue exists yet.
+        'in:body "orbi-health-fingerprint:': "[]",
+    })
+    alerts = runner_health.run_health_check(
+        make_config(tmp_path, unit_name="x"), run_command=fake,
+    )
+    assert alerts == ["crash_loop"]
+    assert set(journal_units(fake)) == {"orbi-x@1.service", "orbi-x@2.service"}
 
 
 def test_stale_pickup_with_ready_issues_alarms(tmp_path):


### PR DESCRIPTION
<!-- orbi:run=dfebc7b6 -->

Fixes #616

P0 Bug：runner_health 是唯一漏传 unit_name 的消费方——改名部署（cloud 托管沙箱方向）崩溃告警恒不触发，系统静默死亡 (run_id=dfebc7b6)
