### PR TITLE
P0：release 门禁读 check-runs 被 App 权限拒绝（403），托管路径下 release 状态机必然 ai-blocked

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2396,7 +2396,10 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
     reconciliation job, not the release gate's.
 
     A real `gh` failure (auth, rate limit, API error) propagates
-    unchanged — a gate that cannot be checked is a failed gate.
+    unchanged — a gate that cannot be checked is a failed gate. The one
+    exception is GitHub's HTTP 403 for the check-runs query: it is reported
+    as a missing Checks:read credential permission so the blocked release is
+    actionable.
     """
     evidence: list[str] = []
     open_deliveries: set[int] = set()
@@ -2436,10 +2439,24 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
         f"{IN_PROGRESS_LABEL} / {PR_OPENED_LABEL} / {FIX_NEEDED_LABEL}"
     )
     def fetch_check_runs() -> list[dict]:
-        return json.loads(run_command([
+        command = [
             "gh", "api", f"repos/{repo}/commits/{release_commit}/check-runs",
             "--jq", ".check_runs",
-        ]))
+        ]
+        try:
+            return json.loads(run_command(command))
+        except subprocess.CalledProcessError as error:
+            output = "\n".join(
+                str(value) for value in (error.stdout, error.stderr)
+                if value
+            )
+            if "403" in output:
+                raise RuntimeError(
+                    "CI gate could not be evaluated: the credential lacks "
+                    "Checks:read permission (GitHub returned HTTP 403 while "
+                    "listing check runs)"
+                ) from error
+            raise
 
     check_runs = fetch_check_runs()
     waited = 0.0

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14779,6 +14779,22 @@ def test_check_release_gates_ci_wait_times_out(monkeypatch, caplog):
     assert "release_waiting_ci" in caplog.text
 
 
+def test_check_release_gates_reports_missing_checks_permission(monkeypatch):
+    """A hosted App token's Checks permission failure is actionable."""
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr=("gh: Resource not accessible by integration "
+                        "(HTTP 403)"),
+            )
+        return "[]"
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    with pytest.raises(RuntimeError, match=r"lacks Checks:read"):
+        runner.check_release_gates("o/r", "main", "abc123", 99)
+
+
 def test_check_release_gates_reraises_real_gh_failure(monkeypatch):
     make_gate_gh(monkeypatch, check_runs=None)
     with pytest.raises(subprocess.CalledProcessError):


### PR DESCRIPTION
<!-- orbi:run=8d02d35d -->

Fixes #650

P0：release 门禁读 check-runs 被 App 权限拒绝（403），托管路径下 release 状态机必然 ai-blocked (run_id=8d02d35d)
