### PR TITLE
Bug：release docs-sync 假设仓库携带 Mintlify docs（docs/docs.json 缺失即必挂）——orbi-cloud v0.5.0 发布实证，外部/无文档仓库需要跳过语义

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3313,7 +3313,8 @@ def sync_release_docs(*, source_repo: str, repo_dir: Path,
       publish time, release task Issue number);
     - moves the `(latest)` title marker from the previous latest page;
     - inserts the new version at the head of the `Releases`/`发布`
-      navigation groups in `docs/docs.json` (both languages);
+      navigation groups in `docs/docs.json` (both languages), or skips
+      this Mintlify-only step when that file is absent;
     - commits exactly those docs paths in the release worktree and
       pushes `HEAD:refs/heads/<base_branch>` under the base-sync lock
       (the release path has no PR — a direct commit to the base branch,
@@ -3325,6 +3326,10 @@ def sync_release_docs(*, source_repo: str, repo_dir: Path,
     (never overwritten). Any failure propagates so the release fails
     fast and enters `ai-blocked` like every other step.
     """
+    docs_config = worktree / "docs" / "docs.json"
+    if not docs_config.is_file():
+        return "docs sync skipped (no Mintlify docs in repo)"
+
     raw = run_command([
         "gh", "release", "view", tag, "--repo", source_repo,
         "--json", "tagName,publishedAt,url,body",
@@ -3372,12 +3377,6 @@ def sync_release_docs(*, source_repo: str, repo_dir: Path,
             )
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
-    docs_config = worktree / "docs" / "docs.json"
-    if not docs_config.is_file():
-        raise RuntimeError(
-            f"release {tag}: {docs_config} is missing — the docs "
-            "navigation cannot be updated"
-        )
     config_text = docs_config.read_text(encoding="utf-8")
     old_slug = current_latest_release_slug(config_text)
     if old_slug != new_slug:

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16947,6 +16947,25 @@ def test_move_latest_marker_fails_fast_when_the_previous_page_is_missing(
         )
 
 
+def test_sync_release_docs_skips_repositories_without_mintlify_docs(
+        tmp_path, monkeypatch):
+    """External/product repositories without docs.json opt out of the
+    Mintlify-only sync step and expose that decision as release evidence."""
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def unexpected_release_lookup(*args, **kwargs):
+        raise AssertionError("a docs-less repository must not fetch a release")
+
+    monkeypatch.setattr(runner, "run_command", unexpected_release_lookup)
+    evidence = runner.sync_release_docs(
+        source_repo="o/r", repo_dir=work, worktree=work,
+        base_branch="main", tag="v0.4.0", release_commit="c" * 40,
+        issue_number=77,
+    )
+    assert evidence == "docs sync skipped (no Mintlify docs in repo)"
+
+
 def test_sync_release_docs_generates_pages_navigation_marker_and_commits(
         tmp_path, monkeypatch):
     work = make_release_docs_repo(tmp_path)
@@ -17448,20 +17467,18 @@ def test_sync_release_docs_fails_fast_when_the_body_is_not_a_string(
     assert bad_body(["git", "rev-parse", "HEAD"], cwd=work)
 
 
-def test_sync_release_docs_fails_fast_when_docs_json_is_missing(
-        tmp_path, monkeypatch):
+def test_sync_release_docs_skips_when_docs_json_is_missing(tmp_path):
     work = make_release_docs_repo(tmp_path)
     head = git_out(work, "rev-parse", "HEAD")
     subprocess.run(["git", "-C", str(work), "tag", "-a", "v0.4.0",
                     "-m", "rel", head], check=True, capture_output=True)
     (work / "docs" / "docs.json").unlink()
-    fake_gh_release_view(monkeypatch, body=RELEASE_DOCS_BODY_V040)
-    with pytest.raises(RuntimeError, match="docs.json.*is missing"):
-        runner.sync_release_docs(
-            source_repo="o/r", repo_dir=work, worktree=work,
-            base_branch="main", tag="v0.4.0", release_commit=head,
-            issue_number=77,
-        )
+    evidence = runner.sync_release_docs(
+        source_repo="o/r", repo_dir=work, worktree=work,
+        base_branch="main", tag="v0.4.0", release_commit=head,
+        issue_number=77,
+    )
+    assert evidence == "docs sync skipped (no Mintlify docs in repo)"
 
 
 def test_sync_release_docs_fails_fast_on_a_real_git_diff_error(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16947,25 +16947,6 @@ def test_move_latest_marker_fails_fast_when_the_previous_page_is_missing(
         )
 
 
-def test_sync_release_docs_skips_repositories_without_mintlify_docs(
-        tmp_path, monkeypatch):
-    """External/product repositories without docs.json opt out of the
-    Mintlify-only sync step and expose that decision as release evidence."""
-    work = tmp_path / "work"
-    work.mkdir()
-
-    def unexpected_release_lookup(*args, **kwargs):
-        raise AssertionError("a docs-less repository must not fetch a release")
-
-    monkeypatch.setattr(runner, "run_command", unexpected_release_lookup)
-    evidence = runner.sync_release_docs(
-        source_repo="o/r", repo_dir=work, worktree=work,
-        base_branch="main", tag="v0.4.0", release_commit="c" * 40,
-        issue_number=77,
-    )
-    assert evidence == "docs sync skipped (no Mintlify docs in repo)"
-
-
 def test_sync_release_docs_generates_pages_navigation_marker_and_commits(
         tmp_path, monkeypatch):
     work = make_release_docs_repo(tmp_path)


### PR DESCRIPTION
<!-- orbi:run=32c4824f -->

Fixes #636

Bug：release docs-sync 假设仓库携带 Mintlify docs（docs/docs.json 缺失即必挂）——orbi-cloud v0.5.0 发布实证，外部/无文档仓库需要跳过语义 (run_id=32c4824f)
