### PR TITLE
fix: _drain_stream 改静默窗有界 drain——孙进程继承管道写端时不再永久阻塞 (Fixes #709)

### DIFF
--- a/src/orbi/pi_process.py
+++ b/src/orbi/pi_process.py
@@ -296,12 +296,30 @@ class RateLimitExhaustedError(RuntimeError):
     must see the provider quota, not the task, as the cause."""
 
 
-def _drain_stream(stream, chunks: list[bytes]) -> None:
-    """Read a pipe to EOF, appending chunks (process must be finished)."""
+_DRAIN_SILENCE_S = 30.0
+
+
+def _drain_stream(stream, chunks: list[bytes],
+                  silence_s: float = 30.0) -> bool:
+    """Read a pipe to EOF, appending chunks (process must be finished).
+
+    Issue #709: Pi's tool subprocesses inherit this pipe's write end and
+    can outlive Pi — after Pi is reaped, EOF then never arrives and an
+    unbounded blocking read would wedge the tick (and its slot) forever,
+    past every timeout mechanism. Each received chunk restarts the
+    `silence_s` window (silence, not total, time: a busy legitimate
+    writer must never be cut off mid-verdict); when the stream stays
+    silent for the whole window the tail is abandoned. Returns False
+    when the drain was abandoned, True on EOF.
+    """
+    fd = stream.fileno()
     while True:
-        data = os.read(stream.fileno(), 65536)
+        ready, _, _ = select.select([fd], [], [], silence_s)
+        if not ready:
+            return False
+        data = os.read(fd, 65536)
         if not data:
-            return
+            return True
         chunks.append(data)
 
 
@@ -1465,8 +1483,19 @@ def _stream_pi_once(
         # The child is reaped (or dead): the stop handler must never
         # signal an already-exited process (Issue #48).
         set_active_pi(None)
-        _drain_stream(process.stdout, stdout_chunks)
-        _drain_stream(process.stderr, stderr_chunks)
+        # Issue #709: a tool grandchild may hold the pipe write end past
+        # Pi's death — abandon the silent tail instead of wedging the
+        # tick inside this finally block.
+        drained = _drain_stream(process.stdout, stdout_chunks,
+                                silence_s=_DRAIN_SILENCE_S)
+        drained = _drain_stream(process.stderr, stderr_chunks,
+                                silence_s=_DRAIN_SILENCE_S) and drained
+        if not drained:
+            LOGGER.warning(
+                "pi_drain_abandoned issue=%s role=%s "
+                "reason=pipe_write_end_outlives_pi",
+                issue_ref, role,
+            )
     stdout = _decode_chunks(stdout_chunks)
     stderr = _decode_chunks(stderr_chunks)
     # Issue #656: the last live poll can predate the journal Pi flushed

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -20645,3 +20645,80 @@ def test_run_failed_scene_logged_in_one_place():
         "the run_failed scene must be logged in exactly one place (the "
         f"_fail_run helper, Issue #292); sites at lines: {sites}"
     )
+
+
+def test_drain_stream_returns_true_at_eof_and_captures_content():
+    """Issue #709 contract, happy arm: EOF ends the drain with True and
+    every written chunk is captured."""
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"chunk-one")
+    os.write(write_fd, b" chunk-two")
+    os.close(write_fd)
+    chunks: list[bytes] = []
+    try:
+        with os.fdopen(read_fd, "rb") as stream:
+            drained = pi_process._drain_stream(stream, chunks, silence_s=5.0)
+    finally:
+        pass
+    assert drained is True
+    assert b"".join(chunks) == b"chunk-one chunk-two"
+
+
+def test_drain_stream_abandons_when_grandchild_holds_write_end():
+    """Issue #709 contract, abandonment arm: Pi's tool grandchild
+    inherits the pipe write end and outlives Pi — the drain must give up
+    after the silence bound (capturing what arrived) instead of blocking
+    until the grandchild happens to exit. On the pre-#709 code this test
+    blocks for the holder's entire lifetime."""
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"partial-verdict")
+    holder = subprocess.Popen(
+        [sys.executable, "-c",
+         "import time; time.sleep(40)  # orbi709-holder-one"],
+        pass_fds=(write_fd,),
+    )
+    os.close(write_fd)  # the writer (Pi) is dead; only the holder remains
+    chunks: list[bytes] = []
+    try:
+        with os.fdopen(read_fd, "rb") as stream:
+            started = time.monotonic()
+            drained = pi_process._drain_stream(stream, chunks, silence_s=1.0)
+            elapsed = time.monotonic() - started
+    finally:
+        holder.kill()
+        holder.wait()
+    assert b"partial-verdict" in b"".join(chunks)
+    assert drained is False
+    assert elapsed < 15, elapsed
+
+
+def test_stream_pi_journals_drain_abandonment_when_grandchild_holds_pipe(
+    tmp_path, caplog, monkeypatch,
+):
+    """Issue #709 end to end: the fake Pi spawns a tool grandchild that
+    inherits stdout and outlives it — the run still completes with the
+    captured verdict and the abandonment is journaled instead of the
+    tick wedging inside the finally block."""
+    monkeypatch.setattr(pi_process, "_DRAIN_SILENCE_S", 1.0)
+    command = make_fake_pi(
+        tmp_path, session_records=fake_session_records(),
+        stdout="final answer",
+    )
+    wrapper = (
+        "import subprocess, sys\n"
+        "subprocess.Popen([sys.executable, '-c',\n"
+        "    'import time; time.sleep(40)  # orbi709-holder-two'])\n"
+        f"exec({command[2]!r})\n"
+    )
+    try:
+        with caplog.at_level("WARNING"):
+            result = runner.stream_pi(
+                [sys.executable, "-c", wrapper], cwd=tmp_path,
+                poll_interval=0.1, run_id="deadbeef", issue=24,
+                source_repo="xqliu/orbi",
+                branch="orbi/xqliu-orbi-issue-24",
+            )
+    finally:
+        subprocess.run(["pkill", "-f", "orbi709-holder-two"], check=False)
+    assert result == "final answer"
+    assert "pi_drain_abandoned" in caplog.text


