### PR TITLE
并发认领竞态：同一 Issue 被两个 run 同时认领，后者 push 失败将已成功交付的票误标 ai-blocked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,12 @@ system merely to make an end-to-end claim.
 - A failed P0 run enters `ai-blocked` ALONE — no tick re-claims it, so there is no infinite retry.
 - Explanation: `docs/workflow.mdx` (EN/ZH); the `active_milestone` field: `docs/getting-started.mdx`.
 
+## Claim mutual exclusion (Issue #702)
+
+- The ready scan reads GitHub's eventually-consistent search index and the flock slot only serializes runners sharing one state dir, so the claim is verified at claim time: immediately before the claim label patch the Issue's labels are re-read LIVE (`gh issue view`, REST); any delivery state present means another run owns the Issue — the claim is skipped (`claim_race_lost`), no label, no worktree, no run.
+- A push rejected as non-fast-forward on the stable delivery branch is checked against the branch's delivery PRs (bounded probe): an open PR, or a merged PR at the branch's current remote head, proves the concurrent run delivered — the losing run exits with the `superseded` outcome and NEVER marks the Issue `ai-blocked`; a rejected push without a matching delivery PR stays a genuine failure.
+- Explanation: `docs/workflow.mdx` (EN/ZH).
+
 ## Epic Issues (ai-epic)
 
 - An Epic is a coordination Issue that groups related tasks; it carries the plain `ai-epic` label and is NOT an executable task — the work is split into independent `ai-ready` sub-Issues, each with one PR, one independent review and one merge.

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -115,6 +115,36 @@ commits — initialize them per repository (see
 | `ai-merged` | Success terminal state; the Runner merged the PR and confirmed the merge commit on the protected branch |
 | `ai-blocked` | Only an external precondition the AI cannot safely judge or fix (Issue #50); the blocked comment states why automatic recovery is impossible; a human must decide the next step |
 
+## Claim mutual exclusion (Issue #702)
+
+Two Runner triggers can race for the same Issue (two checkouts or
+containers, a manual run beside the service, or simply GitHub's
+eventually-consistent search index, which can keep a just-claimed Issue
+visible to the ready scan for seconds). The local flock slot serializes
+only the runners that share one state dir, so the claim itself carries
+two guards:
+
+- **Live claim verification.** The ready scan (`gh issue list --search`)
+  reads the search index; immediately before the claim label patch the
+  Runner re-reads the Issue's labels with `gh issue view` (REST,
+  strongly consistent). Any delivery state present there
+  (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`, `ai-merged`,
+  `ai-blocked`) means another run owns the Issue: the Runner logs
+  `claim_race_lost`, changes nothing and ends the tick — no label, no
+  worktree, no session.
+- **Superseded-delivery backstop.** If two claims landed anyway, both
+  runs deliver on the SAME stable branch (`orbi/<repo>-issue-<N>`), so
+  the loser's push is rejected `(fetch first)`. Before any failure is
+  reported, the Runner probes the branch's delivery PRs (a few seconds,
+  bounded): an OPEN PR — or a MERGED PR whose head is exactly the
+  branch's current remote head — proves the concurrent run delivered.
+  The losing run then logs `delivery_superseded`, posts a run-marked
+  explanation, cleans its own worktree and exits WITHOUT the terminal
+  `ai-blocked` transition: the labels stay exactly as the winning run
+  set them, and its flow completes `ai-pr-opened` → `ai-merged`
+  untouched. A rejected push with no matching delivery PR remains a
+  genuine failure (the normal terminal path, unchanged).
+
 ## Ticket dispatch: content, dev and ops
 
 `ai-ready` is the execution switch for every task type; a second label

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -96,6 +96,29 @@ GitHub 标签是外部状态机。它们不是 commit 创建的——每个仓�
 | `ai-merged` | 成功终态；Runner 已合并 PR 并确认 merge commit 落在保护分支 |
 | `ai-blocked` | 只用于 AI 无法安全判断或修复的外部前置条件（Issue #50）；blocked comment 写明为什么不能自动恢复；人工必须决定下一步 |
 
+## 认领互斥（Issue #702）
+
+两个 Runner 触发可能竞争同一张 Issue（两个 checkout 或容器、服务旁边
+的手动运行，或者仅仅是 GitHub 最终一致的搜索索引——刚打上的标签可能在
+几秒内仍让 ready 扫描认为这张票可认领）。本地 flock 槽位只能串行化共享
+同一状态目录的 Runner，所以认领本身带两道防线：
+
+- **认领时的活值校验。** ready 扫描（`gh issue list --search`）读的是
+  搜索索引；在打认领标签之前，Runner 用 `gh issue view`（REST，强一致）
+  重读一次 Issue 的标签。只要出现任何交付态（`ai-in-progress`、
+  `ai-pr-opened`、`ai-fix-needed`、`ai-merged`、`ai-blocked`），就说明
+  另一个 run 已拥有这张票：Runner 记录 `claim_race_lost`，什么也不改，
+  直接结束本 tick——不打标签、不建 worktree、不起会话。
+- **交付已被接管的兜底。** 如果两个认领都已落地，两个 run 会在同一条
+  稳定分支（`orbi/<repo>-issue-<N>`）上交付，输家的 push 会被
+  `(fetch first)` 拒绝。此时 Runner 先探测该分支的交付 PR（有界重试几
+  秒）：存在 OPEN 的 PR——或者 head 恰好等于分支当前远端 head 的 MERGED
+  PR——即证明并发的那次 run 已经交付。输家随后记录 `delivery_superseded`，
+  发一条带 run 标记的说明，清理自己的 worktree，直接结束——**绝不**进入
+  终态 `ai-blocked`：标签保持赢家设置的样式，其流程原样走完
+  `ai-pr-opened` → `ai-merged`。若被拒绝的 push 找不到匹配的交付 PR，
+  仍是真实失败（走原来的终态路径，行为不变）。
+
 ## 票派发：content、dev、ops
 
 `ai-ready` 是所有任务类型的执行开关；第二个标签选择类型（Issue

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -73,6 +73,7 @@ from orbi.delivery_labels import (
     EPIC_LABEL,
     FIX_NEEDED_LABEL,
     IN_PROGRESS_LABEL,
+    LIFECYCLE_STATES,
     MERGED_LABEL,
     OPS_LABEL,
     P0_LABEL,
@@ -264,6 +265,24 @@ class ResumeVerificationError(UnrecoverableDeliveryError):
     evidence. Keeping a distinct type lets the tick boundary end normally
     without swallowing unrelated Runner bugs.
     """
+
+
+class DeliverySupersededError(RuntimeError):
+    """A concurrent run of the SAME Issue won the delivery (Issue #702).
+
+    This is not a failure of the Issue: the stable delivery branch was
+    already pushed by the winning run and its delivery PR exists (open,
+    or merged at exactly the branch's remote head). The losing run must
+    exit WITHOUT the terminal `ai-blocked` transition — the labels stay
+    exactly as the winning run set them (`ai-pr-opened` -> `ai-merged`).
+    `pr_url` is the winning run's delivery PR.
+    """
+
+    def __init__(self, pr_url: str):
+        self.pr_url = pr_url
+        super().__init__(
+            f"delivery superseded by the concurrent run's PR {pr_url}"
+        )
 
 
 class PreExistingCIFailure(UnrecoverableDeliveryError):
@@ -3665,6 +3684,30 @@ def latest_run_id(repo_dir: Path, source_repo: str, number: int) -> str | None:
     return newest.name.rsplit("-", 1)[-1]
 
 
+def live_labels(number: int, repo: str) -> list[str]:
+    """Return the Issue's label names from the LIVE REST read.
+
+    `gh issue view` answers from the REST API, which is strongly
+    consistent — unlike the search index `gh issue list --search` reads,
+    where a just-applied label can stay invisible for seconds (the #702
+    claim race). The claim path must verify against THIS read.
+    """
+    raw = run_command([
+        "gh", "issue", "view", str(number), "--repo", repo,
+        "--json", "labels",
+    ])
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("issue view must be a JSON object")
+    labels = data.get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("issue labels must be a JSON array")
+    return [
+        label.get("name") for label in labels
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    ]
+
+
 def has_in_progress_label(number: int, repo: str) -> bool:
     """True when the Issue still carries `ai-in-progress`.
 
@@ -4432,6 +4475,64 @@ def _agent_delivery_boundary(worktree: Path) -> tuple[str, str]:
     return head, dirty
 
 
+# Issue #702: how hard the superseded-delivery probe looks for the
+# winning run's PR. The winning run may still be inside its push →
+# PR-create gap when the losing run's push is rejected, so the probe
+# retries bounded before classifying the rejection a genuine failure.
+SUPERSEDED_PR_PROBES = 3
+SUPERSEDED_PR_PROBE_SECONDS = 2.0
+
+
+def _push_rejected_non_fast_forward(exc: subprocess.CalledProcessError
+                                    ) -> bool:
+    """True when a push failed because the remote branch moved on (the
+    `(fetch first)` rejection) — the signature of a concurrent writer on
+    the stable delivery branch."""
+    output = f"{getattr(exc, 'stderr', '') or ''}\n" \
+             f"{getattr(exc, 'stdout', '') or ''}"
+    return "! [rejected]" in output and "fetch first" in output
+
+
+def _superseding_delivery_pr(worktree: Path, branch: str) -> dict | None:
+    """Return the delivery PR a concurrent run already has on `branch`.
+
+    Issue #702 backstop: a non-fast-forward rejection on the stable
+    delivery branch means another writer pushed it; for a branch only
+    the Runner writes, that writer is a concurrent run of the SAME
+    Issue. A PR matches when it is OPEN, or MERGED with its head exactly
+    at the branch's current remote head — a MERGED PR of a PREVIOUS
+    delivery on the same branch has a stale head (a redo delivery reuses
+    the branch on top of the old head and pushes fast-forward), so it
+    never matches and a rejection there stays a genuine failure. The
+    probe is bounded (`SUPERSEDED_PR_PROBES`, `SUPERSEDED_PR_PROBE_SECONDS`):
+    the winning run's PR may not exist yet at the first attempt.
+    """
+    remote = run_command(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        cwd=worktree, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
+    ).strip()
+    remote_head = remote.split("\t", 1)[0] if remote else ""
+    if not remote_head:
+        return None
+    for attempt in range(SUPERSEDED_PR_PROBES):
+        raw = run_command([
+            "gh", "pr", "list", "--state", "all", "--head", branch,
+            "--json", "number,url,state,headRefOid", "--limit", "20",
+        ], cwd=worktree, timeout=RESUME_PR_STATE_TIMEOUT_SECONDS)
+        prs = json.loads(raw) if raw.strip() else []
+        if not isinstance(prs, list):
+            raise ValueError("pr list must return an array")
+        for pr in prs:
+            state = pr.get("state")
+            if state == "OPEN" or (
+                state == "MERGED" and pr.get("headRefOid") == remote_head
+            ):
+                return pr
+        if attempt + 1 < SUPERSEDED_PR_PROBES:
+            time.sleep(SUPERSEDED_PR_PROBE_SECONDS)
+    return None
+
+
 def deliver_pr(worktree: Path, branch: str, base_branch: str,
                base_sha: str, run_id: str, *, issue: int,
                issue_title: str, repo_dir: Path) -> str:
@@ -4523,9 +4624,24 @@ def deliver_pr(worktree: Path, branch: str, base_branch: str,
     # The head is re-read after the absorb step: a successful base
     # merge advanced it to the merge commit.
     local_head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
-    run_git_network_command(
-        ["git", "push", "origin", f"HEAD:{branch}"], cwd=worktree,
-    )
+    try:
+        run_git_network_command(
+            ["git", "push", "origin", f"HEAD:{branch}"], cwd=worktree,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Issue #702: a `(fetch first)` rejection on the stable delivery
+        # branch means a concurrent run of the SAME Issue pushed its own
+        # delivery. When that run's delivery PR exists, this delivery is
+        # superseded — never a terminal failure of the Issue.
+        if _push_rejected_non_fast_forward(exc):
+            superseding = _superseding_delivery_pr(worktree, branch)
+            if superseding is not None:
+                LOGGER.info(
+                    "delivery_superseded issue=%s branch=%s pr=%s",
+                    issue, branch, superseding.get("url"),
+                )
+                raise DeliverySupersededError(superseding["url"]) from exc
+        raise
     remote_head = run_command(
         ["git", "rev-parse", f"origin/{branch}"], cwd=worktree,
     )
@@ -6800,6 +6916,28 @@ def process_issue(issue: dict, config: dict, source_repo: str,
     LOGGER.info(
         "issue=%s %s", number, run_info,
     )
+    if not in_progress:
+        # Claim-time race check (Issue #702): the ready scan reads
+        # GitHub's eventually-consistent search index, so a concurrent
+        # run's just-applied `ai-in-progress` can still be invisible
+        # there, and the flock slot only serializes runners sharing the
+        # state dir (a second checkout, container or manual run does
+        # not). Immediately before the claim patch the labels are
+        # re-read LIVE (`gh issue view`, strongly consistent REST): any
+        # delivery state present means another run owns the Issue — the
+        # claim is skipped without touching anything (no label, no
+        # worktree, no run). The resume path above is exempt: it
+        # REUSES the existing claim of the killed runner.
+        race_labels = sorted(
+            (set(live_labels(number, source_repo)) & LIFECYCLE_STATES)
+            - {dispatch_label},
+        )
+        if race_labels:
+            LOGGER.info(
+                "claim_race_lost issue=%s labels=%s",
+                number, ",".join(race_labels),
+            )
+            return IssueResult("claimed_elsewhere", None)
     apply_label_patch(
         number, repo=source_repo, event=EVENT_CLAIM,
         current_labels={label.get("name") for label in issue.get(
@@ -7073,6 +7211,37 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         return IssueResult(
             "external-pr" if external_takeover else "pr", pr_url,
         )
+    except DeliverySupersededError as exc:
+        # Issue #702: a concurrent run of THIS Issue already pushed the
+        # stable branch and opened its delivery PR — the delivery is won
+        # by that run. The losing run must never mark the Issue
+        # `ai-blocked`: the labels stay exactly as the winning run set
+        # them (its flow owns `ai-pr-opened` -> `ai-merged`). This run
+        # leaves a run-marked explanation, cleans its own worktree and
+        # run state (the resume machinery must never resurrect this dead
+        # delivery) and ends the tick cleanly.
+        LOGGER.info(
+            "issue=%s delivery_superseded pr=%s", number, exc.pr_url,
+        )
+        try:
+            comment_issue(
+                number, repo=source_repo,
+                body=(
+                    f"{run_marker(run_id)}\n"
+                    f"Orbi delivery superseded: the delivery branch was "
+                    f"already pushed and its PR ({exc.pr_url}) is owned "
+                    "by the concurrent run of this Issue; this run "
+                    f"exits without changing the Issue state ({run_info})"
+                ),
+            )
+        except Exception:
+            LOGGER.exception("issue=%s superseded_comment_failed", number)
+        # The superseded error can only be raised by `deliver_pr`, which
+        # runs after the worktree exists — the scene is always present.
+        cleanup_task_worktree(
+            worktree, config["repo_dir"], run_id=run_id, issue=number,
+        )
+        return IssueResult("superseded", exc.pr_url)
     except (ModelWaitDeadError, RecoverablePiFailure) as exc:
         # Issue #227/#325: classified Pi/model infrastructure failures are
         # recoverable. Keep the claim, worktree and run-state file so the

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3816,6 +3816,10 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
         if command[:3] == ["gh", "issue", "list"]:
             # No `ai-in-progress` label: the previous run finished.
             return "[]"
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702): a fresh
+            # claimable Issue carries only the ready label.
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:2] == ["gh", "issue"]:
             return ""
         if command[:2] == ["gh", "pr"]:
@@ -3959,6 +3963,14 @@ def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
             return json.dumps(
                 [{"number": 4}] if in_progress else [],
             )
+        if command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702): the labels
+            # match the `in_progress` scene this wiring models.
+            return json.dumps({"labels": [
+                {"name": label}
+                for label in (["ai-ready", "ai-in-progress"]
+                              if in_progress else ["ai-ready"])
+            ]})
         if command[:3] == ["gh", "issue", "comment"]:
             comment_bodies.append(command[-1])
             return ""
@@ -4132,6 +4144,151 @@ def test_process_issue_fails_fast_when_the_run_state_is_missing(
     assert "cannot continue the interrupted run" in failed[0]
     assert "run state" in failed[0]
     assert "resume_continue_failed" in caplog.text
+
+
+def _claim_race_setup(monkeypatch, tmp_path, *, live_labels):
+    """Fake-gh wiring for the Issue #702 claim-race tests.
+
+    `live_labels` is a list of per-call answers for the LIVE REST label
+    read (`gh issue view <n> --json labels`) — the FIRST answer is the
+    claim-time race check itself (has_in_progress_label uses the search
+    API, answered as `[]` below: the rival run's just-applied label is
+    invisible to the search index, the #702 lag). Returns
+    `(edits, comment_bodies, worktree, fake_run)` with `edit_issue`
+    recorded; a lost claim posts no comment and changes nothing.
+    """
+    edits: list = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append(kwargs),
+    )
+    monkeypatch.setattr(
+        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    )
+    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    worktree = tmp_path / "wt"
+    worktree.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        runner, "worktree_resume_scene",
+        lambda repo_dir, source_repo, number: None,
+    )
+    monkeypatch.setattr(
+        runner, "create_worktree", lambda *args, **kwargs: worktree,
+    )
+    comment_bodies: list = []
+    answers = list(live_labels)
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["gh", "issue", "list"]:
+            # The search index lags: the rival run's `ai-in-progress`
+            # is NOT visible here (the #702 race window).
+            return "[]"
+        if command[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"labels": [
+                {"name": label} for label in answers.pop(0)
+            ]})
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    return edits, comment_bodies, worktree, fake_run
+
+
+def test_process_issue_claim_race_lost_skips_the_claim(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #702: the ready scan (eventually-consistent search index)
+    returned the Issue claimable, but a concurrent run applied
+    `ai-in-progress` before this run's claim. The claim-time LIVE label
+    re-read (`gh issue view`, strongly consistent REST) sees the rival
+    delivery state and the claim is skipped: no claim label patch, no
+    worktree, no Pi session, no started-Pi comment — the Issue belongs
+    to the other run."""
+    edits, comment_bodies, worktree, fake_run = _claim_race_setup(
+        monkeypatch, tmp_path,
+        live_labels=[
+            ["ai-ready", "ai-in-progress"],    # the claim-time live check
+        ],
+    )
+    run_pi_calls = []
+    monkeypatch.setattr(
+        runner, "run_pi",
+        lambda *args, **kwargs: run_pi_calls.append(1) or "done",
+    )
+    caplog.set_level("INFO")
+    result = runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/orbi-backlog",
+    )
+    assert result.kind == "claimed_elsewhere"
+    assert result.url is None
+    # Nothing was claimed, nothing was created, no session ran.
+    assert edits == []
+    assert run_pi_calls == []
+    assert comment_bodies == []
+    assert not (tmp_path / "wt" / ".orbi").exists()
+    # The structured race line names the rival's label.
+    race_lines = [
+        message for message in caplog.messages if "claim_race_lost" in message
+    ]
+    assert race_lines == [
+        "[ffffeeee] claim_race_lost issue=4 labels=ai-in-progress",
+    ]
+    # The lost claim never even tries: the fake rejects every other
+    # command (no git, no progress traffic, nothing).
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["git", "status", "--porcelain"])
+
+
+def test_process_issue_claim_race_lost_on_opened_pr_label(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #702: the rival run may already have moved past the claim
+    (`ai-pr-opened`) by the time this run verifies — any delivery state
+    in the live read means the Issue is owned, not claimable."""
+    edits, comment_bodies, _, _ = _claim_race_setup(
+        monkeypatch, tmp_path,
+        live_labels=[
+            ["ai-pr-opened"],
+        ],
+    )
+    caplog.set_level("INFO")
+    result = runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/orbi-backlog",
+    )
+    assert result.kind == "claimed_elsewhere"
+    assert edits == []
+    assert comment_bodies == []
+    assert "claim_race_lost issue=4 labels=ai-pr-opened" in caplog.text
+
+
+def test_process_issue_resume_is_never_blocked_by_the_live_check(
+    monkeypatch, tmp_path,
+):
+    """Issue #702: the live label check guards only the FRESH claim.
+    A resumed run (the killed runner's `ai-in-progress` is visible to
+    the search) re-reads the same label live and continues — the resume
+    reuses the existing claim instead of losing it."""
+    gh_calls, posted, worktree, comment_bodies = _resume_wiring_setup(
+        monkeypatch, tmp_path, in_progress=True,
+    )
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(
+        runner, "deliver_pr",
+        lambda *args, **kwargs:
+        "https://github.com/orbi-build/orbi/pull/4",
+    )
+    result = runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/orbi-backlog",
+    )
+    assert result.kind == "pr"
 
 
 def test_worktree_path_lives_inside_repo_worktrees_and_includes_run_id():
@@ -5267,6 +5424,10 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:2] == ["gh", "issue"]:
             # Scene comments (started Pi / opened PR) go through
             # comment_issue -> run_command; record them like the others.
@@ -5368,6 +5529,10 @@ def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, c
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return "0123456789abcdef0123456789abcdef01234567"
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5403,6 +5568,10 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5476,6 +5645,10 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5513,6 +5686,412 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
     assert blocked
     assert "delivered no commit" in blocked[0]
     assert "<!-- orbi:run=a1b2c3d4 -->" in blocked[0]
+
+
+BRANCH = "orbi/xqliu/orbi-issue-4"
+REMOTE_HEAD = "f" * 40
+
+
+def _deliver_pr_rejection_setup(
+    monkeypatch, tmp_path, *, pr_states, sleeps=None,
+):
+    """Wire the real `deliver_pr` up to the push and its #702 probe.
+
+    `pr_states` is a list of per-probe answers for the branch's delivery
+    PR list (`gh pr list --state all`): each entry is a list of PR dicts
+    or [] — a probe whose answer list is exhausted returns []. `sleeps`
+    records the bounded probe waits. Returns (pr_queries, pushes).
+    """
+    worktree = tmp_path / "wt"
+    worktree.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        runner, "fetch_base_ref", lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        runner, "_is_ancestor", lambda *args, **kwargs: True,
+    )
+    pushes = []
+
+    def fake_push(command, **kwargs):
+        pushes.append(command)
+        raise subprocess.CalledProcessError(
+            1, command,
+            output="To github.com:xqliu/orbi.git\n",
+            stderr=(
+                "! [rejected]        HEAD -> "
+                f"{BRANCH} (fetch first)\n"
+                "error: failed to push some refs to "
+                "'github.com:xqliu/orbi.git'\n"
+                "hint: Updates were rejected because the tip of your "
+                "current branch is behind\n"
+            ),
+        )
+
+    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    pr_queries: list = []
+    answers = list(pr_states)
+    sleeps: list = sleeps if sleeps is not None else []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "ls-remote"]:
+            return f"{REMOTE_HEAD}\trefs/heads/{BRANCH}"
+        if command[:3] == ["gh", "pr", "list"]:
+            pr_queries.append(command)
+            return json.dumps(
+                answers.pop(0) if answers else [],
+            )
+        if command == ["git", "branch", "--show-current"]:
+            return BRANCH
+        if command == ["git", "status", "--porcelain"]:
+            return ""
+        if command == ["git", "rev-parse", "HEAD"]:
+            return "b" * 40
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    real_sleep = runner.time.sleep
+    monkeypatch.setattr(
+        runner.time, "sleep",
+        lambda seconds: sleeps.append(seconds) or real_sleep(0),
+    )
+    return pr_queries, pushes, fake_run
+
+
+def test_deliver_pr_rejected_push_with_open_delivery_pr_is_superseded(
+    monkeypatch, tmp_path,
+):
+    """Issue #702: the push of the stable delivery branch is rejected
+    `(fetch first)` because the CONCURRENT run of the same Issue already
+    pushed it and opened its PR. The delivery is owned by that run —
+    `deliver_pr` raises `DeliverySupersededError` with the PR URL
+    instead of the raw git error (the losing run must never arrive at
+    the terminal `ai-blocked` path)."""
+    pr_queries, pushes, _ = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path,
+        pr_states=[[
+            {"number": 32, "state": "OPEN",
+             "url": "https://github.com/xqliu/orbi/pull/32",
+             "headRefOid": REMOTE_HEAD},
+        ]],
+    )
+    with pytest.raises(runner.DeliverySupersededError) as excinfo:
+        runner.deliver_pr(
+            tmp_path / "wt", BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+    assert excinfo.value.pr_url == "https://github.com/xqliu/orbi/pull/32"
+    assert len(pushes) == 1
+    # The probe names the branch and reads open AND merged PRs.
+    assert pr_queries == [[
+        "gh", "pr", "list", "--state", "all", "--head", BRANCH,
+        "--json", "number,url,state,headRefOid", "--limit", "20",
+    ]]
+
+
+def test_deliver_pr_rejected_push_with_merged_delivery_pr_is_superseded(
+    monkeypatch, tmp_path,
+):
+    """Issue #702: the winning run may have finished the whole review and
+    merge before the losing run even reaches its push. A MERGED PR
+    matches when its head is exactly the branch's current remote head —
+    the delivered proof."""
+    _, _, _ = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path,
+        pr_states=[[
+            {"number": 32, "state": "MERGED",
+             "url": "https://github.com/xqliu/orbi/pull/32",
+             "headRefOid": REMOTE_HEAD},
+        ]],
+    )
+    with pytest.raises(runner.DeliverySupersededError) as excinfo:
+        runner.deliver_pr(
+            tmp_path / "wt", BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+    assert excinfo.value.pr_url == "https://github.com/xqliu/orbi/pull/32"
+
+
+def test_deliver_pr_rejected_push_old_merged_pr_is_not_superseding(
+    monkeypatch, tmp_path,
+):
+    """A MERGED PR of a PREVIOUS delivery on the same stable branch has
+    a stale head (the branch moved on) — it never supersedes: without a
+    matching delivery PR the rejection stays the genuine failure it is
+    and the original error propagates."""
+    _, _, _ = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path,
+        pr_states=[[
+            {"number": 12, "state": "MERGED",
+             "url": "https://github.com/xqliu/orbi/pull/12",
+             "headRefOid": "c" * 40},
+        ]],
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.deliver_pr(
+            tmp_path / "wt", BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+
+
+def test_deliver_pr_rejected_push_without_delivery_pr_reraises(
+    monkeypatch, tmp_path,
+):
+    """A rejection with NO delivery PR for the branch is a genuine
+    failure: the original CalledProcessError propagates into the normal
+    terminal failure path (unchanged #702-adjacent behavior)."""
+    pr_queries, _, _ = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path,
+        pr_states=[[], [], []],
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.deliver_pr(
+            tmp_path / "wt", BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+    # The probe is bounded: three attempts, then the failure stands.
+    assert len(pr_queries) == 3
+
+
+def test_deliver_pr_push_rejected_probe_rejects_unexpected_commands(
+    monkeypatch, tmp_path,
+):
+    """The #702 probe fake stays strict: anything beyond the ls-remote
+    and PR-list traffic it exists for fails the fake (the delivery
+    closeout must not silently grow other commands)."""
+    _, _, fake_run = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path, pr_states=[],
+    )
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
+
+
+def test_deliver_pr_non_rejection_push_failure_skips_the_probe(
+    monkeypatch, tmp_path,
+):
+    """A push failure that is NOT a `(fetch first)` rejection (e.g. an
+    authentication error) is not a concurrent-delivery signal: no probe
+    runs and the original error propagates unchanged."""
+    worktree = tmp_path / "wt"
+    worktree.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        runner, "fetch_base_ref", lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        runner, "_is_ancestor", lambda *args, **kwargs: True,
+    )
+
+    def fake_push(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            128, command,
+            output="",
+            stderr="ERROR: Permission to xqliu/orbi.git denied to "
+                   "deploy-key.",
+        )
+
+    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    probes = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["git", "ls-remote"]:
+            raise AssertionError("no probe expected: non-rejection push "
+                                 "failure is not a concurrent delivery")
+        if command == ["git", "branch", "--show-current"]:
+            return BRANCH
+        if command == ["git", "status", "--porcelain"]:
+            return ""
+        if command == ["git", "rev-parse", "HEAD"]:
+            return "b" * 40
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(subprocess.CalledProcessError):
+        runner.deliver_pr(
+            worktree, BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+    assert probes == []
+    # Direct drivers for the guards the delivery never reaches: a
+    # non-rejection failure must not probe, and nothing else runs.
+    with pytest.raises(AssertionError, match="no probe expected"):
+        fake_run(["git", "ls-remote", "--heads", "origin",
+                  f"refs/heads/{BRANCH}"])
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["gh", "release", "list"])
+
+
+def test_superseding_delivery_pr_returns_none_without_a_remote_branch(
+    monkeypatch, tmp_path,
+):
+    """Issue #702: no remote branch, no superseding PR — the helper
+    answers None without querying the PR list."""
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: "" if command[:2] == ["git", "ls-remote"]
+        else (_ for _ in ()).throw(AssertionError("no probe expected")),
+    )
+    assert runner._superseding_delivery_pr(tmp_path, BRANCH) is None
+
+
+def test_superseding_delivery_pr_rejects_a_malformed_pr_payload(
+    monkeypatch, tmp_path,
+):
+    """A non-array PR answer is a contract violation: fail fast, never
+    guess (the probe's caller re-raises the original push error)."""
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: (
+            f"{REMOTE_HEAD}\trefs/heads/{BRANCH}"
+            if command[:2] == ["git", "ls-remote"] else json.dumps({"x": 1})
+        ),
+    )
+    with pytest.raises(ValueError, match="pr list must return an array"):
+        runner._superseding_delivery_pr(tmp_path, BRANCH)
+
+
+def test_live_labels_fails_fast_on_a_malformed_payload(
+    monkeypatch, tmp_path,
+):
+    """`gh issue view` answers that violate the JSON contract fail fast:
+    a non-object payload, and an object whose labels field is not an
+    array — the claim check never guesses."""
+    def fake_run(command, **kwargs):
+        return "[]"
+
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    with pytest.raises(ValueError, match="issue view must be a JSON object"):
+        runner.live_labels(4, "owner/repo")
+
+    def fake_run_labels(command, **kwargs):
+        return json.dumps({"labels": "ai-ready"})
+
+    monkeypatch.setattr(runner, "run_command", fake_run_labels)
+    with pytest.raises(ValueError, match="issue labels must be a JSON array"):
+        runner.live_labels(4, "owner/repo")
+
+
+def test_deliver_pr_superseded_probe_waits_inside_the_push_pr_window(
+    monkeypatch, tmp_path,
+):
+    """Issue #702: the winning run can still be inside its push →
+    PR-create gap when the loser's push is rejected. The probe retries
+    (bounded) before giving up: the second probe finds the PR and the
+    delivery is classified superseded, not failed."""
+    sleeps: list = []
+    pr_queries, _, _ = _deliver_pr_rejection_setup(
+        monkeypatch, tmp_path,
+        pr_states=[
+            [],
+            [{"number": 32, "state": "OPEN",
+              "url": "https://github.com/xqliu/orbi/pull/32",
+              "headRefOid": REMOTE_HEAD}],
+        ],
+        sleeps=sleeps,
+    )
+    with pytest.raises(runner.DeliverySupersededError) as excinfo:
+        runner.deliver_pr(
+            tmp_path / "wt", BRANCH, "main", "a" * 40, "ffffeeee",
+            issue=4, issue_title="Fix", repo_dir=tmp_path,
+        )
+    assert excinfo.value.pr_url == "https://github.com/xqliu/orbi/pull/32"
+    assert len(pr_queries) == 2
+    assert sleeps == [runner.SUPERSEDED_PR_PROBE_SECONDS]
+
+
+def test_process_issue_superseded_delivery_never_blocks(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #702 acceptance: even when the claim race let two runs
+    deliver, the run that LOSES the push race must not mark the Issue
+    `ai-blocked`. The handler leaves the delivery labels exactly as the
+    winning run set them, posts a run-marked explanation, cleans this
+    run's worktree (the resume machinery must never resurrect the dead
+    delivery) and ends the tick with the `superseded` outcome."""
+    gh_calls, posted, worktree, comment_bodies = _resume_wiring_setup(
+        monkeypatch, tmp_path, in_progress=False,
+    )
+    edits: list = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append(kwargs),
+    )
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+
+    def superseded_deliver_pr(*args, **kwargs):
+        raise runner.DeliverySupersededError(
+            "https://github.com/orbi-build/orbi/pull/32",
+        )
+
+    monkeypatch.setattr(runner, "deliver_pr", superseded_deliver_pr)
+    cleaned = []
+    monkeypatch.setattr(
+        runner, "cleanup_task_worktree",
+        lambda *args, **kwargs: cleaned.append(kwargs),
+    )
+    caplog.set_level("INFO")
+    result = runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/orbi-backlog",
+    )
+    assert result.kind == "superseded"
+    assert result.url == "https://github.com/orbi-build/orbi/pull/32"
+    # The delivery states were never touched: only the claim patch ran.
+    # (The winning run's flow owns `ai-pr-opened` -> `ai-merged`.)
+    assert edits == [{"repo": "xqliu/orbi-backlog", "add": "ai-in-progress"}]
+    superseded_comments = [
+        body for body in comment_bodies
+        if "Orbi delivery superseded" in body
+    ]
+    assert len(superseded_comments) == 1
+    assert "https://github.com/orbi-build/orbi/pull/32" \
+        in superseded_comments[0]
+    assert "<!-- orbi:run=ffffeeee -->" in superseded_comments[0]
+    # This run's scene is cleaned so no tick ever resumes it.
+    assert cleaned == [
+        {"run_id": "ffffeeee", "issue": 4},
+    ]
+    assert "delivery_superseded pr=" in caplog.text
+
+
+def test_process_issue_superseded_comment_failure_is_a_bypass(
+    monkeypatch, tmp_path, caplog,
+):
+    """Issue #702: the superseded explanation comment is a bypass — its
+    failure is logged and the run still exits with the superseded
+    outcome, the worktree cleaned and the labels untouched."""
+    _resume_wiring_setup(monkeypatch, tmp_path, in_progress=False)
+    edits: list = []
+    monkeypatch.setattr(
+        runner, "edit_issue",
+        lambda *args, **kwargs: edits.append(kwargs),
+    )
+    monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
+
+    def superseded_deliver_pr(*args, **kwargs):
+        raise runner.DeliverySupersededError(
+            "https://github.com/orbi-build/orbi/pull/32",
+        )
+
+    monkeypatch.setattr(runner, "deliver_pr", superseded_deliver_pr)
+    monkeypatch.setattr(runner, "cleanup_task_worktree", lambda *a, **k: None)
+
+    def dead_comment(number, repo, body):
+        if "Orbi delivery superseded" in body:
+            raise RuntimeError("github comment failed")
+
+    monkeypatch.setattr(runner, "comment_issue", dead_comment)
+    caplog.set_level("INFO")
+    result = runner.process_issue(
+        {"number": 4, "title": "Fix", "body": "Body"},
+        {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+         "base_branch": "main"},
+        "xqliu/orbi-backlog",
+    )
+    assert result.kind == "superseded"
+    assert result.url == "https://github.com/orbi-build/orbi/pull/32"
+    assert "superseded_comment_failed" in caplog.text
+    assert edits == [{"repo": "xqliu/orbi-backlog", "add": "ai-in-progress"}]
 
 
 def test_process_issue_model_wait_dead_failure_stays_in_progress(
@@ -5559,6 +6138,10 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -5649,6 +6232,10 @@ def test_process_issue_model_wait_failure_records_health_attempt(
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5704,6 +6291,10 @@ def test_process_issue_three_recoverable_failures_raise_health_finding(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5754,6 +6345,10 @@ def test_process_issue_success_records_health_streak_break(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return "0123456789abcdef0123456789abcdef01234567"
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5814,6 +6409,10 @@ def test_process_issue_recoverable_health_record_failure_is_bypassed(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5863,6 +6462,10 @@ def test_process_issue_success_health_record_failure_is_bypassed(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return "0123456789abcdef0123456789abcdef01234567"
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -5931,6 +6534,10 @@ def test_process_issue_model_wait_dead_comment_failure_stays_in_progress(
             raise RuntimeError(
                 "gh issue comment failed: API rate limit exceeded",
             )
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -6000,6 +6607,10 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "api"]:
             return _gh_api(command, posted)
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
@@ -6076,6 +6687,10 @@ def test_process_issue_ends_cleanly_when_reporting_fails(monkeypatch, tmp_path, 
         if command[:3] == ["gh", "issue", "list"]:
             # Restart-resume scan (Issue #18): fresh claim, no label.
             return "[]"
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -6929,6 +7544,10 @@ def test_process_issue_failure_without_session_still_carries_scene(
         if command[:3] == ["git", "worktree", "prune"]:
             # Issue #256 terminal cleanup — not a delivery comment.
             return ""
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -7011,6 +7630,10 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
         if command[:3] == ["git", "worktree", "prune"]:
             # Issue #256 terminal cleanup — not a delivery comment.
             return ""
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -7063,6 +7686,10 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
         if command[:3] == ["git", "worktree", "prune"]:
             # Issue #256 terminal cleanup — not a delivery comment.
             return ""
+        if command[-1] == "labels" \
+                and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
@@ -15552,6 +16179,9 @@ def test_process_issue_keeps_normal_flow_without_release_label(
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
     monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(
+        runner, "live_labels", lambda number, repo: ["ai-ready"],
+    )
     monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
     monkeypatch.setattr(runner, "edit_issue", Mock())
     monkeypatch.setattr(runner, "set_active_run", Mock())
@@ -15599,6 +16229,9 @@ def _ops_issue_mocks(monkeypatch, tmp_path, *, head_sha: str, dirty: str):
     monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
     monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(
+        runner, "live_labels", lambda number, repo: ["ai-ready"],
+    )
     monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
     monkeypatch.setattr(runner, "edit_issue", Mock())
     monkeypatch.setattr(runner, "set_active_run", Mock())
@@ -17204,6 +17837,9 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                         lambda rid: state["run_ids"].append(rid))
     monkeypatch.setattr(release, "has_in_progress_label",
                         lambda n, r: in_progress)
+    monkeypatch.setattr(
+        runner, "live_labels", lambda number, repo: ["ai-ready"],
+    )
     monkeypatch.setattr(release, "latest_run_id",
                         lambda r, s, n: existing_run_id)
     monkeypatch.setattr(release, "freeze_base", lambda r, b: "abc123")

--- a/tests/test_concurrency_e2e.py
+++ b/tests/test_concurrency_e2e.py
@@ -129,6 +129,17 @@ elif args[:2] == ["issue", "view"]:
             {"body": state["issues"][num].get("body", "")}
         ))
     elif args[-1] == "labels":
+        # Issue #702 race injection: an armed hook models the rival
+        # runner's claim landing EXACTLY when this runner re-reads the
+        # labels live at claim time — the constructed concurrent
+        # trigger the acceptance criteria demand.
+        hook = state.get("claim_race_hook")
+        if (hook and hook.get("armed")
+                and str(hook.get("issue")) == num):
+            if hook["label"] not in state["issues"][num]["labels"]:
+                state["issues"][num]["labels"].append(hook["label"])
+            hook["armed"] = False
+            save()
         print(json.dumps({
             "labels": [
                 {"name": label}
@@ -1154,6 +1165,45 @@ def test_killed_runner_slot_is_released_by_the_kernel(clone, tmp_path):
     assert second.returncode == 0, err
     assert "capacity_full" not in err
     assert "no_ready_issue" in err
+    assert slots_held(clone) == [(1, None)], "slot must be released on exit"
+
+
+def test_concurrent_claim_rival_labels_are_seen_at_claim_time(
+    clone, tmp_path,
+):
+    """Issue #702 acceptance (constructed concurrent trigger): a second
+    trigger races the first run's claim — the ready scan's search index
+    still shows the Issue claimable (the fake gh's live state at scan
+    time), and the rival `ai-in-progress` lands EXACTLY at this runner's
+    claim-time live label re-read (the armed hook). The runner must lose
+    the race cleanly: no claim patch of its own (the labels stay the
+    rival's), no worktree, no Pi session, no progress comment, exit 0 —
+    never a second run on the claimed Issue."""
+    bin_dir = install_fakes(tmp_path)
+    state = tmp_path / "gh-state.json"
+    write_state(state, {"7": ["ai-ready"]})
+    armed = read_state(state)
+    armed["claim_race_hook"] = {
+        "issue": "7", "label": "ai-in-progress", "armed": True,
+    }
+    atomic_write_json(state, armed)
+    pi_log = tmp_path / "pi.log"
+    config = write_config(clone, tmp_path, 1)
+
+    loser = start_runner(config, bin_dir, state, pi_log)
+    out, err = loser.communicate(timeout=120)
+    assert loser.returncode == 0, err
+    assert "claim_race_lost issue=7" in err
+    # The rival claim is the only label state; this run added nothing.
+    final = read_state(state)
+    assert final["issues"]["7"]["labels"] == [
+        "ai-ready", "ai-in-progress",
+    ]
+    # No Pi session was ever started for the losing claim.
+    assert pi_invocations(pi_log) == []
+    # No worktree, no progress comment: the claim was lost, not run.
+    assert not (clone / ".worktrees").exists()
+    assert final["comments"] == []
     assert slots_held(clone) == [(1, None)], "slot must be released on exit"
 
 

--- a/tests/test_ops_e2e.py
+++ b/tests/test_ops_e2e.py
@@ -104,6 +104,11 @@ elif args[:2] == ["issue", "comment"]:
     state.setdefault("comments", []).append(
         {"issue": args[2], "body": args[args.index("--body") + 1]})
     save()
+elif args[:2] == ["issue", "view"] and args[-1] == "labels":
+    # The claim-time live label read (Issue #702).
+    print(json.dumps({"labels": [
+        {"name": label} for label in state["issues"][args[2]]["labels"]
+    ]}))
 elif args[:1] == ["api"]:
     if "--method" in args:
         method = args[args.index("--method") + 1]

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -47,6 +47,14 @@ def make_fake_gh(monkeypatch, comments=None, in_progress=False):
             return ""
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps([{"number": 18}] if in_progress else [])
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702): the labels
+            # match the `in_progress` scene this helper models.
+            return json.dumps({"labels": [
+                {"name": label}
+                for label in (["ai-ready", "ai-in-progress"]
+                              if in_progress else ["ai-ready"])
+            ]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
@@ -927,6 +935,9 @@ def make_failing_gh(monkeypatch, is_failing, comments=None):
             return ""
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run_command)
@@ -2043,6 +2054,10 @@ def _make_takeover_gh(monkeypatch, monkeypatched, tmp_path, *, pr_state="OPEN",
         calls.append(command)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702): the scanned
+            # issue carries `ai-ready` (fresh claimable).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         if command[:3] == ["gh", "pr", "list"]:
             return "[]"
         if command[:3] == ["gh", "pr", "view"]:

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -586,6 +586,9 @@ def test_process_issue_applies_repo_base_branch_and_records_sha(
     monkeypatch.setattr(
         runner, "has_in_progress_label", lambda number, repo: False,
     )
+    monkeypatch.setattr(
+        runner, "live_labels", lambda number, repo: ["ai-ready"],
+    )
     monkeypatch.setattr(runner, "open_pr_for_branch", lambda *a: None)
     monkeypatch.setattr(runner, "external_takeover_pr", lambda *a: None)
     monkeypatch.setattr(runner, "stable_branch_exists", lambda *a: False)
@@ -842,6 +845,9 @@ def test_process_issue_accepts_a_pre_resolved_record(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         runner, "has_in_progress_label", lambda number, repo: False,
+    )
+    monkeypatch.setattr(
+        runner, "live_labels", lambda number, repo: ["ai-ready"],
     )
     monkeypatch.setattr(runner, "open_pr_for_branch", lambda *a: None)
     monkeypatch.setattr(runner, "external_takeover_pr", lambda *a: None)

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -214,6 +214,12 @@ def install_fake_gh(monkeypatch, comments: list[str],
                             if "ai-in-progress" in labels[number]
                         ])
                     return "[]"
+                if command[2] == "view" and command[-1] == "labels":
+                    # The claim-time live label read (Issue #702).
+                    number = int(command[3])
+                    return json.dumps({"labels": [
+                        {"name": label} for label in labels.get(number, [])
+                    ]})
             if command[1] == "api":
                 if "--method" in command:
                     method = command[command.index("--method") + 1]

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -186,7 +186,10 @@ def install_fake_gh(monkeypatch, comments: list[str],
     if pr is None:
         pr = {"state": "OPEN", "merged": False}
     if labels is None:
-        labels = ["ai-pr-opened"]
+        # A fresh-claimable Issue (Issue #702: the claim-time live label
+        # read must not see a delivery state) — the delivery states land
+        # here through the runner's own label edits.
+        labels = []
     real_run = runner.run_command
 
     def fake_run(command, **kwargs):
@@ -846,7 +849,7 @@ def test_e2e_pr_closed_while_fix_needed_removes_leftover_label(
     removed too, so the terminal state is `ai-blocked` alone."""
     comments: list[str] = []
     edits: list[list[str]] = []
-    labels = ["ai-pr-opened"]
+    labels: list[str] = []
     pr = {"state": "OPEN", "merged": False}
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
     install_fake_gh(

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -218,6 +218,16 @@ def install_fake_gh(monkeypatch, comments: list[str],
                             ])
                         return "[]"
                     return "[]"
+                if command[2] == "view" and command[-1] == "labels":
+                    # The claim-time live label read (Issue #702).
+                    number = int(command[3])
+                    return json.dumps({"labels": [
+                        {"name": label}
+                        for label in (
+                            labels.get(number, [])
+                            if labels is not None else []
+                        )
+                    ]})
             if command[1] == "api":
                 # The progress publisher (Issue #18) keeps the single
                 # per-run comment via gh api: list (GET), create (POST),

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -963,6 +963,9 @@ def test_process_issue_pickup_record_failure_is_bypass(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return "0123456789abcdef0123456789abcdef01234567"
 
     monkeypatch.setattr(runner, "run_command", fake_run)
@@ -1012,6 +1015,9 @@ def test_process_issue_failure_record_failure_is_bypass(
             return _gh_api(command, posted)
         if command[:3] == ["gh", "issue", "list"]:
             return "[]"
+        if command[-1] == "labels" and command[:3] == ["gh", "issue", "view"]:
+            # The claim-time live label read (Issue #702).
+            return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
     monkeypatch.setattr(runner, "run_command", fake_run)


### PR DESCRIPTION
<!-- orbi:run=8e5174bc -->

Fixes #702

并发认领竞态：同一 Issue 被两个 run 同时认领，后者 push 失败将已成功交付的票误标 ai-blocked (run_id=8e5174bc)
