### PR TITLE
Orbi 执行异常: RuntimeError: no progress comment to update（release 早期失败时 finish() 无评论可更新）

### DIFF
--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -250,8 +250,10 @@ class ProgressPublisher:
     plus the progress header (PATCHing it when it exists, POSTing it when
     it does not) and tracks its id; the run's other marker-carrying
     comments (scene comments, milestones) are never touched.
-    `patch` and `finish` update the tracked comment in place and fail
-    fast when no comment is tracked yet. `milestone` posts a short
+    `patch` updates the tracked comment in place and fails fast when no
+    comment is tracked yet; `finish` publishes the final outcome on the
+    tracked comment, or locates/creates it like `ensure` when the run
+    never got that far (Issue #474). `milestone` posts a short
     standalone comment. Every call goes through `run_command` (gh api)
     and raises on any error.
     """
@@ -360,5 +362,16 @@ class ProgressPublisher:
         ))
 
     def finish(self, body: str) -> None:
-        """Replace the tracked comment with the final outcome body."""
+        """Publish the final outcome body on the run's progress comment.
+
+        When no comment is tracked yet — a run that fails before
+        `ensure` (Issue #474: a release declaration parse error calls
+        `finish` first) — the final outcome is still published: the
+        run's progress comment is located or created exactly like
+        `ensure`, never a `RuntimeError` and never a duplicate comment
+        for a resumed run.
+        """
+        if self.comment_id is None:
+            self.ensure(body)
+            return
         self.patch(body)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -14812,6 +14812,52 @@ def test_run_release_tests_path_is_gone():
     assert not hasattr(runner, "RELEASE_TEST_TIMEOUT_SECONDS")
 
 
+def test_process_release_parse_failure_publishes_final_comment(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #474: a release that fails BEFORE `publisher.ensure` (the
+    body is missing the `## Release` section) still publishes the final
+    progress comment. Before the fix `finish()` raised
+    `RuntimeError: no progress comment to update`, `_safe_publish`
+    logged a `progress_publish_failed` traceback, and the final comment
+    never landed.
+
+    Driven through the real dispatch entry `process_issue`, so the
+    release routing and the failure path are the production ones.
+    """
+    gh_calls, posted = make_fake_gh(monkeypatch)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    issue = {
+        "number": 467,
+        "title": "Release v0.4.2",
+        "body": "this body has no release section",
+        "labels": [{"name": "ai-release"}],
+    }
+    config = {"repo_dir": tmp_path, "base_branch": "main"}
+    with caplog.at_level("INFO"):
+        result = runner.process_issue(issue, config, "orbi-build/orbi")
+    assert result == runner.IssueResult("release", "")
+    # The handled failure is terminal: `ai-blocked` ALONE.
+    edits = [c for c in gh_calls if c[:3] == ["gh", "issue", "edit"]]
+    assert edits == [[
+        "gh", "issue", "edit", "467", "--repo", "orbi-build/orbi",
+        "--add-label", "ai-blocked", "--remove-label", "ai-in-progress",
+    ]]
+    # The concrete failure scene is on the Issue.
+    comments = [c for c in gh_calls if c[:3] == ["gh", "issue", "comment"]]
+    assert any(
+        "Orbi release failed (ai-blocked)" in c[-1] for c in comments
+    )
+    # Issue #474: the final progress comment is created even though
+    # `ensure` never ran.
+    assert any("**Orbi progress**" in body for body in posted)
+    assert not any(
+        "progress_publish_failed" in record.message
+        for record in caplog.records
+    )
+    assert "no progress comment to update" not in caplog.text
+
+
 def make_local_remote_pair(tmp_path):
     """A real local 'origin' bare remote + a working clone with one commit."""
     remote = tmp_path / "remote.git"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -763,7 +763,44 @@ def test_publisher_finish_patches_final_summary_into_tracked_comment():
     ]
 
 
-def test_publisher_finish_fails_fast_without_tracked_comment():
-    publisher, _ = make_publisher()
-    with pytest.raises(RuntimeError, match="no progress comment"):
-        publisher.finish("summary")
+def test_publisher_finish_creates_final_comment_without_tracked_one():
+    # Issue #474: a run that fails before `ensure` (release declaration
+    # parse error) still publishes its final result. `finish` creates
+    # the progress comment instead of raising "no progress comment".
+    publisher, calls = make_publisher()
+    publisher.finish("final delivery summary")
+    assert publisher.comment_id == 42
+    assert calls == [
+        [
+            "gh", "api", "repos/xqliu/orbi/issues/18/comments",
+            "--paginate",
+        ],
+        [
+            "gh", "api", "repos/xqliu/orbi/issues/18/comments",
+            "--method", "POST",
+            "--field", "body=final delivery summary",
+        ],
+    ]
+
+
+def test_publisher_finish_resumes_existing_comment_without_tracked_one():
+    # Issue #474: a resumed run whose publisher has not run `ensure` yet
+    # must PATCH the run's existing progress comment, never duplicate it.
+    publisher, calls = make_publisher(comments=[
+        {
+            "id": 7,
+            "body": (
+                "<!-- orbi:run=abc12345 -->\n\n"
+                "**Orbi progress**"
+            ),
+        },
+    ])
+    publisher.finish("final delivery summary")
+    assert publisher.comment_id == 7
+    assert calls[-1] == [
+        "gh", "api", "repos/xqliu/orbi/issues/comments/7",
+        "--method", "PATCH", "--field", "body=final delivery summary",
+    ]
+    assert not any(
+        "POST" in command for command in calls
+    ), "a resumed finish must not post a duplicate comment"


### PR DESCRIPTION
<!-- orbi:run=a19c88ff -->

Fixes #474

Orbi 执行异常: RuntimeError: no progress comment to update（release 早期失败时 finish() 无评论可更新） (run_id=a19c88ff)
