### PR TITLE
多部署场景下 unit_name 未被使用：手工建的单元绕过 check_unit_drift，模板更新永远不会自动生效

### DIFF
--- a/.orbi.example.toml
+++ b/.orbi.example.toml
@@ -121,6 +121,13 @@ engine_source_track = "release"
 # Runner exits, however it exits. A Runner that cannot take a slot logs
 # capacity_full and exits without claiming an Issue.
 max_concurrency = 1
+# Per-deployment systemd unit name (Issue #747): the multi-deployment
+# runbook field. "core" installs orbi-core@1/2.timer + matching
+# services for THIS config; unset keeps the shared orbi@1/2 names —
+# only ONE deployment per machine may leave it unset. NEVER hand-write
+# unit files: units outside every deployment's managed set are listed
+# by `orbi doctor` under unmanaged_units.
+# unit_name = "core"
 # Optional Pi model selection (Issue #119): passed to EVERY Pi session
 # (implement and review) as --provider/--model/--thinking. Omit a key to
 # keep Pi's own default for that setting; values are passed verbatim and

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -270,6 +270,42 @@ reads the labels, the CLI install and the unit templates from
 `deploy_home` and checks the delivery checkout `repo_dir` (see
 [One-time setup](/setup)).
 
+### One machine, multiple deployments (Issue #747)
+
+One machine can host several independent Orbi deployments — each its
+own checkout, its own `orbi.toml`, its own timer set. Every deployment
+config MUST declare a distinct `unit_name`:
+
+```toml
+# <checkout>/orbi.toml — the "core" deployment
+unit_name = "core"
+```
+
+`orbi setup` / `orbi install-units` then manage exactly this
+deployment's units (`orbi-core@1/2.service` and `orbi-core@1/2.timer`);
+a second deployment with `unit_name = "website"` manages
+`orbi-website@1/2.*` on the same machine. Only ONE deployment per
+machine may leave `unit_name` unset — it owns the shared `orbi@1/2`
+names.
+
+Never hand-write systemd unit files. The per-tick drift self-heal
+compares only the installed template units of the configured
+`unit_name`, so a hand-written `orbi-core.service` is invisible to
+EVERY deployment: template updates never reach it and nothing reports
+the gap. `orbi doctor` makes the bypass visible — it lists such files
+under `unmanaged_units` with the `ORBI_CONFIG` each one points at:
+
+```text
+unmanaged_units: 2
+  orbi-core.service (ORBI_CONFIG=/path/to/deployments/core/orbi.toml)
+  orbi-core.timer (ORBI_CONFIG=-)
+  fix: set unit_name in each deployment config and run `orbi install-units`
+```
+
+The repair is the fix line: set the deployment's `unit_name`, run
+`orbi install-units` so the managed `@` units take over, then retire
+the hand-written files.
+
 ## 4. Configure the model provider
 
 The Runner never starts or manages the model process — it launches Pi,

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -229,6 +229,39 @@ walkthrough、timers）——不变：`orbi setup` 从 `deploy_home` 读标签�
 CLI 安装和 unit 模板，检查交付 checkout `repo_dir`（见[一次性
 setup](/zh/setup)）。
 
