### PR TITLE
P0：gh api installation 在 installation token 下返回 404，trusted-author 判定崩溃，所有托管交付在评审阶段必然 ai-blocked

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4485,11 +4485,17 @@ def _authenticated_github_login() -> str:
     request that cannot identify this credential shape.
     """
     try:
-        status = run_command(["gh", "auth", "status"])
+        # The comments being verified come from github.com.  Restrict the
+        # status query to that host so an active account on another configured
+        # GitHub Enterprise host cannot be mistaken for this credential.
+        status = run_command([
+            "gh", "auth", "status", "--hostname", "github.com",
+        ])
     except Exception as exc:
         raise ValueError(
             "GitHub identity resolution failed: `gh auth status` could not "
-            f"read the active account: {exc}"
+            f"read the active account: {exc}; run `gh auth login` or fix "
+            "the GitHub credentials"
         ) from exc
 
     account: str | None = None
@@ -4505,7 +4511,8 @@ def _authenticated_github_login() -> str:
     if not active_account:
         raise ValueError(
             "GitHub identity resolution failed: `gh auth status` did not "
-            "report an active account"
+            "report an active account; run `gh auth login` or select an "
+            "active github.com account with `gh auth switch`"
         )
     return active_account
 

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4479,18 +4479,35 @@ def parse_pr_comment(body: str) -> dict | None:
 def _authenticated_github_login() -> str:
     """Return the login represented by the active ``gh`` credential.
 
-    Installation tokens identify their GitHub App installation as an account
-    ending in ``[bot]``.  This uses GitHub's authenticated-installation
-    endpoint rather than trusting an arbitrary bot name supplied by a
-    comment.  The ``/user`` endpoint is not supported by installation
-    access tokens.
+    ``gh api installation`` is unavailable with installation tokens, while
+    ``gh auth status`` reports the account selected in gh's credential store.
+    Read that local status instead of guessing a bot name or making an API
+    request that cannot identify this credential shape.
     """
-    app_slug = run_command(
-        ["gh", "api", "installation", "--jq", ".app_slug"],
-    ).strip()
-    if not app_slug:
-        raise ValueError("gh api installation returned an empty app slug")
-    return f"{app_slug}[bot]"
+    try:
+        status = run_command(["gh", "auth", "status"])
+    except Exception as exc:
+        raise ValueError(
+            "GitHub identity resolution failed: `gh auth status` could not "
+            f"read the active account: {exc}"
+        ) from exc
+
+    account: str | None = None
+    active_account: str | None = None
+    for line in status.splitlines():
+        match = re.search(r"\baccount\s+(\S+)", line)
+        if match:
+            account = match.group(1)
+        if re.search(r"Active account:\s*true\b", line, re.IGNORECASE):
+            if account:
+                active_account = account
+
+    if not active_account:
+        raise ValueError(
+            "GitHub identity resolution failed: `gh auth status` did not "
+            "report an active account"
+        )
+    return active_account
 
 
 def _comment_is_trusted(comment: object) -> bool:

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -208,21 +208,49 @@ def test_resume_scene_skips_non_dict_comments():
     assert scene["run_id"] == FAKE_RUN_ID
 
 
-def test_authenticated_github_login_uses_gh_installation_endpoint(monkeypatch):
+def test_authenticated_github_login_uses_active_gh_account(monkeypatch):
     calls = []
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command: calls.append(command) or "orbi-dev-test\n",
+        lambda command: calls.append(command) or (
+            "github.com\n"
+            "  ✓ Logged in to github.com account orbi-dev-test[bot] (keyring)\n"
+            "  - Active account: true\n"
+        ),
     )
     assert runner._authenticated_github_login() == "orbi-dev-test[bot]"
-    assert calls == [[
-        "gh", "api", "installation", "--jq", ".app_slug",
-    ]]
+    assert calls == [["gh", "auth", "status"]]
 
 
-def test_authenticated_github_login_rejects_empty_login(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda command: "\n")
-    with pytest.raises(ValueError, match="empty app slug"):
+def test_authenticated_github_login_selects_active_account(monkeypatch):
+    monkeypatch.setattr(
+        runner,
+        "run_command",
+        lambda command: (
+            "github.com\n"
+            "  ✓ Logged in to github.com account old-bot[bot] (keyring)\n"
+            "  - Active account: false\n"
+            "  ✓ Logged in to github.com account orbi-dev-test[bot] (keyring)\n"
+            "  - Active account: true\n"
+        ),
+    )
+    assert runner._authenticated_github_login() == "orbi-dev-test[bot]"
+
+
+def test_authenticated_github_login_reports_identity_resolution_failure(monkeypatch):
+    def fail(command):
+        raise RuntimeError("gh api installation: 404 Not Found")
+
+    monkeypatch.setattr(runner, "run_command", fail)
+    with pytest.raises(ValueError, match="identity resolution.*gh auth status"):
+        runner._authenticated_github_login()
+
+
+def test_authenticated_github_login_rejects_missing_active_account(monkeypatch):
+    monkeypatch.setattr(
+        runner, "run_command", lambda command: "Active account: true\n",
+    )
+    with pytest.raises(ValueError, match="identity resolution"):
         runner._authenticated_github_login()
 
 
@@ -232,10 +260,16 @@ def test_resume_scene_accepts_the_authenticated_runner_app_bot(monkeypatch):
         "authorAssociation": "NONE",
         "author": {"login": "orbi-dev-test[bot]"},
     }]
-    monkeypatch.setattr(
-        runner, "_authenticated_github_login",
-        lambda: "orbi-dev-test[bot]",
-    )
+
+    def gh_status(command):
+        assert command == ["gh", "auth", "status"]
+        return (
+            "github.com\n"
+            "  ✓ Logged in to github.com account orbi-dev-test[bot] (keyring)\n"
+            "  - Active account: true\n"
+        )
+
+    monkeypatch.setattr(runner, "run_command", gh_status)
     scene = runner.resume_scene(comments)
     assert scene["run_id"] == FAKE_RUN_ID
 

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -219,7 +219,7 @@ def test_authenticated_github_login_uses_active_gh_account(monkeypatch):
         ),
     )
     assert runner._authenticated_github_login() == "orbi-dev-test[bot]"
-    assert calls == [["gh", "auth", "status"]]
+    assert calls == [["gh", "auth", "status", "--hostname", "github.com"]]
 
 
 def test_authenticated_github_login_selects_active_account(monkeypatch):
@@ -262,7 +262,9 @@ def test_resume_scene_accepts_the_authenticated_runner_app_bot(monkeypatch):
     }]
 
     def gh_status(command):
-        assert command == ["gh", "auth", "status"]
+        assert command == [
+            "gh", "auth", "status", "--hostname", "github.com",
+        ]
         return (
             "github.com\n"
             "  ✓ Logged in to github.com account orbi-dev-test[bot] (keyring)\n"


### PR DESCRIPTION
<!-- orbi:run=f1c1e1ff -->

Fixes #648

P0：gh api installation 在 installation token 下返回 404，trusted-author 判定崩溃，所有托管交付在评审阶段必然 ai-blocked (run_id=f1c1e1ff)
