### PR TITLE
CI triage 只要下次变绿就关票，不检查是否真被修过——同一指纹已循环 7 次

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -3,7 +3,9 @@
 # `bug` + `p0` + `ai-ready` Issue per failed job — the Orbi ready queue picks
 # it up and delivers the fix through its normal single-Issue / single-PR /
 # independent-review contract. When CI recovers, the matching Issue gets the
-# recovery run evidence and is closed.
+# recovery run evidence and is closed only with fix evidence — a different
+# head commit, or a closing reference to the Issue on the run's PR; a green
+# re-run of the same commit keeps the Issue open (Issue #715).
 #
 # Runtime contract (verified against the official docs and the live API):
 # `on: workflow_run` reacts ONLY to completed runs of the named validation

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -30,6 +30,12 @@ SCRIPT = REPO_ROOT / "tools" / "ci_failure_triage.py"
 
 OWNER_REPO = "orbi-run/test-repo"
 HEAD_SHA = "abc123def456abc123def456abc123de"
+# Full-length SHAs (the real REST shape) for the Issue #715 recovery-guard
+# scenarios: the guard parses recorded `- commit:` lines and compares them
+# with the recovery run's head SHA.
+FAILURE_SHA = "1111111111111111111111111111111111111111"
+RECURRENCE_SHA = "2222222222222222222222222222222222222222"
+FIX_SHA = "3333333333333333333333333333333333333333"
 RUN_URL = "https://github.com/orbi-run/test-repo/actions/runs/42"
 JOB_URL = "https://github.com/orbi-run/test-repo/actions/runs/42/job/9"
 TRIGGERED_AT = "2026-09-05T05:12:11Z"
@@ -119,6 +125,10 @@ def ep_comment(number):
     return f"repos/{OWNER_REPO}/issues/{number}/comments"
 
 
+def ep_issue_comments(number):
+    return f"repos/{OWNER_REPO}/issues/{number}/comments?per_page=100"
+
+
 def ep_patch(number):
     return f"repos/{OWNER_REPO}/issues/{number}"
 
@@ -167,6 +177,19 @@ def triage_issue(number: int, fingerprints: list[str], state="open") -> dict:
     """An Issue as the REST list endpoint returns it (auto-created shape)."""
     body = "CI failure body\n" + "\n".join(marker(fp) for fp in fingerprints)
     return {"number": number, "state": state, "body": body, "title": "CI failure"}
+
+
+def recorded_issue(number: int, fingerprint_value: str, failure_run: dict) -> dict:
+    """An Issue whose body is EXACTLY what `build_failure_body` writes for
+    the failure run — including the `- commit:` line the recovery guard
+    parses (Issue #715)."""
+    body = mod.build_failure_body(failure_run, job(), None, fingerprint_value)
+    return {"number": number, "state": "open", "body": body, "title": "CI failure"}
+
+
+def recovery_event(head_sha, run_id=43, **over) -> dict:
+    """A successful monitored run at `head_sha` (the recovery guard input)."""
+    return run_event(conclusion="success", id=run_id, head_sha=head_sha, **over)
 
 
 def write_event(monkeypatch, tmp_path, payload):
@@ -807,6 +830,7 @@ def test_recovery_closes_the_matching_issue_with_run_evidence(
         "total_count": 1, "jobs": [job(conclusion="success")],
     }
     gh.routes[ep_issues_list()] = [triage_issue(7, [fp])]
+    gh.routes[ep_issue_comments(7)] = []
     mod.main()
     comments = gh.calls_to(ep_comment(7), "POST")
     assert len(comments) == 1
@@ -846,6 +870,255 @@ def test_recovery_only_considers_succeeded_jobs(gh, monkeypatch, tmp_path):
     mod.main()
     assert gh.calls_to(ep_patch(7), "PATCH") == []
     assert gh.calls_to(ep_comment(7), "POST") == []
