### PR TITLE
release notes 把 NOT_PLANNED 关闭的票与未合并的 PR 当成已发布内容写进 changelog

### DIFF
--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -249,7 +249,11 @@ DAG, no priority numbers, no separate queues:
      gate that cannot be checked because of a real `gh` failure is a
      failed gate.
   4. Verify the scope item by item: `gh pr view` must report `MERGED`,
-     otherwise `gh issue view` must report `CLOSED`. Checkbox parsing
+     otherwise `gh issue view` must report `CLOSED` with `stateReason`
+     `COMPLETED` — a `NOT_PLANNED` closure (duplicate / won't fix) is
+     annotated in the Scope evidence as excluded and never enters the
+     Changelog, and a Changelog PR link is written only when its PR is
+     merged (Issue #707). Checkbox parsing
      is forbidden — every scope item is checked against the live API.
   5. Test acceptance is the CI-wait gate on the release commit: after
      the version bump the gates re-run against that exact commit

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -203,7 +203,10 @@ PR 验收时校验该关键词，缺失即 fail fast。
      PR、多少个、谁提的，与发版无关；滞留 PR 由交付循环自身的
      接管/对账机制处理。因真实 `gh` 失败而查不了的门禁算失败门禁。
   4. 逐项验证 scope：`gh pr view` 必须报告 `MERGED`，否则
-     `gh issue view` 必须报告 `CLOSED`。禁止解析复选框——每个 scope
+     `gh issue view` 必须报告 `CLOSED` 且 `stateReason` 为
+     `COMPLETED`——`NOT_PLANNED` 关闭（重复/不做）的票在 Scope 证据里
+     标注为排除、绝不进入 Changelog，Changelog 的 PR 链接只在 PR 已
+     合并时才写入（Issue #707）。禁止解析复选框——每个 scope
      项都对照 live API 检查。
   5. 测试验收就是 release commit 的 CI-wait 门：版本 bump 之后，门禁会对
      该 commit 重跑（步骤 3 的 `release_ci_wait_seconds` 等待），CI 红或

--- a/src/orbi/release.py
+++ b/src/orbi/release.py
@@ -277,7 +277,11 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
     error when the number is an Issue, verified against the live CLI)
     and, failing that, as an Issue (`gh issue view`). A PR must be
     `MERGED` and its merge commit must be an ancestor of the frozen
-    release commit; an Issue must be `CLOSED`. This ancestor check proves
+    release commit; an Issue must be `CLOSED` with `stateReason`
+    `COMPLETED` (Issue #707): a `NOT_PLANNED` closure (duplicate /
+    won't fix) is not a delivery — its evidence line visibly annotates
+    the exclusion instead of silently counting the ticket into the
+    release. This ancestor check proves
     the scoped PR is actually contained in the tag, rather than merely
     having been merged into some other branch. An item that is neither, a
     PR that is not merged/in the release base, or an Issue that is not
@@ -322,7 +326,7 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
         try:
             raw = run_command([
                 "gh", "issue", "view", str(number), "--repo", repo,
-                "--json", "number,state",
+                "--json", "number,state,stateReason",
             ])
         except subprocess.CalledProcessError as exc:
             if "Could not resolve to an Issue" not in (exc.stderr or ""):
@@ -338,7 +342,15 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
                 f"release scope Issue #{number} is not closed "
                 f"(state={state})"
             )
-        evidence.append(f"Issue #{number} closed")
+        if issue.get("stateReason") == "NOT_PLANNED":
+            # Issue #707: a NOT_PLANNED closure (duplicate / won't fix)
+            # is not released work — annotate the exclusion visibly
+            # instead of silently counting the ticket into the release.
+            evidence.append(
+                f"Issue #{number} closed (not planned, excluded)"
+            )
+        else:
+            evidence.append(f"Issue #{number} closed")
     return evidence
 
 
@@ -459,10 +471,15 @@ def build_release_changelog(repo: str, scope: list[int]) -> str:
     """Render deterministic readable notes from live scoped Issue evidence.
 
     The official ``gh issue view --json`` contract supplies each Issue's
-    title, body, URL, labels, and closing PR references.  A title is the
-    concise change description; when it is absent, the first non-empty body
-    line is usable summary evidence.  Missing or malformed evidence is an
-    unsafe release input and fails before a tag or Release is created.
+    title, body, URL, labels, stateReason, and closing PR references.  A
+    title is the concise change description; when it is absent, the first
+    non-empty body line is usable summary evidence.  A NOT_PLANNED-closed
+    Issue is not released work (Issue #707) — it is excluded from the
+    Changelog (the Scope evidence annotates the exclusion).  A closing
+    PR's link is written only when `gh pr view` reports the PR MERGED:
+    an unmerged PR never appears in the release notes.  Missing or
+    malformed evidence is an unsafe release input and fails before a tag
+    or Release is created.
     """
     grouped: dict[str, list[tuple[int, str]]] = {
         category: [] for category in RELEASE_CHANGELOG_CATEGORIES
@@ -470,9 +487,16 @@ def build_release_changelog(repo: str, scope: list[int]) -> str:
     for number in scope:
         raw = run_command([
             "gh", "issue", "view", str(number), "--repo", repo, "--json",
-            "number,title,body,url,labels,closedByPullRequestsReferences",
+            "number,title,body,url,labels,stateReason,"
+            "closedByPullRequestsReferences",
         ])
         item = json.loads(raw)
+        if item.get("stateReason") == "NOT_PLANNED":
+            LOGGER.info(
+                "release_changelog_issue_excluded number=%d "
+                "reason=NOT_PLANNED", number,
+            )
+            continue
         issue_url = item.get("url")
         issue_path = f"https://github.com/{repo}/issues/{number}"
         pull_path = f"https://github.com/{repo}/pull/{number}"
@@ -506,6 +530,18 @@ def build_release_changelog(repo: str, scope: list[int]) -> str:
                 raise ValueError(
                     f"release changelog Issue #{number} has malformed PR evidence"
                 )
+            # Issue #707: an unmerged PR is not released content — its
+            # link never enters the release notes.
+            pr_state = json.loads(run_command([
+                "gh", "pr", "view", str(pr_number), "--repo", repo,
+                "--json", "state",
+            ])).get("state")
+            if pr_state != "MERGED":
+                LOGGER.info(
+                    "release_changelog_pr_link_dropped issue=%d pr=%d "
+                    "state=%s", number, pr_number, pr_state,
+                )
+                continue
             links.append(f"[PR #{pr_number}]({pr_url})")
         grouped[release_changelog_category(item)].append(
             (number, f"- {summary} ({'; '.join(links)})")

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16092,7 +16092,8 @@ def test_process_issue_ops_with_uncommitted_leftovers_fails_fast(
     )
 
 
-def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):
+def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None,
+                  issue_reason_map=None):
     """Answer `gh pr view` / `gh issue view` for scope verification.
 
     `pr_state_map`: number -> (state, merge_commit_oid) for PRs; a
@@ -16100,9 +16101,12 @@ def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):
     "Could not resolve to a PullRequest" error).
     `issue_state_map`: number -> state for Issues; a number absent from
     BOTH maps is neither.
+    `issue_reason_map`: number -> stateReason for Issues (absent = the
+    null/legacy closure reason).
     """
     pr_state_map = pr_state_map or {}
     issue_state_map = issue_state_map or {}
+    issue_reason_map = issue_reason_map or {}
     calls = []
 
     def fake_run_command(command, **kwargs):
@@ -16133,7 +16137,10 @@ def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None):
                         f"the number of {number}."
                     ),
                 )
