### PR TITLE
P0：GraphQL 的 author.login 不带 [bot] 后缀，_comment_is_trusted 对真实 bot 评论恒假，托管交付评审仍全线阻塞（#648 未完全解决）

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -4607,6 +4607,17 @@ def _authenticated_github_login() -> str:
     return active_account
 
 
+def _strip_bot_suffix(login: str) -> str:
+    """Drop the optional ``[bot]`` suffix from an App login.
+
+    ``gh issue view --json comments`` reads comments through GraphQL and
+    reports ``author.login`` without the ``[bot]`` suffix, while REST's
+    ``user.login`` keeps it (Issue #655). Both shapes name the same App
+    credential, so the suffix is normalized away before comparison.
+    """
+    return login[:-5] if login.endswith("[bot]") else login
+
+
 def _comment_is_trusted(comment: object) -> bool:
     """True when the comment is from a maintainer or this runner's App bot."""
     if not isinstance(comment, dict):
@@ -4615,11 +4626,15 @@ def _comment_is_trusted(comment: object) -> bool:
         return True
     author = comment.get("author")
     login = author.get("login") if isinstance(author, dict) else None
-    if not isinstance(login, str) or not login.endswith("[bot]"):
+    if not isinstance(login, str):
         return False
     # A copied run marker is not sufficient: the author must be the account
-    # represented by the currently authenticated installation token.
-    return login == _authenticated_github_login()
+    # represented by the currently authenticated installation token. The
+    # optional `[bot]` suffix is normalized on both sides because GraphQL
+    # drops it and REST keeps it (Issue #655).
+    return _strip_bot_suffix(login) == _strip_bot_suffix(
+        _authenticated_github_login()
+    )
 
 
 def resume_scene(comments: list[dict]) -> dict:

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -290,6 +290,74 @@ def test_resume_scene_rejects_another_app_bot_even_with_the_marker(monkeypatch):
         runner.resume_scene(comments)
 
 
+# Issue #655: `gh issue view --json comments` (GraphQL) returns
+# `author.login` without the `[bot]` suffix while REST keeps it. Both shapes
+# describe the same App credential and must be trusted; a foreign App, with
+# or without the suffix, must not.
+@pytest.mark.parametrize("login,expected", [
+    # The real GraphQL shape of this App bot (the reported failure).
+    ("orbi-dev-test", True),
+    # The REST shape of this App bot.
+    ("orbi-dev-test[bot]", True),
+    # Another App, suffix-less GraphQL shape.
+    ("other-app", False),
+    # Another App, REST shape.
+    ("other-app[bot]", False),
+    # A shared prefix must not match: the comparison is exact after
+    # normalization.
+    ("orbi-dev-test-2", False),
+])
+def test_comment_is_trusted_normalizes_optional_bot_suffix(
+    monkeypatch, login, expected,
+):
+    monkeypatch.setattr(
+        runner, "_authenticated_github_login",
+        lambda: "orbi-dev-test[bot]",
+    )
+    comment = {
+        "body": opened_pr_comment(),
+        "authorAssociation": "NONE",
+        "author": {"login": login},
+    }
+    assert runner._comment_is_trusted(comment) is expected
+
+
+def test_resume_scene_accepts_graphql_shaped_runner_app_bot(monkeypatch):
+    """End-to-end resume with the exact GraphQL author shape that failed."""
+    comments = [{
+        "body": opened_pr_comment(),
+        "authorAssociation": "NONE",
+        "author": {"login": "orbi-dev-test"},
+    }]
+    monkeypatch.setattr(
+        runner, "_authenticated_github_login",
+        lambda: "orbi-dev-test[bot]",
+    )
+    scene = runner.resume_scene(comments)
+    assert scene["run_id"] == FAKE_RUN_ID
+
+
+@pytest.mark.parametrize("author", [
+    {"login": None},
+    {"login": 7},
+    {},
+    "not-a-dict",
+])
+def test_comment_is_trusted_rejects_missing_or_non_string_login(
+    monkeypatch, author,
+):
+    monkeypatch.setattr(
+        runner, "_authenticated_github_login",
+        lambda: "orbi-dev-test[bot]",
+    )
+    comment = {
+        "body": opened_pr_comment(),
+        "authorAssociation": "NONE",
+        "author": author,
+    }
+    assert runner._comment_is_trusted(comment) is False
+
+
 # ------------------------------------------------- trusted comments (F1)
 
 


### PR DESCRIPTION
<!-- orbi:run=31593623 -->

Fixes #655

P0：GraphQL 的 author.login 不带 [bot] 后缀，_comment_is_trusted 对真实 bot 评论恒假，托管交付评审仍全线阻塞（#648 未完全解决） (run_id=31593623)
