### PR TITLE
docs: 修正 Codex 段 gpt-5.6-luna 上下文窗口 1M → 272K（1M 属于 gpt-5.6-sol，非 luna）

### DIFF
--- a/docs/providers.mdx
+++ b/docs/providers.mdx
@@ -348,7 +348,7 @@ pi_provider = "openai-codex"
 pi_model = "gpt-5.6-luna"
 ```
 
-Pi's catalog checked on **2026-09-07** lists this model as `openai-codex-responses` at `https://chatgpt.com/backend-api`, with reasoning enabled, text/image input, a 1,000,000-token context window, and a 128,000-token output limit. Its catalog thinking map supports `minimal → low`, `xhigh → xhigh`, and `max → max`; leave `pi_thinking` unset for the default, or set one of those verified levels. These are Pi request limits, not a promise about subscription quota.
+Pi's catalog checked on **2026-09-08** lists this model as `openai-codex-responses` at `https://chatgpt.com/backend-api`, with reasoning enabled, text/image input, a 272,000-token context window, and a 128,000-token output limit. Its catalog thinking map supports `minimal → low`, `xhigh → xhigh`, and `max → max`; leave `pi_thinking` unset for the default, or set one of those verified levels. These are Pi request limits, not a promise about subscription quota. The 1,000,000-token context capability is a product-side capability of `gpt-5.6-sol`, not `gpt-5.6-luna`; Pi's current catalog also lists `sol` at 272,000 tokens, so Orbi's actual routing follows the Pi catalog. If selecting `sol`, verify the catalog again at that time.
 
 ### Quota and billing boundary
 

--- a/docs/zh/providers.mdx
+++ b/docs/zh/providers.mdx
@@ -348,7 +348,7 @@ pi_provider = "openai-codex"
 pi_model = "gpt-5.6-luna"
 ```
 
-Pi catalog 在 **2026-09-07** 检查到该模型的 API 是 `openai-codex-responses`，endpoint 是 `https://chatgpt.com/backend-api`；启用 reasoning，支持 text/image 输入，上下文限制 1,000,000 tokens，输出限制 128,000 tokens。其 catalog 的 thinking 映射支持 `minimal → low`、`xhigh → xhigh`、`max → max`；默认可不设 `pi_thinking`，也可设置这些已核实的级别。这些是 Pi 的请求限制，不是订阅额度承诺。
+Pi catalog 在 **2026-09-08** 检查到该模型的 API 是 `openai-codex-responses`，endpoint 是 `https://chatgpt.com/backend-api`；启用 reasoning，支持 text/image 输入，上下文限制 272,000 tokens，输出限制 128,000 tokens。其 catalog 的 thinking 映射支持 `minimal → low`、`xhigh → xhigh`、`max → max`；默认可不设 `pi_thinking`，也可设置这些已核实的级别。这些是 Pi 的请求限制，不是订阅额度承诺。1,000,000 tokens 的上下文能力属于产品侧的 `gpt-5.6-sol`，不是 `gpt-5.6-luna`；Pi 当前 catalog 对 `sol` 同样标为 272,000 tokens，因此 Orbi 实际路由以 Pi catalog 为准。如需选择 `sol`，请在当时重新核验 catalog。
 
 ### 额度与计费边界
 


### PR DESCRIPTION
<!-- orbi:run=60d40d6c -->

Fixes #558

docs: 修正 Codex 段 gpt-5.6-luna 上下文窗口 1M → 272K（1M 属于 gpt-5.6-sol，非 luna） (run_id=60d40d6c)
