### PR TITLE
ops 票需要完整执行能力（部署/写 GitHub/任意平台 CLI）：复用完整执行代理 + ops 剧本，废弃白名单沙箱方案

### DIFF
--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -115,6 +115,44 @@ commits — initialize them per repository (see
 | `ai-merged` | Success terminal state; the Runner merged the PR and confirmed the merge commit on the protected branch |
 | `ai-blocked` | Only an external precondition the AI cannot safely judge or fix (Issue #50); the blocked comment states why automatic recovery is impossible; a human must decide the next step |
 
+## Ticket dispatch: content, dev and ops
+
+`ai-ready` is the execution switch for every task type; a second label
+selects the type (Issue #537). Three types exist — pick one per Issue at
+dispatch time:
+
+| Ticket type | Labels | What the Runner does |
+|---|---|---|
+| dev (the default) | `ai-ready` | The full delivery chain: worktree, dev playbook, one PR, independent review, merge |
+| ops | `ai-ready` + `ai-ops-only` | The SAME full execution session (worktree, shell, network — no command whitelist exists anywhere in the implementation), but the ops playbook replaces the dev one. The deliverable is the evidence posted on the Issue; when the session commits code, the delivery takes the normal PR ceremony |
+| content | `ai-ready` + `ai-content-only` | The content agent: text in, text out, delivered as an Issue comment — no execution, no git; the Issue is closed after the delivery |
+
+Ops semantics (Issue #537):
+
+- **The trust boundary is (credentials, ticket) — never a command
+  whitelist.** The session receives the runner's whole environment
+  unfiltered (gh auth, `CLOUDFLARE_API_TOKEN`, AWS keys, ... plus the
+  deploy-home `.orbi/env` file); how wide the credentials are is the
+  user's decision — the runner never trims them.
+- **The ticket body is the authorization.** The session executes only
+  the ops actions the ticket states (which PR to merge, which
+  environment to deploy); an action beyond the ticket is reported in a
+  comment and the session stops. Human approval gates (environment
+  approval, Release approval) are never performed by the session — a
+  prompt convention, not enforced code.
+- **Delivery = evidence** (the fact culture of Issue #526): every step
+  posts the real command and its real output / API response verbatim on
+  the ticket; a step not executed is labeled as not executed. A
+  pure-ops run (no commit) ends with the Runner closing the Issue and
+  removing `ai-in-progress` — no PR. Committed code takes the normal PR
+  path with review and merge.
+
+Before Issue #537 the label `ai-ops-only` dispatched the content agent
+(the #530 rename never changed the behavior — the name promised ops,
+the mode was content-only); the content path dispatches on
+`ai-content-only` now, and `ai-ops-only` is the full-execution ops
+path.
+
 ## Run marker and run_id
 
 Every task attempt generates one `run_id` (8 hex chars, e.g.

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -96,6 +96,35 @@ GitHub 标签是外部状态机。它们不是 commit 创建的——每个仓�
 | `ai-merged` | 成功终态；Runner 已合并 PR 并确认 merge commit 落在保护分支 |
 | `ai-blocked` | 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50）；blocked comment 写明为什么不能自动恢复；人工必须决定下一步 |
 
+## 票派发：content、dev、ops
+
+`ai-ready` 是所有任务类型的执行开关；第二个标签选择类型（Issue
+#537）。共三类——派发时每个 Issue 选定其一：
+
+| 票类型 | 标签 | Runner 做什么 |
+|---|---|---|
+| dev（默认） | `ai-ready` | 完整交付链：worktree、开发剧本、一个 PR、独立审查、合并 |
+| ops | `ai-ready` + `ai-ops-only` | 同一个完整执行会话（worktree、shell、网络——实现里不存在任何命令白名单），但用 ops 剧本替代开发剧本。交付物 = 回到票上的证据；会话若附带代码 commit，则照常走 PR 流程 |
+| content | `ai-ready` + `ai-content-only` | 内容代理：文本进、文本出，以 Issue 评论交付——无执行、无 git；交付后关闭 Issue |
+
+ops 语义（Issue #537）：
+
+- **信任边界是（凭据，票面）——不是命令白名单。** 会话原样获得 runner
+  的全部环境（gh 凭据、`CLOUDFLARE_API_TOKEN`、AWS keys 等，外加
+  deploy home 的 `.orbi/env` 文件）；凭据给多宽是用户的决定，runner
+  不做二次裁剪。
+- **票面即授权。** 会话只执行票面写明的 ops 动作（合并哪个 PR、部署
+  哪个环境）；票面之外的动作回帖说明并停。人工审批门（environment
+  approval、Release 批准）不由会话代行——这是提示词约定，不是执法代码。
+- **交付 = 证据**（Issue #526 的事实文化）：每一步把真实命令与真实
+  输出 / API 返回原文贴到票上；未执行的步骤如实标注未执行。纯 ops 运行
+  （无 commit）以 Runner 关闭 Issue 并摘除 `ai-in-progress` 收尾——
+  无 PR。附带代码 commit 则照常走 PR 路径（审查 + 合并）。
+
+Issue #537 之前，`ai-ops-only` 标签派发的是内容代理（#530 只改了名，
+模式未变——名字承诺 ops，模式仍是纯内容）；现在 content 路径派发到
+`ai-content-only`，`ai-ops-only` 是完整执行的 ops 路径。
+
 ## Run marker 与 run_id
 
 每个任务 attempt 生成一个 `run_id`（8 位 hex，例如 `e07383c2`），该

--- a/labels.toml
+++ b/labels.toml
@@ -59,6 +59,11 @@ color = "5319e7"
 description = "Release task: Runner runs the deterministic release state machine (tag + GitHub Release)"
 
 [[label]]
+name = "ai-content-only"
+color = "d4c5f9"
+description = "Content-only task: the content agent delivers text to the Issue — no execution, no git"
+
+[[label]]
 name = "ai-ops-only"
 color = "0e8a16"
-description = "Ops-only task: no git delivery — Runner runs non-committable steps and posts evidence to the Issue"
+description = "Ops task: full execution session (ops playbook) — evidence on the Issue, code changes via PR"

--- a/prompts/prompt_ops.md
+++ b/prompts/prompt_ops.md
@@ -1,0 +1,83 @@
+# Orbi Ops Agent
+
+You are the ops execution agent for the configured project. You have the
+same execution capability as a development agent — a task worktree, a
+shell, and network access; there is no command whitelist and no sandbox
+tier (Issue #537). Your playbook is operations, not software development.
+
+Runtime context supplied by the runner:
+
+- Source repository: `{{SOURCE_REPO}}`
+- All source repositories: `{{SOURCE_REPOS}}`
+- Workspace root: `{{WORKSPACE_ROOT}}`
+- Context files to read first:
+  `{{CONTEXT_FILES}}`
+- Skills configured for this run:
+  `{{SKILLS}}`
+- Delivery base branch: `{{BASE_BRANCH}}`
+- Delivery base SHA (frozen `origin/{{BASE_BRANCH}}` at claim time): `{{BASE_SHA}}`
+- Repository test command (declared in `.github/orbi.toml`): `{{TEST_COMMAND}}`
+- Run id: `{{RUN_ID}}`
+
+Run correlation: `{{RUN_ID}}` is the single end-to-end correlation id for
+this attempt — it is part of the branch and worktree names. Every Issue
+or PR comment you post must contain the hidden marker
+`<!-- orbi:run={{RUN_ID}} -->` and the visible field `run_id={{RUN_ID}}`.
+Keep your own run artifacts inside the worktree's `.orbi/` run dir.
+
+## The ticket is the authorization
+
+Issue #{{ISSUE_NUMBER}} — `{{ISSUE_TITLE}}` — authorizes exactly the ops
+actions its body states. The ticket body follows in the task context.
+The trust boundary is the pair (credentials, ticket), never a command
+whitelist:
+
+- **Credentials decide what you CAN do.** The runner passes its whole
+  environment through unfiltered (gh auth, `CLOUDFLARE_API_TOKEN`, AWS
+  keys, ... plus the deploy-home `.orbi/env` file). The runner never
+  trims them; how wide they are is the user's decision.
+- **The ticket decides what you MAY do.** Execute ONLY the actions the
+  ticket authorizes (which PR to merge, which environment to deploy, ...).
+  An action beyond the ticket is not yours: post a comment stating the
+  concrete missing authorization and stop. Never improvise scope.
+- **Human approval gates stay human.** Environment approvals, Release
+  approvals, protected-branch bypasses — you never perform a gate that
+  exists to be a human decision. When an action waits on one, post the
+  exact state and stop (this is a prompt convention, not enforced code —
+  honor it).
+
+## Delivery = evidence on the ticket (the #526 fact culture)
+
+- Post the run evidence as comments on the source Issue: the real
+  command you ran and its real output / the real API response, quoted
+  verbatim. Never paraphrase success, never fabricate output, never
+  invent a return payload.
+- A step you did NOT execute is labeled as not executed, with the
+  reason. An honestly missing step beats an invented one.
+- End with one final evidence comment summarizing: actions executed
+  (each with its evidence), actions not executed (each with its reason),
+  and the resulting state the user can verify themselves.
+
+## Code changes still take the PR ceremony
+
+- Pure ops actions (merge, deploy, verify, rotate) execute directly;
+  their evidence lands on the ticket. No commit, no PR — the Runner
+  closes the ticket when you finish with a clean worktree and no commit.
+- If the ticket requires a code change (a config file, `wrangler.toml`,
+  a workflow), commit it on the current task branch and stop: the Runner
+  pushes the branch and opens the PR. You never push, never open PRs,
+  never merge.
+- Leave the worktree clean otherwise: uncommitted leftovers fail the
+  run. Run artifacts (plans, logs, verification output) go to `.orbi/`.
+
+## Hard rules
+
+- Wrap every command that can block (deploys, installers, polling,
+  network waits, interactive tools) in `timeout <seconds> ...`. A
+  timeout is a signal that the path needs a different approach, never
+  ignorable noise.
+- Fail fast and report: a failed command is reported with its real
+  output and exit code on the ticket — never swallowed, never retried
+  into a fabricated success.
+- If the ticket is unclear or a precondition cannot be verified, stop
+  and explain the blocker in a comment; do not guess your way forward.

--- a/src/orbi/delivery_labels.py
+++ b/src/orbi/delivery_labels.py
@@ -26,15 +26,20 @@ LIFECYCLE_STATES = frozenset({
 # --- Scheduling metadata (NOT delivery lifecycle states) ---
 # `p0` and `bug` only order the ready pickup; `ai-epic` marks a
 # coordination Issue the claim scan never touches; `ai-release` routes
-# to the deterministic release state machine; `ai-ops-only` marks
-# an ops task with no git delivery (the deliverable is posted to the
-# Issue). None of them is a delivery state, and `blockedBy`
-# (a GitHub relation, not a label) is handled by the dependency scan.
+# to the deterministic release state machine; `ai-ops-only` routes to
+# the full-execution ops session (Issue #537: shell/gh/network like a
+# dev ticket, the ops playbook instead of the dev one, the deliverable
+# is evidence posted to the Issue); `ai-content-only` marks a pure
+# content task (the content agent, no execution, the deliverable is
+# posted to the Issue). None of them is a delivery state, and
+# `blockedBy` (a GitHub relation, not a label) is handled by the
+# dependency scan.
 P0_LABEL = "p0"
 BUG_LABEL = "bug"
 EPIC_LABEL = "ai-epic"
 RELEASE_LABEL = "ai-release"
-TICKET_ONLY_LABEL = "ai-ops-only"
+CONTENT_ONLY_LABEL = "ai-content-only"
+OPS_LABEL = "ai-ops-only"
 
 # --- Events that drive label transitions ---
 EVENT_CLAIM = "claim"

--- a/src/orbi/pilot_setup.py
+++ b/src/orbi/pilot_setup.py
@@ -102,9 +102,13 @@ REQUIRED_LABELS = (
     # the deterministic release state machine (never `run_pi`), so the
     # label is platform state the setup entry must guarantee.
     "ai-release",
-    # Ops-only marker (Issue #209, renamed #530): a no-git-delivery ops
-    # task is delivered directly in the Issue, so setup must provision
-    # this explicit, auditable type.
+    # Content-only marker (Issue #209/#537): the pure content agent
+    # delivers text directly in the Issue (no execution, no git), so
+    # setup must provision this explicit, auditable type.
+    "ai-content-only",
+    # Ops marker (Issue #537): a full-execution session (shell/gh/
+    # network, the ops playbook) whose deliverable is evidence posted to
+    # the Issue, so setup must provision this explicit, auditable type.
     "ai-ops-only",
 )
 COLOR_PATTERN = re.compile(r"^[0-9a-fA-F]{6}$")

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -69,15 +69,16 @@ from orbi.pi_activity import (
 )
 from orbi.delivery_labels import (
     BLOCKED_LABEL,
+    CONTENT_ONLY_LABEL,
     EPIC_LABEL,
     FIX_NEEDED_LABEL,
     IN_PROGRESS_LABEL,
     MERGED_LABEL,
+    OPS_LABEL,
     P0_LABEL,
     PR_OPENED_LABEL,
     READY_LABEL,
     RELEASE_LABEL,
-    TICKET_ONLY_LABEL,
     EVENT_BLOCKED,
     EVENT_CLAIM,
     EVENT_FIX_NEEDED,
@@ -3679,11 +3680,32 @@ def has_in_progress_label(number: int, repo: str) -> bool:
     return any(int(issue.get("number", -1)) == number for issue in issues)
 
 
-def is_ticket_only(issue: dict) -> bool:
-    """Return True only for the explicit ticket-only task marker (#209)."""
+def is_content_only(issue: dict) -> bool:
+    """Return True only for the explicit content-only task marker.
+
+    Issue #209 introduced the content agent; #530 renamed its label and
+    #537 gave that name to the full-execution ops path — the content
+    path dispatches on `ai-content-only` now.
+    """
     labels = issue.get("labels", [])
     return isinstance(labels, list) and any(
-        isinstance(label, dict) and label.get("name") == TICKET_ONLY_LABEL
+        isinstance(label, dict) and label.get("name") == CONTENT_ONLY_LABEL
+        for label in labels
+    )
+
+
+def is_ops(issue: dict) -> bool:
+    """Return True only for the explicit ops task marker (Issue #537).
+
+    An ops ticket runs the SAME full-execution session as a dev ticket
+    (worktree, shell, network — no command whitelist exists); the ops
+    playbook replaces the dev one and the deliverable is the evidence
+    posted on the Issue, unless the session commits code (then the
+    delivery takes the normal PR ceremony).
+    """
+    labels = issue.get("labels", [])
+    return isinstance(labels, list) and any(
+        isinstance(label, dict) and label.get("name") == OPS_LABEL
         for label in labels
     )
 
@@ -4385,6 +4407,31 @@ def cleanup_task_worktree(worktree: Path, repo_dir: Path, *, run_id: str,
         )
 
 
+def _agent_delivery_boundary(worktree: Path) -> tuple[str, str]:
+    """Return the agent's commit boundary as (HEAD, dirty status).
+
+    The Runner-owned runtime paths are pinned in the worktree's LOCAL
+    exclude BEFORE the check (Issue #256), so a task that renamed the
+    tracked .gitignore (the #246 scene) cannot make the Runner's own
+    state look like agent leftovers. Only Runner-owned runtime paths
+    that remain (the exclude write raced or the path appeared after it)
+    are repaired by re-writing the exclude — deterministic, no git add,
+    no deletion, no arbitrary whitelisting. Shared by the dev closeout
+    (`deliver_pr`) and the ops closeout (Issue #537).
+    """
+    apply_runner_runtime_excludes(worktree)
+    dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    if dirty and _is_runner_runtime_only(dirty):
+        apply_runner_runtime_excludes(worktree)
+        LOGGER.info(
+            "runner_runtime_exclude_repaired status=%s",
+            " ".join(dirty.splitlines()),
+        )
+        dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
+    return head, dirty
+
+
 def deliver_pr(worktree: Path, branch: str, base_branch: str,
                base_sha: str, run_id: str, *, issue: int,
                issue_title: str, repo_dir: Path) -> str:
@@ -4419,23 +4466,8 @@ def deliver_pr(worktree: Path, branch: str, base_branch: str,
             f"Pi changed branch: expected={branch} actual={current_branch}"
         )
     # Commit boundary (Issue #186 + #256): the Agent's delivery is the
-    # committed worktree state. The Runner-owned runtime paths are
-    # pinned in the worktree's LOCAL exclude BEFORE the check, so a task
-    # that renamed the tracked .gitignore (the #246 scene) cannot make
-    # the Runner's own state look like agent leftovers.
-    apply_runner_runtime_excludes(worktree)
-    dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
-    if dirty and _is_runner_runtime_only(dirty):
-        # Only Runner-owned runtime paths remain (the exclude write raced
-        # or the path appeared after it): re-write the exclude and
-        # re-check. The repair is deterministic — no git add, no
-        # deletion, no arbitrary whitelisting.
-        apply_runner_runtime_excludes(worktree)
-        LOGGER.info(
-            "runner_runtime_exclude_repaired branch=%s status=%s",
-            branch, " ".join(dirty.splitlines()),
-        )
-        dirty = run_command(["git", "status", "--porcelain"], cwd=worktree)
+    # committed worktree state.
+    local_head, dirty = _agent_delivery_boundary(worktree)
     if dirty:
         LOGGER.error(
             "delivery_uncommitted_changes branch=%s status=%s",
@@ -4446,7 +4478,6 @@ def deliver_pr(worktree: Path, branch: str, base_branch: str,
             f"({dirty.strip()}); the runner never commits uncommitted "
             "changes or expands the agent's commit boundary"
         )
-    local_head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
     if local_head == base_sha:
         LOGGER.error(
             "delivery_no_commit branch=%s head=%s",
@@ -6591,9 +6622,15 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         from orbi import release
 
         return IssueResult("release", release.process_release(issue, config, source_repo))
-    if is_ticket_only(issue):
+    if is_content_only(issue):
         process_ticket_only(issue, config, source_repo)
         return IssueResult("ticket-only", None)
+    # Ops task (Issue #537): a full-execution session — the SAME claim,
+    # worktree and run machinery as the dev path below (no command
+    # whitelist exists anywhere), with the ops playbook instead of the
+    # dev one and an evidence-on-the-Issue closeout when the session
+    # delivers no commit.
+    ops = is_ops(issue)
     # The run id is generated once per attempt and bound BEFORE any
     # other step is logged, so every journal line of the attempt
     # carries it — including the claim-time lines of the restart resume
@@ -6753,6 +6790,8 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         f"base_branch={base_branch} base_sha={base_sha} run_id={run_id} "
         f"priority={priority}"
     )
+    if ops:
+        run_info += " task_type=ops"
     if repo_config_record is not None:
         # Issue #527 D4: the run comment carries the repository config sha
         # (the file blob at the default branch tip) so a policy change is
@@ -6850,6 +6889,16 @@ def process_issue(issue: dict, config: dict, source_repo: str,
                 (snapshot.get("session_id") if snapshot else None) or "-",
             )
         config = {**config, "base_sha": base_sha, "run_id": run_id}
+        if ops:
+            config = {
+                **config,
+                # Issue #537: the ops session runs the ops playbook — the
+                # sibling of the configured dev prompt (a custom prompt
+                # deployment carries prompt_ops.md next to it). A missing
+                # file fails the run fast through the delivery failure
+                # path with the exact path in the comment.
+                "prompt": config["prompt"].with_name("prompt_ops.md"),
+            }
         comment_issue(
             number, repo=source_repo,
             body=started_pi_comment_body(
@@ -6887,6 +6936,68 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         publish(
             action=lambda: _publish_test_milestone(publisher, worktree),
         )
+        if ops:
+            # Issue #537: an ops delivery without a commit is COMPLETE —
+            # the evidence the session posted on the Issue (per-step real
+            # command output / API responses, the #526 fact culture) is
+            # the deliverable. Pure ops actions take no PR ceremony; the
+            # terminal transition mirrors the content path (the claim
+            # label is removed, the Issue is closed; the worktree stays
+            # as the run's evidence). Committed code (or uncommitted
+            # leftovers) falls through to the deterministic closeout
+            # below: committed ops code takes the normal PR ceremony,
+            # leftovers fail fast there (the runner never commits
+            # uncommitted changes).
+            head, dirty = _agent_delivery_boundary(worktree)
+            if head == base_sha and not dirty:
+                run_command([
+                    "gh", "issue", "close", str(number),
+                    "--repo", source_repo,
+                ])
+                edit_issue(
+                    number, repo=source_repo, remove=IN_PROGRESS_LABEL,
+                )
+                publish(
+                    action=lambda: publisher.milestone(
+                        f"ops delivered: {run_info}",
+                    ),
+                )
+                publish(
+                    action=lambda: publisher.finish(_progress_body(
+                        _progress_state(
+                            issue=number, title=title, run_id=run_id,
+                            role=ROLE_IMPLEMENT, branch=branch,
+                            worktree=worktree, started=started,
+                            pr_url=None, review_round=0, priority=priority,
+                        ),
+                        outcome="**Orbi ops delivered**",
+                    )),
+                )
+                LOGGER.info(
+                    "run_end %s",
+                    format_end_scene(
+                        run_id=run_id,
+                        issue=issue_context(source_repo, number),
+                        role=ROLE_IMPLEMENT, result="ops_delivered",
+                        elapsed=time.monotonic() - started,
+                        pr="-", commit=head,
+                    ),
+                )
+                # Issue #266: the delivered outcome breaks any failure
+                # streak of this Issue in the health history. Pure
+                # bypass: a state-write failure never changes the
+                # delivery outcome.
+                try:
+                    runner_health.record_run_attempt(
+                        runner_health.health_state_path(config["repo_dir"]),
+                        repo=source_repo, issue=number, run_id=run_id,
+                        outcome="ops_delivered", fingerprint="",
+                    )
+                except Exception:
+                    LOGGER.exception(
+                        "issue=%s health_success_record_failed", number,
+                    )
+                return IssueResult("ops", None)
         # Issue #186: the deterministic closeout (commit boundary, base
         # freshness + absorb, plain push, PR creation, PR verification)
         # is the Runner's job — the agent stopped at the committed

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -6665,7 +6665,13 @@ def test_main_uses_process_result_kind_without_rechecking_task_type(
         lambda *args: runner.IssueResult("pr", "https://x/y/pull/281"),
     )
     monkeypatch.setattr(
-        runner, "is_ticket_only",
+        runner, "is_content_only",
+        lambda issue: (_ for _ in ()).throw(
+            AssertionError("main must not recheck task type")
+        ),
+    )
+    monkeypatch.setattr(
+        runner, "is_ops",
         lambda issue: (_ for _ in ()).throw(
             AssertionError("main must not recheck task type")
         ),
@@ -6721,7 +6727,7 @@ def test_main_ticket_only_finishes_without_entering_pr_delivery_wait(
     """Ticket-only work has no PR, so the normal review/merge wait is invalid."""
     issue = {
         "number": 12, "title": "Launch copy", "body": "Write copy",
-        "labels": [{"name": "ai-ready"}, {"name": "ai-ops-only"}],
+        "labels": [{"name": "ai-ready"}, {"name": "ai-content-only"}],
     }
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
@@ -15352,10 +15358,26 @@ def test_process_issue_routes_release_to_process_release(monkeypatch):
     assert calls == ["release"]
 
 
-def test_is_ticket_only_requires_the_explicit_label():
-    assert runner.is_ticket_only({"labels": [{"name": "ai-ops-only"}]}) is True
-    assert runner.is_ticket_only({"labels": [{"name": "marketing"}]}) is False
-    assert runner.is_ticket_only({"labels": "ai-ops-only"}) is False
+def test_is_content_only_requires_the_explicit_label():
+    """Issue #537: the content（纯内容）path dispatches on
+    `ai-content-only`; the old `ai-ops-only` name now means ops."""
+    assert runner.is_content_only(
+        {"labels": [{"name": "ai-content-only"}]},
+    ) is True
+    assert runner.is_content_only(
+        {"labels": [{"name": "ai-ops-only"}]},
+    ) is False
+    assert runner.is_content_only({"labels": [{"name": "marketing"}]}) is False
+    assert runner.is_content_only({"labels": "ai-content-only"}) is False
+
+
+def test_is_ops_requires_the_explicit_label():
+    """Issue #537: `ai-ops-only` is the full-execution ops marker — it
+    must NOT dispatch the content agent anymore."""
+    assert runner.is_ops({"labels": [{"name": "ai-ops-only"}]}) is True
+    assert runner.is_ops({"labels": [{"name": "ai-content-only"}]}) is False
+    assert runner.is_ops({"labels": [{"name": "marketing"}]}) is False
+    assert runner.is_ops({"labels": "ai-ops-only"}) is False
 
 
 def test_run_ticket_agent_uses_a_temporary_session_without_git(monkeypatch, tmp_path):
@@ -15435,7 +15457,7 @@ def test_progress_state_passes_startup_sub_phase_to_comment(tmp_path):
 def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch):
     """A labeled content task is delivered in its Issue, never through Git."""
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ready"}, {"name": "ai-ops-only"}]}
+             "labels": [{"name": "ai-ready"}, {"name": "ai-content-only"}]}
     edits = []
     comments = []
     commands = []
@@ -15467,7 +15489,7 @@ def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch
 
 def test_process_ticket_only_rejects_empty_agent_content(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ops-only"}]}
+             "labels": [{"name": "ai-content-only"}]}
     edits = []
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
@@ -15484,7 +15506,7 @@ def test_process_ticket_only_rejects_empty_agent_content(monkeypatch):
 
 def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ops-only"}]}
+             "labels": [{"name": "ai-content-only"}]}
     edits = []
     comments = []
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
@@ -15507,7 +15529,7 @@ def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypa
 
 def test_process_ticket_only_keeps_original_error_when_failure_reporting_fails(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ops-only"}]}
+             "labels": [{"name": "ai-content-only"}]}
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
     monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
@@ -15556,6 +15578,192 @@ def test_process_issue_keeps_normal_flow_without_release_label(
     monkeypatch.setattr(runner, "_finish_progress", Mock())
     runner.process_issue(
         issue, {"base_branch": "main", "repo_dir": tmp_path}, "o/r",
+    )
+
+
+def _ops_issue_mocks(monkeypatch, tmp_path, *, head_sha: str, dirty: str):
+    """Shared mock set for the `process_issue` ops-dispatch tests.
+
+    `head_sha` answers `git rev-parse HEAD` (the frozen base means the
+    session delivered no commit); `dirty` answers `git status
+    --porcelain`. Every `gh`/`git`/pi collaborator is captured.
+    """
+    issue = {
+        "number": 99, "title": "Merge the beta PR and verify deploy",
+        "body": "Merge PR #7 into main, then verify the deployment.",
+        "labels": [{"name": "ai-ready"}, {"name": "ai-ops-only"}],
+    }
+    commands: list[list[str]] = []
+    configs: list[dict] = []
+    monkeypatch.setattr(runner, "is_release", lambda i: False)
+    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
+    monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(runner, "edit_issue", Mock())
+    monkeypatch.setattr(runner, "set_active_run", Mock())
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    monkeypatch.setattr(runner, "create_worktree", lambda *a, **k: worktree)
+    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(runner, "ProgressPublisher", Mock())
+    monkeypatch.setattr(runner, "activity_snapshot", lambda p: None)
+    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda issue_arg, wt, config, repo, **k: configs.append(config),
+    )
+    monkeypatch.setattr(runner.runner_health, "record_run_attempt", Mock())
+    monkeypatch.setattr(runner.runner_health, "record_pickup", Mock())
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        if command[:2] == ["git", "rev-parse"]:
+            return head_sha
+        if command[:2] == ["git", "status"]:
+            return dirty
+        return ""
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    return issue, commands, worktree, configs
+
+
+def test_process_issue_ops_without_commit_closes_with_evidence(
+    monkeypatch, tmp_path,
+):
+    """Issue #537: a pure-ops session (real shell/gh work, evidence
+    comments, no commit) is COMPLETE — the Runner closes the Issue,
+    removes the claim label, and never enters the PR ceremony."""
+    issue, commands, worktree, configs = _ops_issue_mocks(
+        monkeypatch, tmp_path, head_sha="abc123", dirty="",
+    )
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "prompt.md").write_text("dev", encoding="utf-8")
+    ops_prompt = prompts / "prompt_ops.md"
+    ops_prompt.write_text("ops playbook", encoding="utf-8")
+    monkeypatch.setattr(
+        runner, "deliver_pr",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("pure ops delivery must not open a PR")
+        ),
+    )
+    monkeypatch.setattr(runner, "format_end_scene", lambda **k: "end")
+
+    result = runner.process_issue(
+        issue, {"base_branch": "main", "repo_dir": tmp_path,
+                "prompt": prompts / "prompt.md"},
+        "o/r",
+    )
+
+    assert result == runner.IssueResult("ops", None)
+    # The full-execution session ran with the OPS playbook, not the dev
+    # one — and with the same worktree machinery (no --no-tools content
+    # agent).
+    assert len(configs) == 1
+    assert configs[0]["prompt"] == ops_prompt
+    # Terminal transition mirrors the content path: close + claim label
+    # removed. No PR, no push.
+    assert ["gh", "issue", "close", "99", "--repo", "o/r"] in commands
+    # The claim added the label at pickup; the delivery removes it.
+    runner.edit_issue.assert_any_call(
+        99, repo="o/r", remove=runner.IN_PROGRESS_LABEL,
+    )
+
+
+def test_process_issue_ops_health_record_failure_is_a_bypass(
+    monkeypatch, tmp_path,
+):
+    """Issue #537/#266: the health state write is pure bypass — a state
+    failure never turns a delivered pure-ops run into a failed one."""
+    issue, commands, worktree, configs = _ops_issue_mocks(
+        monkeypatch, tmp_path, head_sha="abc123", dirty="",
+    )
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "prompt.md").write_text("dev", encoding="utf-8")
+    (prompts / "prompt_ops.md").write_text("ops playbook", encoding="utf-8")
+    monkeypatch.setattr(
+        runner.runner_health, "record_run_attempt",
+        Mock(side_effect=OSError("state file unwritable")),
+    )
+    monkeypatch.setattr(runner, "deliver_pr", Mock())
+    monkeypatch.setattr(runner, "format_end_scene", lambda **k: "end")
+
+    result = runner.process_issue(
+        issue, {"base_branch": "main", "repo_dir": tmp_path,
+                "prompt": prompts / "prompt.md"},
+        "o/r",
+    )
+
+    assert result == runner.IssueResult("ops", None)
+
+
+def test_process_issue_ops_with_commit_takes_the_pr_ceremony(
+    monkeypatch, tmp_path,
+):
+    """Issue #537: an ops session that commits code (e.g. a
+    wrangler.toml change) is delivered through the SAME deterministic
+    closeout as a dev ticket — push + PR, `ai-pr-opened`."""
+    issue, commands, worktree, configs = _ops_issue_mocks(
+        monkeypatch, tmp_path, head_sha="def456", dirty="",
+    )
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "prompt.md").write_text("dev", encoding="utf-8")
+    (prompts / "prompt_ops.md").write_text("ops playbook", encoding="utf-8")
+    deliver_calls: list[tuple] = []
+    monkeypatch.setattr(
+        runner, "deliver_pr",
+        lambda *a, **k: deliver_calls.append(a) or (
+            "https://github.com/o/r/pull/7"
+        ),
+    )
+    monkeypatch.setattr(runner, "format_end_scene", lambda **k: "end")
+
+    result = runner.process_issue(
+        issue, {"base_branch": "main", "repo_dir": tmp_path,
+                "prompt": prompts / "prompt.md"},
+        "o/r",
+    )
+
+    assert result == runner.IssueResult("pr", "https://github.com/o/r/pull/7")
+    assert len(deliver_calls) == 1
+    assert any(c[:2] == ["git", "rev-parse"] for c in commands)
+
+
+def test_process_issue_ops_with_uncommitted_leftovers_fails_fast(
+    monkeypatch, tmp_path,
+):
+    """Issue #537: no commit but uncommitted leftovers is neither a pure
+    ops delivery nor a code delivery — the deterministic closeout's
+    fail-fast (never commit uncommitted changes) applies."""
+    issue, commands, worktree, configs = _ops_issue_mocks(
+        monkeypatch, tmp_path, head_sha="abc123", dirty=" M a.txt\n",
+    )
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "prompt.md").write_text("dev", encoding="utf-8")
+    (prompts / "prompt_ops.md").write_text("ops playbook", encoding="utf-8")
+
+    def failing_deliver_pr(*a, **k):
+        raise RuntimeError(
+            "the agent left uncommitted changes in the worktree"
+        )
+
+    monkeypatch.setattr(runner, "deliver_pr", failing_deliver_pr)
+
+    result = runner.process_issue(
+        issue, {"base_branch": "main", "repo_dir": tmp_path,
+                "prompt": prompts / "prompt.md"},
+        "o/r",
+    )
+
+    # The failure path reports the terminal state; the Issue is blocked.
+    assert result == runner.IssueResult("failed", None)
+    runner.edit_issue.assert_any_call(
+        99, repo="o/r", add=runner.BLOCKED_LABEL,
+        remove=runner.IN_PROGRESS_LABEL,
     )
 
 

--- a/tests/test_delivery_labels.py
+++ b/tests/test_delivery_labels.py
@@ -200,7 +200,7 @@ def test_lifecycle_states_are_exactly_the_six_delivery_labels():
 
 def test_scheduling_metadata_labels_are_not_lifecycle_states():
     for label in (dl.P0_LABEL, dl.BUG_LABEL, dl.EPIC_LABEL,
-                  dl.RELEASE_LABEL, dl.TICKET_ONLY_LABEL):
+                  dl.RELEASE_LABEL, dl.CONTENT_ONLY_LABEL, dl.OPS_LABEL):
         assert label not in dl.LIFECYCLE_STATES
 
 
@@ -257,13 +257,15 @@ _OLD_OPS_LABEL = "ai-" "ticket-only"
 
 
 def test_ops_only_label_is_the_renamed_marker_with_no_stale_reference():
-    """Issue #530: the no-git-delivery ops marker is `ai-ops-only`; the
-    old label name must survive nowhere in the tracked tree.
+    """Issue #530/#537: `ai-ops-only` is the FULL-EXECUTION ops marker
+    (the content path moved to `ai-content-only`); the old label name
+    must survive nowhere in the tracked tree.
 
     `git grep` reads only tracked files, so run artifacts and Pi session
     logs can never decide this contract.
     """
-    assert dl.TICKET_ONLY_LABEL == "ai-ops-only"
+    assert dl.OPS_LABEL == "ai-ops-only"
+    assert dl.CONTENT_ONLY_LABEL == "ai-content-only"
     result = subprocess.run(
         ["git", "grep", "-n", _OLD_OPS_LABEL],
         cwd=REPO_ROOT, capture_output=True, text=True,

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -42,6 +42,8 @@ KNOWN_LABELS = frozenset({
     "ai-ready",
     "ai-epic",
     runner.RELEASE_LABEL,
+    runner.CONTENT_ONLY_LABEL,
+    runner.OPS_LABEL,
     runner.IN_PROGRESS_LABEL,
     runner.PR_OPENED_LABEL,
     runner.FIX_NEEDED_LABEL,

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -37,7 +37,8 @@ KNOWN_LABELS = frozenset({
     runner.BLOCKED_LABEL,
     runner.EPIC_LABEL,
     runner.RELEASE_LABEL,
-    runner.TICKET_ONLY_LABEL,
+    runner.CONTENT_ONLY_LABEL,
+    runner.OPS_LABEL,
 })
 
 LABEL_PATTERN = re.compile(r"\bai-[a-z][a-z-]*\b")

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -49,6 +49,8 @@ KNOWN_LABELS = frozenset({
     "ai-ready",
     "ai-epic",
     runner.RELEASE_LABEL,
+    runner.CONTENT_ONLY_LABEL,
+    runner.OPS_LABEL,
     runner.IN_PROGRESS_LABEL,
     runner.PR_OPENED_LABEL,
     runner.FIX_NEEDED_LABEL,

--- a/tests/test_ops_e2e.py
+++ b/tests/test_ops_e2e.py
@@ -1,0 +1,472 @@
+"""E2E ops-delivery tests (Issue #537).
+
+Real git (local bare origin + clone) plus REAL subprocess executables:
+a fake ``pi`` that behaves like the ops agent (it executes real shell
+commands and posts the evidence comment through a stateful fake ``gh``
+on PATH) and the same fake ``gh`` answering the runner. This proves the
+acceptance criteria at the real user path:
+
+- an `ai-ready`+`ai-ops-only` Issue is claimed into a FULL execution
+  session (a worktree like a dev ticket — there is no content-agent
+  `--no-tools` dispatch and no command whitelist anywhere): the session
+  really executes the authorized merge, really verifies the resulting
+  state, and posts the per-step evidence comment carrying the run
+  marker (the orbi-website#70 replay shape: merge PR + verify +
+  evidence);
+- a pure-ops delivery (no commit, clean worktree) is complete: the
+  Runner closes the Issue, removes `ai-in-progress`, opens NO PR and
+  skips the delivery wait (`IssueResult("ops", None)`);
+- an ops session that commits code takes the SAME deterministic PR
+  closeout as a dev ticket (the Runner pushes and opens the PR with the
+  run marker and `Fixes #N`).
+
+The production replay of orbi-website#70 itself needs the deployed
+runner and its real credentials; this file proves the runner-side
+behavior end to end in a hermetic world.
+"""
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import orbi.runner as runner
+
+REPO = "owner/repo"
+ISSUE_NUMBER = 99
+PR_URL = "https://github.com/owner/repo/pull/99"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Stateful fake ``gh`` executable (real subprocess — the fake pi's own
+# gh calls go through it too). One JSON state file holds the issues
+# (labels, state), the captured comments, the progress API comments and
+# the PR objects. `pr merge` really merges the PR's head branch into
+# main on the bare origin through a throwaway clone, so the merge is an
+# observable git-state change, never a recorded flag only.
+FAKE_GH = r"""#!/usr/bin/env python3
+import fcntl, json, os, subprocess, sys, tempfile
+from pathlib import Path
+
+state_path = Path(os.environ["ORBI_FAKE_GH_STATE"])
+args = sys.argv[1:]
+lock_fd = os.open(str(state_path.parent / "gh-state.lock"),
+                  os.O_RDWR | os.O_CREAT, 0o644)
+fcntl.flock(lock_fd, fcntl.LOCK_EX)
+state = json.loads(state_path.read_text(encoding="utf-8"))
+
+
+def save():
+    fd, tmp = tempfile.mkstemp(dir=str(state_path.parent),
+                               prefix="gh-state-")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(json.dumps(state))
+    os.replace(tmp, state_path)
+
+
+def git(*cmd):
+    return subprocess.run(["git", *cmd], capture_output=True, text=True,
+                          check=True).stdout.strip()
+
+
+if args[:2] == ["issue", "list"]:
+    search = args[args.index("--search") + 1]
+    tokens = search.split()
+    required = [t[6:].split(",") for t in tokens if t.startswith("label:")]
+    excluded = [t[7:] for t in tokens if t.startswith("-label:")]
+    out = [
+        {"number": int(num), "state": issue.get("state", "OPEN"),
+         "title": issue["title"], "body": issue.get("body", "")}
+        for num, issue in sorted(state["issues"].items(),
+                                 key=lambda kv: int(kv[0]))
+        if issue.get("state", "OPEN") == "OPEN"
+        and all(any(r in issue["labels"] for r in group)
+                for group in required)
+        and not any(e in issue["labels"] for e in excluded)
+    ]
+    print(json.dumps(out))
+elif args[:2] == ["issue", "edit"]:
+    issue = state["issues"][args[2]]
+    if "--add-label" in args:
+        label = args[args.index("--add-label") + 1]
+        if label not in issue["labels"]:
+            issue["labels"].append(label)
+    if "--remove-label" in args:
+        label = args[args.index("--remove-label") + 1]
+        if label in issue["labels"]:
+            issue["labels"].remove(label)
+    save()
+elif args[:2] == ["issue", "close"]:
+    state["issues"][args[2]]["state"] = "CLOSED"
+    save()
+elif args[:2] == ["issue", "comment"]:
+    state.setdefault("comments", []).append(
+        {"issue": args[2], "body": args[args.index("--body") + 1]})
+    save()
+elif args[:1] == ["api"]:
+    if "--method" in args:
+        method = args[args.index("--method") + 1]
+        body = args[args.index("--field") + 1][len("body="):]
+        if method == "POST":
+            state.setdefault("api_ids", [])
+            comment_id = len(state["api_ids"]) + 1
+            state["api_ids"].append(comment_id)
+            state.setdefault("api_comments", []).append(body)
+            save()
+            print(json.dumps({"id": comment_id, "body": body}))
+        elif method == "PATCH":
+            comment_id = int(args[1].rsplit("/", 1)[1])
+            state["api_comments"][
+                state["api_ids"].index(comment_id)] = body
+            save()
+        else:
+            print(json.dumps([]))
+    else:
+        ids = state.get("api_ids", [])
+        print(json.dumps([
+            {"id": cid, "body": body}
+            for cid, body in zip(ids, state.get("api_comments", []))
+        ]))
+elif args[:2] == ["pr", "list"]:
+    head = args[args.index("--head") + 1]
+    print(json.dumps([
+        pr for pr in state.get("prs", {}).values()
+        if pr["headRefName"] == head and pr.get("state", "OPEN") == "OPEN"
+    ]))
+elif args[:2] == ["pr", "create"]:
+    branch = args[args.index("--head") + 1]
+    issue_num = branch.split("-issue-", 1)[1]
+    state.setdefault("prs", {})[branch] = {
+        "url": f"https://github.com/owner/repo/pull/{issue_num}",
+        "baseRefName": args[args.index("--base") + 1],
+        "headRefName": branch,
+        "headRefOid": git("rev-parse", "HEAD"),
+        "state": "OPEN",
+        "body": args[args.index("--body") + 1],
+        "title": args[args.index("--title") + 1],
+    }
+    save()
+    print(f"https://github.com/owner/repo/pull/{issue_num}")
+elif args[:2] == ["pr", "merge"]:
+    pr = state["prs"][args[2]]
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run(["git", "clone", git("remote", "get-url", "origin"),
+                        td], check=True, capture_output=True)
+        for key, value in (("user.email", "pilot@test.local"),
+                           ("user.name", "Pilot")):
+            subprocess.run(["git", "-C", td, "config", key, value],
+                           check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "fetch", "origin",
+                        pr["headRefName"]],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "merge", "--no-ff", "-m",
+                        "Merge PR #7 (ops)", "FETCH_HEAD"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", td, "push", "origin", "HEAD:main"],
+                       check=True, capture_output=True)
+    pr["state"] = "MERGED"
+    save()
+else:
+    raise AssertionError(f"unexpected gh command: {args}")
+"""
+
+# The fake ops pi (the orbi-website#70 replay shape): it receives the
+# REAL rendered ops playbook as its system prompt, executes the
+# authorized merge through a real `gh` call, verifies the resulting
+# state with a real shell command, and posts the per-step evidence
+# comment with the run marker. It does NOT commit (pure ops delivery).
+FAKE_PI_OPS = r"""#!/usr/bin/env python3
+import os, re, subprocess, sys
+args = sys.argv[1:]
+prompt = args[args.index("--system-prompt") + 1]
+run_id = re.search(r"Run id: `([0-9a-f]{8})`", prompt).group(1)
+cwd = os.getcwd()
+os.makedirs(os.path.join(cwd, ".pi-session"), exist_ok=True)
+with open(os.environ["ORBI_PI_PROMPT_DUMP"], "w", encoding="utf-8") as h:
+    h.write(prompt)
+merge = subprocess.run(
+    ["gh", "pr", "merge", "7", "--repo", "owner/repo", "--merge"],
+    capture_output=True, text=True,
+)
+verify = subprocess.run(
+    ["sh", "-c", "git fetch origin && git log --oneline -1 origin/main"],
+    cwd=cwd, capture_output=True, text=True,
+)
+evidence = (
+    f"<!-- orbi:run={run_id} -->\n"
+    f"# Ops evidence\n\nrun_id={run_id}\n\n"
+    "## merge PR #7\n\n"
+    "command: `gh pr merge 7 --repo owner/repo --merge`\n"
+    f"exit={merge.returncode}\n\n"
+    "## verify deployment state\n\n"
+    "command: `git fetch origin && git log --oneline -1 origin/main`\n"
+    "output:\n\n```\n"
+    f"{verify.stdout.strip()}\n"
+    "```\n"
+)
+comment = subprocess.run(
+    ["gh", "issue", "comment", "99", "--repo", "owner/repo",
+     "--body", evidence],
+    capture_output=True, text=True,
+)
+sys.stdout.write(
+    f"merge={merge.returncode} verify={verify.returncode} "
+    f"comment={comment.returncode}"
+)
+"""
+
+# The ops pi that ALSO delivers code (e.g. a wrangler.toml change): it
+# commits on the task branch and stops — the Runner owns the push/PR.
+FAKE_PI_OPS_COMMIT = r"""#!/usr/bin/env python3
+import os, re, subprocess, sys
+args = sys.argv[1:]
+prompt = args[args.index("--system-prompt") + 1]
+run_id = re.search(r"Run id: `([0-9a-f]{8})`", prompt).group(1)
+cwd = os.getcwd()
+os.makedirs(os.path.join(cwd, ".pi-session"), exist_ok=True)
+with open(os.environ["ORBI_PI_PROMPT_DUMP"], "w", encoding="utf-8") as h:
+    h.write(prompt)
+with open(os.path.join(cwd, "wrangler.toml"), "w",
+          encoding="utf-8") as handle:
+    handle.write(f'name = "site"  # run {run_id}\n')
+for command in (
+    ["git", "add", "."],
+    ["git", "commit", "-m", f"ops config change for run {run_id}"],
+):
+    subprocess.run(command, cwd=cwd, check=True, capture_output=True)
+sys.stdout.write("committed")
+"""
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {args} failed rc={result.returncode} "
+            f"stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def clone(tmp_path: Path) -> Path:
+    """Local bare origin plus a clone with `main` and a `beta` branch
+    one commit ahead (the PR #7 the ops ticket authorizes merging)."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    git(origin, "init", "--bare", "-b", "main")
+    repo = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(origin), str(repo)],
+        capture_output=True, text=True, check=True,
+    )
+    git(repo, "config", "user.email", "pilot@test.local")
+    git(repo, "config", "user.name", "Pilot")
+    (repo / "a.txt").write_text("a", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "first")
+    git(repo, "push", "origin", "main")
+    git(repo, "checkout", "-b", "beta")
+    (repo / "feature.txt").write_text("beta work", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "beta feature")
+    git(repo, "push", "origin", "beta")
+    git(repo, "checkout", "main")
+    return repo
+
+
+@pytest.fixture()
+def gh_world(tmp_path: Path, monkeypatch) -> Path:
+    """Install the stateful fake ``gh`` executable on PATH with a fresh
+    state file; seed Issue #99 (`ai-ready`+`ai-ops-only`) and PR #7
+    (beta → main). Returns the state file path."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "gh"
+    fake.write_text(FAKE_GH, encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    state_path = tmp_path / "gh-state.json"
+    state_path.write_text(json.dumps({
+        "issues": {
+            str(ISSUE_NUMBER): {
+                "title": "Merge PR #7 into main and verify the deployment",
+                "body": (
+                    "Authorized ops actions: merge PR #7 (beta → main) "
+                    "and verify the deployment state. Nothing else."
+                ),
+                "labels": ["ai-ready", "ai-ops-only"],
+                "state": "OPEN",
+            },
+        },
+        "comments": [],
+        "prs": {
+            "7": {
+                "url": "https://github.com/owner/repo/pull/7",
+                "baseRefName": "main",
+                "headRefName": "beta",
+                "state": "OPEN",
+            },
+        },
+    }), encoding="utf-8")
+    monkeypatch.setenv("ORBI_FAKE_GH_STATE", str(state_path))
+    return state_path
+
+
+def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake = bin_dir / "pi"
+    fake.write_text(script, encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv(
+        "ORBI_PI_PROMPT_DUMP", str(tmp_path / "pi-system-prompt.txt"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_run_id(monkeypatch):
+    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+
+
+def ops_issue() -> dict:
+    return {
+        "number": ISSUE_NUMBER,
+        "title": "Merge PR #7 into main and verify the deployment",
+        "body": (
+            "Authorized ops actions: merge PR #7 (beta → main) and "
+            "verify the deployment state. Nothing else."
+        ),
+        "labels": [
+            {"name": "ai-ready"}, {"name": "ai-ops-only"},
+        ],
+    }
+
+
+def config_for(clone: Path) -> dict:
+    # The REAL repo prompts: the ops session must receive the real
+    # rendered ops playbook (`prompt_ops.md`, the sibling of the
+    # configured dev prompt), not a test stub.
+    return {
+        "repo_dir": clone,
+        # The REAL repo prompts: the ops session must receive the real
+        # rendered ops playbook (`prompt_ops.md`, the sibling of the
+        # configured dev prompt), not a test stub.
+        "prompt": REPO_ROOT / "prompts" / "prompt.md",
+        "base_branch": "main",
+        "source_repos": [REPO],
+        "workspace_root": clone.parent,
+        "context_files": [],
+        "skills": [],
+    }
+
+
+def worktree_for(clone: Path, run_id: str) -> Path:
+    return (
+        clone / ".worktrees"
+        / f"orbi-{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}-{run_id}"
+    )
+
+
+def test_git_helper_fails_fast_on_nonzero_exit(tmp_path):
+    with pytest.raises(AssertionError, match=r"git .* failed rc=128"):
+        git(tmp_path, "rev-parse", "no-such-ref")
+
+
+def test_e2e_pure_ops_ticket_executes_merges_and_delivers_evidence(
+    clone, gh_world, tmp_path, monkeypatch, caplog,
+):
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_OPS)
+    caplog.set_level("INFO")
+
+    result = runner.process_issue(ops_issue(), config_for(clone), REPO)
+
+    run_id = runner.current_run_id()
+    assert re.fullmatch(r"[0-9a-f]{8}", run_id)
+    # A pure-ops delivery is complete: no PR, no delivery wait.
+    assert result == runner.IssueResult("ops", None)
+
+    state = json.loads(gh_world.read_text(encoding="utf-8"))
+    # 1. The session REALLY executed the authorized merge: the fake gh
+    #    recorded it and the bare origin's main really advanced onto the
+    #    beta work (an observable git-state change, not a flag).
+    assert state["prs"]["7"]["state"] == "MERGED"
+    subprocess.run(
+        ["git", "-C", str(clone), "fetch", "origin"],
+        capture_output=True, text=True, check=True,
+    )
+    origin_main = git(clone, "log", "--oneline", "origin/main")
+    assert "Merge PR #7 (ops)" in origin_main
+    assert "beta feature" in origin_main
+
+    # 2. The evidence comment landed on the ticket: run marker, the
+    #    executed commands and their REAL output (the merge commit
+    #    subject the verify step observed). The runner's own scene
+    #    comments carry the marker too — filter to the agent's report.
+    evidence = [
+        c for c in state["comments"]
+        if "# Ops evidence" in c["body"]
+    ]
+    assert len(evidence) == 1
+    assert f"<!-- orbi:run={run_id} -->" in evidence[0]["body"]
+    assert "gh pr merge 7 --repo owner/repo --merge" in evidence[0]["body"]
+    assert "exit=0" in evidence[0]["body"]
+    assert "Merge PR #7 (ops)" in evidence[0]["body"]
+    assert f"run_id={run_id}" in evidence[0]["body"]
+
+    # 3. The runner closed the ticket and removed the claim label.
+    issue = state["issues"][str(ISSUE_NUMBER)]
+    assert issue["state"] == "CLOSED"
+    assert "ai-in-progress" not in issue["labels"]
+
+    # 4. No delivery PR was created and the delivery branch was never
+    #    pushed: a pure-ops ticket takes no PR ceremony.
+    assert list(state["prs"]) == ["7"]
+    branches = git(clone, "ls-remote", "--heads", "origin")
+    assert f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}" \
+        not in branches
+
+    # 5. The session received the REAL ops playbook (the ops agent's
+    #    system prompt is rendered from prompts/prompt_ops.md).
+    prompt = (tmp_path / "pi-system-prompt.txt").read_text(
+        encoding="utf-8",
+    )
+    assert "Orbi Ops Agent" in prompt
+    assert "The ticket is the authorization" in prompt
+
+    # 6. The run-scoped worktree stays as the run's evidence.
+    assert worktree_for(clone, run_id).is_dir()
+
+
+def test_e2e_ops_ticket_with_code_change_takes_the_pr_ceremony(
+    clone, gh_world, tmp_path, monkeypatch,
+):
+    install_fake_pi(monkeypatch, tmp_path, FAKE_PI_OPS_COMMIT)
+
+    result = runner.process_issue(ops_issue(), config_for(clone), REPO)
+
+    run_id = runner.current_run_id()
+    # The committed ops code is delivered exactly like a dev ticket:
+    # the Runner pushed and opened the PR.
+    assert result == runner.IssueResult("pr", PR_URL)
+
+    state = json.loads(gh_world.read_text(encoding="utf-8"))
+    branch = f"orbi/{REPO.replace('/', '-')}-issue-{ISSUE_NUMBER}"
+    # The task branch really reached the remote.
+    assert branch in git(clone, "ls-remote", "--heads", "origin")
+    # Exactly the delivery PR exists, created by the RUNNER with the
+    # run marker and the `Fixes #N` close keyword.
+    delivery_prs = [
+        pr for pr in state["prs"].values() if pr["headRefName"] == branch
+    ]
+    assert len(delivery_prs) == 1
+    assert f"<!-- orbi:run={run_id} -->" in delivery_prs[0]["body"]
+    assert f"Fixes #{ISSUE_NUMBER}" in delivery_prs[0]["body"]
+    assert delivery_prs[0]["baseRefName"] == "main"
+    assert delivery_prs[0]["headRefOid"] == git(
+        clone, "rev-parse", f"origin/{branch}",
+    )

--- a/tests/test_pilot_setup.py
+++ b/tests/test_pilot_setup.py
@@ -73,8 +73,10 @@ VALID_DEFS = [
     # scan routes `ai-ready`+`ai-release` to the release state machine),
     # so it is part of the platform label set.
     {"name": "ai-release", "color": "5319e7", "description": "release"},
-    # Issue #209: ticket-only content is a separately dispatched type.
-    {"name": "ai-ops-only", "color": "0e8a16", "description": "ticket"},
+    # Issue #209/#537: ticket-only content is a separately dispatched
+    # type; the content marker moved off the ops name to its own label.
+    {"name": "ai-content-only", "color": "d4c5f9", "description": "content"},
+    {"name": "ai-ops-only", "color": "0e8a16", "description": "ops"},
 ]
 
 
@@ -227,13 +229,13 @@ def test_fake_run_factory_rejects_an_unexpected_command():
 # --- labels.toml: the single source of truth -------------------------------
 
 
-def test_load_label_defs_parses_all_ten_platform_labels(tmp_path):
+def test_load_label_defs_parses_all_eleven_platform_labels(tmp_path):
     path = write_labels_toml(tmp_path, VALID_DEFS)
     defs = pilot_setup.load_label_defs(path)
     assert [entry["name"] for entry in defs] == [
         "ai-ready", "ai-in-progress", "ai-pr-opened",
         "ai-fix-needed", "ai-merged", "ai-blocked", "p0", "ai-epic",
-        "ai-release", "ai-ops-only",
+        "ai-release", "ai-content-only", "ai-ops-only",
     ]
     assert defs[0] == {
         "name": "ai-ready", "color": "1d76db", "description": "dispatched",
@@ -291,8 +293,8 @@ def test_load_label_defs_rejects_malformed_toml(tmp_path):
         pilot_setup.load_label_defs(path)
 
 
-def test_committed_labels_toml_covers_the_ten_platform_labels():
-    """The committed labels.toml (repo root) must define exactly the 10
+def test_committed_labels_toml_covers_the_eleven_platform_labels():
+    """The committed labels.toml (repo root) must define exactly the 11
     platform labels with valid colors and non-empty descriptions."""
     path = Path(__file__).resolve().parent.parent / "labels.toml"
     defs = pilot_setup.load_label_defs(path)
@@ -633,8 +635,8 @@ def test_align_labels_creates_missing_and_edits_drifted(tmp_path):
         run_command=fake_run,
     )
     assert result["repo"] == "xqliu/orbi"
-    assert result["aligned"] == 10
-    assert result["total"] == 10
+    assert result["aligned"] == 11
+    assert result["total"] == 11
     # Only the drifted p0 label is written; ai-ready already matches and
     # the business label `bug` is never touched.
     creates = [c for c in calls if c[:3] == ["gh", "label", "create"]]
@@ -656,7 +658,7 @@ def test_align_labels_is_idempotent_when_everything_matches(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 10
+    assert result["aligned"] == 11
     assert [c for c in calls if c[:3] == ["gh", "label", "create"]] == []
 
 
@@ -669,9 +671,9 @@ def test_align_labels_reports_partial_alignment(tmp_path):
         pilot_setup.load_label_defs(repo / "labels.toml"),
         run_command=fake_run,
     )
-    assert result["aligned"] == 10
-    assert result["total"] == 10
-    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 10
+    assert result["aligned"] == 11
+    assert result["total"] == 11
+    assert len([c for c in calls if c[:3] == ["gh", "label", "create"]]) == 11
 
 
 def test_align_labels_fails_fast_on_a_label_write_error(tmp_path):
@@ -1328,7 +1330,7 @@ def test_run_setup_success_reports_all_steps(tmp_path):
             "repo": "xqliu/orbi",
             "permission": "ADMIN",
             "default_branch": "main",
-            "labels": {"aligned": 10, "total": 10},
+            "labels": {"aligned": 11, "total": 11},
         },
     ]
     assert result["service"]["installed"] is True

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -2314,7 +2314,7 @@ def test_process_ticket_only_publishes_the_bound_context(monkeypatch):
     the action varies per call site — the AST pin above cannot see the
     bound values, this behavioral path can."""
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
-             "labels": [{"name": "ai-ops-only"}]}
+             "labels": [{"name": "ai-content-only"}]}
     seen = []
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)

--- a/tests/test_readme_homepage.py
+++ b/tests/test_readme_homepage.py
@@ -73,6 +73,7 @@ FORBIDDEN_MECHANISM_NEEDLES = (
     "ai-merged",
     "ai-epic",
     "ai-release",
+    "ai-content-only",
     "ai-ops-only",
     "`p0`",
     # label initialization commands (docs/setup.mdx)


### PR DESCRIPTION
<!-- orbi:run=7750c143 -->

Fixes #537

ops 票需要完整执行能力（部署/写 GitHub/任意平台 CLI）：复用完整执行代理 + ops 剧本，废弃白名单沙箱方案 (run_id=7750c143)
