### PR TITLE
P0 Bug：空闲 tick 的 milestone 推进无保护——milestone 改名即每 tick 非零退出，健康检查判为崩溃循环并自动开 ai-ready bug Issue（自激）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -10598,12 +10598,22 @@ def main(argv: list[str] | None = None) -> int:
                         config["active_milestone"],
                     )
                 # Issue #274: validate and advance only after the arm attempt.
-                advance_active_milestone_on_idle(
-                    config["source_repos"][0],
-                    config["active_milestone"],
-                    config["config_path"],
-                    auto_next_milestone=config["auto_next_milestone"],
-                )
+                # Issue #614: like the arm above, the advance is an idle-path
+                # pure bypass — a renamed/deleted milestone or a failed `gh`
+                # call must not turn an idle tick into a non-zero exit.
+                try:
+                    advance_active_milestone_on_idle(
+                        config["source_repos"][0],
+                        config["active_milestone"],
+                        config["config_path"],
+                        auto_next_milestone=config["auto_next_milestone"],
+                    )
+                except Exception:
+                    LOGGER.exception(
+                        "active_milestone_advance_failed repo=%s milestone=%s",
+                        config["source_repos"][0],
+                        config["active_milestone"],
+                    )
             return 0
         source_repo, issue, scene = selected
         result = None

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -74,15 +74,19 @@ VOLATILE_TOKEN_RE = re.compile(
 # Fail-fast validation errors a HUMAN must fix in the config (Issue #345):
 # there is nothing for any agent to implement until a human edits the
 # config. These are the exact messages the Runner raises at config load
-# (`_check_pi_provider_api_key`, `load_config`); a crash loop whose journal
-# carries one of them is a deployment-config problem, not an orbi bug.
+# (`_check_pi_provider_api_key`, `load_config`) and the milestone errors
+# `advance_active_milestone_on_idle` raises for a misconfigured
+# `active_milestone` (Issue #614); a crash loop whose journal carries one
+# of them is a deployment-config problem, not an orbi bug.
 CONFIG_CAUSE_RE = re.compile(
     r"missing environment variable"
     r"|API key for provider"
     r"|must be a non-empty"
     r"|must be a boolean"
     r"|must be a positive integer"
-    r"|is not defined for provider",
+    r"|is not defined for provider"
+    r"|active_milestone_missing"
+    r"|ambiguous exact-title match",
 )
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -6045,6 +6045,35 @@ def test_main_idle_release_arm_failure_is_bypassed(monkeypatch, tmp_path, caplog
     assert "permission denied" in caplog.text
 
 
+def test_main_idle_advance_failure_is_bypassed(monkeypatch, tmp_path, caplog):
+    """Issue #614: the idle milestone advance is a pure bypass — a missing
+    or ambiguous `active_milestone` (or any `gh` failure) must not change
+    the idle outcome; the tick still returns 0 and only journals."""
+    _write_prompts(tmp_path)
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        'source_repos = ["owner/repo"]\nactive_milestone = "v0.4.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(runner, "pick_next_delivery", lambda *args: None)
+    monkeypatch.setattr(runner, "arm_release_ticket", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runner, "advance_active_milestone_on_idle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError(
+                "active_milestone_missing current=v0.4.0; "
+                "open milestones: v0.5.0(2)"
+            )
+        ),
+    )
+
+    with caplog.at_level("ERROR"):
+        assert runner.main(["--config", str(config)]) == 0
+
+    assert "active_milestone_advance_failed" in caplog.text
+    assert "active_milestone_missing" in caplog.text
+
+
 def _write_prompts(tmp_path):
     prompts = tmp_path / "prompts"
     prompts.mkdir(exist_ok=True)

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -743,6 +743,34 @@ def test_classify_crash_prefers_most_recent_config_marker():
     assert reason == CONFIG_REASON_LINE
 
 
+def test_classify_crash_active_milestone_missing_is_config():
+    """Issue #614: the idle advance's missing-milestone error names a
+    deployment-config problem a human must fix — never a dispatchable bug."""
+    line = (
+        "ERROR [abc12345] Runner failed to start: RuntimeError: "
+        "active_milestone_missing current=v0.4.0; open milestones: v0.5.0(2)"
+    )
+    assert runner_health.classify_crash([CRASH_LINE, line]) == (
+        "config",
+        line,
+    )
+
+
+def test_classify_crash_ambiguous_exact_title_is_config():
+    """Issue #614: the ambiguous exact-title refusal is the advance's
+    second config-caused raise (its actual wording — there is no
+    `active_milestone_ambiguous` literal)."""
+    line = (
+        "ERROR [abc12345] Runner failed to start: RuntimeError: "
+        "active_milestone v0.4.0: ambiguous exact-title match in "
+        "owner/repo, refusing to guess"
+    )
+    assert runner_health.classify_crash([CRASH_LINE, line]) == (
+        "config",
+        line,
+    )
+
+
 def test_crash_reason_fingerprint_is_stable_and_empty_for_blank():
     fp = runner_health.crash_reason_fingerprint(CONFIG_REASON_LINE)
     assert fp == runner_health.crash_reason_fingerprint(CONFIG_REASON_LINE)


### PR DESCRIPTION
<!-- orbi:run=70ebadaf -->

Fixes #614

P0 Bug：空闲 tick 的 milestone 推进无保护——milestone 改名即每 tick 非零退出，健康检查判为崩溃循环并自动开 ai-ready bug Issue（自激） (run_id=70ebadaf)