-            return json.dumps({"number": number, "state": issue_state_map[number]})
+            return json.dumps({
+                "number": number, "state": issue_state_map[number],
+                "stateReason": issue_reason_map.get(number),
+            })
         if command[:3] == ["git", "merge-base", "--is-ancestor"]:
             return ""
         raise AssertionError(f"unexpected command: {command}")
@@ -16153,6 +16160,26 @@ def test_verify_release_scope_evidence_for_pr_and_issue(monkeypatch):
     assert evidence == [
         "PR #123 merged (mergeCommit=aaa111)",
         "Issue #124 closed",
+    ]
+
+
+def test_verify_release_scope_annotates_not_planned_and_counts_completed(
+        monkeypatch):
+    """Issue #707: a CLOSED Issue counts as released only when its
+    stateReason is COMPLETED; a NOT_PLANNED closure (duplicate / won't
+    fix) is never a delivery — the Scope evidence annotates it as
+    excluded instead of silently counting it in."""
+    make_scope_gh(
+        monkeypatch,
+        issue_state_map={124: "CLOSED", 125: "CLOSED"},
+        issue_reason_map={124: "COMPLETED", 125: "NOT_PLANNED"},
+    )
+    evidence = release.verify_release_scope(
+        "o/r", [124, 125], Path("/repo"), "release123",
+    )
+    assert evidence == [
+        "Issue #124 closed",
+        "Issue #125 closed (not planned, excluded)",
     ]
 
 
