### PR TITLE
fix: 发版分发无让路路径——双实例可并发跑同一发布状态机 (Fixes #708)

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -3695,6 +3695,23 @@ def has_in_progress_label(number: int, repo: str) -> bool:
     )
 
 
+def _another_live_runner(slot_dir: Path, max_concurrency: int) -> bool:
+    """True when a slot is held by another pid — a live co-runner.
+
+    The #39 liveness rule `pick_in_progress_issue` applies to the orphan
+    scan (runner.py:2412): a slot held by another process proves a live
+    runner is working, so state it owns is in flight, not orphaned.
+    Issue #708 reuses the same rule for the release dispatch — an
+    in-progress release found while another runner is live is being
+    released right now; only a runner that is alone may resume it.
+    """
+    mine = os.getpid()
+    for _, holder in slot_occupancy(slot_dir, max_concurrency):
+        if holder is not None and holder != mine:
+            return True
+    return False
+
+
 def is_content_only(issue: dict) -> bool:
     """Return True only for the explicit content-only task marker.
 
@@ -6634,6 +6651,26 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         # `orbi.release` imports the runner primitives back, so the
         # dispatch imports it lazily here — a module-level import would
         # be circular (Issue #286).
+        #
+        # Issue #708: the ready scan's stale snapshot can hand an
+        # already-claimed release ticket to a second live runner. The
+        # dev path got the direct-read yield in #658; the release path
+        # needs the same semantics — an in-progress release owned by a
+        # LIVE co-runner is yielded this tick (never run the state
+        # machine concurrently); an orphaned one (this runner is alone)
+        # still resumes inside process_release (#98 restart resume).
+        # The millisecond truly-simultaneous window remains, exactly as
+        # documented for #658 — the label write is not a CAS.
+        if has_in_progress_label(number, source_repo):
+            slot_dir = config.get("slot_dir")
+            max_concurrency = config.get("max_concurrency")
+            if (slot_dir is not None and max_concurrency is not None
+                    and _another_live_runner(slot_dir, max_concurrency)):
+                LOGGER.info(
+                    "issue=%s claim_yield "
+                    "reason=release_in_progress_live_runner", number,
+                )
+                return IssueResult("claim-yielded", None)
         from orbi import release
 
         return IssueResult("release", release.process_release(issue, config, source_repo))

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3890,6 +3890,16 @@ def test_release_dispatch_fresh_ticket_unchanged_by_the_guard(
     assert len(calls) == 1
 
 
+def test_release_race_gh_rejects_unexpected_commands(monkeypatch):
+    """The #708 fake is a contract, not a sink: the strict-raise arm is
+    driven here so it cannot silently rot into a permissive fake that
+    answers commands the dispatch no longer issues (the #658 fake keeps
+    the same discipline via its own contract test)."""
+    fake = _release_race_deps(monkeypatch, in_progress=True, live_holders=[])
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake(["gh", "release", "view"])
+
+
 def test_another_live_runner_reads_slot_occupancy(monkeypatch, tmp_path):
     """_another_live_runner 是 #39 存活规则的独立助手：别的 pid 持槽
     =True，None/自己 =False（与 pick_in_progress_issue 同一语义，
