### PR TITLE
fix: check_release_gates 区分空 check-runs 的两种世界——repo_has_ci=True 时空列表=首个 check 未注册，在同一预算内轮询等待而非按 nothing to gate 放行（CI 门假成功）

### DIFF
--- a/src/orbi/release.py
+++ b/src/orbi/release.py
@@ -527,8 +527,14 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
                         delivery_waited_seconds: float = 0.0,
                         on_wait: Callable[[str], None] | None = None,
                         on_delivery_wait: Callable[[str], None] | None = None,
-                        ) -> list[str]:
+                        repo_has_ci: bool = False,
+                        ) -> tuple[list[str], bool]:
     """Enforce the pre-release gates (Issue #98) and return their evidence.
+
+    Returns ``(evidence, repo_has_ci)`` — the second element is whether
+    any check run was observed on the gated commit, so the release flow
+    can feed gate 1's observation (on the frozen base) into gate 2 (on
+    the just-pushed version commit) as ``repo_has_ci``.
 
     Two gates, each checked against GitHub (never against local
     state), each failure raising with the concrete offender:
@@ -547,7 +553,14 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
        the GitHub API for the commit is `completed` with a
        `success`/`neutral`/`skipped` conclusion (a failing, cancelled
        or error check fails the gate; no check runs at all is recorded
-       as such, not invented). A PENDING check (queued/in_progress —
+       as such, not invented — EXCEPT when the caller passes
+       ``repo_has_ci=True``, the frozen base already showed checks, so
+       this repository runs CI and an empty list on a freshly pushed
+       commit means the checks have not REGISTERED yet (GitHub creates
+       CheckRuns seconds after the push, Issue #657): the gate then
+       polls within the same budget until the first check appears and
+       never passes an empty list as "nothing to gate"). A PENDING
+       check (queued/in_progress —
        the release commit is born from the last delivery merge, so its
        CI is almost always still running, Issue #268) is not a
        conclusion: the gate polls until every check completes (one
@@ -639,6 +652,16 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
             f"{check.get('status')}/{check.get('conclusion')}"
             for check in check_runs if check.get("status") != "completed"
         ]
+        if repo_has_ci and not check_runs:
+            # Issue #657: an empty list on a just-pushed commit in a CI
+            # repository is "not registered yet", not "nothing to gate"
+            # — wait for the first check within the same budget; a
+            # timeout below fails with the wait-timeout reason.
+            pending = [
+                "the first check run to register on the just-pushed "
+                f"commit {release_commit} (GitHub creates CheckRuns "
+                "seconds after the push)"
+            ]
         if not pending:
             break
         detail = ", ".join(pending)
@@ -689,7 +712,7 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
         )
     # Issue #608: no open-PR gate — an open PR is queue state, not a
     # release premise (see the docstring for the maintainer ruling).
-    return evidence
+    return evidence, bool(check_runs)
 
 
 def prepare_release_version(worktree: Path, tag: str,
@@ -1665,7 +1688,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         target_milestone = release_target_milestone(
             issue, config.get("active_milestone"),
         )
-        gate_evidence = check_release_gates(
+        gate_evidence, repo_has_ci = check_release_gates(
             source_repo, base_branch, release_commit, number,
             milestone=target_milestone,
             # Issue #268: the gate waits out pending CI checks on the
@@ -1750,10 +1773,14 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
         # Version preparation creates the commit that will be tagged. Re-run
         # the commit-specific gates so the recorded CI result and final
         # no-open-PR check cover that exact release commit, not the frozen
-        # pre-version source commit.
-        gate_evidence = check_release_gates(
+        # pre-version source commit. The just-pushed commit may hit the
+        # CheckRun registration lag, so gate 1's observation (checks on the
+        # frozen base = this repository runs CI) forbids the empty-list
+        # pass here (Issue #657).
+        gate_evidence, _ = check_release_gates(
             source_repo, base_branch, release_commit, number,
             milestone=target_milestone,
+            repo_has_ci=repo_has_ci,
             ci_wait_seconds=config.get(
                 "release_ci_wait_seconds", RELEASE_CI_WAIT_SECONDS,
             ),

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16392,13 +16392,18 @@ def test_check_release_gates_scopes_leftover_scan_to_the_milestone(monkeypatch):
         leftover_milestones={7: "v0.4.4", 8: None},
         check_runs=[],
     )
-    evidence = release.check_release_gates(
+    evidence, repo_has_ci = release.check_release_gates(
         "o/r", "main", "abc123", 99, milestone="v0.4.3",
     )
-    assert evidence[0] == (
+    assert evidence == [
         "no open Issue in milestone 'v0.4.3' carries "
-        "ai-in-progress / ai-pr-opened / ai-fix-needed"
-    )
+        "ai-in-progress / ai-pr-opened / ai-fix-needed",
+        # Issue #657: no check runs at all is recorded as evidence; the
+        # repo_has_ci flag decides whether that is a pass or a wait.
+        "CI on the release commit: no check runs on abc123 (nothing to "
+        "gate)",
+    ]
+    assert repo_has_ci is False  # no check runs seen anywhere -> not proven
     scans = [c for c in calls if c[:3] == ["gh", "issue", "list"]]
     assert scans and all(
         c[c.index("--milestone") + 1] == "v0.4.3" for c in scans
@@ -16414,7 +16419,7 @@ def test_check_release_gates_ignores_leftover_outside_the_milestone(monkeypatch)
         leftover_milestones={657: None, 658: None},
         check_runs=[],
     )
-    evidence = release.check_release_gates(
+    evidence, _ = release.check_release_gates(
         "o/r", "main", "abc123", 99, milestone="v0.4.3",
     )
     assert evidence[0].startswith("no open Issue in milestone 'v0.4.3'")

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16124,7 +16124,7 @@ def test_check_release_gates_pass_clean(monkeypatch):
         check_runs=[("tests", "completed", "success"),
                     ("lint", "completed", "skipped")],
     )
-    evidence = release.check_release_gates("o/r", "main", "abc123", 99)
+    evidence, _ = release.check_release_gates("o/r", "main", "abc123", 99)
     assert evidence == [
         "no open Issue carries ai-in-progress / ai-pr-opened / ai-fix-needed",
         "CI on the release commit: 2 check(s) all success/neutral/skipped",
@@ -16139,29 +16139,47 @@ def test_check_release_gates_pass_clean(monkeypatch):
     assert labels == ["ai-in-progress", "ai-pr-opened", "ai-fix-needed"]
 
 
+def make_registration_lag_gh(monkeypatch, api_responses):
+    """Answer the gh calls of `check_release_gates` for the #657 world.
+
+    `api_responses`: popped once per `gh api` poll — each entry is the
+    (name, status, conclusion) list for that poll (`[]` = no check run
+    registered yet). The leftover-label scans always answer empty. The
+    returned fake raises on any unexpected command (one shared guard
+    line, driven by its own test below).
+    """
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([])
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([
+                {"name": name, "status": status, "conclusion": conclusion}
+                for name, status, conclusion in api_responses.pop(0)
+            ])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    return fake_run_command
+
+
+def test_registration_lag_gh_rejects_unexpected_commands(monkeypatch):
+    fake = make_registration_lag_gh(monkeypatch, api_responses=[[]])
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake(["gh", "pr", "list"])
+
+
 def test_check_release_gates_waits_for_late_registered_checks(monkeypatch):
     """repo_has_ci=True 时空 check-runs = 首个 check 尚未注册（Issue
     #657）：gate 2 跑在刚 push 到 base 的版本提交上，GitHub 创建
     CheckRun 有秒级滞后，空列表绝不能立即按 "nothing to gate" 放行——
     必须在同一预算内轮询等首个 check 出现，再按其结论判门。"""
-    responses = [
+    make_registration_lag_gh(monkeypatch, api_responses=[
         [],                                   # first poll: not registered yet
         [("tests", "completed", "success")],  # second poll: registered, green
-    ]
-
-    def fake_run_command(command, **kwargs):
-        if command[:2] == ["gh", "api"]:
-            return json.dumps([
-                {"name": name, "status": status, "conclusion": conclusion}
-                for name, status, conclusion in responses.pop(0)
-            ])
-        if command[:3] == ["gh", "issue", "list"]:
-            return json.dumps([])
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    ])
     monkeypatch.setattr("time.sleep", lambda seconds: None)
-    evidence, has_ci = runner.check_release_gates(
+    evidence, has_ci = release.check_release_gates(
         "o/r", "main", "abc123", 99, repo_has_ci=True,
     )
     assert has_ci is True
@@ -16174,17 +16192,12 @@ def test_check_release_gates_times_out_when_ci_never_registers(monkeypatch):
     """repo_has_ci=True 且 check-runs 恒为空：等待宽限耗尽后必须按
     wait-timeout 失败（不是 CI 失败、更不是放行），下 tick 可恢复重试
     （Issue #657）。"""
