### PR TITLE
fix: 认领竞态守卫——在途复查改 gh issue view 直读（不再依赖最终一致的搜索索引）+ 认领写之前双守卫让路（label/stable branch 窗口内落位=输掉认领，不打 ai-blocked 不打断胜者）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3672,12 +3672,27 @@ def has_in_progress_label(number: int, repo: str) -> bool:
     failure path, so it is the marker of a run that is (or was, when
     the runner died) in flight — as opposed to the preserved worktrees
     of completed runs (Issue #18).
+
+    Read via `gh issue view` — a direct, strongly consistent read. The
+    pre-#658 implementation used `gh issue list --search`, the same
+    eventually-consistent index the pickup scan reads, so it could not
+    see a label another instance added seconds ago — exactly the moment
+    this check exists to catch (the pre-claim race guard).
     """
-    issues = list_issues(
-        repo, state="all", search=f"label:{IN_PROGRESS_LABEL}",
-        json_fields="number", limit=50,
+    raw = run_command([
+        "gh", "issue", "view", str(number), "--repo", repo,
+        "--json", "labels",
+    ])
+    details = json.loads(raw)
+    if not isinstance(details, dict):
+        raise ValueError("issue view must return a JSON object")
+    labels = details.get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("issue view labels must be a JSON array")
+    return any(
+        isinstance(label, dict) and label.get("name") == IN_PROGRESS_LABEL
+        for label in labels
     )
-    return any(int(issue.get("number", -1)) == number for issue in issues)
 
 
 def is_content_only(issue: dict) -> bool:
@@ -6800,6 +6815,28 @@ def process_issue(issue: dict, config: dict, source_repo: str,
     LOGGER.info(
         "issue=%s %s", number, run_info,
     )
+    if not in_progress and READY_LABEL in claim_labels \
+            and takeover_pr is None:
+        # Issue #658: the pickup scan and the in-progress recheck above
+        # both predate freeze_base (a seconds-long network round trip).
+        # A label — or the stable branch — appearing inside that window
+        # means another instance claimed this Issue while we were
+        # preparing: yield. No label writes, no comments, nothing that
+        # could interrupt the winner's in-flight delivery; the next
+        # tick's scan picks work up again on its own.
+        if has_in_progress_label(number, source_repo):
+            LOGGER.info(
+                "issue=%s claim_yield reason=in_progress_label", number,
+            )
+            return IssueResult("claim-yielded", None)
+        if not stable_branch_present and stable_branch_exists(
+                config["repo_dir"], stable_branch,
+        ):
+            LOGGER.info(
+                "issue=%s claim_yield reason=stable_branch_appeared",
+                number,
+            )
+            return IssueResult("claim-yielded", None)
     apply_label_patch(
         number, repo=source_repo, event=EVENT_CLAIM,
         current_labels={label.get("name") for label in issue.get(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3594,28 +3594,29 @@ def test_has_in_progress_label_checks_the_issue_label(monkeypatch, tmp_path):
 
     def fake_run(command, **kwargs):
         calls.append(command)
-        return json.dumps([{"number": 4}])
+        return json.dumps({"labels": [{"name": "ai-in-progress"}]})
 
     monkeypatch.setattr(runner, "run_command", fake_run)
     assert runner.has_in_progress_label(4, "owner/repo") is True
     assert calls == [[
-        "gh", "issue", "list", "--repo", "owner/repo", "--state", "all",
-        "--search", "label:ai-in-progress",
-        "--json", "number", "--limit", "50",
+        "gh", "issue", "view", "4", "--repo", "owner/repo",
+        "--json", "labels",
     ]]
 
 
 def test_has_in_progress_label_is_false_without_the_label(monkeypatch):
     monkeypatch.setattr(
         runner, "run_command",
-        lambda command, **kwargs: json.dumps([{"number": 5}]),
+        lambda command, **kwargs: json.dumps(
+            {"labels": [{"name": "ai-fix-needed"}]},
+        ),
     )
     assert runner.has_in_progress_label(4, "owner/repo") is False
 
 
 def test_has_in_progress_label_fails_fast_on_malformed_output(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "{}")
-    with pytest.raises(ValueError, match="issue list must be a JSON array"):
+    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
+    with pytest.raises(ValueError, match="issue view must return a JSON object"):
         runner.has_in_progress_label(4, "owner/repo")
 
 
@@ -3779,6 +3780,8 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
                 # The existing progress comment of the dead run.
                 return json.dumps([existing_comment])
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # The Issue still carries `ai-in-progress` (the runner died).
             return json.dumps([{"number": 4}])
@@ -3875,6 +3878,8 @@ def test_process_issue_binds_run_id_before_the_resume_scan(
         gh_calls.append(command)
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps([{"number": 4}])
         if command[:2] == ["gh", "issue"]:
@@ -3945,6 +3950,8 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
         gh_calls.append(command)
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # No `ai-in-progress` label: the previous run finished.
             return "[]"
@@ -4013,6 +4020,8 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
         gh_calls.append(command)
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps([{"number": 4}])
         if command[:2] == ["gh", "issue"]:
@@ -4087,6 +4096,11 @@ def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
         gh_calls.append(command)
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [
+                {"name": "ai-in-progress"}] if in_progress
+                else [{"name": "ai-ready"}],
+            })
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps(
                 [{"number": 4}] if in_progress else [],
@@ -5396,6 +5410,8 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
         gh_calls.append(command)
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5497,6 +5513,8 @@ def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, c
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5535,6 +5553,8 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5608,6 +5628,8 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5691,6 +5713,8 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5778,6 +5802,8 @@ def test_process_issue_model_wait_failure_records_health_attempt(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5834,6 +5860,8 @@ def test_process_issue_three_recoverable_failures_raise_health_finding(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return ""
@@ -5884,6 +5912,8 @@ def test_process_issue_success_records_health_streak_break(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
@@ -5944,6 +5974,8 @@ def test_process_issue_recoverable_health_record_failure_is_bypassed(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return ""
@@ -5993,6 +6025,8 @@ def test_process_issue_success_health_record_failure_is_bypassed(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
@@ -6055,6 +6089,8 @@ def test_process_issue_model_wait_dead_comment_failure_stays_in_progress(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -6132,6 +6168,8 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -6205,6 +6243,8 @@ def test_process_issue_ends_cleanly_when_reporting_fails(monkeypatch, tmp_path, 
             # test_process_issue_failure_path_progress_failure_keeps_
             # blocked_transition.)
             raise RuntimeError("github report failed")
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -6274,6 +6314,8 @@ def test_advance_active_milestone_pending_creates_one_p0_ready_issue(
 
     def fake_run(command, **kwargs):
         calls.append(command)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return json.dumps([milestones])
@@ -6394,6 +6436,8 @@ def test_advance_active_milestone_pending_issue_failure_is_bypassed(
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
 
     def fail_pending(command, **kwargs):
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         if command[:3] == ["gh", "issue", "create"]:
@@ -7055,6 +7099,8 @@ def test_process_issue_failure_without_session_still_carries_scene(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -7137,6 +7183,8 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -7189,6 +7237,8 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -16222,6 +16272,8 @@ def make_gate_gh(monkeypatch, *, leftover_labels=None, check_runs=None,
 
     def fake_run_command(command, **kwargs):
         calls.append(command)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         if command[:3] == ["gh", "issue", "list"]:
             label = command[command.index("--label") + 1]
             numbers = leftover_labels.get(label, [])

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3619,6 +3619,138 @@ def test_has_in_progress_label_fails_fast_on_malformed_output(monkeypatch):
         runner.has_in_progress_label(4, "owner/repo")
 
 
+def test_has_in_progress_label_reads_directly_not_via_the_search_index(
+    monkeypatch,
+):
+    """Issue #658：认领前复查必须直读（gh issue view，强一致）——不能走
+    与扫描同一套最终一致的搜索索引：另一实例几秒前刚打上的
+    ai-in-progress，索引可能尚未收录，复查必须看到它才能让路。"""
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
+        if command[:3] == ["gh", "issue", "list"]:
+            # The stale search index has not ingested the label yet.
+            return json.dumps([])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    assert runner.has_in_progress_label(4, "owner/repo") is True
+
+
+def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
+                     stable_branch_seq=None):
+    """Minimal process_issue deps for the #658 claim-race tests.
+
+    Everything after the claim decision is irrelevant (the guard must
+    fire before any of it); run_pi returning normally keeps the
+    unguarded path moving so its downstream label writes become
+    observable — that is exactly what the red assertions catch.
+    """
+    if stable_branch_seq is not None:
+        seq = list(stable_branch_seq)
+        monkeypatch.setattr(
+            runner, "stable_branch_exists",
+            lambda repo_dir, branch: seq.pop(0) if seq else False,
+        )
+    if freeze_side_effect is not None:
+        def fake_freeze_base(repo_dir, base_branch):
+            freeze_side_effect()
+            return "0123456789abcdef0123456789abcdef01234567"
+        monkeypatch.setattr(runner, "freeze_base", fake_freeze_base)
+    else:
+        monkeypatch.setattr(
+            runner, "freeze_base",
+            lambda repo_dir, base_branch:
+                "0123456789abcdef0123456789abcdef01234567",
+        )
+    monkeypatch.setattr(
+        runner, "new_run_id", lambda: "feedface",
+    )
+
+    def fake_create_worktree(*args, **kwargs):
+        path = tmp_path / "wt"
+        (path / ".orbi").mkdir(parents=True, exist_ok=True)
+        return path
+
+    monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+
+
+def test_process_issue_yields_when_the_label_lands_mid_preparation(
+    monkeypatch, tmp_path,
+):
+    """Issue #658：扫描与认领写之间隔着 freeze_base 的秒级网络往返；
+    另一实例在该窗口内认领（ai-in-progress 出现）时，本实例必须让路
+    ——不打任何标签、不发失败评论、绝不能把胜者打成 ai-blocked。"""
+    state = {"in_progress": False}
+
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "issue", "view"]:
+            labels = ([{"name": "ai-in-progress"}]
+                      if state["in_progress"] else [])
+            return json.dumps({"labels": labels})
+        if command[:3] == ["gh", "issue", "list"]:
+            # The search index lags behind the other instance's claim.
+            return json.dumps(
+                [{"number": 18}] if state["in_progress"] else [],
+            )
+        if command[:3] == ["gh", "pr", "list"]:
+            return json.dumps([])
+        if command[:2] == ["git", "ls-remote"]:
+            # The scan-time stable-branch probe (before the race lands).
+            return ""
+        if command[:2] == ["gh", "api"]:
+            if "--method" not in command:
+                return json.dumps([])
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    _claim_race_deps(
+        monkeypatch, tmp_path,
+        freeze_side_effect=lambda: state.__setitem__("in_progress", True),
+    )
+    issue = {"number": 18, "title": "t", "body": "b",
+             "labels": [{"name": "ai-ready"}]}
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+              "base_branch": "main"}
+    result = runner.process_issue(issue, config, "owner/repo")
+    assert result == runner.IssueResult("claim-yielded", None)
+
+
+def test_process_issue_yields_when_the_stable_branch_lands_mid_preparation(
+    monkeypatch, tmp_path,
+):
+    """Issue #658 的撞分支面：扫描时 stable branch 尚不存在，freeze_base
+    的窗口内被另一实例创建（它先认领）——认领写之前必须复查到并让路，
+    而不是径直 create_worktree 撞分支后走 ai-blocked 失败路径。"""
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([])
+        if command[:3] == ["gh", "pr", "list"]:
+            return json.dumps([])
+        if command[:2] == ["gh", "api"]:
+            if "--method" not in command:
+                return json.dumps([])
+            return ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    # First probe (scan-time): absent. Second probe (the pre-claim
+    # guard): the other instance created it while we were preparing.
+    _claim_race_deps(
+        monkeypatch, tmp_path, stable_branch_seq=[False, True],
+    )
+    issue = {"number": 18, "title": "t", "body": "b",
+             "labels": [{"name": "ai-ready"}]}
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+              "base_branch": "main"}
+    result = runner.process_issue(issue, config, "owner/repo")
+    assert result == runner.IssueResult("claim-yielded", None)
+
+
 def test_process_issue_resumes_existing_run_and_same_progress_comment(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3620,22 +3620,42 @@ def test_has_in_progress_label_fails_fast_on_malformed_output(monkeypatch):
         runner.has_in_progress_label(4, "owner/repo")
 
 
+def test_has_in_progress_label_fails_fast_on_malformed_labels(monkeypatch):
+    """view 返回 JSON 对象但 labels 字段不是数组（Issue #658）：解析
+    失败必须 fail-fast，绝不落入默认 False（那会让竞态守卫失明）。"""
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps({"labels": "ai-in-progress"}),
+    )
+    with pytest.raises(ValueError, match="labels must be a JSON array"):
+        runner.has_in_progress_label(4, "owner/repo")
+
+
 def test_has_in_progress_label_reads_directly_not_via_the_search_index(
     monkeypatch,
 ):
     """Issue #658：认领前复查必须直读（gh issue view，强一致）——不能走
     与扫描同一套最终一致的搜索索引：另一实例几秒前刚打上的
     ai-in-progress，索引可能尚未收录，复查必须看到它才能让路。"""
+    calls = []
+
     def fake_run_command(command, **kwargs):
+        calls.append(command)
         if command[:3] == ["gh", "issue", "view"]:
             return json.dumps({"labels": [{"name": "ai-in-progress"}]})
-        if command[:3] == ["gh", "issue", "list"]:
-            # The stale search index has not ingested the label yet.
-            return json.dumps([])
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
     assert runner.has_in_progress_label(4, "owner/repo") is True
+    # The fixed path reads the Issue directly — the search index (which
+    # has not ingested the other instance's claim yet) is never queried.
+    assert calls == [[
+        "gh", "issue", "view", "4", "--repo", "owner/repo",
+        "--json", "labels",
+    ]]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run_command(["gh", "issue", "list", "--search",
+                          "label:ai-in-progress"])
 
 
 def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
@@ -3669,14 +3689,10 @@ def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
     monkeypatch.setattr(
         runner, "new_run_id", lambda: "feedface",
     )
-
-    def fake_create_worktree(*args, **kwargs):
-        path = tmp_path / "wt"
-        (path / ".orbi").mkdir(parents=True, exist_ok=True)
-        return path
-
-    monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
-    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    # create_worktree/run_pi stay REAL: on the fixed path the guard
+    # yields before either is reached, and a regression that skips the
+    # guard then fails loudly on the real calls (tmp_path is no git
+    # repo) — no dead fake arms.
 
 
 def make_claim_race_gh(monkeypatch, state):
@@ -3712,8 +3728,29 @@ def make_claim_race_gh(monkeypatch, state):
     return fake_run_command
 
 
-def test_claim_race_gh_rejects_unexpected_commands(monkeypatch):
-    fake = make_claim_race_gh(monkeypatch, {"in_progress": False})
+def test_claim_race_gh_answers_every_expected_command(monkeypatch):
+    """The shared #658 fake is a contract, not a sink: every branch it
+    answers is one the claim flow issues — driven here (in_progress=True
+    arm; the False arm is driven by the two yield tests) so no arm is
+    dead in the fixed world, and anything else fails loud."""
+    fake = make_claim_race_gh(monkeypatch, {"in_progress": True})
+    assert json.loads(fake([
+        "gh", "issue", "view", "18", "--repo", "o/r", "--json", "labels",
+    ])) == {"labels": [{"name": "ai-in-progress"}]}
+    assert json.loads(fake([
+        "gh", "issue", "list", "--search", "label:ai-in-progress",
+    ])) == [{"number": 18}]
+    assert json.loads(fake(["gh", "pr", "list", "--state", "open"])) == []
+    assert fake([
+        "git", "ls-remote", "--heads", "origin", "refs/heads/x",
+    ]) == ""
+    assert json.loads(fake([
+        "gh", "api", "repos/o/r/issues/18/comments",
+    ])) == []
+    assert fake([
+        "gh", "api", "repos/o/r/issues/18/comments",
+        "--method", "POST", "--field", "body=x",
+    ]) == ""
     with pytest.raises(AssertionError, match="unexpected command"):
         fake(["gh", "release", "view"])
 
@@ -6320,8 +6357,6 @@ def test_advance_active_milestone_pending_creates_one_p0_ready_issue(
 
     def fake_run(command, **kwargs):
         calls.append(command)
-        if command[:3] == ["gh", "issue", "view"]:
-            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return json.dumps([milestones])
@@ -6442,8 +6477,6 @@ def test_advance_active_milestone_pending_issue_failure_is_bypassed(
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
 
     def fail_pending(command, **kwargs):
-        if command[:3] == ["gh", "issue", "view"]:
-            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         if command[:3] == ["gh", "issue", "create"]:
@@ -16278,8 +16311,6 @@ def make_gate_gh(monkeypatch, *, leftover_labels=None, check_runs=None,
 
     def fake_run_command(command, **kwargs):
         calls.append(command)
-        if command[:3] == ["gh", "issue", "view"]:
-            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         if command[:3] == ["gh", "issue", "list"]:
             label = command[command.index("--label") + 1]
             numbers = leftover_labels.get(label, [])

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3906,6 +3906,110 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
     assert "- branch: orbi/xqliu-orbi-backlog-issue-4" in last_body
 
 
+def test_process_issue_second_tick_behind_the_index_resumes_not_reclaims(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #658 单实例面（xqliu 09-11 生产现场，orbi#702 并入 #658）：
+    同一 timer 的两次 tick 竞争同一张票——第一次 tick 早已完成认领
+    （`ai-in-progress` 落位在本 tick 之前，worktree 的 run 在飞），而搜索
+    索引滞后，把这张票连同陈旧的 `ai-ready` labels 快照一起递给本 tick。
+    认领复查的 `gh issue view` 直读必须看到标签：本 tick 走 resume 复用
+    在飞 run 的 id，绝不 fresh claim（不消费新 run_id、不建第二个分支
+    把在途交付撞成 push rejected → ai-blocked）——修复不依赖
+    `max_concurrency` 的取值，单实例双 tick 与双实例同根因。"""
+    existing_comment = {
+        "id": 77,
+        "body": (
+            "<!-- orbi:run=a1b2c3d4 -->\n\n"
+            "**Orbi progress**\n\nfirst tick's run is in flight"
+        ),
+    }
+    gh_calls, posted = make_fake_gh(
+        monkeypatch, comments=[existing_comment], in_progress=True,
+    )
+    branch = "orbi/xqliu-orbi-backlog-issue-4"
+    head = "0123456789abcdef0123456789abcdef01234567"
+
+    def fake_run(command, **kwargs):
+        gh_calls.append(command)
+        if command[:2] == ["gh", "api"]:
+            if "--method" not in command:
+                # The in-flight run's progress comment.
+                return json.dumps([existing_comment])
+            return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            # The strongly-consistent direct read: the label the first
+            # tick wrote IS live truth, no matter how stale the index
+            # that delivered the Issue was.
+            return json.dumps({"labels": [{"name": "ai-in-progress"}]})
+        if command[:2] == ["gh", "issue"]:
+            return ""
+        if command[:2] == ["gh", "pr"]:
+            return json.dumps([{
+                "url": "https://github.com/orbi-build/orbi/pull/4",
+                "baseRefName": "main",
+                "headRefName": branch,
+                "headRefOid": head,
+                "headRepository": {"name": "orbi"},
+                "headRepositoryOwner": {"login": "orbi-build"},
+                "body": "<!-- orbi:run=a1b2c3d4 -->\n\nFixes #4\n\nPlan",
+            }])
+        if command[:3] == ["git", "branch", "--show-current"]:
+            return branch
+        if command[:2] == ["git", "rev-parse"]:
+            return head
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(
+        runner, "freeze_base",
+        lambda repo_dir, base_branch: "abc123def456",
+    )
+    # If a regression makes this tick a FRESH claim, the fresh id leaks
+    # into the scene comments and the assertions below catch it.
+    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(
+        runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
+        ("a1b2c3d4", tmp_path / "wt"),
+    )
+    monkeypatch.setattr(
+        runner, "create_worktree",
+        lambda *args, **kwargs: tmp_path / "wt",
+    )
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    # The stale scan snapshot: still showing ai-ready even though the
+    # first tick already claimed the Issue.
+    issue = {"number": 4, "title": "Fix", "body": "Body",
+             "labels": [{"name": "ai-ready"}]}
+    config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+              "base_branch": "main"}
+    with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
+        result = runner.process_issue(
+            issue, config, "xqliu/orbi-backlog",
+        )
+    assert result == runner.IssueResult(
+        "pr", "https://github.com/orbi-build/orbi/pull/4",
+    )
+    # The direct read routed this tick into the resume: the in-flight
+    # run's id owns every scene comment — a fresh claim never starts.
+    assert "fresh_claim_route" not in caplog.text
+    assert "resuming_run" in caplog.text
+    # And the claim recheck never asked the lagging index for the label
+    # (the pre-#658 list search): the direct read is the only source.
+    assert not any(
+        command[:3] == ["gh", "issue", "list"] for command in gh_calls
+    )
+    scene_bodies = [
+        call[-1] for call in gh_calls
+        if call[:2] == ["gh", "issue"] and "comment" in call
+    ]
+    assert scene_bodies, "no scene comment was published"
+    for body in scene_bodies:
+        assert "ffffeeee" not in body
+    # And the claim-time label write stayed the shared idempotent patch
+    # (run=a1b2c3d4 marker), never a second run's footprint.
+
+
 def test_process_issue_binds_run_id_before_the_resume_scan(
     monkeypatch, tmp_path, caplog,
 ):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3649,9 +3649,11 @@ def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
     """
     if stable_branch_seq is not None:
         seq = list(stable_branch_seq)
+        # Exactly two probes consume the sequence: the scan-time probe
+        # and the pre-claim guard (Issue #658).
         monkeypatch.setattr(
             runner, "stable_branch_exists",
-            lambda repo_dir, branch: seq.pop(0) if seq else False,
+            lambda repo_dir, branch: seq.pop(0),
         )
     if freeze_side_effect is not None:
         def fake_freeze_base(repo_dir, base_branch):
@@ -3677,21 +3679,21 @@ def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
 
 
-def test_process_issue_yields_when_the_label_lands_mid_preparation(
-    monkeypatch, tmp_path,
-):
-    """Issue #658：扫描与认领写之间隔着 freeze_base 的秒级网络往返；
-    另一实例在该窗口内认领（ai-in-progress 出现）时，本实例必须让路
-    ——不打任何标签、不发失败评论、绝不能把胜者打成 ai-blocked。"""
-    state = {"in_progress": False}
+def make_claim_race_gh(monkeypatch, state):
+    """The gh fake for the #658 claim-race world.
 