### PR DESCRIPTION
## 背景（Background）

Pi 的工具子进程（dev server、file watcher、卡住的 git hook…）会继承 Pi 的 stdout/stderr 管道写端。Pi 被杀后，孙进程被重挂到 init 继续持有写端——管道的 EOF 永不到来。

## 根源（Root Cause）

三个事实叠加：

1. Pi 以普通 `Popen(stdout=PIPE, stderr=PIPE)` 拉起（pi_process.py:1137），无新会话/进程组；
2. 所有 kill 路径（timeout :1203、idle-recovery :1356/:1421、model-wait :1459）只 SIGKILL Pi 本体，不碰 Pi 的子进程；
3. 进程收尸后的 `_drain_stream`（:299-305，finally :1468-1469 调用）是**无界阻塞** `os.read` 直到 EOF——写端被长寿孙进程持有时，EOF 永不来。

爆炸半径：tick 在 finally 块里永久挂死，slot 被活进程持有永不释放，journal/进度证据永不落盘；runner_health 只在 tick 开头跑，观测层自己先哑了。systemd 部署下 timer 的启动请求被忽略（unit 自述），只能人工 `systemctl stop`。生产触发前提：Pi 或其 spawn 链把 fd1/2 传给比 Pi 长寿的进程（idle-recovery 只杀窗口前发现的工具，窗口后启动的恰是"Pi 死时还活着"的那批）。

## 修复（Fix）

`_drain_stream` 改为 **select 静默窗有界 drain**（默认 30s，模块常量 `_DRAIN_SILENCE_S` 可调）：每收到数据就重置静默窗（**静默而非总时长**——活跃的合法写者永不截断，review 的 stdout 是 verdict 载体）；整个静默窗无数据即放弃尾部，返回 False，调用点记 `pi_drain_abandoned` journal（带 issue/role）。EOF 语义不变（返回 True）。

## 验证（Verification）

- 3 个测试：EOF 契约（捕获全部内容返回 True）、孙进程持写端放弃契约（1s 静默即返回，旧实现阻塞至孙进程退出）、stream_pi 全链（假 Pi 产孙进程后退出：run 正常完成、verdict 完整、journal 含 pi_drain_abandoned）——藏起修复三用例全红；
- 全量回归：12 失败全部与 main 基线一致（macOS 固有 stream_pi 时序家族），零新增；全仓覆盖门 98.39%/98.65%，diff 门 100%。

Fixes #709