-    def fake_run_command(command, **kwargs):
-        if command[:2] == ["gh", "api"]:
-            return json.dumps([])
-        if command[:3] == ["gh", "issue", "list"]:
-            return json.dumps([])
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    make_registration_lag_gh(
+        monkeypatch, api_responses=[[], [], [], [], [], []],
+    )
     monkeypatch.setattr("time.sleep", lambda seconds: None)
     with pytest.raises(RuntimeError, match="wait timeout, not a CI failure"):
-        runner.check_release_gates(
+        release.check_release_gates(
             "o/r", "main", "abc123", 99,
             repo_has_ci=True, ci_wait_seconds=60,
         )
@@ -16194,15 +16207,8 @@ def test_check_release_gates_empty_without_ci_still_passes(monkeypatch):
     """repo_has_ci=False（门控提交上无任何 check）＝无 CI 仓库：空列表
     仍立即放行，"nothing to gate" 语义保持（Issue #657 的判据只收紧
     有 CI 的仓库）。"""
-    def fake_run_command(command, **kwargs):
-        if command[:2] == ["gh", "api"]:
-            return json.dumps([])
-        if command[:3] == ["gh", "issue", "list"]:
-            return json.dumps([])
-        raise AssertionError(f"unexpected command: {command}")
-
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    evidence, has_ci = runner.check_release_gates("o/r", "main", "abc123", 99)
+    make_registration_lag_gh(monkeypatch, api_responses=[[]])
+    evidence, has_ci = release.check_release_gates("o/r", "main", "abc123", 99)
     assert has_ci is False
     assert any("nothing to gate" in line for line in evidence)
 
@@ -16213,7 +16219,7 @@ def test_check_release_gates_excludes_the_release_issue_itself(monkeypatch):
         leftover_labels={"ai-in-progress": [99]},  # the release Issue
         check_runs=[],
     )
