### PR TITLE
P0：示例配置本身跑不起来——.orbi.example.toml 的两个 source_repos 被 runner 拒绝，而 cli 不校验导致 doctor 全绿

### DIFF
--- a/.orbi.example.toml
+++ b/.orbi.example.toml
@@ -1,7 +1,8 @@
 # Copy this file to orbi.toml and edit it for your machine.
+# Exactly ONE source repository until multi-repo workspaces ship
+# (Issue #133): multiple entries fail fast at startup.
 source_repos = [
   "OWNER/PILOT-REPO",
-  "OWNER/BACKLOG-REPO",
 ]
 
 repo_dir = "."

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -154,7 +154,7 @@ directory):
 
 | Field | Required | Default | Meaning |
 |---|---|---|---|
-| `source_repos` | yes | — | One `owner/repo` task pool scanned each tick. Multiple entries fail fast because the current execution layer has only one checkout; multi-repo workspaces are not available yet |
+| `source_repos` | yes | — | One `owner/repo` task pool scanned each tick. Multiple entries fail fast because the current execution layer has only one checkout; multi-repo workspaces are not available yet (Issue #133) |
 | `repo_dir` | no | `.` | The delivery checkout: the repository whose Issues the Runner delivers. Task worktrees are created from its frozen `origin/<base_branch>` SHA, PRs open against it, and the slot locks live in `<repo_dir>/.orbi/slots/`. In bootstrap mode this is the orbi checkout itself; in the external single-repo mode (Issue #330) it is a foreign user repo X |
 | `deploy_home` | no | `repo_dir` | The orbi SOURCE checkout (Issue #330): the editable CLI install source (the self-update), the `systemd/` unit templates, `labels.toml`, and the prompt defaults (`prompts/prompt.md`, `prompts/prompt_review.md` when unset). Absent = `repo_dir` (bootstrap mode, unchanged). Set it to the orbi checkout when `repo_dir` is a foreign repo X. Must be a non-empty string; a missing directory fails the start fast |
 | `unit_name` | no | unset | Optional per-deployment systemd name. `website` installs `orbi-website@1/2.timer` and matching services; unset keeps the compatible `orbi@1/2` names. |
@@ -184,9 +184,10 @@ directory):
 Minimal example:
 
 ```toml
+# Exactly ONE source repository until multi-repo workspaces ship
+# (Issue #133): multiple entries fail fast at startup.
 source_repos = [
   "OWNER/PILOT-REPO",
-  "OWNER/BACKLOG-REPO",
 ]
 
 repo_dir = "."

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -131,7 +131,7 @@ checkout 根目录**没有** `orbi.py`（与 package 同名的 flat 文件
 
 | 字段 | 必填 | 默认 | 含义 |
 |---|---|---|---|
-| `source_repos` | 是 | — | 每个 tick 扫描的一个 `owner/repo` 任务池。多个条目会因当前执行层只有一个 checkout 而 fail fast；多仓库 workspace 尚未提供 |
+| `source_repos` | 是 | — | 每个 tick 扫描的一个 `owner/repo` 任务池。多个条目会因当前执行层只有一个 checkout 而 fail fast；多仓库 workspace 尚未提供（Issue #133） |
 | `repo_dir` | 否 | `.` | 交付 checkout：Runner 交付 Issue 的仓库。任务 worktree 从它冻结的 `origin/<base_branch>` SHA 创建，PR 对它打开，slot 锁在 `<repo_dir>/.orbi/slots/`。自举模式下它就是 orbi checkout 自身；外部单仓库模式（Issue #330）下是外部用户仓库 X |
 | `deploy_home` | 否 | `repo_dir` | orbi **源码** checkout（Issue #330）：editable CLI 安装来源（自更新）、`systemd/` unit 模板、`labels.toml`、prompt 默认（`prompts/prompt.md`、`prompts/prompt_review.md` 未设置时）。缺省 = `repo_dir`（自举模式，行为不变）。`repo_dir` 是外部仓库 X 时把它设为 orbi checkout。必须是非空字符串；目录不存在会启动 fail fast |
 | `workspace_root` | 否 | `..` | 包含任务 worktree 和 agent 可修改仓库的目录 |
@@ -159,9 +159,10 @@ checkout 根目录**没有** `orbi.py`（与 package 同名的 flat 文件
 最小示例：
 
 ```toml
+# 在多仓库 workspace 提供之前（Issue #133）只能配置一个 source 仓库：
+# 多个条目会在启动时 fail fast。
 source_repos = [
   "OWNER/PILOT-REPO",
-  "OWNER/BACKLOG-REPO",
 ]
 
 repo_dir = "."

--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -49,6 +49,7 @@ from orbi.runner import (
     log_format,
     run_command,
     validate_config,
+    validate_execution_source_repos,
 )
 from orbi import pilot_setup
 from orbi.pilot_slots import slot_occupancy
@@ -668,6 +669,10 @@ def main(argv: list[str] | None = None) -> int:
             allow_missing_pi_providers=args.command in ("setup", "doctor"),
         )
         validate_config(config)
+        # Issue #697: every command path (doctor included) enforces the
+        # same single-source-repo contract as runner.main, so a config
+        # the Runner will reject is reported instead of all-green.
+        validate_execution_source_repos(config["source_repos"])
     except (ValueError, pilot_setup.SetupError) as exc:
         if args.command == "setup":
             print(f"setup_failed reason={exc}", file=sys.stderr)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -137,6 +137,17 @@ def test_validate_execution_source_repos_rejects_multiple_checkouts():
         )
 
 
