### PR TITLE
重命名 ai-ticket-only → ai-ops-only：标签名应覆盖 ops 类无 git 交付任务（labels.toml + 代码常量 + 测试 + 各仓库实际标签同步）

### DIFF
--- a/labels.toml
+++ b/labels.toml
@@ -59,6 +59,6 @@ color = "5319e7"
 description = "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
 
 [[label]]
-name = "ai-ticket-only"
+name = "ai-ops-only"
 color = "0e8a16"
-description = "Content task: Agent posts the deliverable directly to the Issue without Git delivery"
+description = "Ops-only task: no git delivery — Runner runs non-committable steps and posts evidence to the Issue"

--- a/src/orbi/delivery_labels.py
+++ b/src/orbi/delivery_labels.py
@@ -26,14 +26,15 @@ LIFECYCLE_STATES = frozenset({
 # --- Scheduling metadata (NOT delivery lifecycle states) ---
 # `p0` and `bug` only order the ready pickup; `ai-epic` marks a
 # coordination Issue the claim scan never touches; `ai-release` routes
-# to the deterministic release state machine; `ai-ticket-only` is a
-# content marker. None of them is a delivery state, and `blockedBy`
+# to the deterministic release state machine; `ai-ops-only` marks
+# an ops task with no git delivery (the deliverable is posted to the
+# Issue). None of them is a delivery state, and `blockedBy`
 # (a GitHub relation, not a label) is handled by the dependency scan.
 P0_LABEL = "p0"
 BUG_LABEL = "bug"
 EPIC_LABEL = "ai-epic"
 RELEASE_LABEL = "ai-release"
-TICKET_ONLY_LABEL = "ai-ticket-only"
+TICKET_ONLY_LABEL = "ai-ops-only"
 
 # --- Events that drive label transitions ---
 EVENT_CLAIM = "claim"

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -102,9 +102,10 @@ REQUIRED_LABELS = (
     # the deterministic release state machine (never `run_pi`), so the
     # label is platform state the setup entry must guarantee.
     "ai-release",
-    # Ticket-only marker (Issue #209): content is delivered directly in
-    # the Issue, so setup must provision this explicit, auditable type.
-    "ai-ticket-only",
+    # Ops-only marker (Issue #209, renamed #530): a no-git-delivery ops
+    # task is delivered directly in the Issue, so setup must provision
+    # this explicit, auditable type.
+    "ai-ops-only",
 )
 COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")
 

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -222,7 +222,7 @@ _CURRENT_RUN_ID: str | None = None
 # GitHub labels are the only state store (Issue #45). The delivery
 # lifecycle states (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`,
 # `ai-merged`, `ai-blocked`), the scheduling-metadata labels (`p0`,
-# `bug`, `ai-epic`, `ai-release`, `ai-ticket-only`), the event → label
+# `bug`, `ai-epic`, `ai-release`, `ai-ops-only`), the event → label
 # patch transition rules, and the pickup/resume/human-intervention
 # decisions all live in `orbi.delivery_labels` (Issue #175) — the single
 # source of truth. They are imported above; `p0`/`bug`/`ai-epic` are

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -6610,7 +6610,7 @@ def test_main_ticket_only_finishes_without_entering_pr_delivery_wait(
     """Ticket-only work has no PR, so the normal review/merge wait is invalid."""
     issue = {
         "number": 12, "title": "Launch copy", "body": "Write copy",
-        "labels": [{"name": "ai-ready"}, {"name": "ai-ticket-only"}],
+        "labels": [{"name": "ai-ready"}, {"name": "ai-ops-only"}],
     }
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
@@ -14452,9 +14452,9 @@ def test_process_issue_routes_release_to_process_release(monkeypatch):
 
 
 def test_is_ticket_only_requires_the_explicit_label():
-    assert runner.is_ticket_only({"labels": [{"name": "ai-ticket-only"}]}) is True
+    assert runner.is_ticket_only({"labels": [{"name": "ai-ops-only"}]}) is True
     assert runner.is_ticket_only({"labels": [{"name": "marketing"}]}) is False
-    assert runner.is_ticket_only({"labels": "ai-ticket-only"}) is False
+    assert runner.is_ticket_only({"labels": "ai-ops-only"}) is False
 
 
 def test_run_ticket_agent_uses_a_temporary_session_without_git(monkeypatch, tmp_path):
@@ -14534,7 +14534,7 @@ def test_progress_state_passes_startup_sub_phase_to_comment(tmp_path):
 def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch):
     """A labeled content task is delivered in its Issue, never through Git."""
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ready"}, {"name": "ai-ticket-only"}]}
+             "labels": [{"name": "ai-ready"}, {"name": "ai-ops-only"}]}
     edits = []
     comments = []
     commands = []
@@ -14566,7 +14566,7 @@ def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch
 
 def test_process_ticket_only_rejects_empty_agent_content(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ticket-only"}]}
+             "labels": [{"name": "ai-ops-only"}]}
     edits = []
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
@@ -14583,7 +14583,7 @@ def test_process_ticket_only_rejects_empty_agent_content(monkeypatch):
 
 def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ticket-only"}]}
+             "labels": [{"name": "ai-ops-only"}]}
     edits = []
     comments = []
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
@@ -14606,7 +14606,7 @@ def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypa
 
 def test_process_ticket_only_keeps_original_error_when_failure_reporting_fails(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ticket-only"}]}
+             "labels": [{"name": "ai-ops-only"}]}
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)