-    evidence = release.check_release_gates("o/r", "main", "abc123", 99)
+    evidence, _ = release.check_release_gates("o/r", "main", "abc123", 99)
     assert evidence[0].startswith("no open Issue carries")
 
 
@@ -16284,7 +16290,7 @@ def test_check_release_gates_waits_for_pending_ci_then_passes(
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
     waits = []
     with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
-        evidence = release.check_release_gates(
+        evidence, _ = release.check_release_gates(
             "o/r", "main", "abc123", 99, on_wait=waits.append,
         )
     assert evidence == [

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16139,6 +16139,74 @@ def test_check_release_gates_pass_clean(monkeypatch):
     assert labels == ["ai-in-progress", "ai-pr-opened", "ai-fix-needed"]
 
 
+def test_check_release_gates_waits_for_late_registered_checks(monkeypatch):
+    """repo_has_ci=True 时空 check-runs = 首个 check 尚未注册（Issue
+    #657）：gate 2 跑在刚 push 到 base 的版本提交上，GitHub 创建
+    CheckRun 有秒级滞后，空列表绝不能立即按 "nothing to gate" 放行——
+    必须在同一预算内轮询等首个 check 出现，再按其结论判门。"""
+    responses = [
+        [],                                   # first poll: not registered yet
+        [("tests", "completed", "success")],  # second poll: registered, green
+    ]
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([
+                {"name": name, "status": status, "conclusion": conclusion}
+                for name, status, conclusion in responses.pop(0)
+            ])
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    evidence, has_ci = runner.check_release_gates(
+        "o/r", "main", "abc123", 99, repo_has_ci=True,
+    )
+    assert has_ci is True
+    assert not any("nothing to gate" in line for line in evidence)
+    assert any("1 check(s) all success" in line for line in evidence)
+    assert any("waited" in line for line in evidence)
+
+
+def test_check_release_gates_times_out_when_ci_never_registers(monkeypatch):
+    """repo_has_ci=True 且 check-runs 恒为空：等待宽限耗尽后必须按
+    wait-timeout 失败（不是 CI 失败、更不是放行），下 tick 可恢复重试
+    （Issue #657）。"""
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([])
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    with pytest.raises(RuntimeError, match="wait timeout, not a CI failure"):
+        runner.check_release_gates(
+            "o/r", "main", "abc123", 99,
+            repo_has_ci=True, ci_wait_seconds=60,
+        )
+
+
+def test_check_release_gates_empty_without_ci_still_passes(monkeypatch):
+    """repo_has_ci=False（门控提交上无任何 check）＝无 CI 仓库：空列表
+    仍立即放行，"nothing to gate" 语义保持（Issue #657 的判据只收紧
+    有 CI 的仓库）。"""
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ["gh", "api"]:
+            return json.dumps([])
+        if command[:3] == ["gh", "issue", "list"]:
+            return json.dumps([])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    evidence, has_ci = runner.check_release_gates("o/r", "main", "abc123", 99)
+    assert has_ci is False
+    assert any("nothing to gate" in line for line in evidence)
+
+
 def test_check_release_gates_excludes_the_release_issue_itself(monkeypatch):
     make_gate_gh(
         monkeypatch,


### PR DESCRIPTION
## 背景

Issue #657：发布状态机的第二次 gate 跑在 `prepare_release_version` 刚 push 到 base 的版本提交上；GitHub Actions 创建 CheckRun 有秒级注册滞后，查询落在滞后窗口内时 `check_runs == []`，现行代码按 "no check runs (nothing to gate)" **立即放行**——带 CI 仓库的 release 提交可能完全未经 CI 门控就打 tag、发 Release。

## 根因

空 check-runs 列表的两种语义（仓库无 CI vs 提交太新 CI 未注册）未被区分；而 gate 1（跑在冻结基线上）已经掌握"仓库有没有 CI"的现成证据（基线上的 check 数），没有传递给 gate 2。

## 修复

- `check_release_gates` 返回 `(evidence, repo_has_ci)`：第二元 = 本次门控提交上是否观察到 check run。
- gate 1（:3703）解包 `repo_has_ci`，gate 2（:3792）传入 `repo_has_ci=repo_has_ci`。
- `repo_has_ci=True` 且空列表 → 视为 "首个 check 尚未注册"，进入与现有 pending 完全相同的轮询（复用 `RELEASE_CI_POLL_INTERVAL` 节奏与 `ci_wait_seconds` 预算、走 `on_wait`）；超时按既有 "wait timeout, not a CI failure" 语义失败，下 tick 可恢复重试。
- `repo_has_ci=False` → 无 CI 仓库语义原样保留（立即放行 + "nothing to gate" evidence）。
- 无新配置项（宽限预算复用 `release_ci_wait_seconds`）。

已知残余（issue 中明示）：CI 在 gate 1 与 gate 2 之间才被启用的仓库仍漏过——判据以 gate 1 观察为准。

## 验证

- 新增三测试：等首个 check 注册后判绿（evidence 不含 "nothing to gate"、含 waited）；恒空按 wait-timeout 失败；无 CI 空列表仍立即放行（语义锁定）。
- 全量测试 2137 passed / 24 failed（macOS 本机固有，与 main 同数）/ 3 deselected（macOS 死循环三项）。
- coverage_gate：line 98.16% / branch 98.58%（双 ≥95%）。
- diff_coverage_gate origin/main：改动行/分支 100% 被踩。

Fixes #657