+### 一台机器跑多个部署（Issue #747）
+
+一台机器可以承载多个相互独立的 Orbi 部署——各自的 checkout、各自的
+`orbi.toml`、各自的 timer 组。每个部署的 config 必须声明一个互不相同的
+`unit_name`：
+
+```toml
+# <checkout>/orbi.toml —— 名为 "core" 的部署
+unit_name = "core"
+```
+
+此后 `orbi setup` / `orbi install-units` 管理的正是这个部署的单元
+（`orbi-core@1/2.service` 和 `orbi-core@1/2.timer`）；第二个部署配
+`unit_name = "website"`，在同一台机器上管理 `orbi-website@1/2.*`。
+一台机器上只允许一个部署不设 `unit_name`——它独占共享的 `orbi@1/2`
+命名。
+
+不要手工编写 systemd unit 文件。每个 tick 的漂移自愈只比对当前
+`unit_name` 对应的已装模板单元，手工写的 `orbi-core.service` 对
+所有部署都不可见：模板更新永远到不了它，也没有任何地方报这个缺口。
+`orbi doctor` 让这种绕过可见——它把这些文件列在 `unmanaged_units`
+下，并带出各自指向的 `ORBI_CONFIG`：
+
+```text
+unmanaged_units: 2
+  orbi-core.service (ORBI_CONFIG=/path/to/deployments/core/orbi.toml)
+  orbi-core.timer (ORBI_CONFIG=-)
+  fix: set unit_name in each deployment config and run `orbi install-units`
+```
+
+修复就是 fix 行：给部署配好 `unit_name`，运行 `orbi install-units`
+让受管理的 `@` 单元接管，然后移除手写的单元文件。
+
 ## 4. 配置模型 provider
 
 Runner 从不启动或管理模型进程——它启动 Pi，而 Pi 需要一个能真正

--- a/src/orbi/cli.py
+++ b/src/orbi/cli.py
@@ -503,6 +503,19 @@ def doctor_report(config: dict, installed_dir: Path | None) -> str:
             lines.append(
                 f"  {entry['unit']}: sha256={entry['installed_sha256']}"
             )
