### PR TITLE
P0：release fallback 不校验 milestone 完整性，blocker 未完成时抢跑并推出 bump commit

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -1859,6 +1859,56 @@ def release_fallback_search(active_milestone: str | None = None) -> str:
     )
 
 
+def milestone_open_issue_count(repo: str, milestone_title: str) -> int:
+    """Return the Open-Issue count of one Milestone (Issue #663).
+
+    A single `gh api` call reads GitHub's own `open_issues` counter —
+    the authority on whether the Milestone still has unfinished work.
+    Unlike the search-based ready scans it does not depend on the search
+    index and it is not affected by a delivery-state label, so an Issue
+    temporarily outside the ready queue (`ai-blocked`, `ai-pr-opened`,
+    or not yet indexed) still counts. The title-filtered `--jq` is the
+    command documented in the Issue, verified against the live API. An
+    empty result means the Milestone could not be found: that is a
+    failed check, never a silent 0 (the caller must not release on it).
+    """
+    raw = run_command(
+        [
+            "gh", "api", f"repos/{repo}/milestones",
+            "--jq",
+            f'.[] | select(.title=="{milestone_title}") | .open_issues',
+        ],
+        timeout=30,
+    )
+    if not raw:
+        raise RuntimeError(
+            f"Milestone {milestone_title!r} not found in {repo}"
+        )
+    return int(raw)
+
+
+def release_target_milestone(
+    issue: dict, active_milestone: str | None = None,
+) -> str | None:
+    """Return the Milestone a release Issue releases (Issue #663).
+
+    The completeness gate judges the Milestone the release belongs to:
+    the Issue's own GitHub Milestone is authoritative, and the configured
+    `active_milestone` is the fallback (the release fallback scan is
+    already scoped to it). Without any Milestone there is nothing to
+    check and the release keeps the pre-#663 behavior, so the function
+    returns None and the caller skips the gate.
+    """
+    milestone = issue.get("milestone")
+    if isinstance(milestone, dict):
+        title = milestone.get("title")
+        if isinstance(title, str) and title:
+            return title
+    if isinstance(active_milestone, str) and active_milestone:
+        return active_milestone
+    return None
+
+
 def issue_priority(issue: dict) -> str:
     """Return the pickup priority of one issue (Issue #101).
 
@@ -4003,6 +4053,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
 
 def _pick_from_scan(
     issues: list[dict], repo: str, allow_release: bool = False,
+    active_milestone: str | None = None,
 ) -> dict | None:
     """Return the first claimable Issue of one scan result, else None.
 
