### PR TITLE
P0 Bug：setup 的 label 权限预检把 installation token 误判为无权限（viewerPermission 对 ghs_ 恒空，实际 API 能力足够）

### DIFF
--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -52,7 +52,12 @@ non-zero exit code.
    default; exactly one with `--repo OWNER/REPO`):
    - the repo exists and the viewer has write permission
      (`gh repo view` → `viewerPermission` must be `WRITE`, `MAINTAIN`
-     or `ADMIN`);
+     or `ADMIN`). A GitHub App installation token (`ghs_`) reports an
+     empty `viewerPermission` although its issues:write manages labels
+     (Issue #613): setup decides the empty field with a one-shot
+     create+delete label probe (`gh api`) and reports
+     `permission=INSTALLATION`; a user token keeps the plain
+     permission requirement;
    - the eight platform labels are aligned **declaratively** from the
      deployment home's `labels.toml` (`<deploy_home>/labels.toml`,
      Issue #330) — the single source of truth for label name, color and
@@ -201,6 +206,7 @@ setup_failed reason=systemctl --user user bus unavailable (is a systemd user ses
 setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
 setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
+setup_failed reason=installation token cannot manage labels in owner/repo: ... (the GitHub App needs the Issues read/write repository permission and must be installed on owner/repo)
 setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)
 setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted changes: ' M src/orbi/runner.py') — commit or stash them first: ...
 setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry

--- a/docs/zh/setup.mdx
+++ b/docs/zh/setup.mdx
@@ -42,7 +42,11 @@ setup 是 **fail-fast**：核心前提失败会在任何后续变更之前停下
 4. **每个目标仓库**（默认每个配置的 `source_repos` 条目；`--repo
    OWNER/REPO` 时恰好一个）：
    - 仓库存在且 viewer 有写权限（`gh repo view` → `viewerPermission`
-     必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）；
+     必须是 `WRITE`、`MAINTAIN` 或 `ADMIN`）。GitHub App 的
+     installation token（`ghs_`）下该字段恒为空，而其 issues:write 足以
+     管理 labels（Issue #613）：setup 对空字段改用一次性 create+delete
+     标签探针（`gh api`）判定，并报告 `permission=INSTALLATION`；用户
+     token 保持原有的权限要求；
    - 八个平台标签从部署 home 的 `labels.toml`
      （`<deploy_home>/labels.toml`，Issue #330）**声明式**对齐——标签
      名/颜色/描述的唯一事实源：缺的创建、漂移的更新、从不删除，业务
@@ -172,6 +176,7 @@ setup_failed reason=systemctl --user user bus unavailable (is a systemd user ses
 setup_failed reason=editable tool install failed for /path/to/checkout: ... (fix: uv tool install --force --reinstall --editable --python /usr/bin/python3 /path/to/checkout)
 setup_failed reason=repo not accessible: nobody/no-such (gh repo view failed: ...)
 setup_failed reason=insufficient permission for owner/repo: viewerPermission='READ' (one of ['ADMIN', 'MAINTAIN', 'WRITE'] required to manage labels)
+setup_failed reason=installation token cannot manage labels in owner/repo: ... (the GitHub App needs the Issues read/write repository permission and must be installed on owner/repo)
 setup_failed reason=label alignment failed for owner/repo: ai-ready (gh label create failed: ...)
 setup_failed reason=checkout is not clean: /path/to/checkout (uncommitted changes: ' M src/orbi/runner.py') — commit or stash them first: ...
 setup_failed reason=checkout check failed for /path/to/checkout: ssh_unreachable: git ls-remote git@github.com:owner/repo.git failed: ... stderr=git@github.com: Permission denied (publickey). — fix SSH and retry

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -38,6 +38,7 @@ import json
 import logging
 import re
 import subprocess
+from uuid import uuid4
 import shutil
 import tomllib
 from pathlib import Path
@@ -338,6 +339,56 @@ def check_auth(run_command) -> None:
         ) from exc
 
 
