### PR TITLE
P0：429 重试计数随进程重启归零，limit=5 永不生效——交付无限循环、永不转 ai-fix-needed

### DIFF
--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -375,13 +375,18 @@ Stable `key=value` lines you will see:
   escalation (30 s doubling), both capped at 5 minutes. The line
   carries run id, issue, role, `attempt`, `next_retry_in`, the retry
   `limit` (5) and the session; the slot is held for the whole wait (no
-  new Issue is claimed while this run waits). After 5 backoff retries
-  still end in a 429 exit (6 consecutive 429 exits) the EXISTING
-  failure path runs — the same error type a
-  non-retried exit raises (pre-session terminal `ai-blocked` /
-  recoverable interrupted session) — marked
-  `reason=provider_rate_limited`. Long-term quota exhaustion is NOT
-  handled here (the #313 rotation semantics own it);
+  new Issue is claimed while this run waits). The `attempt` count is
+  the RUN's, not the process's (Issue #698): it is persisted in the
+  worktree's `.orbi/` run dir and keeps rising across runner restarts,
+  so the limit actually reaches a terminal. After 5 backoff retries
+  still end in a 429 exit (6 consecutive 429 exits) the delivery is
+  TERMINAL in every phase — `ai-blocked`, never a recoverable resume —
+  with the failure comment carrying the cumulative count and the
+  repair (relabel the Issue `ai-ready` after the quota window resets;
+  the terminal clears the persisted counter, so the requeued attempt
+  starts with a full budget), marked `reason=provider_rate_limited`.
+  Long-term quota exhaustion is NOT handled here (the #313 rotation
+  semantics own it);
 - `run_failed` — the full scene plus the reason
   (`pi_exit_N`, `timeout_...s`, `model_wait_swallowed_idle_...s` when
   the `/slots` probe confirms every slot idle for the sustained grace

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -304,9 +304,13 @@ journalctl --user -u orbi@1.service -u orbi@2.service | grep e07383c2
   重试提示（`retry in Ns` / `retryDelay: Ns`），没有就默认递增
   （30 秒翻倍），两者都封顶 5 分钟。行带 run id、issue、role、
   `attempt`、`next_retry_in`、重试上限 `limit`（5）和 session；
-  等待期间持有 slot（本 run 等待时不认领新 Issue）。5 次退避重试仍以
-  429 退出（连续 6 次 429 退出）之后走既有失败路径——与非重试退出抛同一类异常（session 前终态
-  `ai-blocked` / 可恢复的中断 session）——`run_failed` 现场标记
+  等待期间持有 slot（本 run 等待时不认领新 Issue）。`attempt` 计数是
+  RUN 的，不是进程的（Issue #698）：它持久化在工作树的 `.orbi/`
+  运行目录里，跨 runner 重启持续累加，上限才能真正触达终态。5 次退避
+  重试仍以 429 退出（连续 6 次 429 退出）之后，交付在每个阶段都是
+  终态——`ai-blocked`，绝不走可恢复续跑——失败评论带累计次数与修复
+  动作（配额窗口恢复后把 Issue 重新标为 `ai-ready`；终态会清掉持久化
+  计数，重排的尝试从全新预算开始），`run_failed` 现场标记
   `reason=provider_rate_limited`。长期额度耗尽不在这里处理
   （#313 的轮换语义接管）；
 - `run_failed` — 完整现场加原因（`pi_exit_N`、`timeout_...s`，或

--- a/src/orbi/pi_process.py
+++ b/src/orbi/pi_process.py
@@ -10,6 +10,7 @@ imported lazily inside `stream_pi` so this module never imports `runner`
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -119,14 +120,85 @@ PI_IDLE_RECOVERY_CYCLES = 3
 # cap. The slot is held for the whole wait (the #233 positioning: the
 # Runner never claims a new Issue while this run waits). Only after
 # PI_RATE_LIMIT_RETRIES backoff retries still end in a 429 exit (6
-# consecutive 429 exits at the default 5) does the EXISTING failure
-# path run — marked `reason=provider_rate_limited` so a human (or the
-# #313 rotation semantics) can take over. Long-term quota exhaustion is
-# OUT of scope here (#313): this loop only bridges short burst windows.
+# consecutive 429 exits at the default 5) does the terminal failure run
+# — `RateLimitExhaustedError` (`ai-blocked`), with the cumulative count
+# and the quota repair action in the message (Issue #698: the count is
+# the RUN's, persisted across restarts, so the limit actually bites).
+# Long-term quota exhaustion is OUT of scope here (#313): this loop
+# only bridges short burst windows.
 PI_RATE_LIMIT_MARKERS = ("429", "quota", "resource_exhausted", "retry in")
 PI_RATE_LIMIT_RETRIES = 5
 PI_RATE_LIMIT_BACKOFF_SECONDS = 30.0
 PI_RATE_LIMIT_BACKOFF_MAX_SECONDS = 300.0
+
+
+# The 429 retry counter is per-DELIVERY-ATTEMPT state, not per-process
+# state (Issue #698): the pre-#698 counter lived in a `stream_pi` local
+# and reset on every runner restart, so `PI_RATE_LIMIT_RETRIES` was
+# unreachable as a terminal outcome (the beta incident: 22 restarts,
+# 19×429, zero output, the Issue stuck `ai-in-progress`). The count is
+# persisted in the task worktree's gitignored `.orbi/` run dir — a
+# resumed run (same run_id, same worktree) continues where the killed
+# process stopped, and the worktree dies with the terminal cleanup, so a
+# NEW attempt (new run_id, new worktree) starts from 0.
+PI_429_ATTEMPTS_FILENAME = "pi-429-attempts.json"
+
+
+def pi_429_attempts_path(cwd: Path) -> Path:
+    """The persisted 429 retry counter file of one task worktree."""
+    return cwd / ".orbi" / PI_429_ATTEMPTS_FILENAME
+
+
+def _load_429_attempts(cwd: Path, run_id: str) -> int:
+    """Return the cumulative 429 retry count of this run, or 0.
+
+    An unreadable, malformed or foreign-run file counts as 0 with one
+    warning line: the worst case is the pre-#698 behavior (the count
+    restarts), never a false terminal — the delivery must not fail on
+    its own observability artifact.
+    """
+    path = pi_429_attempts_path(cwd)
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return 0
+    except (OSError, ValueError):
+        LOGGER.warning(
+            "pi_429_attempts_reset path=%s reason=unreadable", path,
+        )
+        return 0
+    valid = (
+        isinstance(state, dict)
+        and state.get("run_id") == run_id
+        and isinstance(state.get("attempts"), int)
+        and not isinstance(state.get("attempts"), bool)
+        and state["attempts"] >= 0
+    )
+    if not valid:
+        LOGGER.warning(
+            "pi_429_attempts_reset path=%s reason=foreign_or_invalid",
+            path,
+        )
+        return 0
+    return state["attempts"]
+
+
+def _record_429_attempts(cwd: Path, run_id: str, attempts: int) -> None:
+    """Persist the cumulative count BEFORE the backoff sleep (Issue
+    #698): a kill during the wait keeps every retry already spent. A
+    failed write never breaks the retry loop — the in-memory count
+    still bounds this invocation."""
+    path = pi_429_attempts_path(cwd)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"run_id": run_id, "attempts": attempts}) + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        LOGGER.warning(
+            "pi_429_attempts_write_failed path=%s", path,
+        )
 
 
 # The bootstrap runner streams every Pi session of a run through the same