@@ -17318,7 +17345,11 @@ def test_build_release_changelog_groups_descriptions_links_and_orders(monkeypatc
     }
 
     def fake_run_command(command, **kwargs):
-        assert command[:3] == ["gh", "issue", "view"]
+        # Issue #707: every closedBy PR link is merged-checked before it
+        # is written; this test's PRs are all merged.
+        if command[:3] == ["gh", "pr", "view"]:
+            return json.dumps({"number": int(command[3]), "state": "MERGED"})
+        assert command[:3] == ["gh", "issue", "view"], command
         return json.dumps(source[int(command[3])])
 
     monkeypatch.setattr(release, "run_command", fake_run_command)
@@ -17337,6 +17368,65 @@ def test_build_release_changelog_groups_descriptions_links_and_orders(monkeypatc
 ### Documentation
 
 - Explain the full setup workflow ([Issue #20](https://github.com/o/r/issues/20))"""
+
+
+def test_build_release_changelog_skips_not_planned_issues(monkeypatch):
+    """Issue #707 (the v0.4.6 scene): #702 was closed NOT_PLANNED as a
+    duplicate — it must not enter the Changelog, and its unmerged
+    closedBy PR (#705) must not leak in through any entry."""
+    item = {
+        "number": 702, "title": "Duplicate delivery ticket",
+        "body": "Duplicate of #658",
+        "url": "https://github.com/o/r/issues/702", "labels": [],
+        "stateReason": "NOT_PLANNED",
+        "closedByPullRequestsReferences": [{
+            "number": 705, "url": "https://github.com/o/r/pull/705",
+        }],
+    }
+
+    def fake_run_command(command, **kwargs):
+        # Any second command (e.g. a pr view) would fail this assert: a
+        # NOT_PLANNED issue is skipped before its closedBy PRs are read.
+        assert command[:3] == ["gh", "issue", "view"], command
+        return json.dumps(item)
+
+    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    changelog = release.build_release_changelog("o/r", [702])
+    assert "#702" not in changelog
+    assert "#705" not in changelog
+    assert "Duplicate delivery ticket" not in changelog
+
+
+def test_build_release_changelog_omits_unmerged_pr_links(monkeypatch):
+    """Issue #707: a closedBy PR link is written only when the PR is
+    actually MERGED — an OPEN PR never appears in the release notes."""
+    source = {
+        10: {
+            "number": 10, "title": "Ship the claim-race fix",
+            "body": "detail",
+            "url": "https://github.com/o/r/issues/10", "labels": [],
+            "stateReason": "COMPLETED",
+            "closedByPullRequestsReferences": [
+                {"number": 11, "url": "https://github.com/o/r/pull/11"},
+                {"number": 705, "url": "https://github.com/o/r/pull/705"},
+            ],
+        },
+    }
+    pr_states = {11: "MERGED", 705: "OPEN"}
+
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "pr", "view"]:
+            number = int(command[3])
+            return json.dumps({"number": number, "state": pr_states[number]})
+        assert command[:3] == ["gh", "issue", "view"], command
+        return json.dumps(source[int(command[3])])
+
+    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    changelog = release.build_release_changelog("o/r", [10])
+    assert "[PR #11](https://github.com/o/r/pull/11)" in changelog
+    assert "#705" not in changelog
 
 
 def test_release_changelog_category_covers_reliability_bug_and_features():
@@ -17511,8 +17601,11 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             if fields == "comments":
                 return json.dumps({"comments": []})
             number = int(command[3])
-            if fields == "number,state" and number == 124:
-                return json.dumps({"number": 124, "state": "CLOSED"})
+            if fields == "number,state,stateReason" and number == 124:
+                return json.dumps({
+                    "number": 124, "state": "CLOSED",
+                    "stateReason": "COMPLETED",
+                })
             if fields.startswith("number,title,") and number in (123, 124):
                 return json.dumps({
                     "number": number,
@@ -17520,6 +17613,7 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                     "body": "Concrete release behavior.",
                     "url": f"https://github.com/o/r/issues/{number}",
                     "labels": [],
+                    "stateReason": "COMPLETED",
                     "closedByPullRequestsReferences": [],
                 })
             raise subprocess.CalledProcessError(


### PR DESCRIPTION
<!-- orbi:run=08ff8dbf -->

Fixes #707

release notes 把 NOT_PLANNED 关闭的票与未合并的 PR 当成已发布内容写进 changelog (run_id=08ff8dbf)
