### PR TITLE
fix: health 状态文件并发完整性——pid 唯一 tmp 名 + 叶子锁串行化跨实例 RMW (Fixes #710)

### DIFF
--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -29,9 +29,11 @@ State lives in ONE lightweight JSON file in the existing state dir
 """
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -179,10 +181,61 @@ def load_health_state(path: Path) -> dict:
     return state
 
 
+HEALTH_LOCK_TIMEOUT_S = 5.0
+
+
+def _health_lock_path(state_path: Path) -> Path:
+    return state_path.parent / (state_path.name + ".lock")
+
+
+def _acquire_health_lock(state_path: Path, *,
+                         blocking: bool) -> int | None:
+    """Take the cross-instance health-state lock; None when unavailable.
+
+    Issue #710: health.json is the one state file two runner instances
+    both read and write with no other synchronization — their
+    load..save spans interleave and the last writer rolls the other's
+    updates back. This is a LEAF lock: it is never taken while holding
+    another lock (the check runs before slot acquisition; the recorders
+    run inside a delivery), so no ordering hazard exists with the slot
+    or base-sync flocks. The returned fd owns the flock — closing it
+    releases.
+
+    `blocking=False` bounds the wait at HEALTH_LOCK_TIMEOUT_S and gives
+    up for the tick: the check is a documented pure bypass, so a busy
+    lock skips this tick's check with the same semantics as a check
+    failure.
+    """
+    lock_path = _health_lock_path(state_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    if blocking:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return fd
+    deadline = time.monotonic() + HEALTH_LOCK_TIMEOUT_S
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except OSError:
+            if time.monotonic() >= deadline:
+                os.close(fd)
+                return None
+            time.sleep(0.05)
+
+
 def save_health_state(path: Path, state: dict) -> None:
-    """Write the health state atomically (tmp file + rename)."""
+    """Write the health state atomically (tmp file + rename).
+
+    Issue #710: the tmp name is pid-scoped. The previous shared
+    `health.tmp` meant two instances saving concurrently wrote the same
+    tmp inode — interleaved truncate/write produced torn JSON that the
+    read side then treated as fresh state (a silent reset of every
+    alert/counter). Unique tmp names make each writer's rename
+    all-or-nothing regardless of interleaving.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
     tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
     tmp.replace(path)
 
@@ -208,33 +261,52 @@ def record_run_attempt(
     state_path: Path, *, repo: str, issue: int, run_id: str,
     outcome: str, fingerprint: str,
 ) -> None:
-    """Append one run attempt to the bounded health history."""
-    state = load_health_state(state_path)
-    if outcome != "failed":
-        # A non-failure outcome breaks the repeated-failure streak. The
-        # issue's alert history must turn a fresh page with it: a later
-        # NEW streak on the same issue alerts again instead of staying
-        # silent forever behind the key recorded for the old streak.
-        prefix = f"{repo}#{issue}:"
-        state["alerted"] = [
-            key for key in state["alerted"]
-            if not key.startswith(prefix)
-        ]
-    state["runs"].append({
-        "repo": repo, "issue": issue, "run_id": run_id,
-        "outcome": outcome, "fingerprint": fingerprint,
-        "ts": time.time(),
-    })
-    state["runs"] = state["runs"][-RECENT_RUNS_KEEP:]
-    save_health_state(state_path, state)
+    """Append one run attempt to the bounded health history.
+
+    Issue #710: the load..save span is a cross-instance RMW — the
+    blocking lock serializes it (the critical section is pure file
+    work, milliseconds).
+    """
+    lock_fd = _acquire_health_lock(state_path, blocking=True)
+    try:
+        state = load_health_state(state_path)
+        if outcome != "failed":
+            # A non-failure outcome breaks the repeated-failure streak. The
+            # issue's alert history must turn a fresh page with it: a later
+            # NEW streak on the same issue alerts again instead of staying
+            # silent forever behind the key recorded for the old streak.
+            prefix = f"{repo}#{issue}:"
+            state["alerted"] = [
+                key for key in state["alerted"]
+                if not key.startswith(prefix)
+            ]
+        state["runs"].append({
+            "repo": repo, "issue": issue, "run_id": run_id,
+            "outcome": outcome, "fingerprint": fingerprint,
+            "ts": time.time(),
+        })
+        state["runs"] = state["runs"][-RECENT_RUNS_KEEP:]
+        save_health_state(state_path, state)
+    finally:
+        os.close(lock_fd)
 
 
 def record_pickup(repo_dir: Path) -> None:
-    """Record a successful ticket pickup (resets the stale-pickup clock)."""
+    """Record a successful ticket pickup (resets the stale-pickup clock).
+
+    Issue #710: locked like :func:`record_run_attempt` — an unlocked RMW
+    here is exactly the mechanism behind the false `stale_pickup` alarm
+    (one instance's check saves back an old pickup timestamp over the
+    other instance's fresh one).
+    """
     path = health_state_path(repo_dir)
-    state = load_health_state(path)
-    state["last_pickup_ts"] = time.time()
-    save_health_state(path, state)
+    lock_fd = _acquire_health_lock(path, blocking=True)
+    try:
+        state = load_health_state(path)
+        state["last_pickup_ts"] = time.time()
+        save_health_state(path, state)
+    finally:
+        os.close(lock_fd)
 
 
 def crash_journal_lines(
@@ -503,10 +575,28 @@ def repeat_failure_comment(finding: dict) -> str:
 def run_health_check(config: dict, *, run_command) -> list[str]:
     """Run the tick-start self-health check. Returns the fired check names.
 
+    Issue #710: the state read-modify-write is serialized across
+    instances with the leaf health lock, acquired non-blocking with a
+    bounded wait — the check is a documented pure bypass, so a lock
+    that stays busy skips this tick's check with the same semantics as
+    a check failure (callers log it and never fail the delivery).
+
     Pure bypass: callers wrap this in try/except — a check failure logs and
     never fails the delivery. The state file is saved even when a check
     raises (the alerted-dedup set must survive partial runs).
     """
+    state_path = health_state_path(config["repo_dir"])
+    lock_fd = _acquire_health_lock(state_path, blocking=False)
+    if lock_fd is None:
+        LOGGER.info("health_check_skipped reason=health_lock_busy")
+        return []
+    try:
+        return _run_health_check_locked(config, run_command=run_command)
+    finally:
+        os.close(lock_fd)
+
+
+def _run_health_check_locked(config: dict, *, run_command) -> list[str]:
     alerts: list[str] = []
     state_path = health_state_path(config["repo_dir"])
     state = load_health_state(state_path)

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -16,7 +16,10 @@ journal. These tests pin the active detection contract:
 - normal multi-round review/fix cycles (different fingerprints, a successful
   run breaking the streak) never produce a finding.
 """
+import fcntl
 import json
+import os
+import threading
 import time
 from pathlib import Path
 from unittest.mock import Mock
@@ -1230,3 +1233,73 @@ def test_count_crashes_counts_unparseable_clock_lines_conservatively():
         "journalctl --user -u orbi@2.service": "",
     })
     assert runner_health.count_crashes(fake) == 2
+
+
+def test_save_health_state_tmp_is_pid_scoped(tmp_path, monkeypatch):
+    """Issue #710 (R5): the atomic-write tmp name must be pid-scoped.
+    The old shared `health.tmp` let two instances save concurrently onto
+    the same tmp inode — interleaved truncate/write tore the JSON and
+    the read side then silently reset every alert/counter."""
+    captured = {}
+
+    def fake_replace(self, target):
+        captured["tmp"] = self
+        raise RuntimeError("stop before the rename")
+
+    monkeypatch.setattr("pathlib.Path.replace", fake_replace)
+    with pytest.raises(RuntimeError):
+        runner_health.save_health_state(tmp_path / "health.json", {"a": 1})
+    assert captured["tmp"].name.startswith("health.json.")
+    assert captured["tmp"].name.endswith(".tmp")
+    # NOT the shared suffix name two instances would collide on.
+    assert captured["tmp"] != tmp_path / "health.tmp"
+
+
+def test_record_pickup_blocks_behind_a_busy_health_lock(tmp_path):
+    """Issue #710 (R6): record_pickup's read-modify-write takes the leaf
+    lock — while another instance holds it, the record WAITS instead of
+    racing (the unlocked RMW is exactly the mechanism behind the false
+    stale_pickup alarm)."""
+    (tmp_path / ".orbi").mkdir(exist_ok=True)
+    path = runner_health.health_state_path(tmp_path)
+    lock_fd = os.open(str(runner_health._health_lock_path(path)),
+                      os.O_CREAT | os.O_RDWR, 0o644)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)  # a foreign instance holds it
+    done: list[bool] = []
+    thread = threading.Thread(
+        target=lambda: (runner_health.record_pickup(tmp_path), done.append(True)),
+    )
+    thread.start()
+    try:
+        time.sleep(0.4)
+        assert done == [], "record_pickup must wait for the lock"
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    finally:
+        thread.join(timeout=5)
+        os.close(lock_fd)
+    assert done == [True]
+    state = runner_health.load_health_state(path)
+    assert state["last_pickup_ts"] is not None
+
+
+def test_run_health_check_skips_when_the_lock_stays_busy(
+    tmp_path, monkeypatch,
+):
+    """Issue #710: a lock held by another instance skips this tick's
+    check (documented pure bypass, same semantics as a check failure) —
+    no journal/gh command may run, nothing may be recorded."""
+    (tmp_path / ".orbi").mkdir(exist_ok=True)
+    path = runner_health.health_state_path(tmp_path)
+    lock_fd = os.open(str(runner_health._health_lock_path(path)),
+                      os.O_CREAT | os.O_RDWR, 0o644)
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+    try:
+        monkeypatch.setattr(runner_health, "HEALTH_LOCK_TIMEOUT_S", 0.2)
+        probe = Mock(side_effect=AssertionError("must not run any command"))
+        alerts = runner_health.run_health_check(
+            make_config(tmp_path), run_command=probe,
+        )
+        assert alerts == []
+        probe.assert_not_called()
+    finally:
+        os.close(lock_fd)


### PR DESCRIPTION
## 背景（Background）

`health.json` 是全库唯一一个双实例高频读写、却既无互斥、临时文件又同名的状态文件（`.orbi/health.json`：`alerted` 去重键、连败计数、`last_pickup_ts`）。`max_concurrency=2`（文档支持、部署模板显式使用）+ 定时器每 5 分钟同刻触发，并发写是常态而非边角。

## 根源（Root Cause）

两个洞，一个文件：

1. **共享 tmp 名（撕裂）**：`save_health_state` 写 `path.with_suffix(".tmp")`（runner_health.py:185）——两实例并发保存写同一个 tmp inode，交错 truncate/write 产出撕裂 JSON；读侧捕获 ValueError 后按 `fresh_state()` 处理（:163-165）——**静默全量重置且永久化**（下一个写者以内存里的 fresh 态落盘）：runs 史 wiped → 连败计数清零（漏报需再攒 3 次）、alerted wiped → 旧 streak 重复告警、`last_pickup_ts=None` → stale 检测致盲（#266 要抓的停摆场景反而发不出告警）。
2. **无锁读-改-写（丢更新）**：检查路径 load→save 跨 journalctl/gh 子进程调用（告警路径最坏分钟级），record 路径（`record_run_attempt`/`record_pickup`）同样无锁。两个实例交错 load→mutate→save，末位写者整体覆盖对方：丢 runs 条目（连败漏报）、丢 alerted 键（重复开票/评论）、**伪 stale_pickup 告警**（A 的检查载入旧 `last_pickup_ts`，B 认领写入新值，A 的 finally-save 把旧值写回——#627 裸票告警的成因之一）。

## 修复（Fix）

- tmp 名加 pid 后缀（`health.json.<pid>.tmp`）：原子写语义不变，两个写者永不共享 tmp 文件，rename 全有或全无与交错无关；
- 新增 `.orbi/health.lock` **叶子锁**（flock，锁归 fd，进程退出自释）：
  - record 路径：阻塞锁——临界区是纯文件操作，毫秒级；
  - 主检查：`LOCK_NB` + 有界等待（`HEALTH_LOCK_TIMEOUT_S=5s`），锁忙跳过本拍检查并记 `health_check_skipped` journal——检查是文档化纯旁路（"a check failure never fails the delivery"），跳一拍语义同级于检查失败。
- 无死锁面：锁顺序恒为 slot → health.lock（检查在 `acquire_slot` 之前单独持锁，record 在交付中持 slot 后取锁），不存在反向路径；锁内无其他锁嵌套。

## 验证（Verification）

- 3 个测试：tmp 名 pid 作用域（拦截 rename 断言非共享 `health.tmp`）、record 在锁忙时阻塞直至释放、锁忙时主检查零命令跳拍——藏起修复三用例全红；
- 存量 66 个 runner_health 测试全绿（锁对单线程全透明）；
- 全量回归：24 失败与 main 基线逐条一致；全仓覆盖门 98.39%/98.65%，diff 门 100%。

Fixes #710