@@ -4020,6 +4071,15 @@ def _pick_from_scan(
     ordinary scans skip an `ai-release` Issue (`release_not_claimed`) so
     a release never competes with an ordinary delivery for the slot; the
     release fallback scan passes `allow_release=True` and claims it.
+
+    A release candidate additionally passes the Milestone completeness
+    gate (Issue #663): while the Milestone still counts any other open
+    Issue (`open_issues > 1`), the release is skipped with the
+    structured `release_milestone_incomplete` line and the Issue stays
+    `ai-ready` for the next tick — a recoverable wait, never
+    `ai-blocked`. A Milestone query that cannot be evaluated skips the
+    release too (`release_milestone_check_failed`): a bad release is
+    irreversible, so the check fails safe and the next tick retries.
     """
     for issue in issues:
         if is_epic(issue):
@@ -4034,6 +4094,30 @@ def _pick_from_scan(
                 issue.get("number"), repo,
             )
             continue
+        if allow_release and is_release(issue):
+            target_milestone = release_target_milestone(
+                issue, active_milestone,
+            )
+            if target_milestone is not None:
+                try:
+                    open_issues = milestone_open_issue_count(
+                        repo, target_milestone,
+                    )
+                except Exception as exc:
+                    LOGGER.error(
+                        "release_milestone_check_failed issue=%s repo=%s "
+                        "milestone=%s error=%s",
+                        issue.get("number"), repo, target_milestone, exc,
+                    )
+                    return None
+                if open_issues > 1:
+                    LOGGER.info(
+                        "release_milestone_incomplete issue=%s repo=%s "
+                        "milestone=%s open_issues=%d",
+                        issue.get("number"), repo, target_milestone,
+                        open_issues,
+                    )
+                    continue
         blockers = open_blocker_numbers(issue)
         if blockers:
             LOGGER.info(
@@ -4100,13 +4184,15 @@ def pick_issue(repo: str, active_milestone: str | None = None) -> dict | None:
     # Release fallback (Issue #255): only when no ordinary delivery
     # (p0/bug/plain) is claimable. The query keeps `label:ai-ready` +
     # `label:ai-release` and the same delivery-state exclusions; the Epic
-    # and blockedBy guards still apply via `_pick_from_scan`. A failed
-    # fallback query fails open exactly like any other scan.
+    # and blockedBy guards still apply via `_pick_from_scan`. Issue
+    # #663: the release candidate also passes the Milestone completeness
+    # gate inside `_pick_from_scan`, so the query fetches `milestone`.
+    # A failed fallback query fails open exactly like any other scan.
     try:
         raw = run_command([
             "gh", "issue", "list", "--repo", repo, "--state", "open",
             "--search", release_fallback_search(active_milestone),
-            "--json", "number,title,body,labels,blockedBy",
+            "--json", "number,title,body,labels,blockedBy,milestone",
             "--limit", "200",
         ])
         issues = parse_issue_array(raw)
@@ -4116,7 +4202,10 @@ def pick_issue(repo: str, active_milestone: str | None = None) -> dict | None:
             repo, exc,
         )
         return None
-    return _pick_from_scan(issues, repo, allow_release=True)
+    return _pick_from_scan(
+        issues, repo, allow_release=True,
+        active_milestone=active_milestone,
+    )
 
 
 def pick_in_progress_issue(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -1870,6 +1870,11 @@ def test_release_fallback_scoped_to_active_milestone(monkeypatch):
     searches = []
 
     def fake_run(command, **kwargs):
+        # Issue #663: with `active_milestone` the release candidate now
+        # passes the Milestone completeness gate; this Milestone has only
+        # the release ticket itself.
+        if command[1] == "api":
+            return "1"
         searches.append(command[command.index("--search") + 1])
         if "label:ai-release" in searches[-1]:
             return json.dumps([release])
@@ -1933,6 +1938,200 @@ def test_release_fallback_scan_failure_fails_open(monkeypatch, caplog):
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert "blocked_by_check_failed" in caplog.text
+
+
+# --- Issue #663: release Milestone completeness gate ----------------------
+
+
+def test_milestone_open_issue_count_reads_github_counter(monkeypatch):
+    """Issue #663: the completeness judgment is GitHub's own Milestone
+    `open_issues` counter, read with the one API call documented in the
+    Issue (title-filtered jq) — not the search index, not a label."""
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return "3"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.milestone_open_issue_count("xqliu/orbi", "v0.4.2") == 3
+    assert commands == [[
+        "gh", "api", "repos/xqliu/orbi/milestones",
+        "--jq", '.[] | select(.title=="v0.4.2") | .open_issues',
+    ]]
+
+
+def test_milestone_open_issue_count_missing_milestone_raises(monkeypatch):
+    """Issue #663: an empty result (the Milestone is gone) is a failed
+    check, not a silent zero — the caller must never claim on it."""
+    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "")
+    with pytest.raises(RuntimeError, match="v0.4.2"):
+        runner.milestone_open_issue_count("xqliu/orbi", "v0.4.2")
+
+
+def test_release_target_milestone_prefers_issue_then_active():
+    """Issue #663: the release's Milestone is the Issue's GitHub
+    Milestone, falling back to the configured `active_milestone` (the
+    fallback scan is scoped to it). No Milestone ⇒ no gate."""
+    assert runner.release_target_milestone(
+        {"milestone": {"title": "v0.4.2"}}, None,
+    ) == "v0.4.2"
+    assert runner.release_target_milestone({}, "v0.4.2") == "v0.4.2"
+    assert runner.release_target_milestone({}, None) is None
+    assert runner.release_target_milestone(
+        {"milestone": {"title": ""}}, "v0.4.2",
+    ) == "v0.4.2"
+    assert runner.release_target_milestone({"milestone": "bad"}, None) is None
+    assert runner.release_target_milestone(
+        {"milestone": {"title": 7}}, None,
+    ) is None
+
+
+RELEASE_663 = {
+    "number": 254, "title": "release", "body": "",
+    "labels": [{"name": "ai-ready"}, {"name": "ai-release"}],
+    "blockedBy": {"nodes": [], "totalCount": 0},
+    "milestone": {"title": "v0.4.2"},
+}
+
+
+def _release_scan_fake(api_result):
+    """Return a `run_command` fake: empty ordinary scans, the release
+    in the fallback scan, and `api_result` (a string or an exception)
+    for the Milestone counter query."""
+
+    def fake_run(command, **kwargs):
+        if command[1] == "api":
+            if isinstance(api_result, Exception):
+                raise api_result
+            return api_result
+        search = command[command.index("--search") + 1]
+        if "label:ai-release" in search:
+            return json.dumps([RELEASE_663])
+        return json.dumps([])
+
+    return fake_run
+
+
+def test_release_not_claimed_when_milestone_incomplete(monkeypatch, caplog):
+    """Issue #663: a release ticket is not claimed while its Milestone
+    still has open Issues — here an `ai-blocked` P0 that no ready scan
+    sees. The gate reads GitHub's own `open_issues` counter, so a
+    temporarily un-claimable Issue (ai-blocked / ai-pr-opened / not yet
+    indexed) can no longer let the release run ahead."""
+    monkeypatch.setattr(runner, "run_command", _release_scan_fake("3"))
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/orbi") is None
+    assert "release_milestone_incomplete" in caplog.text
+    assert "milestone=v0.4.2" in caplog.text
+    assert "open_issues=3" in caplog.text
+    # The Issue stays `ai-ready`: it was never claimed.
+    assert "picked issue=254" not in caplog.text
+
+
+def test_release_claimed_when_milestone_only_has_the_release(
+    monkeypatch, caplog,
+):
+    """Issue #663: with only the release ticket itself left
+    (`open_issues=1`) the release is claimed exactly as before."""
+    monkeypatch.setattr(runner, "run_command", _release_scan_fake("1"))
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/orbi") == RELEASE_663
+    assert "picked issue=254" in caplog.text
+
+
+def test_release_not_claimed_when_milestone_check_fails(monkeypatch, caplog):
+    """Issue #663: a milestone query that cannot be evaluated never
+    claims — a bad release is irreversible, so the check fails safe and
+    the next tick retries (recoverable, never `ai-blocked`)."""
+    error = subprocess.CalledProcessError(1, ["gh"], output="boom")
+    monkeypatch.setattr(runner, "run_command", _release_scan_fake(error))
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/orbi") is None
+    assert "release_milestone_check_failed" in caplog.text
+    assert "picked issue=254" not in caplog.text
+
+
+def test_release_without_milestone_claimed_without_api_call(
+    monkeypatch, caplog,
+):
+    """Issue #663: a release with no Milestone (and no configured
+    `active_milestone`) keeps the pre-#663 behavior — claimed with no
+    extra API call."""
+    release = {
+        "number": 254, "title": "release", "body": "",
+        "labels": [{"name": "ai-ready"}, {"name": "ai-release"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    commands_seen = []
+
+    def fake_run(command, **kwargs):
+        commands_seen.append(command)
+        if "label:ai-release" in " ".join(command):
+            return json.dumps([release])
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue("xqliu/orbi") == release
+    assert not [c for c in commands_seen if c[1] == "api"]
+    assert "picked issue=254" in caplog.text
+
+
+def test_release_milestone_falls_back_to_active_milestone(
+    monkeypatch, caplog,
+):
+    """Issue #663: without a Milestone on the release Issue, the
+    configured `active_milestone` (the fallback scan's scope) is the
+    Milestone whose completeness is checked."""
+    release = {
+        "number": 254, "title": "release", "body": "",
+        "labels": [{"name": "ai-ready"}, {"name": "ai-release"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    api_calls = []
+
+    def fake_run(command, **kwargs):
+        if command[1] == "api":
+            api_calls.append(command)
+            return "2"
+        search = command[command.index("--search") + 1]
+        if "label:ai-release" in search:
+            return json.dumps([release])
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with caplog.at_level("INFO"):
+        assert runner.pick_issue(
+            "xqliu/orbi", active_milestone="v0.3.0",
+        ) is None
+    assert api_calls
+    assert "milestone=v0.3.0" in caplog.text
+    assert "open_issues=2" in caplog.text
+
+
+def test_release_fallback_scan_fetches_milestone(monkeypatch):
+    """Issue #663: the release fallback scan fetches `milestone` so the
+    completeness gate reads the release's GitHub Milestone from the same
+    query — no extra `gh issue view`."""
+    release = {
+        "number": 254, "title": "release", "body": "",
+        "labels": [{"name": "ai-ready"}, {"name": "ai-release"}],
+        "blockedBy": {"nodes": [], "totalCount": 0},
+    }
+    scans = []
+
+    def fake_run(command, **kwargs):
+        scans.append(command)
+        search = command[command.index("--search") + 1]
+        if "label:ai-release" in search:
+            return json.dumps([release])
+        return json.dumps([])
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.pick_issue("xqliu/orbi") == release
+    fields = scans[-1][scans[-1].index("--json") + 1]
+    assert "milestone" in fields.split(",")
 
 
 def test_pick_issue_p0_blocked_by_open_blocker_falls_back_to_bug(


### PR DESCRIPTION
<!-- orbi:run=50f9b9c9 -->

Fixes #663

P0：release fallback 不校验 milestone 完整性，blocker 未完成时抢跑并推出 bump commit (run_id=50f9b9c9)