+def test_example_config_passes_execution_source_repos_validation():
+    """Issue #697: README tells a new user to copy the committed example
+    (`cp .orbi.example.toml orbi.toml`), so the example must be a config
+    the Runner accepts — exactly one source repository until multi-repo
+    workspaces are available (Issue #133)."""
+    example = Path(__file__).resolve().parent.parent / ".orbi.example.toml"
+    config = runner.load_config(example)
+    assert len(config["source_repos"]) == 1
+    runner.validate_execution_source_repos(config["source_repos"])
+
+
 def test_load_config_requires_source_repos(tmp_path):
     config_path = tmp_path / "orbi.toml"
     config_path.write_text("prompt = \"prompt.md\"\n", encoding="utf-8")

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -296,7 +296,7 @@ def test_status_report_marks_empty_lookups(monkeypatch):
 def test_main_add_dispatches_to_selected_source_repo(monkeypatch, tmp_path, capsys):
     config = tmp_path / "orbi.toml"
     config.write_text(
-        "source_repos = [\"xqliu/orbi\", \"xqliu/orbi-backlog\"]\n",
+        "source_repos = [\"xqliu/orbi\"]\n",
         encoding="utf-8",
     )
     _write_prompts(tmp_path)
@@ -318,7 +318,7 @@ def test_main_add_dispatches_to_selected_source_repo(monkeypatch, tmp_path, caps
 def test_main_add_uses_explicit_repo_override(monkeypatch, tmp_path, capsys):
     config = tmp_path / "orbi.toml"
     config.write_text(
-        "source_repos = [\"xqliu/orbi\", \"xqliu/orbi-backlog\"]\n",
+        "source_repos = [\"xqliu/orbi\"]\n",
         encoding="utf-8",
     )
     _write_prompts(tmp_path)
@@ -328,9 +328,9 @@ def test_main_add_uses_explicit_repo_override(monkeypatch, tmp_path, capsys):
         lambda repo, title, body: calls.append(repo) or "https://github.com/x/y/issues/1",
     )
     assert orbi.main([
-        "add", "T", "--repo", "xqliu/orbi-backlog", "--config", str(config),
+        "add", "T", "--repo", "xqliu/orbi", "--config", str(config),
     ]) == 0
-    assert calls == ["xqliu/orbi-backlog"]
+    assert calls == ["xqliu/orbi"]
 
 
 def test_main_add_rejects_repo_not_in_config(monkeypatch, tmp_path):
@@ -355,6 +355,27 @@ def test_main_status_prints_report(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "source: xqliu/orbi" in out
     assert "current: -" in out
+
+
+def test_main_doctor_fails_fast_on_multiple_source_repos(tmp_path, caplog):
+    """Issue #697: the CLI command paths enforce the Runner's
+    single-source-repo contract, so `orbi doctor` reports a config the
+    Runner will reject instead of staying green while every tick fails."""
+    config = tmp_path / "orbi.toml"
+    config.write_text(
+        "source_repos = [\"xqliu/orbi\", \"xqliu/orbi-backlog\"]\n",
+        encoding="utf-8",
+    )
+    _write_prompts(tmp_path)
+    with caplog.at_level("ERROR"):
+        assert orbi.main(["doctor", "--config", str(config)]) == 1
+    # endswith: the RunIdFilter may prefix the line when a run id is
+    # bound (the same pattern as the structured-reason test below).
+    assert caplog.records[-1].message.endswith(
+        "config_invalid reason=multiple source_repos are not supported "
+        "with one checkout; configure exactly one source repository "
+        "until multi-repo workspaces are available"
+    )
 
 
 def test_main_rejects_unknown_command(tmp_path):


### PR DESCRIPTION
<!-- orbi:run=bf7f55c4 -->

Fixes #697

P0：示例配置本身跑不起来——.orbi.example.toml 的两个 source_repos 被 runner 拒绝，而 cli 不校验导致 doctor 全绿 (run_id=bf7f55c4)
