### PR TITLE
CI triage 的 recovery 守卫只看 head_sha 变没变，不看变化是否与该票相关——同指纹已循环 9 次

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -1,11 +1,13 @@
 # CI Failure Issue (Issue #106): when the CI workflow (`.github/workflows/
 # ci.yml`) fails on a pull_request or a push to main, file ONE deduplicated
 # `bug` + `p0` + `ai-ready` Issue per failed job — the Orbi ready queue picks
-# it up and delivers the fix through its normal single-Issue / single-PR /
-# independent-review contract. When CI recovers, the matching Issue gets the
-# recovery run evidence and is closed only with fix evidence — a different
-# head commit, or a closing reference to the Issue on the run's PR; a green
-# re-run of the same commit keeps the Issue open (Issue #715).
+# it up and delivers the fix through its normal single-Issue /
+# single-PR / independent-review contract. When CI recovers, the matching
+# Issue gets the recovery run evidence and is closed only with fix evidence
+# relevant to it — a closing reference to the Issue on the run's PR
+# (`Fixes #N`, Issue #715), or a diff since the latest recorded failure that
+# touches the failing test's file (Issue #718); a green re-run of the same
+# commit, or of any unrelated commit, keeps the Issue open.
 #
 # Runtime contract (verified against the official docs and the live API):
 # `on: workflow_run` reacts ONLY to completed runs of the named validation
@@ -18,7 +20,8 @@
 # and the jobs API response; no secret or token ever reaches it.
 #
 # Minimal permission set, declared explicitly: `actions: read` (read the
-# completed CI run's jobs), `contents: read` (check out the triage script),
+# completed CI run's jobs and the recorded failure job's log), `contents:
+# read` (check out the triage script),
 # `issues: write` (create/update/close the bug Issue), `pull-requests: read`
 # (the triage resolves a pull_request run's PR number via
 # `GET commits/{sha}/pulls`, whose documented fine-grained permission is

--- a/tests/test_ci_failure_triage.py
+++ b/tests/test_ci_failure_triage.py
@@ -14,7 +14,9 @@ layer, asserting the real GitHub REST contract:
 - the same fingerprint again → a re-occurrence comment on the existing Issue,
   never a second Issue (no storm);
 - `success` → the matching Issue gets the recovery run evidence and is closed
