### PR TITLE
部署检出里有 344 行未提交的历史 changelog 补全（v0.1.0–v0.4.4，中英各 6 份），挡住 base checkout 的 ff-only 同步

### DIFF
--- a/docs/release-v0.1.0.mdx
+++ b/docs/release-v0.1.0.mdx
@@ -89,3 +89,49 @@ delivered by their own PRs; that does not change the v0.1 scope.)
 
 No protected branch was modified, no second business PR was created, and
 the existing `v0.1.0` tag was neither moved nor force-pushed.
+
+## Changelog
+
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Features
+
+- Scan Pilot tasks before business tasks ([Issue #1](https://github.com/orbi-build/orbi/issues/1); [PR #5](https://github.com/orbi-build/orbi/pull/5))
+- Add task dispatch and status commands ([Issue #3](https://github.com/orbi-build/orbi/issues/3); [PR #9](https://github.com/orbi-build/orbi/pull/9); [PR #17](https://github.com/orbi-build/orbi/pull/17))
+- Add repository AGENTS.md development contract ([Issue #12](https://github.com/orbi-build/orbi/issues/12); [PR #29](https://github.com/orbi-build/orbi/pull/29))
+- Keep task worktrees inside the project workspace ([Issue #14](https://github.com/orbi-build/orbi/issues/14); [PR #28](https://github.com/orbi-build/orbi/pull/28))
+- Tune idle polling interval from 5 to 15 minutes ([Issue #21](https://github.com/orbi-build/orbi/issues/21); [PR #26](https://github.com/orbi-build/orbi/pull/26))
+- Stream live Pi activity during active runs ([Issue #24](https://github.com/orbi-build/orbi/issues/24); [PR #37](https://github.com/orbi-build/orbi/pull/37))
+- Create tasks from latest main and make retries conflict-safe ([Issue #31](https://github.com/orbi-build/orbi/issues/31); [PR #36](https://github.com/orbi-build/orbi/pull/36))
+- Run the Pilot scheduler 24 hours a day ([Issue #33](https://github.com/orbi-build/orbi/issues/33); [PR #35](https://github.com/orbi-build/orbi/pull/35))
+- Automatically review, fix, and merge delivered PRs ([Issue #34](https://github.com/orbi-build/orbi/issues/34); [PR #38](https://github.com/orbi-build/orbi/pull/38))
+- Make live activity logs concise and readable ([Issue #40](https://github.com/orbi-build/orbi/issues/40); [PR #44](https://github.com/orbi-build/orbi/pull/44))
+- Propagate run_id as the end-to-end correlation ID ([Issue #41](https://github.com/orbi-build/orbi/issues/41); [PR #43](https://github.com/orbi-build/orbi/pull/43))
+- 交付契约:PR body 使用 Fixes #N,GitHub 原生自动关闭 Issue ([Issue #53](https://github.com/orbi-build/orbi/issues/53); [PR #69](https://github.com/orbi-build/orbi/pull/69))
+- Add an SPDX LICENSE file for the public repo ([Issue #81](https://github.com/orbi-build/orbi/issues/81); [PR #88](https://github.com/orbi-build/orbi/pull/88))
+- Pass different --skill lists to implement vs review Pi ([Issue #83](https://github.com/orbi-build/orbi/issues/83); [PR #86](https://github.com/orbi-build/orbi/pull/86))
+
+
+### Reliability and recovery
+
+- Configure and enforce maximum concurrent Pilot tasks ([Issue #39](https://github.com/orbi-build/orbi/issues/39); [PR #46](https://github.com/orbi-build/orbi/pull/46))
+- Successful PR open then progress finish() 404 labels the Issue ai-blocked and skips review ([Issue #60](https://github.com/orbi-build/orbi/issues/60); [PR #62](https://github.com/orbi-build/orbi/pull/62))
+- Bug: progress PATCH 404 after opening a PR skips review and blocks the Issue ([Issue #70](https://github.com/orbi-build/orbi/issues/70); [PR #85](https://github.com/orbi-build/orbi/pull/85))
+
+
+### Deployment and operations
+
+- Add systemd timer for automatic two-source polling ([Issue #2](https://github.com/orbi-build/orbi/issues/2); [PR #6](https://github.com/orbi-build/orbi/pull/6))
+
+
+### Observability
+
+- Journal lines print run_id twice on activity/heartbeat ([Issue #57](https://github.com/orbi-build/orbi/issues/57); [PR #59](https://github.com/orbi-build/orbi/pull/59))
+
+
+### Bug fixes
+
+- Reviewer may fix in the same session; do not cold-start Fixer plus a third Review ([Issue #82](https://github.com/orbi-build/orbi/issues/82); [PR #87](https://github.com/orbi-build/orbi/pull/87))

--- a/docs/release-v0.1.0.mdx
+++ b/docs/release-v0.1.0.mdx
@@ -129,6 +129,7 @@ Corrected 2026-09-10: the entries below shipped in this release but were missing
 
 ### Observability
 
+- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #42](https://github.com/orbi-build/orbi/pull/42))
 - Journal lines print run_id twice on activity/heartbeat ([Issue #57](https://github.com/orbi-build/orbi/issues/57); [PR #59](https://github.com/orbi-build/orbi/pull/59))
 
 

--- a/docs/release-v0.1.2.mdx
+++ b/docs/release-v0.1.2.mdx
@@ -58,7 +58,6 @@ Corrected 2026-09-10: the entries below shipped in this release but were missing
 
 ### Observability
 
-- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #92](https://github.com/orbi-build/orbi/pull/92))
 - GitHub progress comments must not be on the main delivery path ([Issue #79](https://github.com/orbi-build/orbi/issues/79); [PR #107](https://github.com/orbi-build/orbi/pull/107))
 - Progress comment：Issue 行同时显示编号和标题 ([Issue #100](https://github.com/orbi-build/orbi/issues/100); [PR #115](https://github.com/orbi-build/orbi/pull/115))
 

--- a/docs/release-v0.1.2.mdx
+++ b/docs/release-v0.1.2.mdx
@@ -25,3 +25,51 @@ main line.
 
 The existing `v0.1.0` and `v0.1.1` tags stay immutable; `v0.1.2` is
 the final 0.1 release of the current complete main.
+
+## Changelog
+
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Features
+
+- v0.1: first release checklist (close this when tagged) ([Issue #80](https://github.com/orbi-build/orbi/issues/80); [PR #92](https://github.com/orbi-build/orbi/pull/92))
+- Release：对账 v0.1.0 子 Issue、tag 与发布证据 ([Issue #97](https://github.com/orbi-build/orbi/issues/97); [PR #125](https://github.com/orbi-build/orbi/pull/125))
+- Runner：支持 P0 紧急任务优先 pickup，避免故障循环 ([Issue #101](https://github.com/orbi-build/orbi/issues/101); [PR #113](https://github.com/orbi-build/orbi/pull/113))
+
+
+### Reliability and recovery
+
+- Pi hangs in model_wait after llama proxy timeout and holds the slot forever ([Issue #75](https://github.com/orbi-build/orbi/issues/75); [PR #110](https://github.com/orbi-build/orbi/pull/110))
+- Bug: resume 使用评论里的 PR URL，不再 verify_pr ([Issue #89](https://github.com/orbi-build/orbi/issues/89); [PR #102](https://github.com/orbi-build/orbi/pull/102))
+- Bug: resume 时 worktree 缺失不再 mutation 前 fail-fast ([Issue #90](https://github.com/orbi-build/orbi/issues/90); [PR #99](https://github.com/orbi-build/orbi/pull/99))
+- Bug: resume 不校验 scene base_branch 与配置是否一致 ([Issue #91](https://github.com/orbi-build/orbi/issues/91); [PR #96](https://github.com/orbi-build/orbi/pull/96))
+- Prompt 契约：可能阻塞的命令必须加 timeout，无界循环测试必须带终止保护 ([Issue #95](https://github.com/orbi-build/orbi/issues/95); [PR #121](https://github.com/orbi-build/orbi/pull/121))
+
+
+### Deployment and operations
+
+- 部署一致性：自动安装 systemd units 并检测配置漂移 ([Issue #103](https://github.com/orbi-build/orbi/issues/103); [PR #112](https://github.com/orbi-build/orbi/pull/112))
+- Git transport：bootstrap 默认使用 SSH，支持 workflow 文件可靠推送 ([Issue #114](https://github.com/orbi-build/orbi/issues/114); [PR #122](https://github.com/orbi-build/orbi/pull/122))
+- Setup：提供一次性配置脚本初始化 GitHub、labels 和本地运行前提 ([Issue #117](https://github.com/orbi-build/orbi/issues/117); [PR #120](https://github.com/orbi-build/orbi/pull/120))
+
+
+### Observability
+
+- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #92](https://github.com/orbi-build/orbi/pull/92))
+- GitHub progress comments must not be on the main delivery path ([Issue #79](https://github.com/orbi-build/orbi/issues/79); [PR #107](https://github.com/orbi-build/orbi/pull/107))
+- Progress comment：Issue 行同时显示编号和标题 ([Issue #100](https://github.com/orbi-build/orbi/issues/100); [PR #115](https://github.com/orbi-build/orbi/pull/115))
+
+
+### Documentation
+
+- v0.1.0：补齐开源项目最小使用与贡献文档 ([Issue #104](https://github.com/orbi-build/orbi/issues/104); [PR #111](https://github.com/orbi-build/orbi/pull/111))
+- 文档：增加中文版本与系统架构 Mermaid 总览图 ([Issue #116](https://github.com/orbi-build/orbi/issues/116); [PR #124](https://github.com/orbi-build/orbi/pull/124))
+
+
+### Bug fixes
+
+- Implementer must not run the independent review-fix loop before opening the PR ([Issue #78](https://github.com/orbi-build/orbi/issues/78); [PR #109](https://github.com/orbi-build/orbi/pull/109))
+- CI checkout must fetch annotated tags for release verification ([Issue #126](https://github.com/orbi-build/orbi/issues/126); [PR #127](https://github.com/orbi-build/orbi/pull/127))

--- a/docs/release-v0.2.0.mdx
+++ b/docs/release-v0.2.0.mdx
@@ -90,3 +90,31 @@ v0.2.0 established the operational foundation for running multiple, recoverable 
 - declared test command and 100% coverage gate passed in a clean worktree at f5dd821dc2cf022923629481bc04a619dfd43126 (timeout 1800s)
 
 run_id=79a24b0f
+
+## Changelog
+
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Features
+
+- Runner：pi_idle 超时后自动清理挂死的 Pi 子进程，让工具失败信号回到模型 ([Issue #94](https://github.com/orbi-build/orbi/issues/94); [PR #123](https://github.com/orbi-build/orbi/pull/123))
+- 多 Repo Registry：显式配置与兼容单 Repo ([Issue #134](https://github.com/orbi-build/orbi/issues/134); [PR #150](https://github.com/orbi-build/orbi/pull/150))
+
+
+### Reliability and recovery
+
+- Change Pilot polling interval from 15 minutes to 5 minutes ([Issue #51](https://github.com/orbi-build/orbi/issues/51); [PR #130](https://github.com/orbi-build/orbi/pull/130))
+
+
+### Documentation
+
+- 修复中文文档站发布版本导航与首页标题 ([Issue #128](https://github.com/orbi-build/orbi/issues/128); [PR #129](https://github.com/orbi-build/orbi/pull/129))
+
+
+### Bug fixes
+
+- 优化 Runner 进度 command 日志为单行输出 ([Issue #143](https://github.com/orbi-build/orbi/issues/143); [PR #148](https://github.com/orbi-build/orbi/pull/148))
+- P0: 修复并发 E2E 测试 delivery HEAD 落后导致 v0.2.0 发布阻塞 ([Issue #201](https://github.com/orbi-build/orbi/issues/201); [PR #203](https://github.com/orbi-build/orbi/pull/203))

--- a/docs/release-v0.3.0.mdx
+++ b/docs/release-v0.3.0.mdx
@@ -12,6 +12,26 @@
 
 ## Changelog
 
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Features
+
+- 重构：抽离 delivery label 生命周期与调度策略 ([Issue #175](https://github.com/orbi-build/orbi/issues/175); [PR #265](https://github.com/orbi-build/orbi/pull/265))
+
+
+### Deployment and operations
+
+- 技术债收尾：运行契约全量剔除 Muyan Pilot 命名，CLI/配置/systemd/标识统一为 orbi ([Issue #246](https://github.com/orbi-build/orbi/issues/246); [PR #261](https://github.com/orbi-build/orbi/pull/261))
+
+
+### Bug fixes
+
+- Bug：隔离 Runner 自有运行状态，避免 .muyan-pilot/ 被误判为 agent 未提交变更 ([Issue #256](https://github.com/orbi-build/orbi/issues/256); [PR #260](https://github.com/orbi-build/orbi/pull/260))
+
+
 ### Features
 
 - Python 项目结构清理：从根目录 flat modules 迁移到清晰的 src layout ([Issue #161](https://github.com/orbi-build/orbi/issues/161))

--- a/docs/release-v0.4.1.mdx
+++ b/docs/release-v0.4.1.mdx
@@ -12,6 +12,17 @@
 
 ## Changelog
 
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Bug fixes
+
+- CI failure: tests on branch fix/release-publish-closeout-bypass (pull_request) ([Issue #601](https://github.com/orbi-build/orbi/issues/601); [PR #605](https://github.com/orbi-build/orbi/pull/605))
+- CI failure: tests on branch fix/review-ci-round-budget (pull_request) ([Issue #602](https://github.com/orbi-build/orbi/issues/602); [PR #603](https://github.com/orbi-build/orbi/pull/603))
+
+
 ### Features
 
 - `发布 scope 推导与 milestone 查询：gh api --paginate 多页输出按单页解析，Milestone 的 issue 超过一页时发布永久失败` ([Issue #584](https://github.com/orbi-build/orbi/issues/584))

--- a/docs/release-v0.4.4.mdx
+++ b/docs/release-v0.4.4.mdx
@@ -12,6 +12,25 @@
 
 ## Changelog
 
+<Note>
+Corrected 2026-09-10: the entries below shipped in this release but were missing from the generated changelog. The generator derived its scope from Milestone membership at publish time, so a ticket filed under another Milestone never reached these notes even though its code is contained in this tag. Each entry below was verified with `git merge-base --is-ancestor <merge commit> <tag>`.
+</Note>
+
+
+### Features
+
+- 技术债：main 启动前置检查全部内联，doctor 无法复用 ([Issue #297](https://github.com/orbi-build/orbi/issues/297); [PR #683](https://github.com/orbi-build/orbi/pull/683))
+- 技术债：gh issue list 重复调用 8 处，收敛成一个函数 ([Issue #299](https://github.com/orbi-build/orbi/issues/299); [PR #680](https://github.com/orbi-build/orbi/pull/680))
+- 技术债：把 Pi 进程执行子系统（11 个函数 / 940 行）从 runner.py 移入 pi_process.py ([Issue #300](https://github.com/orbi-build/orbi/issues/300); [PR #678](https://github.com/orbi-build/orbi/pull/678))
+- 仓库级 config-as-code：.github/orbi.toml 承载交付策略白名单，宿主 orbi.toml 保留身份与安全 ([Issue #527](https://github.com/orbi-build/orbi/issues/527); [PR #677](https://github.com/orbi-build/orbi/pull/677))
+- 重命名 ops 类交付标签：标签名应覆盖 ops 类无 git 交付任务（labels.toml + 代码常量 + 测试 + 各仓库实际标签同步） ([Issue #530](https://github.com/orbi-build/orbi/issues/530); [PR #676](https://github.com/orbi-build/orbi/pull/676))
+
+
+### Deployment and operations
+
+- 技术债：labels.toml 注释引用了不存在的入口 orbi.py setup ([Issue #298](https://github.com/orbi-build/orbi/issues/298); [PR #675](https://github.com/orbi-build/orbi/pull/675))
+
+
 ### Bug fixes
 
 - P0：REVIEW_VERDICT 被 markdown 代码围栏包裹时解析失败，合格交付被误判为 ai-fix-needed ([Issue #679](https://github.com/orbi-build/orbi/issues/679); [PR #681](https://github.com/orbi-build/orbi/pull/681))

--- a/docs/zh/release-v0.1.0.mdx
+++ b/docs/zh/release-v0.1.0.mdx
@@ -125,6 +125,7 @@ incomplete）、或明确排除（excluded）。
 
 ### Observability
 
+- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #42](https://github.com/orbi-build/orbi/pull/42))
 - Journal lines print run_id twice on activity/heartbeat ([Issue #57](https://github.com/orbi-build/orbi/issues/57); [PR #59](https://github.com/orbi-build/orbi/pull/59))
 
 

--- a/docs/zh/release-v0.1.0.mdx
+++ b/docs/zh/release-v0.1.0.mdx
@@ -85,3 +85,49 @@ incomplete）、或明确排除（excluded）。
 
 未修改保护分支、未创建第二个业务 PR、现有 `v0.1.0` tag 既未移动也
 未 force-push。
+
+## Changelog
+
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Features
+
+- Scan Pilot tasks before business tasks ([Issue #1](https://github.com/orbi-build/orbi/issues/1); [PR #5](https://github.com/orbi-build/orbi/pull/5))
+- Add task dispatch and status commands ([Issue #3](https://github.com/orbi-build/orbi/issues/3); [PR #9](https://github.com/orbi-build/orbi/pull/9); [PR #17](https://github.com/orbi-build/orbi/pull/17))
+- Add repository AGENTS.md development contract ([Issue #12](https://github.com/orbi-build/orbi/issues/12); [PR #29](https://github.com/orbi-build/orbi/pull/29))
+- Keep task worktrees inside the project workspace ([Issue #14](https://github.com/orbi-build/orbi/issues/14); [PR #28](https://github.com/orbi-build/orbi/pull/28))
+- Tune idle polling interval from 5 to 15 minutes ([Issue #21](https://github.com/orbi-build/orbi/issues/21); [PR #26](https://github.com/orbi-build/orbi/pull/26))
+- Stream live Pi activity during active runs ([Issue #24](https://github.com/orbi-build/orbi/issues/24); [PR #37](https://github.com/orbi-build/orbi/pull/37))
+- Create tasks from latest main and make retries conflict-safe ([Issue #31](https://github.com/orbi-build/orbi/issues/31); [PR #36](https://github.com/orbi-build/orbi/pull/36))
+- Run the Pilot scheduler 24 hours a day ([Issue #33](https://github.com/orbi-build/orbi/issues/33); [PR #35](https://github.com/orbi-build/orbi/pull/35))
+- Automatically review, fix, and merge delivered PRs ([Issue #34](https://github.com/orbi-build/orbi/issues/34); [PR #38](https://github.com/orbi-build/orbi/pull/38))
+- Make live activity logs concise and readable ([Issue #40](https://github.com/orbi-build/orbi/issues/40); [PR #44](https://github.com/orbi-build/orbi/pull/44))
+- Propagate run_id as the end-to-end correlation ID ([Issue #41](https://github.com/orbi-build/orbi/issues/41); [PR #43](https://github.com/orbi-build/orbi/pull/43))
+- 交付契约:PR body 使用 Fixes #N,GitHub 原生自动关闭 Issue ([Issue #53](https://github.com/orbi-build/orbi/issues/53); [PR #69](https://github.com/orbi-build/orbi/pull/69))
+- Add an SPDX LICENSE file for the public repo ([Issue #81](https://github.com/orbi-build/orbi/issues/81); [PR #88](https://github.com/orbi-build/orbi/pull/88))
+- Pass different --skill lists to implement vs review Pi ([Issue #83](https://github.com/orbi-build/orbi/issues/83); [PR #86](https://github.com/orbi-build/orbi/pull/86))
+
+
+### Reliability and recovery
+
+- Configure and enforce maximum concurrent Pilot tasks ([Issue #39](https://github.com/orbi-build/orbi/issues/39); [PR #46](https://github.com/orbi-build/orbi/pull/46))
+- Successful PR open then progress finish() 404 labels the Issue ai-blocked and skips review ([Issue #60](https://github.com/orbi-build/orbi/issues/60); [PR #62](https://github.com/orbi-build/orbi/pull/62))
+- Bug: progress PATCH 404 after opening a PR skips review and blocks the Issue ([Issue #70](https://github.com/orbi-build/orbi/issues/70); [PR #85](https://github.com/orbi-build/orbi/pull/85))
+
+
+### Deployment and operations
+
+- Add systemd timer for automatic two-source polling ([Issue #2](https://github.com/orbi-build/orbi/issues/2); [PR #6](https://github.com/orbi-build/orbi/pull/6))
+
+
+### Observability
+
+- Journal lines print run_id twice on activity/heartbeat ([Issue #57](https://github.com/orbi-build/orbi/issues/57); [PR #59](https://github.com/orbi-build/orbi/pull/59))
+
+
+### Bug fixes
+
+- Reviewer may fix in the same session; do not cold-start Fixer plus a third Review ([Issue #82](https://github.com/orbi-build/orbi/issues/82); [PR #87](https://github.com/orbi-build/orbi/pull/87))

--- a/docs/zh/release-v0.1.2.mdx
+++ b/docs/zh/release-v0.1.2.mdx
@@ -23,3 +23,51 @@
 
 已有 `v0.1.0` 与 `v0.1.1` tag 保持不可变；`v0.1.2` 是当前完整 main
 的最终 0.1 发布。
+
+## Changelog
+
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Features
+
+- v0.1: first release checklist (close this when tagged) ([Issue #80](https://github.com/orbi-build/orbi/issues/80); [PR #92](https://github.com/orbi-build/orbi/pull/92))
+- Release：对账 v0.1.0 子 Issue、tag 与发布证据 ([Issue #97](https://github.com/orbi-build/orbi/issues/97); [PR #125](https://github.com/orbi-build/orbi/pull/125))
+- Runner：支持 P0 紧急任务优先 pickup，避免故障循环 ([Issue #101](https://github.com/orbi-build/orbi/issues/101); [PR #113](https://github.com/orbi-build/orbi/pull/113))
+
+
+### Reliability and recovery
+
+- Pi hangs in model_wait after llama proxy timeout and holds the slot forever ([Issue #75](https://github.com/orbi-build/orbi/issues/75); [PR #110](https://github.com/orbi-build/orbi/pull/110))
+- Bug: resume 使用评论里的 PR URL，不再 verify_pr ([Issue #89](https://github.com/orbi-build/orbi/issues/89); [PR #102](https://github.com/orbi-build/orbi/pull/102))
+- Bug: resume 时 worktree 缺失不再 mutation 前 fail-fast ([Issue #90](https://github.com/orbi-build/orbi/issues/90); [PR #99](https://github.com/orbi-build/orbi/pull/99))
+- Bug: resume 不校验 scene base_branch 与配置是否一致 ([Issue #91](https://github.com/orbi-build/orbi/issues/91); [PR #96](https://github.com/orbi-build/orbi/pull/96))
+- Prompt 契约：可能阻塞的命令必须加 timeout，无界循环测试必须带终止保护 ([Issue #95](https://github.com/orbi-build/orbi/issues/95); [PR #121](https://github.com/orbi-build/orbi/pull/121))
+
+
+### Deployment and operations
+
+- 部署一致性：自动安装 systemd units 并检测配置漂移 ([Issue #103](https://github.com/orbi-build/orbi/issues/103); [PR #112](https://github.com/orbi-build/orbi/pull/112))
+- Git transport：bootstrap 默认使用 SSH，支持 workflow 文件可靠推送 ([Issue #114](https://github.com/orbi-build/orbi/issues/114); [PR #122](https://github.com/orbi-build/orbi/pull/122))
+- Setup：提供一次性配置脚本初始化 GitHub、labels 和本地运行前提 ([Issue #117](https://github.com/orbi-build/orbi/issues/117); [PR #120](https://github.com/orbi-build/orbi/pull/120))
+
+
+### Observability
+
+- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #92](https://github.com/orbi-build/orbi/pull/92))
+- GitHub progress comments must not be on the main delivery path ([Issue #79](https://github.com/orbi-build/orbi/issues/79); [PR #107](https://github.com/orbi-build/orbi/pull/107))
+- Progress comment：Issue 行同时显示编号和标题 ([Issue #100](https://github.com/orbi-build/orbi/issues/100); [PR #115](https://github.com/orbi-build/orbi/pull/115))
+
+
+### Documentation
+
+- v0.1.0：补齐开源项目最小使用与贡献文档 ([Issue #104](https://github.com/orbi-build/orbi/issues/104); [PR #111](https://github.com/orbi-build/orbi/pull/111))
+- 文档：增加中文版本与系统架构 Mermaid 总览图 ([Issue #116](https://github.com/orbi-build/orbi/issues/116); [PR #124](https://github.com/orbi-build/orbi/pull/124))
+
+
+### Bug fixes
+
+- Implementer must not run the independent review-fix loop before opening the PR ([Issue #78](https://github.com/orbi-build/orbi/issues/78); [PR #109](https://github.com/orbi-build/orbi/pull/109))
+- CI checkout must fetch annotated tags for release verification ([Issue #126](https://github.com/orbi-build/orbi/issues/126); [PR #127](https://github.com/orbi-build/orbi/pull/127))

--- a/docs/zh/release-v0.1.2.mdx
+++ b/docs/zh/release-v0.1.2.mdx
@@ -56,7 +56,6 @@
 
 ### Observability
 
-- Automatically publish live task progress and outcomes ([Issue #18](https://github.com/orbi-build/orbi/issues/18); [PR #92](https://github.com/orbi-build/orbi/pull/92))
 - GitHub progress comments must not be on the main delivery path ([Issue #79](https://github.com/orbi-build/orbi/issues/79); [PR #107](https://github.com/orbi-build/orbi/pull/107))
 - Progress comment：Issue 行同时显示编号和标题 ([Issue #100](https://github.com/orbi-build/orbi/issues/100); [PR #115](https://github.com/orbi-build/orbi/pull/115))
 

--- a/docs/zh/release-v0.2.0.mdx
+++ b/docs/zh/release-v0.2.0.mdx
@@ -92,3 +92,31 @@ v0.2.0 建立了以 GitHub Issue 为任务池、支持多 Runner 和失败恢复
 - declared test command and 100% coverage gate passed in a clean worktree at f5dd821dc2cf022923629481bc04a619dfd43126 (timeout 1800s)
 
 run_id=79a24b0f
+
+## Changelog
+
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Features
+
+- Runner：pi_idle 超时后自动清理挂死的 Pi 子进程，让工具失败信号回到模型 ([Issue #94](https://github.com/orbi-build/orbi/issues/94); [PR #123](https://github.com/orbi-build/orbi/pull/123))
+- 多 Repo Registry：显式配置与兼容单 Repo ([Issue #134](https://github.com/orbi-build/orbi/issues/134); [PR #150](https://github.com/orbi-build/orbi/pull/150))
+
+
+### Reliability and recovery
+
+- Change Pilot polling interval from 15 minutes to 5 minutes ([Issue #51](https://github.com/orbi-build/orbi/issues/51); [PR #130](https://github.com/orbi-build/orbi/pull/130))
+
+
+### Documentation
+
+- 修复中文文档站发布版本导航与首页标题 ([Issue #128](https://github.com/orbi-build/orbi/issues/128); [PR #129](https://github.com/orbi-build/orbi/pull/129))
+
+
+### Bug fixes
+
+- 优化 Runner 进度 command 日志为单行输出 ([Issue #143](https://github.com/orbi-build/orbi/issues/143); [PR #148](https://github.com/orbi-build/orbi/pull/148))
+- P0: 修复并发 E2E 测试 delivery HEAD 落后导致 v0.2.0 发布阻塞 ([Issue #201](https://github.com/orbi-build/orbi/issues/201); [PR #203](https://github.com/orbi-build/orbi/pull/203))

--- a/docs/zh/release-v0.3.0.mdx
+++ b/docs/zh/release-v0.3.0.mdx
@@ -12,6 +12,26 @@
 
 ## Changelog
 
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Features
+
+- 重构：抽离 delivery label 生命周期与调度策略 ([Issue #175](https://github.com/orbi-build/orbi/issues/175); [PR #265](https://github.com/orbi-build/orbi/pull/265))
+
+
+### Deployment and operations
+
+- 技术债收尾：运行契约全量剔除 Muyan Pilot 命名，CLI/配置/systemd/标识统一为 orbi ([Issue #246](https://github.com/orbi-build/orbi/issues/246); [PR #261](https://github.com/orbi-build/orbi/pull/261))
+
+
+### Bug fixes
+
+- Bug：隔离 Runner 自有运行状态，避免 .muyan-pilot/ 被误判为 agent 未提交变更 ([Issue #256](https://github.com/orbi-build/orbi/issues/256); [PR #260](https://github.com/orbi-build/orbi/pull/260))
+
+
 ### Features
 
 - Python 项目结构清理：从根目录 flat modules 迁移到清晰的 src layout ([Issue #161](https://github.com/orbi-build/orbi/issues/161))

--- a/docs/zh/release-v0.4.1.mdx
+++ b/docs/zh/release-v0.4.1.mdx
@@ -12,6 +12,17 @@
 
 ## Changelog
 
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Bug fixes
+
+- CI failure: tests on branch fix/release-publish-closeout-bypass (pull_request) ([Issue #601](https://github.com/orbi-build/orbi/issues/601); [PR #605](https://github.com/orbi-build/orbi/pull/605))
+- CI failure: tests on branch fix/review-ci-round-budget (pull_request) ([Issue #602](https://github.com/orbi-build/orbi/issues/602); [PR #603](https://github.com/orbi-build/orbi/pull/603))
+
+
 ### Features
 
 - `发布 scope 推导与 milestone 查询：gh api --paginate 多页输出按单页解析，Milestone 的 issue 超过一页时发布永久失败` ([Issue #584](https://github.com/orbi-build/orbi/issues/584))

--- a/docs/zh/release-v0.4.4.mdx
+++ b/docs/zh/release-v0.4.4.mdx
@@ -12,6 +12,25 @@
 
 ## Changelog
 
+<Note>
+2026-09-10 勘误：以下条目确实随本版本发出，但生成 changelog 时缺失。生成器按发布那一刻的 Milestone 归属推导 scope，因此挂在其它 Milestone 下的票即便代码已包含在本 tag 中，也不会出现在这份 notes 里。下列每一条都用 `git merge-base --is-ancestor <merge commit> <tag>` 验证过。
+</Note>
+
+
+### Features
+
+- 技术债：main 启动前置检查全部内联，doctor 无法复用 ([Issue #297](https://github.com/orbi-build/orbi/issues/297); [PR #683](https://github.com/orbi-build/orbi/pull/683))
+- 技术债：gh issue list 重复调用 8 处，收敛成一个函数 ([Issue #299](https://github.com/orbi-build/orbi/issues/299); [PR #680](https://github.com/orbi-build/orbi/pull/680))
+- 技术债：把 Pi 进程执行子系统（11 个函数 / 940 行）从 runner.py 移入 pi_process.py ([Issue #300](https://github.com/orbi-build/orbi/issues/300); [PR #678](https://github.com/orbi-build/orbi/pull/678))
+- 仓库级 config-as-code：.github/orbi.toml 承载交付策略白名单，宿主 orbi.toml 保留身份与安全 ([Issue #527](https://github.com/orbi-build/orbi/issues/527); [PR #677](https://github.com/orbi-build/orbi/pull/677))
+- 重命名 ops 类交付标签：标签名应覆盖 ops 类无 git 交付任务（labels.toml + 代码常量 + 测试 + 各仓库实际标签同步） ([Issue #530](https://github.com/orbi-build/orbi/issues/530); [PR #676](https://github.com/orbi-build/orbi/pull/676))
+
+
+### Deployment and operations
+
+- 技术债：labels.toml 注释引用了不存在的入口 orbi.py setup ([Issue #298](https://github.com/orbi-build/orbi/issues/298); [PR #675](https://github.com/orbi-build/orbi/pull/675))
+
+
 ### Bug fixes
 
 - P0：REVIEW_VERDICT 被 markdown 代码围栏包裹时解析失败，合格交付被误判为 ai-fix-needed ([Issue #679](https://github.com/orbi-build/orbi/issues/679); [PR #681](https://github.com/orbi-build/orbi/pull/681))


### PR DESCRIPTION
<!-- orbi:run=162a5d57 -->

Fixes #721

部署检出里有 344 行未提交的历史 changelog 补全（v0.1.0–v0.4.4，中英各 6 份），挡住 base checkout 的 ff-only 同步 (run_id=162a5d57)