+    # Issue #747: hand-written orbi units without the @ template form
+    # are invisible to every deployment's check_unit_drift — the drift
+    # self-heal never reaches them. Doctor surfaces them read-only so
+    # the bypass becomes visible instead of silently failing.
+    unmanaged = systemd_deploy.unmanaged_units(installed_dir)
+    lines.append(f"unmanaged_units: {len(unmanaged)}")
+    for entry in unmanaged:
+        lines.append(
+            f"  {entry['unit']} (ORBI_CONFIG="
+            f"{entry['config'] if entry['config'] else '-'})"
+        )
+    if unmanaged:
+        lines.append(f"  fix: {systemd_deploy.UNMANAGED_FIX}")
     finding = config.get("pi_provider_key_finding")
     if finding and finding.get("variable") != "-":
         lines.append(

--- a/src/orbi/systemd_deploy.py
+++ b/src/orbi/systemd_deploy.py
@@ -64,6 +64,13 @@ REPO_DIR_PLACEHOLDER = "{{ORBI_REPO_DIR}}"
 # script), not a hand-written Python file entry.
 FIX_COMMAND = "orbi install-units"
 
+# Issue #747: the repair path for a hand-written orbi unit — every
+# deployment declares its own unit_name and installs its own managed
+# set; a hand-written unit file is never migrated automatically.
+UNMANAGED_FIX = (
+    "set unit_name in each deployment config and run `orbi install-units`"
+)
+
 
 class UnitDriftError(RuntimeError):
     """The installed units have drifted from the repo templates."""
@@ -104,6 +111,39 @@ def installed_config(unit_path: Path) -> Path | None:
     # otherwise a reinstall of the same deployment is mistaken for a conflict.
     value = value.replace("%h", str(Path.home()))
     return Path(value).expanduser().resolve()
+
+
+def unmanaged_units(installed_dir: Path) -> list[dict]:
+    """List the orbi unit files no deployment's drift check can see.
+
+    Every managed orbi unit is an installed template (``orbi@.service``,
+    ``orbi-<unit_name>@.service``, and their ``@`` instances):
+    ``check_unit_drift`` compares exactly those names. A hand-written
+    orbi unit WITHOUT the ``@`` template form (``orbi-core.service``,
+    the pre-#149 ``orbi.timer``, ...) is invisible to every
+    ``unit_names()`` set — it never drift-checks and never self-heals
+    (Issue #747). One entry per such file, sorted by name: the unit
+    name and the ``ORBI_CONFIG`` the unit points at (``None`` when the
+    file carries none — timers never do). A missing unit dir has
+    nothing to scan (the missing managed units are ``unit_drift``'s
+    report, not this one).
+    """
+    installed_dir = Path(installed_dir)
+    if not installed_dir.is_dir():
+        return []
+    entries: list[dict] = []
+    for path in sorted(installed_dir.iterdir(), key=lambda p: p.name):
+        name = path.name
+        if not (
+            path.is_file()
+            and name.startswith("orbi")
+            and (name.endswith(".service") or name.endswith(".timer"))
+        ):
+            continue
+        if "@" in name:
+            continue
+        entries.append({"unit": name, "config": installed_config(path)})
+    return entries
 
 
 def reject_different_deployment(repo_dir: Path, installed_dir: Path,

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -74,6 +74,10 @@ KNOWN_CONFIG_FIELDS = frozenset({
     # Issue #139: the active Milestone claim scope (optional string).
     "active_milestone",
     "max_concurrency",
+    # Issue #747: the per-deployment systemd unit name (multi-
+    # deployment runbook; documented in the getting-started field
+    # table and the committed example, commented out).
+    "unit_name",
     # Issue #525: the runner source freshness gate's offline escape
     # hatch (explicit boolean, default false).
     "allow_stale_runner",

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -79,6 +79,10 @@ KNOWN_CONFIG_FIELDS = frozenset({
     # Issue #139: the active Milestone claim scope (optional string).
     "active_milestone",
     "max_concurrency",
+    # Issue #747: the per-deployment systemd unit name (multi-
+    # deployment runbook; documented in the getting-started field
+    # table and the committed example, commented out).
+    "unit_name",
     "skills",
     "context_files",
     # Issue #119/#157: the optional Pi model selection keys (load_config

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -1628,6 +1628,48 @@ def test_doctor_report_clean(tmp_path, monkeypatch):
         "-u", "orbi@2.service",
         "-n", "20", "--no-pager",
     ] in calls
+    # Issue #747: no hand-written units in this world — the scan runs
+    # and reports zero.
+    assert "unmanaged_units: 0" in lines
+
+
+def test_doctor_report_lists_unmanaged_units(tmp_path, monkeypatch):
+    """Issue #747: hand-written orbi units without the @ template form
+    bypass every deployment's check_unit_drift, so doctor must surface
+    them with their ORBI_CONFIG and the repair path."""
+    from orbi import systemd_deploy
+
+    config, installed = _deploy_world(tmp_path, drift=False)
+    _fake_doctor_commands(monkeypatch)
+    monkeypatch.setattr(orbi, "current_issue", lambda repo: None)
+    core_cfg = tmp_path / "zcode-core" / "orbi-zai.toml"
+    core_cfg.parent.mkdir()
+    (installed / "orbi-core.service").write_text(
+        f"[Service]\nEnvironment=ORBI_CONFIG={core_cfg}\n", encoding="utf-8",
+    )
+    (installed / "orbi-core-2.service").write_text(
+        f"[Service]\nEnvironment=ORBI_CONFIG=\"{core_cfg}\"\n",
+        encoding="utf-8",
+    )
+    (installed / "orbi-core.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
+    )
+    report = orbi.doctor_report(config, installed)
+    lines = report.splitlines()
+    assert "unmanaged_units: 3" in lines
+    assert (
+        f"  orbi-core.service (ORBI_CONFIG={core_cfg.resolve()})"
+    ) in lines
+    assert (
+        f"  orbi-core-2.service (ORBI_CONFIG={core_cfg.resolve()})"
+    ) in lines
+    # A timer carries no ORBI_CONFIG — rendered as '-'.
+    assert "  orbi-core.timer (ORBI_CONFIG=-)" in lines
+    assert (
+        f"  fix: {systemd_deploy.UNMANAGED_FIX}"
+    ) in lines
+    # The managed template units are NOT listed as unmanaged.
+    assert "  orbi@.service (ORBI_CONFIG=" not in report
 
 
 def test_doctor_report_includes_the_engine_source_channel(

--- a/tests/test_systemd_deploy.py
+++ b/tests/test_systemd_deploy.py
@@ -812,3 +812,75 @@ def test_unit_status_drifts_when_installed_differs_from_the_rendered_template(
     service = [e for e in status if e["unit"] == "orbi@.service"][0]
     assert service["drifted"] is True
     assert service["repo_sha256"] != service["installed_sha256"]
+
+
+# --- unmanaged units (Issue #747) ----------------------------------------------
+
+
+def test_unmanaged_units_is_empty_without_the_unit_dir(tmp_path):
+    # A missing user unit dir has nothing to scan; the missing managed
+    # units are already reported by unit_drift.
+    assert systemd_deploy.unmanaged_units(tmp_path / "absent") == []
+
+
+def test_unmanaged_units_is_empty_with_only_template_units(tmp_path):
+    repo = make_repo(tmp_path)
+    installed = make_installed(tmp_path, repo)
+    assert systemd_deploy.unmanaged_units(installed) == []
+
+
+def test_unmanaged_units_lists_the_hand_written_units(tmp_path):
+    """The #747 scene: hand-written units without the @ template form are
+    invisible to EVERY deployment's check_unit_drift (unit_names() only
+    ever produces orbi[<name>]@.service/.timer) — doctor must list them
+    with the ORBI_CONFIG each one points at."""
+    installed = tmp_path / "user"
+    installed.mkdir()
+    core_cfg = tmp_path / "zcode-core" / "orbi-zai.toml"
+    core_cfg.parent.mkdir()
+    (installed / "orbi-core.service").write_text(
+        f"[Service]\nEnvironment=ORBI_CONFIG={core_cfg}\n", encoding="utf-8",
+    )
+    (installed / "orbi-core-2.service").write_text(
+        f"[Service]\nEnvironment=ORBI_CONFIG=\"{core_cfg}\"\n",
+        encoding="utf-8",
+    )
+    # A timer carries no ORBI_CONFIG.
+    (installed / "orbi-core.timer").write_text(
+        "[Timer]\nOnCalendar=*-*-* *:00/5\n", encoding="utf-8",
+    )
+    # The pre-#149 legacy units are unmanaged too (their presence means
+    # the migration never ran on this machine).
+    (installed / "orbi.service").write_text("[Service]\n", encoding="utf-8")
+    (installed / "orbi.timer").write_text("[Timer]\n", encoding="utf-8")
+    entries = systemd_deploy.unmanaged_units(installed)
+    assert [entry["unit"] for entry in entries] == [
+        "orbi-core-2.service",
+        "orbi-core.service",
+        "orbi-core.timer",
+        "orbi.service",
+        "orbi.timer",
+    ]
+    assert entries[1]["config"] == core_cfg.resolve()
+    # The quoted ORBI_CONFIG form resolves the same way.
+    assert entries[0]["config"] == core_cfg.resolve()
+    # A timer/legacy service without ORBI_CONFIG carries None (doctor
+    # renders it as '-').
+    assert entries[2]["config"] is None
+    assert entries[4]["config"] is None
+
+
+def test_unmanaged_units_skips_template_form_non_orbi_and_dirs(tmp_path):
+    installed = tmp_path / "user"
+    installed.mkdir()
+    # Template and instance form files belong to a prefix deployment's
+    # managed set — never unmanaged.
+    for name in ("orbi@.service", "orbi@.timer",
+                 "orbi-core@.service", "orbi-core@1.timer"):
+        (installed / name).write_text("[Unit]\n", encoding="utf-8")
+    # Foreign units and non-unit files are not orbi units.
+    (installed / "nginx.service").write_text("[Service]\n", encoding="utf-8")
+    (installed / "orbi-notes.txt").write_text("notes", encoding="utf-8")
+    # A directory named like a unit is not a unit file.
+    (installed / "orbi-dir.service").mkdir()
+    assert systemd_deploy.unmanaged_units(installed) == []


### PR DESCRIPTION
<!-- orbi:run=67027a19 -->

Fixes #747

多部署场景下 unit_name 未被使用：手工建的单元绕过 check_unit_drift，模板更新永远不会自动生效 (run_id=67027a19)