-  (`state_reason: completed`);
+  (`state_reason: completed`) ONLY with ticket-relevant fix evidence
+  (Issue #718): a closing reference (`Fixes #N`) on the run's PR, or a diff
+  since the latest recorded failure that touches the failing test's file;
 - every other conclusion/event/target is a logged no-op (exit 0);
 - every environment/API failure is a structured error + exit 1 (fail fast,
   never a fake success).
@@ -76,6 +78,16 @@ class FakeGh:
             raise AssertionError(f"unexpected gh api {method} {endpoint}")
         return self.routes[endpoint]
 
+    def text(self, endpoint):
+        """The raw (non-JSON) `gh_api_text` route: same route table, plain
+        string answers (the job-log endpoint)."""
+        self.calls.append({"endpoint": endpoint, "method": "GET", "payload": None})
+        if self.error is not None and endpoint.startswith(self.error[0]):
+            raise mod.GhApiError(endpoint, self.error[1])
+        if endpoint not in self.routes:
+            raise AssertionError(f"unexpected gh api GET {endpoint}")
+        return self.routes[endpoint]
+
     def calls_to(self, endpoint, method):
         return [
             call for call in self.calls
@@ -87,6 +99,12 @@ def test_fake_gh_rejects_unrouted_get_calls():
     fake = FakeGh()
     with pytest.raises(AssertionError, match="unexpected gh api GET repos/x"):
         fake("repos/x")
+
+
+def test_fake_gh_text_rejects_unrouted_log_calls():
+    fake = FakeGh()
+    with pytest.raises(AssertionError, match="unexpected gh api GET repos/x"):
+        fake.text("repos/x")
 
 
 def ep_jobs(run_id=42):
@@ -126,7 +144,18 @@ def ep_comment(number):
 
 
 def ep_issue_comments(number):
-    return f"repos/{OWNER_REPO}/issues/{number}/comments?per_page=100"
+    return (
+        f"repos/{OWNER_REPO}/issues/{number}/comments"
+        "?per_page=100&sort=created&direction=asc"
+    )
+
+
+def ep_log(job_id=9):
+    return f"repos/{OWNER_REPO}/actions/jobs/{job_id}/logs"
+
+
+def ep_compare(base, head):
+    return f"repos/{OWNER_REPO}/compare/{base}...{head}"
 
 
 def ep_patch(number):
@@ -200,9 +229,11 @@ def write_event(monkeypatch, tmp_path, payload):
 
 @pytest.fixture
 def gh(monkeypatch):
-    """Default environment; the returned FakeGh is installed as mod.gh_api."""
+    """Default environment; the returned FakeGh is installed as mod.gh_api
+    (JSON calls) AND mod.gh_api_text (the raw job-log call)."""
     fake = FakeGh()
     monkeypatch.setattr(mod, "gh_api", fake)
+    monkeypatch.setattr(mod, "gh_api_text", fake.text)
     monkeypatch.setenv("GITHUB_REPOSITORY", OWNER_REPO)
     return fake
 
@@ -822,15 +853,16 @@ def test_malformed_source_issue_response_is_not_an_active_source(gh):
 def test_recovery_closes_the_matching_issue_with_run_evidence(
     gh, monkeypatch, tmp_path, capsys
 ):
-    """Acceptance: after CI recovers, the matching bug Issue is associated
-    with the successful run and closed."""
-    write_event(monkeypatch, tmp_path, run_event(conclusion="success", id=43))
-    fp = mod.fingerprint("push", "main", "tests")
-    gh.routes[ep_jobs(43)] = {
-        "total_count": 1, "jobs": [job(conclusion="success")],
-    }
-    gh.routes[ep_issues_list()] = [triage_issue(7, [fp])]
-    gh.routes[ep_issue_comments(7)] = []
+    """Acceptance (Issue #718): after CI recovers, the matching bug Issue is
+    associated with the successful run and closed — but only because the
+    diff since the recorded failure TOUCHES the failing test's file."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.routes[ep_log()] = FAILED_TEST_LOG
+    gh.routes[ep_compare(FAILURE_SHA, FIX_SHA)] = {"files": [
+        {"filename": "docs/intro.mdx"},
+        {"filename": FAILED_TEST_FILE},
+        {"filename": "src/orbi/cli.py"},
+    ]}
     mod.main()
     comments = gh.calls_to(ep_comment(7), "POST")
     assert len(comments) == 1
@@ -838,7 +870,8 @@ def test_recovery_closes_the_matching_issue_with_run_evidence(
     assert "CI recovered" in body
     assert f"- run id: `43` (attempt 1), conclusion: `success`" in body
     assert f"- run URL: {RUN_URL}" in body
-    assert f"- commit: `{HEAD_SHA}`" in body
+    assert f"- commit: `{FIX_SHA}`" in body
+    assert "Closing as completed" in body
     patches = gh.calls_to(ep_patch(7), "PATCH")
     assert len(patches) == 1
     assert patches[0]["payload"] == {"state": "closed", "state_reason": "completed"}
@@ -873,8 +906,50 @@ def test_recovery_only_considers_succeeded_jobs(gh, monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Recovery guard (Issue #715): a close needs real fix evidence
+# Recovery guard (Issue #715 + #718): a close needs ticket-relevant fix
+# evidence
 # ---------------------------------------------------------------------------
+
+# Issue #718 evidence captured from the live repo: the failing test file of
+# the real #714 flaky failure (job log of run 34576656221, job 103190539333;
+# Actions timestamps prefix every line) and the REAL probed file list of the
+# unrelated `a2d5db7...8b4dfaf` diff (release notes + the triage guard
+# itself) that wrongly closed #714 the 9th time.
+FAILED_TEST_FILE = "tests/test_concurrency_e2e.py"
+FAILED_TEST_LOG = "\n".join([
+    "2026-09-11T08:01:10.1183155Z =================================== FAILURES"
+    " ===================================",
+    "2026-09-11T08:01:10.1229038Z =========================== short test summary info"
+    " ============================",
+    "2026-09-11T08:01:10.1230016Z FAILED tests/test_concurrency_e2e.py::"
+    "test_capacity_two_allows_two_runners_and_rejects_third"
+    " - AssertionError: timed out waiting for both runners to auto-merge"
+    " their PRs",
+    "2026-09-11T08:01:10.1230873Z 1 failed, 2379 passed in 330.14s (0:05:30)",
+])
+UNRELATED_DIFF_FILES = [
+    ".github/workflows/ci-failure-issue.yml",
+    "pyproject.toml",
+    "src/orbi/__init__.py",
+    "tests/test_ci_failure_triage.py",
+    "tools/ci_failure_triage.py",
+]
+
+
+def recovery_setup(gh, monkeypatch, tmp_path, *, head_sha):
+    """A recorded #715-style Issue (failure at FAILURE_SHA, job 9) plus the
+    routes for a successful recovery run at `head_sha`: no associated PR."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(head_sha))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(head_sha)] = []
+    return gh
 
 
 def test_recovery_same_head_sha_keeps_the_issue_open(
@@ -939,27 +1014,31 @@ def test_recovery_after_n_recurrences_same_sha_keeps_the_issue_open(
     assert len(gh.calls_to(ep_comment(7), "POST")) == 1
 
 
-def test_recovery_new_head_sha_still_closes(gh, monkeypatch, tmp_path, capsys):
-    """A recovery run on a different head commit carries the fix evidence:
-    the Issue is closed exactly as before (Issue #715 leaves this path
-    unchanged), and no PR resolution is spent once the SHA check verified."""
-    fp = mod.fingerprint("push", "main", "tests")
-    write_event(monkeypatch, tmp_path, recovery_event(FIX_SHA))
-    gh.routes[ep_jobs(43)] = {
-        "total_count": 1, "jobs": [job(conclusion="success")],
-    }
-    gh.routes[ep_issues_list()] = [
-        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
-    ]
-    gh.routes[ep_issue_comments(7)] = []
+def test_recovery_unrelated_new_head_sha_keeps_the_issue_open(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """Acceptance (Issue #718): a recovery run on a NEW head commit whose
+    diff does NOT touch the failing test's file is NOT fix evidence — the
+    recovery evidence is appended and the Issue stays open. The diff and
+    log fixtures are the REAL probed #714 scene: the `a2d5db7...8b4dfaf`
+    diff (release bump + the triage guard itself) wrongly closed #714 the
+    9th time; the recorded failure's job log names
+    `tests/test_concurrency_e2e.py`."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.routes[ep_log()] = FAILED_TEST_LOG
+    gh.routes[ep_compare(FAILURE_SHA, FIX_SHA)] = {"files": [
+        *[{"filename": name} for name in UNRELATED_DIFF_FILES],
+        "junk",           # malformed file entries are skipped, never crash
+        {"filename": 42},
+    ]}
     mod.main()
-    body = gh.calls_to(ep_comment(7), "POST")[0]["payload"]["body"]
-    assert "Closing as completed" in body
-    patches = gh.calls_to(ep_patch(7), "PATCH")
-    assert len(patches) == 1
-    assert patches[0]["payload"] == {"state": "closed", "state_reason": "completed"}
-    assert "ci_triage recovered issue=7" in capsys.readouterr().err
-    assert gh.calls_to(ep_pulls(FIX_SHA), "GET") == []
+    comments = gh.calls_to(ep_comment(7), "POST")
+    assert len(comments) == 1
+    assert "Not closing" in comments[0]["payload"]["body"]
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    err = capsys.readouterr().err
+    assert "recovery_unverified issue=7" in err
+    assert "reason=no_relevant_fix" in err
 
 
 def test_recovery_same_head_sha_with_closing_reference_closes(
@@ -1042,6 +1121,151 @@ def test_recovery_same_head_sha_pr_without_body_keeps_open(
     assert gh.calls_to(ep_patch(7), "PATCH") == []
 
 
+def test_recovery_new_head_sha_with_closing_reference_closes(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """Acceptance (Issue #718, #715 non-regression): `Fixes #N` closes the
+    Issue on a new head too — and the cheap reference check passes before
+    any log fetch or compare call is spent."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.routes[ep_pulls(FIX_SHA)] = [{"number": 328}]
+    gh.routes[ep_pr()] = {"number": 328, "body": "Fixes #7"}
+    mod.main()
+    patches = gh.calls_to(ep_patch(7), "PATCH")
+    assert len(patches) == 1
+    assert patches[0]["payload"] == {"state": "closed", "state_reason": "completed"}
+    assert "ci_triage recovered issue=7" in capsys.readouterr().err
+    assert not any(
+        call["endpoint"].startswith(f"repos/{OWNER_REPO}/actions/jobs/")
+        for call in gh.calls
+    )
+    assert not any(
+        call["endpoint"].startswith(f"repos/{OWNER_REPO}/compare/")
+        for call in gh.calls
+    )
+
+
+def test_recovery_after_n_recurrences_unrelated_head_keeps_open(
+    gh, monkeypatch, tmp_path
+):
+    """Acceptance (Issue #718, Nth recurrence): failure at FAILURE_SHA (body),
+    re-occurrences at FAILURE_SHA and RECURRENCE_SHA (comments), then a green
+    run at FIX_SHA. The relevance diff runs from the LATEST recorded failure
+    (RECURRENCE_SHA, the last re-occurrence comment) and its job log is the
+    evidence source; an unrelated diff keeps the Issue open. Only comments
+    carrying the re-occurrence prefix are failure evidence."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FIX_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [
+        recorded_issue(7, fp, run_event(head_sha=FAILURE_SHA)["workflow_run"])
+    ]
+    gh.routes[ep_issue_comments(7)] = [
+        {"body": mod.build_reoccurrence_comment(
+            run_event(head_sha=FAILURE_SHA, run_attempt=2)["workflow_run"], job(),
+        )},
+        {"body": mod.build_reoccurrence_comment(
+            run_event(head_sha=RECURRENCE_SHA, run_attempt=3)["workflow_run"], job(),
+        )},
+        {"body": mod.build_recovery_comment(
+            recovery_event(RECURRENCE_SHA)["workflow_run"], job(), closing=False,
+        )},
+        {"body": "a human comment linking "
+                 "https://github.com/orbi-run/test-repo/actions/runs/42/job/99"},
+    ]
+    gh.routes[ep_pulls(FIX_SHA)] = []
+    gh.routes[ep_log()] = FAILED_TEST_LOG
+    gh.routes[ep_compare(RECURRENCE_SHA, FIX_SHA)] = {
+        "files": [{"filename": "docs/intro.mdx"}]
+    }
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    compares = [
+        call["endpoint"] for call in gh.calls
+        if call["endpoint"].startswith(f"repos/{OWNER_REPO}/compare/")
+    ]
+    assert compares == [ep_compare(RECURRENCE_SHA, FIX_SHA)]
+
+
+def test_recovery_log_unavailable_keeps_issue_open_and_posts_evidence(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """Failure path (Issue #718): the recorded failure job's log is gone
+    (expired retention) — relevance is unverifiable, so the guard degrades
+    to no-close with a structured line while the recovery evidence comment
+    is still posted; the triage job itself stays green."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.error = (ep_log(), "HTTP 404 (Not Found)")
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert len(gh.calls_to(ep_comment(7), "POST")) == 1
+    err = capsys.readouterr().err
+    assert "recovery_log_unavailable" in err
+    assert "reason=no_relevant_fix" in err
+
+
+def test_recovery_log_without_failed_test_paths_keeps_open(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """A log with no `FAILED <path>.py` / `ERROR <path>.py` evidence (a
+    non-pytest failure) names no failing test file: relevance is
+    undecidable — no close, and the compare call is not spent."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.routes[ep_log()] = (
+        "2026-09-11T08:01:10.1230016Z ##[error]The docs build failed\n"
+        "2026-09-11T08:01:10.1230873Z ##[error]Process completed with exit code 1.\n"
+    )
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert not any(
+        call["endpoint"].startswith(f"repos/{OWNER_REPO}/compare/")
+        for call in gh.calls
+    )
+    err = capsys.readouterr().err
+    assert "reason=no_relevant_fix" in err
+    assert "no_failed_test_files" in err
+
+
+def test_recovery_new_head_without_recorded_failure_evidence_keeps_open(
+    gh, monkeypatch, tmp_path, capsys
+):
+    """An Issue body without recorded failure evidence (e.g. created before
+    the `- commit:` line existed) gives the relevance check no base: no
+    close, and no log/compare calls are spent."""
+    fp = mod.fingerprint("push", "main", "tests")
+    write_event(monkeypatch, tmp_path, recovery_event(FIX_SHA))
+    gh.routes[ep_jobs(43)] = {
+        "total_count": 1, "jobs": [job(conclusion="success")],
+    }
+    gh.routes[ep_issues_list()] = [triage_issue(7, [fp])]
+    gh.routes[ep_issue_comments(7)] = []
+    gh.routes[ep_pulls(FIX_SHA)] = []
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert not any(
+        call["endpoint"].startswith(f"repos/{OWNER_REPO}/actions/jobs/")
+        for call in gh.calls
+    )
+    err = capsys.readouterr().err
+    assert "reason=no_relevant_fix" in err
+    assert "no_failure_evidence" in err
+
+
+def test_recovery_malformed_compare_response_keeps_open(
+    gh, monkeypatch, tmp_path
+):
+    """A compare response without a usable files list is no evidence: the
+    Issue stays open (never a wrong close)."""
+    recovery_setup(gh, monkeypatch, tmp_path, head_sha=FIX_SHA)
+    gh.routes[ep_log()] = FAILED_TEST_LOG
+    gh.routes[ep_compare(FAILURE_SHA, FIX_SHA)] = ["not-an-object"]
+    mod.main()
+    assert gh.calls_to(ep_patch(7), "PATCH") == []
+    assert len(gh.calls_to(ep_comment(7), "POST")) == 1
+
+
 def test_recovery_run_without_head_sha_keeps_the_issue_open(
     gh, monkeypatch, tmp_path, capsys
 ):
@@ -1067,21 +1291,66 @@ def test_recovery_run_without_head_sha_keeps_the_issue_open(
     assert "reason=no_head_sha" in err
 
 
-def test_recorded_failure_shas_uses_body_and_reoccurrence_comments_only():
-    """The failure evidence set: the body's `- commit:` line plus the
-    `- commit:` line of every RE-OCCURRENCE comment. Recovery comments and
-    unprefixed comments never count as failure evidence (Issue #715)."""
-    body = f"evidence\n- commit: `{FAILURE_SHA}`\n"
+def test_recorded_failures_uses_body_and_reoccurrence_comments_only():
+    """The failure evidence list (Issue #718): the body first, then every
+    RE-OCCURRENCE comment in order. Recovery comments and unprefixed
+    comments never count as failure evidence (Issue #715 rule)."""
+    body = mod.build_failure_body(
+        run_event(head_sha=FAILURE_SHA)["workflow_run"], job(), None,
+        mod.fingerprint("push", "main", "tests"),
+    )
     comments = [
         mod.build_reoccurrence_comment(
-            run_event(head_sha=RECURRENCE_SHA)["workflow_run"], job(),
+            run_event(head_sha=FAILURE_SHA, run_attempt=2)["workflow_run"], job(),
+        ),
+        mod.build_reoccurrence_comment(
+            run_event(head_sha=RECURRENCE_SHA, run_attempt=3)["workflow_run"], job(),
         ),
         mod.build_recovery_comment(
             recovery_event(FAILURE_SHA)["workflow_run"], job(), closing=False,
         ),
-        f"a plain comment quoting - commit: `{FIX_SHA}` offline",
+        f"a plain comment quoting - commit: `{FIX_SHA}` and "
+        f"{JOB_URL} offline",
     ]
-    assert mod.recorded_failure_shas(body, comments) == {FAILURE_SHA, RECURRENCE_SHA}
+    assert mod.recorded_failures(body, comments) == [
+        {"sha": FAILURE_SHA, "job_id": "9"},
+        {"sha": FAILURE_SHA, "job_id": "9"},
+        {"sha": RECURRENCE_SHA, "job_id": "9"},
+    ]
+
+
+def test_recorded_failures_tolerates_missing_evidence_lines():
+    """A body/comment without a `- commit:` line or a job-logs URL yields
+    None fields (the guard treats the entry as no evidence, never crashes)."""
+    runs = mod.recorded_failures(
+        "CI failure body\n<!-- ci-failure-fingerprint:x -->\n",
+        ["CI failure re-occurred (job `tests`, same fingerprint):\n- run URL: x"],
+    )
+    assert runs == [{"sha": None, "job_id": None}, {"sha": None, "job_id": None}]
+
+
+def test_failed_test_files_parses_the_real_pytest_summary_lines():
+    """The parser reads the REAL #714 log shape: Actions timestamps prefix
+    every line (no `^` anchor), `FAILED <path>::<test> - <exc>` and
+    `ERROR <path>` carry the failing module; the lowercase count line does
+    not match."""
+    assert mod.failed_test_files(FAILED_TEST_LOG) == {FAILED_TEST_FILE}
+    assert mod.failed_test_files(
+        "2026-09-11T08:01:10.1230016Z ERROR tests/test_collection.py"
+        " - ImportError: no module named x\n"
+    ) == {"tests/test_collection.py"}
+
+
+def test_failed_test_files_ignores_prose_and_lowercase_counts():
+    """Prose `FAILED` mentions without a `.py` path and the lowercase
+    summary count never produce a file (verified shapes from the real
+    job log)."""
+    assert mod.failed_test_files("\n".join([
+        "make sure FAILED tests do not hide failures",
+        "2026-09-11T08:01:10.1230016Z FAILED (unittest.loader._FailedTest) did not run",
+        "2026-09-11T08:01:10.1230873Z 1 failed, 2379 passed in 330.14s (0:05:30)",
+        "2026-09-11T08:01:10.7263769Z ##[error]Process completed with exit code 1.",
+    ])) == set()
 
 
 def test_recovery_comment_tail_reflects_the_closing_decision():
@@ -1188,6 +1457,41 @@ def test_gh_api_empty_success_body_is_an_empty_dict(monkeypatch):
         mod.subprocess, "run", lambda command, **kwargs: FakeProc(stdout="")
     )
     assert mod.gh_api("repos/o/r/x") == {}
+
+
+def test_gh_api_text_requests_the_log_with_escape_sequences_allowed(monkeypatch):
+    """The raw job-log call pins the verified command shape (gh 2.100, live
+    probe of job 103190539333): `gh api --allow-escape-sequences` — gh ≥2.63
+    refuses terminal-escape output without the flag, and Actions logs carry
+    them."""
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        return FakeProc(stdout="2026-09-11T08:01:10.1230016Z FAILED tests/t.py::x\n")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert "tests/t.py" in mod.gh_api_text("repos/o/r/actions/jobs/9/logs")
+    assert captured["command"] == [
+        "gh", "api", "--allow-escape-sequences", "repos/o/r/actions/jobs/9/logs",
+    ]
+
+
+@pytest.mark.parametrize("stdout,stderr,expected", [
+    ("", "HTTP 404: gone\n", "HTTP 404: gone"),
+    ("", "", "exit code 1"),
+])
+def test_gh_api_text_nonzero_exit_raises_a_structured_error(
+    monkeypatch, stdout, stderr, expected
+):
+    monkeypatch.setattr(
+        mod.subprocess, "run",
+        lambda command, **kwargs: FakeProc(returncode=1, stdout=stdout, stderr=stderr),
+    )
+    with pytest.raises(mod.GhApiError) as exc:
+        mod.gh_api_text("repos/o/r/actions/jobs/9/logs")
+    assert exc.value.endpoint == "repos/o/r/actions/jobs/9/logs"
+    assert exc.value.detail == expected
 
 
 def test_gh_api_non_json_success_body_is_a_structured_error(monkeypatch):

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -20,11 +20,12 @@ gh 2.97):
 - A monitored run concluded `success`: every SUCCEEDED job's fingerprint is
   matched against the open triage Issues; a match gets the recovery run
   evidence as a comment. It is closed (`state_reason: completed`) only with
-  fix evidence — the recovery run's head SHA differs from every failure SHA
-  recorded on the Issue (body + re-occurrence comments), or the run's
-  associated PR body carries a closing reference to it. A green re-run of
-  the SAME commit that failed is a flaky pass, not a fix (Issue #715): the
-  comment is appended and the Issue stays open.
+  fix evidence RELEVANT to the Issue (Issue #718): the recovery run's
+  associated PR body carries a closing reference to it (Issue #715), or the
+  diff from the latest recorded failure run to the recovery head touches the
+  failing test's file (the `FAILED <path>.py` lines of that failure job's
+  log). A green re-run of the SAME commit — or of any unrelated commit — is
+  not a fix: the comment is appended and the Issue stays open.
 - Anything else (another workflow, another event, a push off `main`, any
   other conclusion) is a logged no-op with exit 0.
 
@@ -93,13 +94,27 @@ EXTERNAL_PR_MARKER = "orbi:external-pr:"
 EXTERNAL_PR_RE = re.compile(
     r"<!--\s*" + re.escape(EXTERNAL_PR_MARKER) + r"(\d+)\s*-->"
 )
-# Issue #715: the recovery guard's failure-evidence markers. The `- commit:`
+# Issue #715/#718: the recovery guard's failure-evidence markers. The `- commit:`
 # line is written by `build_failure_body` (the Issue body) and by
 # `build_reoccurrence_comment` (one comment per re-occurrence); only comments
 # starting with REOCCURRENCE_PREFIX are failure evidence — a recovery comment
 # records the recovery run's SHA, which must never count as a failure.
+# JOB_LOG_URL_RE parses the job id from the same evidence (`- job logs:` in a
+# re-occurrence comment, the `[job logs](...)` link in the body) so the
+# relevance check can read the failure job's raw log.
 REOCCURRENCE_PREFIX = "CI failure re-occurred"
 COMMIT_LINE_RE = re.compile(r"- commit: `([0-9a-f]{40})`")
+JOB_LOG_URL_RE = re.compile(
+    r"https://github\.com/[^/\s)\]]+/[^/\s)\]]+/actions/runs/\d+/job/(\d+)"
+)
+# Issue #718: the failing test's file, from the pytest summary of the
+# recorded failure job's log — `FAILED tests/test_x.py::test - ...` and
+# `ERROR tests/test_x.py - ...`. Actions log lines carry an ISO timestamp
+# prefix, so the match is deliberately NOT line-anchored; the `.py` suffix
+# keeps prose mentions of FAILED/ERROR and the lowercase count line
+# (`1 failed, 2379 passed`) from matching (verified against the real job
+# log of run 34576656221).
+FAILED_TEST_RE = re.compile(r"\b(?:FAILED|ERROR)\s+([^\s:]+\.py)(?:::|\s|$)", re.MULTILINE)
 
 
 class GhApiError(Exception):
@@ -146,6 +161,24 @@ def gh_api(endpoint: str, *, method: str = "GET", payload: dict | None = None):
         raise GhApiError(endpoint, f"non-JSON response: {exc}") from exc
 
 
+def gh_api_text(endpoint: str) -> str:
+    """Call `gh api` and return the RAW response body.
+
+    Used for the job-log endpoint (`repos/{owner}/{repo}/actions/jobs/
+    {job_id}/logs`), which answers with a plain-text log, not JSON. The flag
+    is required: gh >= 2.63 refuses to print a response carrying terminal
+    escape sequences, and Actions job logs carry them — verified against
+    gh 2.100 with the live job log of run 34576656221 (the unflagged call
+    exits 1 with `the response contains terminal escape sequences`).
+    """
+    command = ["gh", "api", "--allow-escape-sequences", endpoint]
+    proc = subprocess.run(command, capture_output=True, text=True)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        raise GhApiError(endpoint, detail or f"exit code {proc.returncode}")
+    return proc.stdout
+
+
 def load_event() -> dict:
     """Read the workflow_run event payload from GITHUB_EVENT_PATH."""
     path = os.environ.get("GITHUB_EVENT_PATH")
@@ -188,17 +221,33 @@ def issue_fingerprints(body: str) -> list[str]:
     return seen
 
 
-def recorded_failure_shas(body: str, comments: list[str]) -> set[str]:
-    """Every failure head SHA recorded on an Issue (Issue #715).
+def recorded_failures(body: str, comments: list[str]) -> list[dict]:
+    """Every failure run recorded on an Issue, oldest first (Issue #718).
 
-    The body's `- commit:` line plus the `- commit:` line of each
-    re-occurrence comment; other comments never carry failure evidence.
+    The body's evidence first, then each re-occurrence comment in comment
+    order; every other comment never carries failure evidence (Issue #715
+    rule). Each entry carries the `- commit:` SHA and the job id parsed
+    from the job-logs URL — the relevance check's diff base and log source.
     """
-    shas = set(COMMIT_LINE_RE.findall(body))
-    for comment in comments:
-        if comment.startswith(REOCCURRENCE_PREFIX):
-            shas.update(COMMIT_LINE_RE.findall(comment))
-    return shas
+    runs: list[dict] = []
+    texts = [body, *comments]
+    for position, text in enumerate(texts):
+        if position > 0 and not text.startswith(REOCCURRENCE_PREFIX):
+            continue
+        shas = COMMIT_LINE_RE.findall(text)
+        job_ids = JOB_LOG_URL_RE.findall(text)
+        runs.append({
+            "sha": shas[0] if shas else None,
+            "job_id": job_ids[0] if job_ids else None,
+        })
+    return runs
+
+
+def failed_test_files(job_log: str) -> set[str]:
+    """The failing test modules named by the pytest summary of a job log
+    (the FAILED_TEST_RE shapes; see the constant's comment for the format
+    evidence)."""
+    return set(FAILED_TEST_RE.findall(job_log))
 
 
 def triage_scope(run: dict) -> tuple[str, str]:
@@ -352,10 +401,12 @@ def build_failure_body(
         "### Dedup and recovery",
         "A re-run of the same failure (same workflow/job/branch fingerprint)",
         "updates this Issue instead of creating a new one. A later successful",
-        "run of the same workflow/job/branch closes this Issue only with fix",
-        "evidence: a different head commit, or a closing reference to this",
-        "Issue on its PR (Issue #715) — a green re-run of the same commit is",
-        "recorded as recovery evidence while this Issue stays open.",
+        "run closes this Issue only with fix evidence relevant to it",
+        "(Issue #718): a closing reference to this Issue on the run's PR",
+        "(`Fixes #N`), or a diff since the latest recorded failure that",
+        "touches the failing test's file. Anything else — a green re-run of",
+        "the same commit, or any unrelated commit — is recorded as recovery",
+        "evidence while this Issue stays open.",
         "",
     ]
     if external_pr is not None:
@@ -409,11 +460,11 @@ def build_recovery_comment(run: dict, job: dict, *, closing: bool) -> str:
         )
     else:
         lines.append(
-            "Not closing: this recovery run used a head commit that previously"
-            " failed with this fingerprint and no closing reference"
-            " (`Fixes #N`) is associated with it — nothing was fixed; this"
-            " looks like a flaky pass. The Issue stays open for a real fix"
-            " (Issue #715)."
+            "Not closing: no fix evidence for this Issue — the recovery run's"
+            " PR carries no closing reference (`Fixes #N`) and the diff since"
+            " the latest recorded failure does not touch the failing test's"
+            " file; this may be a flaky pass or an unrelated commit (Issue"
+            " #718). The Issue stays open for a real fix."
         )
     return "\n".join(lines)
 
@@ -665,9 +716,12 @@ def triage_failure(run: dict, owner: str, repo: str, jobs: list) -> None:
 
 
 def fetch_issue_comments(owner: str, repo: str, number: int) -> list[str]:
-    """The Issue's comments, their bodies only (verified shape: a list)."""
+    """The Issue's comments, their bodies only, oldest first (the explicit
+    `sort=created&direction=asc` pins the order `recorded_failures` relies
+    on; verified against the live endpoint)."""
     data = gh_api(
-        f"repos/{owner}/{repo}/issues/{number}/comments?per_page=100"
+        f"repos/{owner}/{repo}/issues/{number}/comments"
+        "?per_page=100&sort=created&direction=asc"
     )
     if not isinstance(data, list):
         fail("fetch_issue_comments", f"comments API did not return a list: {data!r}")
@@ -697,14 +751,56 @@ def recovery_closing_reference(
     return issue_number in closing_issue_numbers(body, owner, repo)
 
 
-def triage_recovery(run: dict, owner: str, repo: str, jobs: list) -> None:
-    """Close the Issue of every succeeded job with the recovery evidence.
+def recovery_touches_failed_tests(
+    owner: str, repo: str, recovery_sha: str, failure_runs: list[dict],
+) -> tuple[bool, str]:
+    """Issue #718 relevance check: True only when the diff from the LATEST
+    recorded failure run to the recovery head touches the failing test's
+    file (the `FAILED <path>.py` lines of that failure job's log). The
+    second value is the no-evidence detail for the structured log line.
 
-    Issue #715: a close needs fix evidence — the recovery run's head SHA
-    differs from every failure SHA recorded on the Issue (body + re-occurrence
-    comments), or the run's associated PR body carries a closing reference to
-    it. A green re-run of the same commit that failed is a flaky pass: the
-    recovery evidence is appended and the Issue stays open.
+    The failure log is the evidence source; when it is unavailable (e.g.
+    expired log retention) the check degrades to no-close with a structured
+    line — an unverifiable close is never performed. Every other API error
+    keeps failing fast (the module contract).
+    """
+    # `recorded_failures` always yields at least the body's entry, possibly
+    # with None fields — an entry lacking the SHA or the job id carries no
+    # usable evidence for this check.
+    latest = failure_runs[-1]
+    base_sha, job_id = latest["sha"], latest["job_id"]
+    if not base_sha or not job_id:
+        return False, "no_failure_evidence"
+    try:
+        failure_log = gh_api_text(
+            f"repos/{owner}/{repo}/actions/jobs/{job_id}/logs"
+        )
+    except GhApiError as exc:
+        log(f"recovery_log_unavailable detail={exc.detail}")
+        return False, "log_fetch_failed"
+    test_files = failed_test_files(failure_log)
+    if not test_files:
+        return False, "no_failed_test_files"
+    comparison = gh_api(f"repos/{owner}/{repo}/compare/{base_sha}...{recovery_sha}")
+    files = comparison.get("files", []) if isinstance(comparison, dict) else []
+    changed = {
+        item.get("filename")
+        for item in files
+        if isinstance(item, dict) and isinstance(item.get("filename"), str)
+    }
+    if test_files & changed:
+        return True, ""
+    return False, "diff_does_not_touch_failed_tests"
+
+
+def triage_recovery(run: dict, owner: str, repo: str, jobs: list) -> None:
+    """Close the Issue of every succeeded job ONLY with ticket-relevant fix
+    evidence (Issue #718): the recovery run's PR carries a closing reference
+    to the Issue (`Fixes #N`, Issue #715), or the diff from the latest
+    recorded failure run to the recovery head touches the failing test's
+    file. A green run without either — the same commit again, or any
+    unrelated commit — is recorded as recovery evidence while the Issue
+    stays open.
     """
     succeeded = jobs_with_conclusion(jobs, (SUCCESS_CONCLUSION,))
     if not succeeded:
@@ -722,19 +818,32 @@ def triage_recovery(run: dict, owner: str, repo: str, jobs: list) -> None:
             log(f"recovery_no_match job={item['name']} run_id={run.get('id')}")
             continue
         number = match["number"]
-        failure_shas = recorded_failure_shas(
+        failure_runs = recorded_failures(
             match["body"],
             fetch_issue_comments(owner, repo, number),
         )
+        failure_shas = {entry["sha"] for entry in failure_runs}
         if not isinstance(recovery_sha, str) or not recovery_sha:
             verified = False
             reason = "reason=no_head_sha"
-        elif recovery_sha not in failure_shas:
-            verified = True
-            reason = ""
-        else:
+        elif recovery_sha in failure_shas:
+            # Same head SHA as a recorded failure: the diff is definitionally
+            # empty, so only the closing reference can verify (Issue #715).
             verified = recovery_closing_reference(run, owner, repo, number)
             reason = "" if verified else "reason=same_head_sha"
+        else:
+            verified = recovery_closing_reference(run, owner, repo, number)
+            if verified:
+                reason = ""
+            else:
+                touched, detail = recovery_touches_failed_tests(
+                    owner, repo, recovery_sha, failure_runs,
+                )
+                verified = touched
+                reason = (
+                    "" if touched
+                    else f"reason=no_relevant_fix detail={detail}"
+                )
         comment_issue(
             owner, repo, number,
             build_recovery_comment(run, item, closing=verified),


### PR DESCRIPTION
<!-- orbi:run=89f8bf1e -->

Fixes #718

CI triage 的 recovery 守卫只看 head_sha 变没变，不看变化是否与该票相关——同指纹已循环 9 次 (run_id=89f8bf1e)