+    The direct read (`gh issue view`) answers the LIVE label truth from
+    `state["in_progress"]`; the search index (`gh issue list`) answers
+    from the same state — a lagging index is modeled by flipping the
+    state only AFTER the pickup scan, exactly when the other instance's
+    claim lands. One shared guard line, driven by its own test below.
+    """
     def fake_run_command(command, **kwargs):
         if command[:3] == ["gh", "issue", "view"]:
             labels = ([{"name": "ai-in-progress"}]
                       if state["in_progress"] else [])
             return json.dumps({"labels": labels})
         if command[:3] == ["gh", "issue", "list"]:
-            # The search index lags behind the other instance's claim.
             return json.dumps(
                 [{"number": 18}] if state["in_progress"] else [],
             )
@@ -3707,6 +3709,23 @@ def test_process_issue_yields_when_the_label_lands_mid_preparation(
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
+    return fake_run_command
+
+
+def test_claim_race_gh_rejects_unexpected_commands(monkeypatch):
+    fake = make_claim_race_gh(monkeypatch, {"in_progress": False})
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake(["gh", "release", "view"])
+
+
+def test_process_issue_yields_when_the_label_lands_mid_preparation(
+    monkeypatch, tmp_path,
+):
+    """Issue #658：扫描与认领写之间隔着 freeze_base 的秒级网络往返；
+    另一实例在该窗口内认领（ai-in-progress 出现）时，本实例必须让路
+    ——不打任何标签、不发失败评论、绝不能把胜者打成 ai-blocked。"""
+    state = {"in_progress": False}
+    make_claim_race_gh(monkeypatch, state)
     _claim_race_deps(
         monkeypatch, tmp_path,
         freeze_side_effect=lambda: state.__setitem__("in_progress", True),
@@ -3725,20 +3744,7 @@ def test_process_issue_yields_when_the_stable_branch_lands_mid_preparation(
     """Issue #658 的撞分支面：扫描时 stable branch 尚不存在，freeze_base
     的窗口内被另一实例创建（它先认领）——认领写之前必须复查到并让路，
     而不是径直 create_worktree 撞分支后走 ai-blocked 失败路径。"""
-    def fake_run_command(command, **kwargs):
-        if command[:3] == ["gh", "issue", "view"]:
-            return json.dumps({"labels": [{"name": "ai-ready"}]})
-        if command[:3] == ["gh", "issue", "list"]:
-            return json.dumps([])
-        if command[:3] == ["gh", "pr", "list"]:
-            return json.dumps([])
-        if command[:2] == ["gh", "api"]:
-            if "--method" not in command:
-                return json.dumps([])
-            return ""
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    make_claim_race_gh(monkeypatch, {"in_progress": False})
     # First probe (scan-time): absent. Second probe (the pre-claim
     # guard): the other instance created it while we were preparing.
     _claim_race_deps(

--- a/tests/test_ops_e2e.py
+++ b/tests/test_ops_e2e.py
@@ -70,7 +70,14 @@ def git(*cmd):
                           check=True).stdout.strip()
 
 
-if args[:2] == ["issue", "list"]:
+if args[:2] == ["issue", "view"]:
+    # Issue #658: the pre-claim recheck reads the LIVE label truth
+    # directly (`gh issue view`) instead of the search index.
+    issue = state["issues"][args[2]]
+    print(json.dumps(
+        {"labels": [{"name": label} for label in issue["labels"]]},
+    ))
+elif args[:2] == ["issue", "list"]:
     search = args[args.index("--search") + 1]
     tokens = search.split()
     required = [t[6:].split(",") for t in tokens if t.startswith("label:")]

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -45,6 +45,14 @@ def make_fake_gh(monkeypatch, comments=None, in_progress=False):
                 return json.dumps({"id": 77, "body": body[len("body="):],
                                    "url": "https://x/77"})
             return ""
+        if command[:3] == ["gh", "issue", "view"]:
+            # The pre-claim in-progress recheck reads the Issue
+            # directly (Issue #658) — the same `in_progress` truth the
+            # search-based resume scan encodes.
+            return json.dumps({"labels": [
+                {"name": "ai-in-progress"}] if in_progress
+                else [{"name": "ai-ready"}],
+            })
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps([{"number": 18}] if in_progress else [])
         return ""
@@ -925,6 +933,8 @@ def make_failing_gh(monkeypatch, is_failing, comments=None):
                 return json.dumps({"id": 77, "body": body[len("body="):],
                                    "url": "https://x/77"})
             return ""
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return ""
@@ -2041,6 +2051,8 @@ def _make_takeover_gh(monkeypatch, monkeypatched, tmp_path, *, pr_state="OPEN",
 
     def fake_run_command(command, **kwargs):
         calls.append(command)
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         if command[:3] == ["gh", "pr", "list"]:

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -214,6 +214,14 @@ def install_fake_gh(monkeypatch, comments: list[str],
                             if "ai-in-progress" in labels[number]
                         ])
                     return "[]"
+                if command[2] == "view":
+                    # The pre-claim in-progress recheck reads the Issue
+                    # directly (Issue #658): answer from the live label
+                    # truth, not from any index.
+                    return json.dumps({"labels": [
+                        {"name": label}
+                        for label in labels.get(int(command[3]), [])
+                    ]})
             if command[1] == "api":
                 if "--method" in command:
                     method = command[command.index("--method") + 1]
@@ -627,9 +635,10 @@ def test_fake_gh_handler_answers_the_unreached_transitions(
     with pytest.raises(AssertionError, match="unexpected gh command"):
         fake(["gh", "release", "list"])
     # A `gh issue` subcommand the flow never issues falls through the
-    # comment/edit/list handlers and fails fast.
+    # comment/edit/list/view handlers and fails fast (`issue view` is
+    # now an expected call — the #658 direct-read recheck).
     with pytest.raises(AssertionError, match="unexpected gh command"):
-        fake(["gh", "issue", "view", str(ISSUE_NUMBER)])
+        fake(["gh", "issue", "lock", str(ISSUE_NUMBER)])
     # A `gh api` method that is neither POST nor PATCH falls through
     # to the plain GET answer.
     get = fake(["gh", "api", "repos/owner/repo/issues/219/comments",

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -206,6 +206,14 @@ def install_fake_gh(monkeypatch, comments: list[str],
                             if label in current:
                                 current.remove(label)
                     return ""
+                if command[2] == "view":
+                    # The pre-claim in-progress recheck reads the Issue
+                    # directly (Issue #658): answer from the tracked
+                    # labels, like the real GitHub state.
+                    tracked = (labels or {}).get(int(command[3]), [])
+                    return json.dumps({"labels": [
+                        {"name": label} for label in tracked
+                    ]})
                 if command[2] == "list":
                     # The restart-resume scan (Issue #18): answer from
                     # the tracked labels, like the real GitHub state.

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -1076,6 +1076,9 @@ def test_process_issue_pickup_record_failure_is_bypass(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            # Fresh claim: no ai-in-progress (Issue #658 direct read).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
@@ -1125,6 +1128,9 @@ def test_process_issue_failure_record_failure_is_bypass(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[:3] == ["gh", "issue", "view"]:
+            # Fresh claim: no ai-in-progress (Issue #658 direct read).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
         return ""


### PR DESCRIPTION
## 背景

Issue #658：`max_concurrency=2`（文档支持配置）下双实例同 tick 扫描会拿到同一 ai-ready Issue。认领前的在途复查 `has_in_progress_label` 与扫描用**同一套最终一致的搜索索引**——索引未追上时复查形同虚设，败者认领后在 `create_worktree` 撞"stable branch already exists"，通用失败路径以本地推演的标签打 `EVENT_BLOCKED`：**拔掉胜者的在途标签**，胜者的 PR 随后被 `needs_human_intervention` 拦截。

## 根因

1. 复查走搜索索引而非直读（`gh issue view` 强一致，仓库已有 5 处先例）；
2. 扫描复查（:9254）与认领写（apply_label_patch(EVENT_CLAIM)）之间隔着 `freeze_base` 的秒级网络往返，窗口敞开无二次确认；
3. 败者失败路径无条件打终态标签，无法区分"输掉认领"与"真实失败"。

## 修复（票中方案 A+C）

- **A（直读复查）**：`has_in_progress_label` 改用 `gh issue view <n> --json labels` 直读，非一致输出的解析失败保持 fail-fast；两个调用方（release 路径 :3578、认领路径 :9254）同时受益。
- **A'（认领前守卫）**：`process_issue` fresh-claim 路径在 `apply_label_patch(EVENT_CLAIM)` 之前复查：`ai-in-progress` 在准备期间**出现**（:9254 时还不在）＝活竞态 → 让路。
- **C（撞分支让路）**：同一守卫处，stable branch 在准备期间**出现**（扫描时不存在，`stable_branch_exists` 复查）＝输掉认领 → 让路。
- **让路语义**：不打任何标签、不发任何评论、不动胜者状态，返回 `IssueResult("claim-yielded", None)`；主循环对非 pr/external-pr 的 kind 既有的跳过行为不变。
- 守卫条件窄化：仅 `not in_progress and READY_LABEL in claim_labels and takeover_pr is None`（resume 语义、takeover 路由、死自跑场景行为全部不变）。
- 残余窗口明示：守卫与认领写之间仍有毫秒级窗口，GitHub label 无 CAS 可用，不假装根除。

## 测试

- 红→绿三测试：索引滞后时直读必须看到 ai-in-progress（旧实现返回 False=复现）；freeze_base 窗口内标签落位 → `claim-yielded`（旧实现径直写认领标签=复现）；窗口内 stable branch 落位 → 同上。
- 共享假体 `make_claim_race_gh`：view 答现场真值、search 答同源状态——正是"索引滞后、直读即时"的现实建模；守卫 raise 行由专属测试驱动（无死臂）。
- 既有假体（make_fake_gh/_resume_wiring_setup/resume_continue e2e 严格假体等）补 view 应答，语义与各自 in_progress 真值一致。

## 验证

- 全量测试 2138 passed / 24 failed（macOS 本机固有，与 main 同数）/ 3 deselected（macOS 死循环三项）。
- 覆盖门由 CI 验证（本地全量门禁本轮未跑；改动行已按无死臂纪律收敛）。

Fixes #658