+
+
+# ---------------------------------------------------------------------------
+# Recovery guard (Issue #715): a close needs real fix evidence
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_same_head_sha_keeps_the_issue_open(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """Acceptance (Issue #715): a green RE-RUN of the exact commit that
+    failed is a flaky pass, not a fix — the recovery evidence is appended
+    and the Issue stays open."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FAILURE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FAILURE_SHA)] = []
+    mod.main()
+    comments = gh.calls_to(ep_comment(7), "POST")
+    assert len(comments) == 1
+    body = comments[0]["payload"]["body"]
+    assert "CI recovered" in body
+    assert "Closing as completed" not in body
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    err = capsys.readouterr().err
+    assert "recovery_unverified issue=7" in err
+    assert "reason=same_head_sha" in err
+
+
+def test_recovery_after_n_recurrences_same_sha_keeps_the_issue_open(
+    gh, monkeypatch, tmp_path
+):
+    """Acceptance (Issue #715, Nth recurrence): failure at FAILURE_SHA (body),
+    recurrences at FAILURE_SHA and RECURRENCE_SHA (comments), then a green
+    re-run of RECURRENCE_SHA — the recovery run's SHA matches the LATEST
+    recorded failure, so the Issue must stay open. Only comments carrying
+    the re-occurrence prefix are failure evidence."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(RECURRENCE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = [
+        {"body": mod.build_reoccurrence_comment(
+            run_event(head_sha=FAILURE_SHA, run_attempt=2)["workflow_run"], job(),
+        )},
+        {"body": mod.build_reoccurrence_comment(
+            run_event(head_sha=RECURRENCE_SHA, run_attempt=3)["workflow_run"], job(),
+        )},
+        {"body": "a human comment mentioning - commit: `c0ffee` offline"},
+        {"body": mod.build_recovery_comment(
+            recovery_event(RECURRENCE_SHA)["workflow_run"], job(), closing=False,
+        )},
+    ]
+    gh.routes[ep_pulls(RECURRENCE_SHA)] = []
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert len(gh.calls_to(ep_comment(7), "POST")) == 1
+
+
+def test_recovery_new_head_sha_still_closes(gh, monkeypatch, tmp_path, capsys):
+    """A recovery run on a different head commit carries the fix evidence:
+    the Issue is closed exactly as before (Issue #715 leaves this path
+    unchanged), and no PR resolution is spent once the SHA check verified."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FIX_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    mod.main()
+    body = gh.calls_to(ep_comment(7), "POST")[0]["payload"]["body"]
+    assert "Closing as completed" in body
+    patches = gh.calls_to(ep_patch(7), "PATCH")
+    assert len(patches) == 1
+    assert patches[0]["payload"] == {"state": "closed", "state_reason": "completed"}
+    assert "ci_triage recovered issue=7" in capsys.readouterr().err
+    assert gh.calls_to(ep_pulls(FIX_SHA), "GET") == []
+
+
+def test_recovery_same_head_sha_with_closing_reference_closes(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """Acceptance (Issue #715): even on the same head SHA, an associated PR
+    body carrying `Fixes #N` for THIS Issue still closes it (behavior
+    unchanged for real fix deliveries)."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FAILURE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FAILURE_SHA)] = [{"number": 328}]
+    gh.routes[ep_pr()] = {"number": 328, "body": "Fixes #7"}
+    mod.main()
+    patches = gh.calls_to(ep_patch(7), "PATCH")
+    assert len(patches) == 1
+    assert patches[0]["payload"] == {"state": "closed", "state_reason": "completed"}
+    assert "ci_triage recovered issue=7" in capsys.readouterr().err
+
+
+def test_recovery_same_head_sha_reference_to_another_issue_keeps_open(
+    gh, monkeypatch, tmp_path
+):
+    """The closing reference must name THIS Issue, not another one."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FAILURE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FAILURE_SHA)] = [{"number": 328}]
+    gh.routes[ep_pr()] = {"number": 328, "body": "Fixes #999"}
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert len(gh.calls_to(ep_comment(7), "POST")) == 1
+
+
+def test_recovery_same_head_sha_without_associated_pr_keeps_open(
+    gh, monkeypatch, tmp_path
+):
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FAILURE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FAILURE_SHA)] = []
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert gh.calls_to(ep_pr(), "GET") == []
+
+
+def test_recovery_same_head_sha_pr_without_body_keeps_open(
+    gh, monkeypatch, tmp_path
+):
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FAILURE_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FAILURE_SHA)] = [{"number": 328}]
+    gh.routes[ep_pr()] = {"number": 328}
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+
+
+def test_recovery_run_without_head_sha_keeps_the_issue_open(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """No head SHA means no comparable fix evidence: comment only, and no
+    PR resolution call is spent."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(None))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert not any(
+        call["endpoint"].startswith(f"repos/{OWNER_REPO}/commits/")
+        for call in gh.calls
+    )
+    err = capsys.readouterr().err
+    assert "recovery_unverified issue=7" in err
+    assert "reason=no_head_sha" in err
+
+
+def test_recorded_failure_shas_uses_body_and_reoccurrence_comments_only():
+    """The failure evidence set: the body's `- commit:` line plus the
+    `- commit:` line of every RE-OCCURRENCE comment. Recovery comments and
+    unprefixed comments never count as failure evidence (Issue #715)."""
+    body = f"evidence\n- commit: `{FAILURE_SHA}`\n"
+    comments = [
+        mod.build_reoccurrence_comment(
+            run_event(head_sha=RECURRENCE_SHA)["workflow_run"], job(),
+        ),
+        mod.build_recovery_comment(
+            recovery_event(FAILURE_SHA)["workflow_run"], job(), closing=False,
+        ),
+        f"a plain comment quoting - commit: `{FIX_SHA}` offline",
+    ]
+    assert mod.recorded_failure_shas(body, comments) == {FAILURE_SHA, RECURRENCE_SHA}
+
+
+def test_recovery_comment_tail_reflects_the_closing_decision():
+    run = recovery_event(FAILURE_SHA)["workflow_run"]
+    closing = mod.build_recovery_comment(run, job(), closing=True)
+    kept_open = mod.build_recovery_comment(run, job(), closing=False)
+    assert "Closing as completed" in closing
+    assert "Closing as completed" not in kept_open
+    assert "CI recovered" in kept_open
+    assert f"- commit: `{FAILURE_SHA}`" in kept_open
+    assert "Not closing" in kept_open
+
+
+def test_fetch_issue_comments_returns_comment_bodies_only(gh):
+    gh.routes[ep_issue_comments(7)] = [
+        {"body": "one"},
+        {"id": 2},   # no body
+        "junk",      # not an object
+    ]
+    assert mod.fetch_issue_comments("orbi-run", "test-repo", 7) == ["one"]
+
+
+def test_recovery_comments_api_malformed_response_fails_fast(
+    gh, monkeypatch, tmp_path
+):
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FIX_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = {"unexpected": "object"}
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+    assert exc.value.code == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -19,7 +19,12 @@ gh 2.97):
   existing Issue instead of creating a second one.
 - A monitored run concluded `success`: every SUCCEEDED job's fingerprint is
   matched against the open triage Issues; a match gets the recovery run
