### PR TITLE
发版关闭里程碑存在竞态：gh issue close 后立刻查 open issues 读到陈旧索引，v0.4.10 因此抛 RuntimeError

### DIFF
--- a/src/orbi/release.py
+++ b/src/orbi/release.py
@@ -1074,6 +1074,17 @@ def publish_release(*, repo: str, tag: str, version: str,
     return json.loads(raw)["url"]
 
 
+# Issue #754: the GitHub issue index is eventually consistent —
+# `gh issue close` returning success does not mean the
+# `issues?milestone=N&state=open` list reflects it yet, and v0.4.10 read
+# a stale non-empty list in the same second as the close. A non-empty
+# gate read is re-checked with these backoff delays first; only a list
+# that stays non-empty across all of them fails fast (bounded ≈ 10 s
+# including the reads — a real unfinished issue must not drag the
+# release out).
+MILESTONE_OPEN_RETRY_DELAYS = (1.0, 2.0, 4.0)
+
+
 def close_release_milestone(repo: str, version: str, *, run_id: str | None = None) -> str:
     """Close the Milestone whose title is exactly `version` (Issue #214).
 
@@ -1089,7 +1100,10 @@ def close_release_milestone(repo: str, version: str, *, run_id: str | None = Non
       forbidden);
     - already `closed` -> idempotent success (no mutation, no reopen);
     - `open` with open issues -> fail fast with the version, the
-      Milestone number/url and the open issue list;
+      Milestone number/url and the open issue list — but only after
+      bounded backoff re-reads (Issue #754: the issue index is
+      eventually consistent, so a list read in the same second as the
+      release Issue's `gh issue close` can still show it as open);
     - `open` with 0 open issues -> closed via the official REST
       contract `PATCH /repos/{owner}/{repo}/milestones/{number}`
       with `state=closed` (OpenAPI `issues/update-milestone`).
@@ -1140,6 +1154,15 @@ def close_release_milestone(repo: str, version: str, *, run_id: str | None = Non
         # Every listed Epic is verified from its children and blockers before
         # the authoritative exact-Milestone list is checked again.
         epic_evidence = reconcile_release_epics(repo, int(number), version, run_id)
+        open_issues = milestone_open_issues(repo, int(number))
+    retries = 0
+    while open_issues and retries < len(MILESTONE_OPEN_RETRY_DELAYS):
+        # The release Issue close succeeded seconds ago; a non-empty read
+        # here is more likely the index lagging (Issue #754) than real
+        # unfinished work. Re-read with bounded backoff; the raise below
+        # fires only once the list stays non-empty across all retries.
+        time.sleep(MILESTONE_OPEN_RETRY_DELAYS[retries])
+        retries += 1
         open_issues = milestone_open_issues(repo, int(number))
     if open_issues:
         listing = ", ".join(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -18732,15 +18732,86 @@ def test_close_release_milestone_fails_fast_when_open_issues_remain(monkeypatch)
 
     monkeypatch.setattr(release, "run_command", fake_run)
     monkeypatch.setattr(runner, "run_command", fake_run)
+    sleeps: list[float] = []
+    monkeypatch.setattr("time.sleep", sleeps.append)
     with pytest.raises(RuntimeError, match="Milestone #5") as excinfo:
         release.close_release_milestone("o/r", "v0.3.0")
     # The error carries the version, the Milestone number/url and the
-    # open issue list — never a silent skip.
+    # open issue list — never a silent skip. The list was re-read with
+    # the bounded backoff first (Issue #754) and stayed non-empty.
     assert "v0.3.0" in str(excinfo.value)
     assert "https://github.com/o/r/milestone/5" in str(excinfo.value)
     assert "#101" in str(excinfo.value)
     assert "#102" in str(excinfo.value)
+    assert sleeps == [1.0, 2.0, 4.0]
     # No close was attempted.
+    assert not [c for c in calls if "PATCH" in c]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_retries_the_stale_issue_index_after_close(monkeypatch):
+    """Issue #754: `gh issue close` 返回成功不代表
+    `issues?milestone=N&state=open` 索引已跟上（最终一致）——v0.4.10 在
+    关票后 0-1 秒读到陈旧的非空列表，里程碑没有被关闭，release 评论
+    留下 `milestone evidence unavailable`。读到非空时必须先按有界退避
+    重查，索引跟上后正常关闭。"""
+    calls = []
+    sleeps: list[float] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([[_milestone(5, "v0.3.0", "open", 1)]])
+        if command == MILESTONE_ISSUES_COMMAND:
+            # First read (the same second as the close): stale index still
+            # lists the just-closed issue; the re-read catches up.
+            stale = json.dumps([[{"number": 748, "title": "Release v0.3.0"}]])
+            return stale if calls.count(command) == 1 else json.dumps([[]])
+        if command == ["gh", "api", "repos/o/r/milestones/5",
+                       "--method", "PATCH", "-f", "state=closed"]:
+            return json.dumps(_milestone(5, "v0.3.0", "closed", 0))
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(release, "run_command", fake_run)
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr("time.sleep", sleeps.append)
+    evidence = release.close_release_milestone("o/r", "v0.3.0")
+    assert "Milestone #5" in evidence
+    assert "closed after release v0.3.0" in evidence
+    # The stale read cost exactly one bounded backoff step, not a raise.
+    assert sleeps == [1.0]
+    assert calls[-1] == ["gh", "api", "repos/o/r/milestones/5",
+                         "--method", "PATCH", "-f", "state=closed"]
+    with pytest.raises(AssertionError, match="unexpected command"):
+        fake_run(["unexpected"])
+
+
+def test_close_release_milestone_fails_after_the_backoff_is_exhausted(monkeypatch):
+    """Issue #754: 重试耗尽仍读到非空 → 仍然抛 RuntimeError——退避只是
+    等索引，不是放松门禁；真有未完成的工作时照样 fail fast（带同样的
+    version / milestone url / open issue 列表），且绝不 PATCH 关闭。"""
+    calls = []
+    sleeps: list[float] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command == MILESTONE_LIST_COMMAND:
+            return json.dumps([[_milestone(5, "v0.3.0", "open", 1)]])
+        if command == MILESTONE_ISSUES_COMMAND:
+            return json.dumps([[{"number": 101, "title": "leftover one"}]])
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(release, "run_command", fake_run)
+    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr("time.sleep", sleeps.append)
+    with pytest.raises(RuntimeError, match="Milestone #5") as excinfo:
+        release.close_release_milestone("o/r", "v0.3.0")
+    assert "v0.3.0" in str(excinfo.value)
+    assert "https://github.com/o/r/milestone/5" in str(excinfo.value)
+    assert "#101" in str(excinfo.value)
+    # Bounded: the delays are exhausted, then the gate fires.
+    assert sleeps == [1.0, 2.0, 4.0]
     assert not [c for c in calls if "PATCH" in c]
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["unexpected"])


### PR DESCRIPTION
<!-- orbi:run=eed69bc2 -->

Fixes #754

发版关闭里程碑存在竞态：gh issue close 后立刻查 open issues 读到陈旧索引，v0.4.10 因此抛 RuntimeError (run_id=eed69bc2)