@@ -15790,6 +15800,13 @@ def test_process_issue_routes_release_to_process_release(monkeypatch):
     issue = {"number": 99, "title": "Release v0.3.0", "body": "",
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
     calls = []
+    # Issue #708: the release dispatch now direct-reads the live label
+    # state before dispatching (`gh issue view`) — the fresh ticket here
+    # answers with no labels, and no slot config means no yield path.
+    monkeypatch.setattr(
+        runner, "run_command",
+        lambda command, **kwargs: json.dumps({"labels": []}),
+    )
     monkeypatch.setattr(release, "process_release",
                         lambda i, c, r: calls.append("release") or "rel-url")
     monkeypatch.setattr(runner, "run_pi", Mock(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -3795,6 +3795,124 @@ def test_process_issue_yields_when_the_stable_branch_lands_mid_preparation(
     assert result == runner.IssueResult("claim-yielded", None)
 
 
+def _release_race_deps(monkeypatch, in_progress: bool, live_holders: list):
+    """Issue #708 fakes: the direct read (`gh issue view`) answers the
+    LIVE label truth; `slot_occupancy` answers the runner-liveness
+    truth (`None`/own pid = alone, another pid = a live co-runner)."""
+    def fake_run_command(command, **kwargs):
+        if command[:3] == ["gh", "issue", "view"]:
+            labels = ([{"name": "ai-in-progress"}]
+                      if in_progress else [])
+            return json.dumps({"labels": labels})
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(
+        runner, "slot_occupancy", lambda *a, **k: list(live_holders),
+    )
+    return fake_run_command
+
+
+def _release_issue() -> dict:
+    return {"number": 30, "title": "Release 1.2.3", "body": "## Release",
+            "labels": [{"name": "ai-release"}, {"name": "ai-ready"}]}
+
+
+def _release_dispatch_config(tmp_path) -> dict:
+    return {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
+            "base_branch": "main", "slot_dir": tmp_path / "slots",
+            "max_concurrency": 2}
+
+
+def _spy_process_release(monkeypatch) -> list:
+    calls = []
+
+    def spy(*args, **kwargs):
+        calls.append(args)
+        return "done"
+
+    import orbi.release as release_module
+    monkeypatch.setattr(release_module, "process_release", spy)
+    return calls
+
+
+def test_release_dispatch_yields_when_in_progress_and_another_runner_live(
+    monkeypatch, tmp_path,
+):
+    """Issue #708：ready 扫描的滞后快照可把已被认领的发布票递给第二个
+    活实例。开发路径在 #658 拿到了直读让路；发布分发同样必须让路——
+    在途且另一活 runner 持槽 = 该发布正在被做，本 tick 退出，绝不与
+    状态机并发（成功发布不会被败者改写成 ai-blocked）。"""
+    _release_race_deps(
+        monkeypatch, in_progress=True,
+        live_holders=[(tmp_path / "slot-0", 424242)],
+    )
+    calls = _spy_process_release(monkeypatch)
+    result = runner.process_issue(
+        _release_issue(), _release_dispatch_config(tmp_path), "owner/repo",
+    )
+    assert result == runner.IssueResult("claim-yielded", None)
+    assert calls == [], "the release state machine must not start"
+
+
+def test_release_dispatch_resumes_orphan_when_no_other_runner_live(
+    monkeypatch, tmp_path,
+):
+    """Issue #708 的另一半：在途但无其他活 runner = 死 runner 留下的
+    孤儿发布——照旧进 process_release 复用 run_id 续跑（#98 的重启
+    resume 语义不因让路守卫而丢失）。"""
+    _release_race_deps(
+        monkeypatch, in_progress=True,
+        live_holders=[(tmp_path / "slot-0", None)],
+    )
+    calls = _spy_process_release(monkeypatch)
+    result = runner.process_issue(
+        _release_issue(), _release_dispatch_config(tmp_path), "owner/repo",
+    )
+    assert result == runner.IssueResult("release", "done")
+    assert len(calls) == 1
+
+
+def test_release_dispatch_fresh_ticket_unchanged_by_the_guard(
+    monkeypatch, tmp_path,
+):
+    """直读没有 ai-in-progress（新票）时，守卫零作用——照常分发；
+    活 runner 存在与否只对在途票有意义。"""
+    _release_race_deps(
+        monkeypatch, in_progress=False,
+        live_holders=[(tmp_path / "slot-0", 424242)],
+    )
+    calls = _spy_process_release(monkeypatch)
+    result = runner.process_issue(
+        _release_issue(), _release_dispatch_config(tmp_path), "owner/repo",
+    )
+    assert result == runner.IssueResult("release", "done")
+    assert len(calls) == 1
+
+
+def test_another_live_runner_reads_slot_occupancy(monkeypatch, tmp_path):
+    """_another_live_runner 是 #39 存活规则的独立助手：别的 pid 持槽
+    =True，None/自己 =False（与 pick_in_progress_issue 同一语义，
+    runner.py:2412 的循环抽出来共用）。"""
+    slot_dir = tmp_path / "slots"
+    slot_dir.mkdir()
+    seen = {}
+
+    def foreign(directory, limit):
+        seen["args"] = (directory, limit)
+        return [(slot_dir / "slot-0", 424242)]
+
+    monkeypatch.setattr(runner, "slot_occupancy", foreign)
+    assert runner._another_live_runner(slot_dir, 2) is True
+    assert seen["args"] == (slot_dir, 2)
+    monkeypatch.setattr(
+        runner, "slot_occupancy",
+        lambda d, m: [(slot_dir / "slot-0", None),
+                      (slot_dir / "slot-1", os.getpid())],
+    )
+    assert runner._another_live_runner(slot_dir, 2) is False
+
+
 def test_process_issue_resumes_existing_run_and_same_progress_comment(
     monkeypatch, tmp_path,
 ):


### PR DESCRIPTION
## 背景（Background）

#658 实锤并修复了开发路径的认领竞态：GitHub 搜索索引是最终一致的，滞后快照会把已认领的 Issue 递给第二个实例，败者把胜者的在途交付打成 ai-blocked。#668 在 v0.4.6 落地了直读让路。但发版任务（`ai-release`）在 `process_issue` 里走独立分发分支、先行返回——#668 的守卫在控制流上罩不到它。

## 根源（Root Cause）

三个事实叠加成洞：

1. `main()` 先持槽再扫描——`max_concurrency=2`（文档支持的配置，部署模板显式使用）下两个实例都合法持槽；
2. 发版分发点（`process_issue` 的 `is_release` 分支）直接进入 `process_release`，**无任何认领前复查**；
3. `process_release` 入口的直读（`has_in_progress_label`，release.py:1564）结果只用于"复用同 run_id 续跑"，没有"别的活实例在做 → 让路"分支；认领标签（EVENT_CLAIM，:1638）在声明解析之后才落，也关不上窗口。

最坏交错：A 成功发布（ai-merged + 关票）后，B 在 `freeze_base`/tag push 的 git 锁冲突上失败，走通用失败路径给票打 ai-blocked + 留失败评论——**成功发布被改写成失败终态**，与 #658/#705 同形。

## 修复（Fix）

发版分发前加一次直读复查：票在途**且**另一个活实例持槽（`slot_occupancy`，与 `pick_in_progress_issue` 同一条 #39 存活规则）→ `claim-yielded` 让路，零标签写、零评论、不进状态机。边界语义各钉一个测试：

- 在途但无其他活实例 = 孤儿 → 照旧续跑（#98 重启恢复语义不丢）；
- 全新票 → 检查零介入。

诚实残余：与 #668 相同，毫秒级真正同时认领的窗口仍在——标签写入不是 CAS。

## 验证（Verification）

- 4 个新测试：让路（在途+活对手）、孤儿续跑、新票不介入、存活助手语义——红验证（修复前让路用例立红：状态机被调起）；
- 1 个既有路由测试补 `gh issue view` 应答（新检查的一次直读）+ 1 个假体契约测试（严格拒绝臂，照 #658 假体的既有纪律）；
- 全量回归：24 失败/2346 通过，与 main 基线逐条一致（macOS 固有）；全仓覆盖门 98.40%/98.68%，diff 门 100%。

Fixes #708