+def token_is_installation(run_command) -> bool:
+    """Is the gh credential a GitHub App installation token (``ghs_``)?
+
+    Issue #613: ``viewerPermission`` is only meaningful for a user
+    token; an installation token reports an empty field there. The
+    token prefix (verified against gh 2.100.0 ``gh auth token``) is the
+    credential shape's ground truth. An unreadable token is NOT an
+    installation token: the caller keeps its existing fail-fast.
+    """
+    try:
+        token = run_command(["gh", "auth", "token"]).strip()
+    except Exception:
+        return False
+    return token.startswith("ghs_")
+
+
+def probe_label_capability(repo: str, run_command) -> None:
+    """Prove the credential can manage labels with a one-shot probe.
+
+    Issue #613: create a uniquely-named probe label and delete it again
+    (verified against the real API on 2026-09-09: create → 201 JSON,
+    delete → 204, both for a user token here and for the installation
+    token in the Issue scene). A create failure is a readable fail
+    fast with the repair action; a delete failure still fails fast and
+    names the label a human may have to remove.
+    """
+    name = f"orbi-setup-probe-{uuid4().hex[:8]}"
+    try:
+        run_command([
+            "gh", "api", "-X", "POST", f"repos/{repo}/labels",
+            "-f", f"name={name}", "-f", "color=cccccc",
+            "-f", "description=orbi setup capability probe",
+        ])
+    except Exception as exc:
+        raise SetupError(
+            f"installation token cannot manage labels in {repo}: {exc} "
+            "(the GitHub App needs the Issues read/write repository "
+            f"permission and must be installed on {repo})"
+        ) from exc
+    try:
+        run_command([
+            "gh", "api", "-X", "DELETE", f"repos/{repo}/labels/{name}",
+        ])
+    except Exception as exc:
+        raise SetupError(
+            f"installation token label probe cleanup failed for {repo}: "
+            f"the probe label {name!r} may be left behind: {exc}"
+        ) from exc
+
+
 def check_repo(repo: str, run_command) -> dict:
     """Verify the target repo exists and the viewer may write to it.
 
@@ -345,6 +396,11 @@ def check_repo(repo: str, run_command) -> dict:
     non-zero, a readable repo returns ``nameWithOwner``,
     ``viewerPermission`` and ``defaultBranchRef``). The viewer
     permission must allow label mutation (WRITE/MAINTAIN/ADMIN).
+    Issue #613: an installation token (``ghs_``) reports an empty
+    ``viewerPermission`` although its issues:write manages labels, so
+    the empty field on an installation token is decided by a one-shot
+    create+delete label probe instead of the meaningless field; a user
+    token keeps the exact prior behavior.
     """
     try:
         raw = run_command([
@@ -377,11 +433,15 @@ def check_repo(repo: str, run_command) -> dict:
         )
     permission = data.get("viewerPermission")
     if permission not in WRITE_PERMISSIONS:
-        raise SetupError(
-            f"insufficient permission for {repo}: viewerPermission="
-            f"{permission!r} (one of {sorted(WRITE_PERMISSIONS)} "
-            "required to manage labels)"
-        )
+        if not permission and token_is_installation(run_command):
+            probe_label_capability(repo, run_command)
+            permission = "INSTALLATION"
+        else:
+            raise SetupError(
+                f"insufficient permission for {repo}: viewerPermission="
+                f"{permission!r} (one of {sorted(WRITE_PERMISSIONS)} "
+                "required to manage labels)"
+            )
     name_with_owner = data.get("nameWithOwner")
     if not isinstance(name_with_owner, str) or not name_with_owner:
         raise SetupError(

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -471,6 +471,114 @@ def test_check_repo_fails_fast_on_unparseable_output():
         )
 
 
+# Issue #613: an installation token (ghs_) has no meaningful
+# `viewerPermission` (always empty), but the App's issues:write does
+# manage labels — check_repo must probe the real capability instead of
+# failing on the empty field.
+
+
+def _installation_run_factory(permission="", token="ghs_installationtoken"):
+    """Build a fake run_command: repo view returns `permission`, auth
+    token returns `token`, gh api create/delete succeed (real API
+    verified 2026-09-09: create → 201 JSON, delete → 204)."""
+    def fake_run(command, **kwargs):
+        if command[:3] == ["gh", "repo", "view"]:
+            return json.dumps({
+                "nameWithOwner": "xqliu/orbi",
+                "viewerPermission": permission,
+                "defaultBranchRef": {"name": "main"},
+            })
+        if command == ["gh", "auth", "token"]:
+            return token
+        if command[:2] == ["gh", "api"]:
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+    return fake_run
+
+
+def test_check_repo_probes_labels_for_an_installation_token():
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return _installation_run_factory()(command, **kwargs)
+
+    result = pilot_setup.check_repo("xqliu/orbi", run_command=fake_run)
+    assert result == {
+        "repo": "xqliu/orbi",
+        "permission": "INSTALLATION",
+        "default_branch": "main",
+    }
+    api_calls = [c for c in calls if c[:2] == ["gh", "api"]]
+    assert len(api_calls) == 2
+    create, delete = api_calls
+    assert create[:5] == ["gh", "api", "-X", "POST", "repos/xqliu/orbi/labels"]
+    name_args = [arg for arg in create if arg.startswith("name=")]
+    assert len(name_args) == 1
+    probe_name = name_args[0][len("name="):]
+    assert probe_name.startswith("orbi-setup-probe-")
+    assert delete == [
+        "gh", "api", "-X", "DELETE",
+        f"repos/xqliu/orbi/labels/{probe_name}",
+    ]
+
+
+def test_installation_fake_rejects_an_unexpected_command():
+    with pytest.raises(AssertionError, match="unexpected command"):
+        _installation_run_factory()(["gh", "surprise"])
+
+
+def test_check_repo_fails_fast_when_an_installation_token_cannot_write_labels():
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr="Resource not accessible by integration",
+            )
+        return _installation_run_factory()(command, **kwargs)
+
+    with pytest.raises(pilot_setup.SetupError, match="installation token"):
+        pilot_setup.check_repo("xqliu/orbi", run_command=fake_run)
+
+
+def test_check_repo_fails_fast_when_the_probe_label_delete_fails():
+    created_names = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            if command[3] == "POST":
+                for arg in command:
+                    if arg.startswith("name="):
+                        created_names.append(arg[len("name="):])
+                return ""
+            raise subprocess.CalledProcessError(1, command, stderr="boom")
+        return _installation_run_factory()(command, **kwargs)
+
+    with pytest.raises(pilot_setup.SetupError, match="probe cleanup") as excinfo:
+        pilot_setup.check_repo("xqliu/orbi", run_command=fake_run)
+    # The readable failure names the probe label a human may have to
+    # delete by hand.
+    assert created_names[0] in str(excinfo.value)
+
+
+def test_check_repo_fails_fast_on_an_empty_permission_for_a_user_token():
+    fake_run = _installation_run_factory(token="gho_usertoken")
+    with pytest.raises(pilot_setup.SetupError, match="insufficient permission"):
+        pilot_setup.check_repo("xqliu/orbi", run_command=fake_run)
+
+
+def test_check_repo_treats_an_unreadable_token_as_a_user_token():
+    def fake_run(command, **kwargs):
+        if command == ["gh", "auth", "token"]:
+            raise subprocess.CalledProcessError(
+                1, command, stderr="not logged in",
+            )
+        return _installation_run_factory()(command, **kwargs)
+
+    with pytest.raises(pilot_setup.SetupError, match="insufficient permission"):
+        pilot_setup.check_repo("xqliu/orbi", run_command=fake_run)
+
+
 # --- label alignment ---------------------------------------------------------
 
 


### PR DESCRIPTION
<!-- orbi:run=345c802e -->

Fixes #613

P0 Bug：setup 的 label 权限预检把 installation token 误判为无权限（viewerPermission 对 ghs_ 恒空，实际 API 能力足够） (run_id=345c802e)