@@ -178,13 +250,13 @@ class ProviderRateLimitedError(RuntimeError):
     not a task failure.
 
     Internal to `stream_pi`'s retry loop: the loop either re-spawns the
-    session after the backoff or replays the EXISTING terminal
-    classification through `_fail_rate_limited` — it never escapes
-    `stream_pi`. The exception carries the exit scene (returncode,
-    captured streams, the refreshed session activity) so the terminal
-    replay raises exactly the error type a non-retried exit would. The
-    stderr text itself never reaches the message (only the class — the
-    same no-leak rule as the startup reasons)."""
+    session after the backoff or raises the terminal
+    `RateLimitExhaustedError` through `_fail_rate_limited` — it never
+    escapes `stream_pi` itself. The exception carries the exit scene
+    (returncode, captured streams, the refreshed session activity) for
+    the retry logs and the terminal failure. The stderr text itself
+    never reaches a message (only the class — the same no-leak rule as
+    the startup reasons)."""
 
     def __init__(self, *, returncode: int, stdout: str, stderr: str,
                  activity: dict) -> None:
@@ -195,6 +267,26 @@ class ProviderRateLimitedError(RuntimeError):
         self.stdout = stdout
         self.stderr = stderr
         self.activity = activity
+
+
+class RateLimitExhaustedError(RuntimeError):
+    """The rate-limit backoff budget of one delivery attempt is
+    exhausted (Issue #698): `PI_RATE_LIMIT_RETRIES` cumulative 429 exits
+    across every restart of the same run_id — TERMINAL, never a
+    recoverable resume.
+
+    Deliberately NOT a `RecoverablePiFailure`: the pre-#698 recoverable
+    replay resumed the same run with a reset counter — the unbounded
+    loop this issue fixes. A persistently throttled provider is an
+    external condition the runner must stop retrying: `process_issue`'s
+    generic handler terminates the delivery (`ai-blocked` — the
+    documented no-PR failure terminal; `ai-fix-needed` is an opened-PR
+    state a no-PR Issue cannot resume from) with this message as the
+    operator-facing cause. The retry is a human decision: relabel
+    `ai-ready` and the new run starts with a fresh worktree and counter.
+    The message carries the cumulative count and the repair action —
+    the operator must see the provider quota, not the task, as the
+    cause."""
 
 
 def _drain_stream(stream, chunks: list[bytes]) -> None:
@@ -839,13 +931,14 @@ def stream_pi(
     (`retry in Ns` / `retryDelay: Ns`) capped at 5 minutes; without a
     hint it doubles from 30 s to the same cap. Every retry logs one
     `pi_retry_429` line (run id, attempt, next_retry_in). Only after
-    `PI_RATE_LIMIT_RETRIES` (default 5) backoff retries still end in a
-    429 exit does the EXISTING failure path run — the same error type a
-    non-retried exit raises, so the terminal semantics (pre-session
-    `ai-blocked` / recoverable interrupted session) are unchanged —
-    with the `run_failed` scene marked `reason=provider_rate_limited`.
-    Long-term quota exhaustion stays out of scope (#313); non-429
-    failures are untouched.
+    `PI_RATE_LIMIT_RETRIES` (default 5) CUMULATIVE backoff retries still
+    end in a 429 exit does the terminal failure run —
+    `RateLimitExhaustedError`, never a recoverable resume (Issue #698:
+    the attempt count is persisted per run in the worktree's `.orbi/`
+    dir, so it keeps rising across runner restarts and the limit
+    actually bites) — with the `run_failed` scene marked
+    `reason=provider_rate_limited`. Long-term quota exhaustion stays out
+    of scope (#313); non-429 failures are untouched.
 
     `progress` (Issue #18) is invoked on EVERY poll — an activity change
     or a heartbeat — with the current activity state, while the Pi
@@ -890,7 +983,9 @@ def stream_pi(
     LOGGER.info("command=%s cwd=%s", " ".join(safe_command), cwd)
     issue_ref = issue_context(source_repo, issue)
     session_dir = cwd / ".pi-session"
-    attempt = 0
+    # Issue #698: the counter is the RUN's, not this invocation's — a
+    # resumed run continues where the killed process stopped.
+    attempt = _load_429_attempts(cwd, run_id)
     while True:
         # Session files that already exist before this Pi process starts
         # are never followed (Issue #45 round-5 review, Major 3): a
@@ -917,19 +1012,23 @@ def stream_pi(
         except ProviderRateLimitedError as exc:
             if attempt >= PI_RATE_LIMIT_RETRIES:
                 _fail_rate_limited(
-                    exc, run_id=run_id, issue_ref=issue_ref, role=role,
-                    branch=branch, cwd=cwd, safe_command=safe_command,
+                    exc, attempts=attempt, run_id=run_id,
+                    issue_ref=issue_ref, role=role, branch=branch,
+                    cwd=cwd,
                 )
             delay = _backoff_seconds(attempt, exc.stderr)
+            attempt += 1
+            # Persisted BEFORE the sleep: a kill during the wait keeps
+            # every retry already spent (Issue #698).
+            _record_429_attempts(cwd, run_id, attempt)
             LOGGER.warning(
                 "pi_retry_429 run_id=%s issue=%s role=%s attempt=%d "
                 "next_retry_in=%ds limit=%d session=%s",
-                run_id, issue_ref, role, attempt + 1, int(delay),
+                run_id, issue_ref, role, attempt, int(delay),
                 PI_RATE_LIMIT_RETRIES,
                 exc.activity.get("session_id") or "-",
             )
             time.sleep(delay)
-            attempt += 1
 
 
 def _log_run_failed(activity: dict, *, run_id: str, issue_ref: str,
@@ -950,14 +1049,15 @@ def _log_run_failed(activity: dict, *, run_id: str, issue_ref: str,
 
 
 def _fail_rate_limited(
-    exc: ProviderRateLimitedError, *, run_id: str, issue_ref: str,
-    role: str, branch: str, cwd: Path, safe_command: list[str],
+    exc: ProviderRateLimitedError, *, attempts: int, run_id: str,
+    issue_ref: str, role: str, branch: str, cwd: Path,
 ) -> NoReturn:
-    """The exhausted-retries terminal failure (Issue #321): the EXISTING
-    failure path — the same error type a non-retried exit raises, so the
-    terminal semantics (pre-session `ai-blocked` / recoverable
-    interrupted session) are unchanged — with the `run_failed` scene
-    marked `reason=provider_rate_limited`. The per-attempt
+    """The exhausted-retries terminal failure (Issue #321, terminal since
+    #698): `attempts` cumulative 429 exits (the RUN's count, persisted
+    across restarts) have burned the backoff budget, so the delivery
+    terminates — `RateLimitExhaustedError` is never a recoverable resume.
+    `process_issue`'s generic handler turns it into `ai-blocked` with
+    this message as the operator-facing cause. The per-attempt
     `startup_failed` lines are already in the journal (one per 429 exit
     before the first response), so this is the single terminal log."""
     activity = exc.activity
@@ -965,13 +1065,11 @@ def _fail_rate_limited(
         activity, run_id=run_id, issue_ref=issue_ref, role=role,
         branch=branch, cwd=cwd, reason="provider_rate_limited",
     )
-    error_type = (
-        RecoverablePiProcessError
-        if activity["first_request"]
-        else subprocess.CalledProcessError
-    )
-    raise error_type(
-        exc.returncode, safe_command, output=exc.stdout, stderr=exc.stderr,
+    raise RateLimitExhaustedError(
+        f"provider rate limit retries exhausted: {attempts + 1} "
+        f"consecutive 429 exits (limit={PI_RATE_LIMIT_RETRIES} retries); "
+        "the cause is the provider quota, not the task; repair: relabel "
+        "the Issue ai-ready to retry after the quota window resets"
     )
 
 
@@ -1431,8 +1529,8 @@ def _stream_pi_once(
         # Issue #321: a provider 429 exit is TRANSIENT throttling, not a
         # task failure — the `stream_pi` retry loop backs off and
         # re-spawns this session. The refreshed activity rides on the
-        # exception so the exhausted-retries terminal failure replays
-        # the EXISTING classification below unchanged.
+        # exception so the retry logs and the exhausted-retries terminal
+        # failure carry the exit scene.
         if _is_rate_limited(stderr):
             raise ProviderRateLimitedError(
                 returncode=process.returncode,

--- a/src/orbi/pi_process.py
+++ b/src/orbi/pi_process.py
@@ -140,7 +140,10 @@ PI_RATE_LIMIT_BACKOFF_MAX_SECONDS = 300.0
 # persisted in the task worktree's gitignored `.orbi/` run dir — a
 # resumed run (same run_id, same worktree) continues where the killed
 # process stopped, and the worktree dies with the terminal cleanup, so a
-# NEW attempt (new run_id, new worktree) starts from 0.
+# NEW attempt (new run_id, new worktree) starts from 0. The terminal
+# itself also clears the file: the documented repair (relabel ai-ready)
+# must get a full fresh budget even when the retry reuses the SAME
+# worktree and run_id — the open-PR review resume does exactly that.
 PI_429_ATTEMPTS_FILENAME = "pi-429-attempts.json"
 
 
@@ -278,15 +281,19 @@ class RateLimitExhaustedError(RuntimeError):
     Deliberately NOT a `RecoverablePiFailure`: the pre-#698 recoverable
     replay resumed the same run with a reset counter — the unbounded
     loop this issue fixes. A persistently throttled provider is an
-    external condition the runner must stop retrying: `process_issue`'s
-    generic handler terminates the delivery (`ai-blocked` — the
-    documented no-PR failure terminal; `ai-fix-needed` is an opened-PR
-    state a no-PR Issue cannot resume from) with this message as the
-    operator-facing cause. The retry is a human decision: relabel
-    `ai-ready` and the new run starts with a fresh worktree and counter.
-    The message carries the cumulative count and the repair action —
-    the operator must see the provider quota, not the task, as the
-    cause."""
+    external condition the runner must stop retrying, and it must stop
+    in BOTH phases: the implement phase's generic handler terminates
+    the delivery (`ai-blocked` — the documented no-PR failure terminal;
+    `ai-fix-needed` is an opened-PR state a no-PR Issue cannot resume
+    from), and the opened-PR review phase classifies it through
+    `is_unrecoverable_failure` — the recoverable `ai-fix-needed` there
+    would resume the review with the persisted counter already at the
+    limit: one 429 exit per tick, forever. The failure message is the
+    operator-facing cause and repair: relabel `ai-ready` to retry after
+    the quota window resets (the terminal clears the persisted counter,
+    so the human-requeued retry starts with a full budget — in the
+    review phase it reuses the same worktree and run_id). The operator
+    must see the provider quota, not the task, as the cause."""
 
 
 def _drain_stream(stream, chunks: list[bytes]) -> None:
@@ -1055,9 +1062,14 @@ def _fail_rate_limited(
     """The exhausted-retries terminal failure (Issue #321, terminal since
     #698): `attempts` cumulative 429 exits (the RUN's count, persisted
     across restarts) have burned the backoff budget, so the delivery
-    terminates — `RateLimitExhaustedError` is never a recoverable resume.
-    `process_issue`'s generic handler turns it into `ai-blocked` with
-    this message as the operator-facing cause. The per-attempt
+    terminates — `RateLimitExhaustedError` is never a recoverable resume
+    (the classification is terminal in both phases, implement and
+    opened-PR review). The terminal also CLEARS the persisted counter:
+    this attempt's budget is spent and reported on the Issue, and the
+    documented repair (relabel ai-ready) must start a FULL fresh budget
+    even when the retry reuses the same worktree and run_id. A failed
+    clear is one warning line — the terminal decision never depends on
+    its own artifact cleanup. The per-attempt
     `startup_failed` lines are already in the journal (one per 429 exit
     before the first response), so this is the single terminal log."""
     activity = exc.activity
@@ -1065,6 +1077,13 @@ def _fail_rate_limited(
         activity, run_id=run_id, issue_ref=issue_ref, role=role,
         branch=branch, cwd=cwd, reason="provider_rate_limited",
     )
+    try:
+        pi_429_attempts_path(cwd).unlink(missing_ok=True)
+    except OSError:
+        LOGGER.warning(
+            "pi_429_attempts_clear_failed path=%s",
+            pi_429_attempts_path(cwd),
+        )
     raise RateLimitExhaustedError(
         f"provider rate limit retries exhausted: {attempts + 1} "
         f"consecutive 429 exits (limit={PI_RATE_LIMIT_RETRIES} retries); "

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -127,6 +127,7 @@ from orbi.pi_process import (
     PI_POLL_INTERVAL,
     ROLE_IMPLEMENT,
     ModelWaitDeadError,
+    RateLimitExhaustedError,
     RecoverablePiFailure,
     RecoverablePiProcessError,
     RecoverablePiTimeoutError,
@@ -284,8 +285,13 @@ class ReviewRoundsExhausted(UnrecoverableDeliveryError):
 def is_unrecoverable_failure(exc: BaseException) -> bool:
     """Issue #50: classify one delivery failure.
 
-    True ONLY for an explicit `UnrecoverableDeliveryError` (an external
-    precondition the AI cannot safely judge or fix). Every other
+    True for an explicit `UnrecoverableDeliveryError` (an external
+    precondition the AI cannot safely judge or fix) and for the #698
+    provider-quota exhaustion (`RateLimitExhaustedError`): the backoff
+    budget of the delivery attempt is spent on an external condition,
+    and a recoverable classification would resume the open-PR review
+    with the persisted counter already at the limit — one 429 exit per
+    tick, forever, the unbounded loop the issue bans. Every other
     failure — Pi execution failure (pi exit, upstream dead, idle
     recovery), timeout, runner exception, missing/malformed verdict,
     missing worktree, unpushed local commit, gate failure — is
@@ -293,7 +299,9 @@ def is_unrecoverable_failure(exc: BaseException) -> bool:
     resumes the same run, branch, worktree and PR. A single failure
     must never permanently stop an Issue.
     """
-    return isinstance(exc, UnrecoverableDeliveryError)
+    return isinstance(
+        exc, (UnrecoverableDeliveryError, RateLimitExhaustedError),
+    )
 
 
 class RunIdFilter(logging.Filter):

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -8133,6 +8133,45 @@ def test_stream_pi_429_exhaustion_across_restarts_is_terminal(
     assert "6 consecutive 429 exits" in str(exc_info.value)
 
 
+def test_stream_pi_429_terminal_resets_counter_for_human_retry(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #698: the terminal exhaustion spent this run's backoff
+    budget and CLEARS the persisted counter, so the documented repair
+    (relabel ai-ready) starts a FULL fresh budget even when the retry
+    reuses the SAME worktree and run_id — the open-PR review resume
+    does exactly that. Without the reset the repair would terminal-exit
+    on the first new 429 (zero budget) and the Issue would block
+    again on its first transient hiccup."""
+    pi_process._record_429_attempts(tmp_path, "deadbeef", 5)
+    sleeps: list[float] = []
+    monkeypatch.setattr(pi_process.time, "sleep", sleeps.append)
+    command = make_rate_limit_pi(
+        tmp_path, fail_times=99, stderr="Error 429: rate limited, retry in 2s",
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(pi_process.RateLimitExhaustedError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.05,
+                run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+                branch="b",
+            )
+    # Terminal on the first 429 (the budget was already spent), and the
+    # counter file is gone.
+    assert sleeps == []
+    assert not pi_process.pi_429_attempts_path(tmp_path).exists()
+    # The human-requeued retry (same worktree, same run_id) has the full
+    # budget again: five backoff retries before the next terminal.
+    sleeps.clear()
+    with pytest.raises(pi_process.RateLimitExhaustedError):
+        runner.stream_pi(
+            command, cwd=tmp_path, poll_interval=0.05,
+            run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+            branch="b",
+        )
+    assert sleeps == [2.0] * 5
+
+
 def test_429_attempt_counter_file_round_trip(tmp_path, monkeypatch, caplog):
     """The persisted counter is per-run and fails safe: absent, corrupt,
     foreign-run or invalid files all read as 0 (worst case = today's

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -8172,6 +8172,32 @@ def test_stream_pi_429_terminal_resets_counter_for_human_retry(
     assert sleeps == [2.0] * 5
 
 
+def test_stream_pi_429_terminal_survives_a_failed_counter_clear(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #698: the terminal decision never depends on its own
+    artifact cleanup — a failing counter unlink is one warning line and
+    the RateLimitExhaustedError still raises."""
+    pi_process._record_429_attempts(tmp_path, "deadbeef", 5)
+    monkeypatch.setattr(pi_process.time, "sleep", [])
+
+    def broken_unlink(self, *args, **kwargs):
+        raise OSError("read-only fs")
+
+    monkeypatch.setattr(pi_process.Path, "unlink", broken_unlink)
+    command = make_rate_limit_pi(
+        tmp_path, fail_times=99, stderr="Error 429: rate limited, retry in 2s",
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(pi_process.RateLimitExhaustedError):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.05,
+                run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+                branch="b",
+            )
+    assert "pi_429_attempts_clear_failed" in caplog.text
+
+
 def test_429_attempt_counter_file_round_trip(tmp_path, monkeypatch, caplog):
     """The persisted counter is per-run and fails safe: absent, corrupt,
     foreign-run or invalid files all read as 0 (worst case = today's

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7960,10 +7960,11 @@ def test_stream_pi_rate_limited_exit_retries_then_succeeds(
 def test_stream_pi_rate_limited_exhausted_takes_existing_failure_path(
     tmp_path, monkeypatch, caplog,
 ):
-    """Issue #321 acceptance: 429 through every backoff retry (5) takes
-    the EXISTING failure path — the terminal pre-session classification —
-    marked `reason=provider_rate_limited` on the startup and run_failed
-    lines."""
+    """Issue #698 acceptance: 429 through every backoff retry (5) is a
+    TERMINAL delivery failure — `RateLimitExhaustedError` (never a
+    recoverable resume), marked `reason=provider_rate_limited` on the
+    startup and run_failed lines, with the cumulative count and the
+    quota-not-task repair action in the operator-facing message."""
     sleeps: list[float] = []
     monkeypatch.setattr(pi_process.time, "sleep", sleeps.append)
     command = make_rate_limit_pi(
@@ -7973,7 +7974,7 @@ def test_stream_pi_rate_limited_exhausted_takes_existing_failure_path(
                '"RESOURCE_EXHAUSTED"}}',
     )
     with caplog.at_level("INFO"):
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        with pytest.raises(pi_process.RateLimitExhaustedError) as exc_info:
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.05,
                 run_id="deadbeef", issue=321, source_repo="xqliu/orbi",
@@ -8000,18 +8001,23 @@ def test_stream_pi_rate_limited_exhausted_takes_existing_failure_path(
               if " run_failed " in line]
     assert len(failed) == 1
     assert "reason=provider_rate_limited" in failed[0]
-    # The existing terminal semantics: a plain CalledProcessError (pre-
-    # session), carrying the 429 stderr for the failure comment.
-    assert not isinstance(exc_info.value, runner.RecoverablePiProcessError)
-    assert "429" in (exc_info.value.stderr or "")
+    # Terminal, never recoverable (Issue #698: the exhausted limit must
+    # not resume the same run). The message is the operator-facing cause:
+    # the cumulative count and the repair action.
+    assert not isinstance(exc_info.value, runner.RecoverablePiFailure)
+    message = str(exc_info.value)
+    assert "provider rate limit retries exhausted" in message
+    assert "6 consecutive 429 exits" in message
+    assert "limit=5" in message
+    assert "relabel the Issue ai-ready" in message
 
 
-def test_stream_pi_rate_limited_exhausted_mid_session_stays_recoverable(
+def test_stream_pi_rate_limited_exhausted_mid_session_terminates(
     tmp_path, monkeypatch, caplog,
 ):
-    """Issue #321: exhausting the retries after the session sent its
-    first request keeps the EXISTING recoverable classification — the
-    interrupted work stays resumable, never terminal."""
+    """Issue #698: exhausting the retries after the session sent its
+    first request is TERMINAL too — the exhausted limit must never resume
+    the same run, whatever the session had already produced."""
     sleeps: list[float] = []
     monkeypatch.setattr(pi_process.time, "sleep", sleeps.append)
     command = make_rate_limit_pi(
@@ -8019,13 +8025,15 @@ def test_stream_pi_rate_limited_exhausted_mid_session_stays_recoverable(
         stderr="Error 429: rate limited, retry in 2s",
     )
     with caplog.at_level("INFO"):
-        with pytest.raises(runner.RecoverablePiProcessError):
+        with pytest.raises(pi_process.RateLimitExhaustedError) as exc_info:
             runner.stream_pi(
                 command, cwd=tmp_path, poll_interval=0.05,
                 run_id="deadbeef", issue=321, source_repo="xqliu/orbi",
                 branch="b",
             )
     assert sleeps == [2.0] * 5
+    assert not isinstance(exc_info.value, runner.RecoverablePiFailure)
+    assert "provider rate limit retries exhausted" in str(exc_info.value)
     # After the first response this is a mid-run failure: no
     # startup_failed line, the run_failed scene carries the reason.
     assert not any(" startup_failed " in line
@@ -8034,6 +8042,126 @@ def test_stream_pi_rate_limited_exhausted_mid_session_stays_recoverable(
               if " run_failed " in line]
     assert len(failed) == 1
     assert "reason=provider_rate_limited" in failed[0]
+
+
+def test_stream_pi_429_attempts_persist_across_invocations(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #698 acceptance: the `pi_retry_429` attempt count is
+    cumulative per run_id — a resumed (restarted) runner invocation
+    continues where the killed one stopped, never back at 1. The
+    termination guard (sleep raising on the Nth call) simulates the
+    runner dying mid-backoff, Issue #95."""
+    command = make_rate_limit_pi(
+        tmp_path, fail_times=99, stderr="Error 429: rate limited, retry in 2s",
+    )
+
+    def guard(after: int):
+        """A time.sleep that lets `after` calls pass, then raises: the
+        runner dies mid-backoff (termination guard, Issue #95)."""
+        calls = {"n": 0}
+
+        def _sleep(seconds):
+            calls["n"] += 1
+            if calls["n"] > after:
+                raise RuntimeError("test termination guard")
+
+        return _sleep
+
+    # Invocation 1 (the original runner process): two backoffs survive,
+    # the process dies during the third wait — AFTER the third retry was
+    # persisted (the file below proves persist-before-sleep).
+    monkeypatch.setattr(pi_process.time, "sleep", guard(2))
+    with caplog.at_level("INFO"):
+        with pytest.raises(RuntimeError, match="termination guard"):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.05,
+                run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+                branch="b",
+            )
+    assert json.loads(
+        pi_process.pi_429_attempts_path(tmp_path).read_text()
+    ) == {"run_id": "deadbeef", "attempts": 3}
+
+    # Invocation 2 (the restart scan resumed the same run): the counter
+    # continues — the next retry line says attempt=4, never attempt=1.
+    monkeypatch.setattr(pi_process.time, "sleep", guard(0))
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        with pytest.raises(RuntimeError, match="termination guard"):
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.05,
+                run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+                branch="b",
+            )
+    retries = [line for line in caplog.text.splitlines()
+               if " pi_retry_429 " in line]
+    assert [field for line in retries for field in line.split()
+            if field.startswith("attempt=")] == ["attempt=4"]
+    assert json.loads(
+        pi_process.pi_429_attempts_path(tmp_path).read_text()
+    ) == {"run_id": "deadbeef", "attempts": 4}
+
+
+def test_stream_pi_429_exhaustion_across_restarts_is_terminal(
+    tmp_path, monkeypatch, caplog,
+):
+    """Issue #698 acceptance: the CUMULATIVE count reaches the limit —
+    a resumed invocation whose counter already sits at limit-1 terminates
+    on its next 429 exit instead of restarting a full backoff cycle."""
+    pi_process._record_429_attempts(tmp_path, "deadbeef", 4)
+    sleeps: list[float] = []
+    monkeypatch.setattr(pi_process.time, "sleep", sleeps.append)
+    command = make_rate_limit_pi(
+        tmp_path, fail_times=99, stderr="Error 429: rate limited, retry in 2s",
+    )
+    with caplog.at_level("INFO"):
+        with pytest.raises(pi_process.RateLimitExhaustedError) as exc_info:
+            runner.stream_pi(
+                command, cwd=tmp_path, poll_interval=0.05,
+                run_id="deadbeef", issue=698, source_repo="xqliu/orbi",
+                branch="b",
+            )
+    # One backoff retry (the 5th cumulative), then the 6th 429 exit is
+    # terminal — one session, not a fresh 5-retry cycle.
+    assert sleeps == [2.0]
+    retries = [line for line in caplog.text.splitlines()
+               if " pi_retry_429 " in line]
+    assert [field for line in retries for field in line.split()
+            if field.startswith("attempt=")] == ["attempt=5"]
+    assert not isinstance(exc_info.value, runner.RecoverablePiFailure)
+    assert "6 consecutive 429 exits" in str(exc_info.value)
+
+
+def test_429_attempt_counter_file_round_trip(tmp_path, monkeypatch, caplog):
+    """The persisted counter is per-run and fails safe: absent, corrupt,
+    foreign-run or invalid files all read as 0 (worst case = today's
+    behavior, never a false terminal), and a failed write never breaks
+    the retry loop."""
+    assert pi_process._load_429_attempts(tmp_path, "deadbeef") == 0
+    pi_process._record_429_attempts(tmp_path, "deadbeef", 3)
+    assert pi_process._load_429_attempts(tmp_path, "deadbeef") == 3
+    # Another run never inherits this run's count.
+    assert pi_process._load_429_attempts(tmp_path, "c0ffee00") == 0
+    path = pi_process.pi_429_attempts_path(tmp_path)
+    with caplog.at_level("INFO"):
+        for corrupt in (
+            "{not json",
+            json.dumps({"run_id": "deadbeef", "attempts": "many"}),
+            json.dumps({"run_id": "deadbeef", "attempts": -2}),
+            json.dumps({"attempts": 3}),
+            json.dumps(["deadbeef", 3]),
+        ):
+            path.write_text(corrupt)
+            assert pi_process._load_429_attempts(tmp_path, "deadbeef") == 0
+        assert "pi_429_attempts" in caplog.text
+
+        def broken_write(self, *args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(pi_process.Path, "write_text", broken_write)
+        pi_process._record_429_attempts(tmp_path, "deadbeef", 4)
+        assert "pi_429_attempts" in caplog.text
 
 
 def test_stream_pi_non_rate_limited_exit_never_retries(tmp_path, caplog):

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -104,6 +104,19 @@ def test_is_unrecoverable_failure_true_only_for_explicit_error():
     )
 
 
+def test_is_unrecoverable_failure_true_for_rate_limit_exhaustion():
+    # Issue #698: the exhausted 429 backoff budget is an external
+    # provider-quota precondition the AI cannot fix. The recoverable
+    # classification would resume the open-PR review with the persisted
+    # counter already at the limit — one 429 exit per tick, forever:
+    # exactly the unbounded loop the issue bans.
+    assert runner.is_unrecoverable_failure(
+        runner.RateLimitExhaustedError(
+            "provider rate limit retries exhausted",
+        ),
+    )
+
+
 @pytest.mark.parametrize("exc", [
     RuntimeError(
         "Pi is stuck in model_wait with a frozen session for 10m: "


### PR DESCRIPTION
<!-- orbi:run=26418346 -->

Fixes #698

P0：429 重试计数随进程重启归零，limit=5 永不生效——交付无限循环、永不转 ai-fix-needed (run_id=26418346)
