### PR TITLE
P0：残留孤儿分支让 git worktree add -b 失败（exit 255），被烧成终态 ai-blocked 且不自愈

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -5068,6 +5068,12 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
     the named branch is fetched and reused (a local branch is reused
     with `--force`, never a second `-b` — the exit-255 claim failure of
     Issue #608); without it the branch is created from the frozen base.
+
+    A local branch that already exists (the orphan a SIGKILLed run
+    leaves with no worktree and no remote counterpart, Issue #662) is
+    reused as-is rather than re-created with `-b`: git exits 255 on an
+    existing branch, which used to burn the re-claimed Issue into
+    terminal `ai-blocked`.
     """
     if existing is not None and existing.is_dir():
         return existing
@@ -5094,9 +5100,24 @@ def create_worktree(repo_dir: Path, source_repo: str, number: int,
                 f"origin/{branch}",
             ], cwd=repo_dir)
     else:
-        run_command([
-            "git", "worktree", "add", "-b", branch, str(path), base_sha,
-        ], cwd=repo_dir)
+        # Issue #662 (the #655 incident): a SIGKILLed run can leave the
+        # stable branch behind with no worktree and no remote counterpart
+        # (a pure orphan).  `worktree add -b` cannot re-create it — git
+        # exits 255 (`fatal: a branch named ... already exists`) and the
+        # claim used to be burned into terminal `ai-blocked`.  The branch
+        # is the delivery identity, so a local one is reused as-is; only
+        # a missing branch is created from the frozen base SHA.
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            run_command([
+                "git", "worktree", "add", str(path), branch,
+            ], cwd=repo_dir)
+        else:
+            run_command([
+                "git", "worktree", "add", "-b", branch, str(path), base_sha,
+            ], cwd=repo_dir)
     return path
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -2847,12 +2847,88 @@ def test_create_worktree_reuses_existing_path_for_a_resumed_run(
 def test_create_worktree_adds_branch_from_frozen_base_sha(monkeypatch, tmp_path):
     path = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-run1"
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)))
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: calls.append((command, kwargs)) or "",
+    )
     assert runner.create_worktree(tmp_path, "owner/repo", 3, "run1", "abc123def456") == path
-    assert calls == [(
-        ["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "abc123def456"],
-        {"cwd": tmp_path},
-    )]
+    assert calls == [
+        (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "abc123def456"],
+         {"cwd": tmp_path}),
+    ]
+
+
+def test_create_worktree_reuses_orphan_local_branch_never_exits_255(
+    monkeypatch, tmp_path,
+):
+    """Issue #662 (the #655 incident): a SIGKILLed run can leave the stable
+    branch behind with no worktree and no remote counterpart (a pure orphan).
+    `worktree add -b` cannot re-create it (the exit-255 that burned the Issue
+    into terminal ai-blocked), so the orphan branch is reused by identity."""
+    path = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-run1"
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if command[:3] == ["git", "branch", "--list"]:
+            return "orbi/owner-repo-issue-3"
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    assert runner.create_worktree(
+        tmp_path, "owner/repo", 3, "run1", "base",
+    ) == path
+    assert calls == [
+        (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
+        (["git", "worktree", "add", str(path), "orbi/owner-repo-issue-3"],
+         {"cwd": tmp_path}),
+    ]
+
+
+def test_create_worktree_reuses_orphan_local_branch_real_git(tmp_path):
+    """Real-git acceptance (Issue #662, the #655 scene): the local orphan
+    branch is checked out into the new worktree where the bare `worktree add
+    -b` exited 255 (`fatal: a branch named ... already exists`)."""
+    work, head = make_local_remote_pair(tmp_path)
+    repo_dir = tmp_path / "runner"
+    subprocess.run(
+        ["git", "clone", "-q", str(tmp_path / "remote.git"), str(repo_dir)],
+        check=True, capture_output=True,
+    )
+    for key, value in (("user.email", "t@t"), ("user.name", "t")):
+        subprocess.run(
+            ["git", "-C", str(repo_dir), "config", key, value],
+            check=True, capture_output=True,
+        )
+    # The killed claim left the branch at the base commit; it was never
+    # pushed, so origin has no counterpart (the #655 orphan).
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "branch",
+         "orbi/owner-repo-issue-3", head],
+        check=True, capture_output=True,
+    )
+    remote = subprocess.run(
+        ["git", "-C", str(repo_dir), "ls-remote", "--heads", "origin",
+         "refs/heads/orbi/owner-repo-issue-3"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert remote == "", "the orphan branch must not exist on origin"
+    # The bare `git worktree add -b` of the incident fails (exit 255).
+    incident = subprocess.run(
+        ["git", "-C", str(repo_dir), "worktree", "add", "-b",
+         "orbi/owner-repo-issue-3", str(tmp_path / "incident"), head],
+        capture_output=True, text=True,
+    )
+    assert incident.returncode != 0, incident
+    assert "already exists" in incident.stderr
+    # The orphan-aware path reuses the branch instead.
+    path = runner.create_worktree(repo_dir, "owner/repo", 3, "run1", head)
+    current = subprocess.run(
+        ["git", "-C", str(path), "branch", "--show-current"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert current == "orbi/owner-repo-issue-3"
 
 
 def test_create_worktree_reuses_existing_remote_branch(monkeypatch, tmp_path):

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -107,6 +107,20 @@ sys.stderr.write("a FRESH run started — the resume was lost")
 sys.exit(7)
 """
 
+# A fresh claim delivers a committed change (Issue #662's orphan-branch
+# e2e: the claim must not die on `worktree add -b`).
+FAKE_PI_DELIVERS = """#!/usr/bin/env python3
+import os, subprocess
+cwd = os.getcwd()
+with open(os.path.join(cwd, "work.txt"), "w", encoding="utf-8") as f:
+    f.write("delivered\\n")
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", "deliver the change"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+"""
+
 
 def git(repo: Path, *args: str) -> str:
     result = subprocess.run(
@@ -515,6 +529,53 @@ def test_e2e_corrupt_run_state_fails_fast_without_a_fresh_run(
     assert "corrupt" in failed[0]
     # The existing work is untouched (no fresh redo).
     assert (worktree / "work.txt").read_text() == "part-1\n"
+
+
+def test_e2e_claim_reuses_orphan_local_branch(
+    clone, tmp_path, monkeypatch, caplog,
+):
+    """Issue #662 (the #655 incident): re-claiming an Issue whose stable
+    branch was left behind by a killed run (no worktree, never pushed)
+    reuses the orphan instead of dying on `worktree add -b` (exit 255),
+    and the delivery completes — the Issue is never burned into terminal
+    `ai-blocked`."""
+    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
+    base = git(clone, "rev-parse", "HEAD")
+    git(clone, "branch", branch, base)
+    # Local-only orphan: no worktree, no remote counterpart (the #655
+    # scene verified in the incident).
+    assert git(
+        clone, "ls-remote", "--heads", "origin", f"refs/heads/{branch}",
+    ) == ""
+    assert ".worktrees" not in git(clone, "worktree", "list")
+    comments: list[str] = []
+    labels: dict[int, list[str]] = {ISSUE_NUMBER: ["ai-ready"]}
+    caplog.set_level("INFO")
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_DELIVERS)
+    install_fake_gh(monkeypatch, comments, labels)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "c3d4e5f6")
+
+    result = runner.process_issue(
+        issue(), config_for(clone, tmp_path, REPO), REPO,
+    )
+
+    # The claim succeeded: the worktree exists on the REUSED branch and
+    # the delivery completed (a PR was opened).
+    assert result.url == PR_URL
+    worktree = worktree_for(clone, REPO, "c3d4e5f6")
+    assert worktree.is_dir()
+    assert git(worktree, "branch", "--show-current") == branch
+    assert git(worktree, "show", "HEAD:work.txt") == "delivered"
+    # The orphan branch advanced on top of the base (a real delivery on
+    # the SAME branch, never a second one).
+    assert git(worktree, "rev-parse", "HEAD") != base
+    git(worktree, "merge-base", "--is-ancestor", base, "HEAD")
+    # The Issue is NOT burned into the terminal state.
+    assert "ai-blocked" not in labels[ISSUE_NUMBER]
+    assert "ai-pr-opened" in labels[ISSUE_NUMBER]
+    assert "ai-in-progress" not in labels[ISSUE_NUMBER]
+    # No exit-255 claim failure was logged.
+    assert "command_failed" not in caplog.text
 
 
 def test_git_helper_fails_fast_on_nonzero_exit(tmp_path):


### PR DESCRIPTION
<!-- orbi:run=90a83ba5 -->

Fixes #662

P0：残留孤儿分支让 git worktree add -b 失败（exit 255），被烧成终态 ai-blocked 且不自愈 (run_id=90a83ba5)