--- a/tests/test_delivery_labels.py
+++ b/tests/test_delivery_labels.py
@@ -7,9 +7,14 @@ transitions, illegal combinations, and the pickup/resume/human-intervention
 decisions — including that `p0`/`bug`/`ai-epic`/`blockedBy` are NOT
 modeled as delivery lifecycle states.
 """
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from orbi import delivery_labels as dl
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 # --- label_patch: normal transitions ---------------------------------
@@ -242,3 +247,25 @@ def test_needs_human_intervention_true_only_for_ai_blocked():
     assert dl.needs_human_intervention({"ai-ready", "ai-pr-opened"}) is False
     assert dl.needs_human_intervention({"ai-ready", "ai-fix-needed"}) is False
     assert dl.needs_human_intervention({"ai-ready"}) is False
+
+
+# --- the ops-only marker name (Issue #530) --------------------------------
+
+# Composed so this guard file does not contain the very name it forbids
+# (acceptance criterion: the old literal has zero hits in the repo).
+_OLD_OPS_LABEL = "ai-" "ticket-only"
+
+
+def test_ops_only_label_is_the_renamed_marker_with_no_stale_reference():
+    """Issue #530: the no-git-delivery ops marker is `ai-ops-only`; the
+    old label name must survive nowhere in the tracked tree.
+
+    `git grep` reads only tracked files, so run artifacts and Pi session
+    logs can never decide this contract.
+    """
+    assert dl.TICKET_ONLY_LABEL == "ai-ops-only"
+    result = subprocess.run(
+        ["git", "grep", "-n", _OLD_OPS_LABEL],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 1, result.stdout  # 1 = no match

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -74,7 +74,7 @@ VALID_DEFS = [
     # so it is part of the platform label set.
     {"name": "ai-release", "color": "5319e7", "description": "release"},
     # Issue #209: ticket-only content is a separately dispatched type.
-    {"name": "ai-ticket-only", "color": "0e8a16", "description": "ticket"},
+    {"name": "ai-ops-only", "color": "0e8a16", "description": "ticket"},
 ]
 
 
@@ -233,7 +233,7 @@ def test_load_label_defs_parses_all_ten_platform_labels(tmp_path):
     assert [entry["name"] for entry in defs] == [
         "ai-ready", "ai-in-progress", "ai-pr-opened",
         "ai-fix-needed", "ai-merged", "ai-blocked", "p0", "ai-epic",
-        "ai-release", "ai-ticket-only",
+        "ai-release", "ai-ops-only",
     ]
     assert defs[0] == {
         "name": "ai-ready", "color": "1d76db", "description": "dispatched",
@@ -299,6 +299,16 @@ def test_committed_labels_toml_covers_the_ten_platform_labels():
     assert [entry["name"] for entry in defs] == list(
         pilot_setup.REQUIRED_LABELS,
     )
+
+
+def test_committed_labels_toml_descriptions_fit_the_github_limit():
+    """Issue #530: labels.toml is the source of truth `orbi setup` syncs
+    to GitHub, and the real GitHub API rejects a description longer than
+    100 characters (`gh label edit` → HTTP 422 "description is too long"
+    on the live repos). A longer description would fail every setup run."""
+    path = Path(__file__).resolve().parent.parent / "labels.toml"
+    for entry in pilot_setup.load_label_defs(path):
+        assert len(entry["description"]) <= 100, entry["name"]
 
 
 def test_committed_labels_toml_points_at_the_real_setup_entry():

--- a/tests/test_readme_homepage.py
+++ b/tests/test_readme_homepage.py
@@ -73,7 +73,7 @@ FORBIDDEN_MECHANISM_NEEDLES = (
     "ai-merged",
     "ai-epic",
     "ai-release",
-    "ai-ticket-only",
+    "ai-ops-only",
     "`p0`",
     # label initialization commands (docs/setup.mdx)
     "gh label create",


### PR DESCRIPTION
<!-- orbi:run=e38a8c65 -->

Fixes #530

重命名 ai-ticket-only → ai-ops-only：标签名应覆盖 ops 类无 git 交付任务（labels.toml + 代码常量 + 测试 + 各仓库实际标签同步） (run_id=e38a8c65)