-  evidence as a comment and is closed (`state_reason: completed`).
+  evidence as a comment. It is closed (`state_reason: completed`) only with
+  fix evidence — the recovery run's head SHA differs from every failure SHA
+  recorded on the Issue (body + re-occurrence comments), or the run's
+  associated PR body carries a closing reference to it. A green re-run of
+  the SAME commit that failed is a flaky pass, not a fix (Issue #715): the
+  comment is appended and the Issue stays open.
 - Anything else (another workflow, another event, a push off `main`, any
   other conclusion) is a logged no-op with exit 0.
 
@@ -88,6 +93,13 @@ EXTERNAL_PR_MARKER = "orbi:external-pr:"
 EXTERNAL_PR_RE = re.compile(
     r"<!--\s*" + re.escape(EXTERNAL_PR_MARKER) + r"(\d+)\s*-->"
 )
+# Issue #715: the recovery guard's failure-evidence markers. The `- commit:`
+# line is written by `build_failure_body` (the Issue body) and by
+# `build_reoccurrence_comment` (one comment per re-occurrence); only comments
+# starting with REOCCURRENCE_PREFIX are failure evidence — a recovery comment
+# records the recovery run's SHA, which must never count as a failure.
+REOCCURRENCE_PREFIX = "CI failure re-occurred"
+COMMIT_LINE_RE = re.compile(r"- commit: `([0-9a-f]{40})`")
 
 
 class GhApiError(Exception):
@@ -174,6 +186,19 @@ def issue_fingerprints(body: str) -> list[str]:
         if value not in seen:
             seen.append(value)
     return seen
+
+
+def recorded_failure_shas(body: str, comments: list[str]) -> set[str]:
+    """Every failure head SHA recorded on an Issue (Issue #715).
+
+    The body's `- commit:` line plus the `- commit:` line of each
+    re-occurrence comment; other comments never carry failure evidence.
+    """
+    shas = set(COMMIT_LINE_RE.findall(body))
+    for comment in comments:
+        if comment.startswith(REOCCURRENCE_PREFIX):
+            shas.update(COMMIT_LINE_RE.findall(comment))
+    return shas
 
 
 def triage_scope(run: dict) -> tuple[str, str]:
@@ -326,9 +351,11 @@ def build_failure_body(
         "",
         "### Dedup and recovery",
         "A re-run of the same failure (same workflow/job/branch fingerprint)",
-        "updates this Issue instead of creating a new one; when a later",
-        "successful CI run of the same workflow/job/branch matches, this",
-        "Issue is closed as completed with the recovery run evidence.",
+        "updates this Issue instead of creating a new one. A later successful",
+        "run of the same workflow/job/branch closes this Issue only with fix",
+        "evidence: a different head commit, or a closing reference to this",
+        "Issue on its PR (Issue #715) — a green re-run of the same commit is",
+        "recorded as recovery evidence while this Issue stays open.",
         "",
     ]
     if external_pr is not None:
@@ -342,7 +369,7 @@ def build_failure_body(
 def build_reoccurrence_comment(run: dict, job: dict) -> str:
     """The evidence appended to an existing target when the failure repeats."""
     return "\n".join([
-        f"CI failure re-occurred (job `{job['name']}`, same fingerprint):",
+        f"{REOCCURRENCE_PREFIX} (job `{job['name']}`, same fingerprint):",
         "",
         f"- workflow: `{CI_WORKFLOW_NAME}` (`{CI_WORKFLOW_PATH}`)",
         f"- event: `{run.get('event')}`",
@@ -359,9 +386,13 @@ def build_reoccurrence_comment(run: dict, job: dict) -> str:
     ])
 
 
-def build_recovery_comment(run: dict, job: dict) -> str:
-    """The recovery evidence appended before the Issue is closed."""
-    return "\n".join([
+def build_recovery_comment(run: dict, job: dict, *, closing: bool) -> str:
+    """The recovery evidence appended to the matched Issue.
+
+    `closing=False` records the same-commit flaky-pass verdict and keeps the
+    Issue open (Issue #715).
+    """
+    lines = [
         f"CI recovered: job `{job['name']}` passed with the same fingerprint:",
         "",
         f"- commit: `{run.get('head_sha')}`",
@@ -370,9 +401,21 @@ def build_recovery_comment(run: dict, job: dict) -> str:
         f"- run URL: {run.get('html_url')}",
         f"- triggered at: `{run.get('run_started_at')}`",
         "",
-        "Closing as completed (recovery verified by the `CI Failure Issue`"
-        " workflow, `.github/workflows/ci-failure-issue.yml`).",
-    ])
+    ]
+    if closing:
+        lines.append(
+            "Closing as completed (recovery verified by the `CI Failure Issue`"
+            " workflow, `.github/workflows/ci-failure-issue.yml`)."
+        )
+    else:
+        lines.append(
+            "Not closing: this recovery run used a head commit that previously"
+            " failed with this fingerprint and no closing reference"
+            " (`Fixes #N`) is associated with it — nothing was fixed; this"
+            " looks like a flaky pass. The Issue stays open for a real fix"
+            " (Issue #715)."
+        )
+    return "\n".join(lines)
 
 
 def resolve_pr_number(owner: str, repo: str, head_sha: str) -> int | None:
@@ -621,13 +664,54 @@ def triage_failure(run: dict, owner: str, repo: str, jobs: list) -> None:
             )
 
 
+def fetch_issue_comments(owner: str, repo: str, number: int) -> list[str]:
+    """The Issue's comments, their bodies only (verified shape: a list)."""
+    data = gh_api(
+        f"repos/{owner}/{repo}/issues/{number}/comments?per_page=100"
+    )
+    if not isinstance(data, list):
+        fail("fetch_issue_comments", f"comments API did not return a list: {data!r}")
+    return [
+        item["body"]
+        for item in data
+        if isinstance(item, dict) and isinstance(item.get("body"), str)
+    ]
+
+
+def recovery_closing_reference(
+    run: dict, owner: str, repo: str, issue_number: int,
+) -> bool:
+    """True when the recovery run's head commit resolves to a PR whose body
+    references the Issue with a GitHub closing keyword (`Fixes #N`) — the
+    same contract `active_source_issue` applies (Issue #715).
+
+    `run["head_sha"]` must be a usable string; the caller guards that.
+    """
+    pr_number = resolve_pr_number(owner, repo, run["head_sha"])
+    if pr_number is None:
+        return False
+    pull = fetch_pull_request(owner, repo, pr_number)
+    body = pull.get("body") if pull else None
+    if not isinstance(body, str):
+        return False
+    return issue_number in closing_issue_numbers(body, owner, repo)
+
+
 def triage_recovery(run: dict, owner: str, repo: str, jobs: list) -> None:
-    """Close the Issue of every succeeded job with the recovery evidence."""
+    """Close the Issue of every succeeded job with the recovery evidence.
+
+    Issue #715: a close needs fix evidence — the recovery run's head SHA
+    differs from every failure SHA recorded on the Issue (body + re-occurrence
+    comments), or the run's associated PR body carries a closing reference to
+    it. A green re-run of the same commit that failed is a flaky pass: the
+    recovery evidence is appended and the Issue stays open.
+    """
     succeeded = jobs_with_conclusion(jobs, (SUCCESS_CONCLUSION,))
     if not succeeded:
         log(f"ignored reason=no_succeeded_jobs run_id={run.get('id')}")
         return
     index = index_open_issues(owner, repo)
+    recovery_sha = run.get("head_sha")
     for item in succeeded:
         value = fingerprint(
             run.get("event"), run.get("head_branch", ""), item["name"],
@@ -637,14 +721,35 @@ def triage_recovery(run: dict, owner: str, repo: str, jobs: list) -> None:
         if match is None:
             log(f"recovery_no_match job={item['name']} run_id={run.get('id')}")
             continue
+        number = match["number"]
+        failure_shas = recorded_failure_shas(
+            match["body"],
+            fetch_issue_comments(owner, repo, number),
+        )
+        if not isinstance(recovery_sha, str) or not recovery_sha:
+            verified = False
+            reason = "reason=no_head_sha"
+        elif recovery_sha not in failure_shas:
+            verified = True
+            reason = ""
+        else:
+            verified = recovery_closing_reference(run, owner, repo, number)
+            reason = "" if verified else "reason=same_head_sha"
         comment_issue(
-            owner, repo, match["number"], build_recovery_comment(run, item),
+            owner, repo, number,
+            build_recovery_comment(run, item, closing=verified),
         )
-        close_issue(owner, repo, match["number"])
-        log(
-            f"recovered issue={match['number']} job={item['name']}"
-            f" run_id={run.get('id')}"
-        )
+        if verified:
+            close_issue(owner, repo, number)
+            log(
+                f"recovered issue={number} job={item['name']}"
+                f" run_id={run.get('id')}"
+            )
+        else:
+            log(
+                f"recovery_unverified issue={number} job={item['name']}"
+                f" run_id={run.get('id')} {reason}"
+            )
 
 
 def main() -> None:


### PR DESCRIPTION
<!-- orbi:run=66b3ad00 -->

Fixes #715

CI triage 只要下次变绿就关票，不检查是否真被修过——同一指纹已循环 7 次 (run_id=66b3ad00)
