### PR TITLE
文档里的本地模型速度 ~17 tokens/s 已过时：实测 57–94 tok/s，6 处需更新

### DIFF
--- a/.orbi.example.toml
+++ b/.orbi.example.toml
@@ -90,8 +90,10 @@ engine_source_track = "release"
 # token-level progress into the session JSONL, so it is NOT a
 # token-level model timeout and a slow generation that keeps appending
 # events never trips it. Default: 1800 (30 minutes) — a slow local
-# model (e.g. Qwen 27B at ~17 tokens/s behind a llama-server with a
-# 1200 s request timeout) survives a 10-minute complete message. Must
+# model (e.g. a 27B Q4 GGUF behind a llama-server with a 1200 s request
+# timeout: ~57 tokens/s at 12K context on an RX 7900 XTX with all
+# layers on GPU, well under 20 tokens/s on partial GPU offload or
+# CPU-only) survives a 10-minute complete message. Must
 # be a finite positive number; anything else fails the start fast.
 # model_wait_dead_seconds = 1800
 # Swallowed-model-request probe (Issue #233): the model's /slots

--- a/docs/operations.mdx
+++ b/docs/operations.mdx
@@ -427,9 +427,11 @@ Stable `key=value` lines you will see:
   `reason=hung_model_request`. The threshold measures silence between
   COMPLETE session events (Pi does not stream token-level progress into
   the JSONL), never token-level model progress — a slow generation that
-  keeps appending events never trips it (a slow local model, e.g. Qwen
-  27B at ~17 tokens/s behind a llama-server with a 1200 s request
-  timeout, survives a 10-minute complete message under the default);
+  keeps appending events never trips it (a slow local model, e.g. a
+  27B Q4 GGUF behind a llama-server with a 1200 s request timeout:
+  ~57 tokens/s at 12K context on an RX 7900 XTX with all layers on
+  GPU, well under 20 tokens/s on partial GPU offload or CPU-only,
+  survives a 10-minute complete message under the default);
 - `pi_idle_wait` — the grace line of the idle-stall recovery (Issue
   #181): a coreutils `timeout <seconds> ...` wrapper still inside its
   deadline is a legitimate long-running command, not a hang. The

--- a/docs/zh/operations.mdx
+++ b/docs/zh/operations.mdx
@@ -360,8 +360,10 @@ journalctl --user -u orbi@1.service -u orbi@2.service | grep e07383c2
   阈值、`action=kill_pi`、session、run id 和 `reason=hung_model_request`。
   阈值度量的是**完整** session 事件之间的静默（Pi 不向 JSONL 写
   token 级进度），不是 token 级模型进度——持续追加事件的慢生成永不
-  触发（慢本地模型，如 ~17 tokens/s 的 Qwen 27B、llama-server 请求
-  超时 1200 秒，在默认配置下可以存活超过 10 分钟的完整消息）；
+  触发（慢本地模型，如 27B Q4 GGUF 配 llama-server、请求超时 1200
+  秒：RX 7900 XTX 全层上 GPU 时 12K 上下文约 57 tokens/s，部分上
+  GPU 或纯 CPU 时远低于 20 tokens/s；默认配置下慢端也能存活超过
+  10 分钟的完整消息）；
 - `pi_idle_wait` — idle-stall 恢复的宽限行（Issue #181）：仍在
   deadline 内的 coreutils `timeout <seconds> ...` 包裹是合法的长命令，
   不是 hang。Runner 每次 stall 记一条 `pi_idle_wait` 行（run id、

--- a/src/orbi/pi_process.py
+++ b/src/orbi/pi_process.py
@@ -74,10 +74,12 @@ PI_IDLE_WARN_SECONDS = 300.0
 # COMPLETE session events (Pi does not stream token-level progress
 # into the JSONL), not token-level model progress. Configurable since
 # Issue #228: the TOML field `model_wait_dead_seconds` overrides this
-# default (1800 s, 30 minutes — a slow local model, e.g. Qwen 27B at
-# ~17 tokens/s behind a llama-server with a 1200 s request timeout,
-# must survive a 10-minute complete message; the pre-#228 default of
-# 600 s killed them at exactly 10 minutes, #176/#175/#173/#168).
+# default (1800 s, 30 minutes — a slow local model (e.g. a 27B Q4 GGUF
+# behind a llama-server with a 1200 s request timeout: ~57 tokens/s at
+# 12K context on an RX 7900 XTX with all layers on GPU, well under 20
+# tokens/s on partial GPU offload or CPU-only) must survive a
+# 10-minute complete message; the pre-#228 default of 600 s killed
+# them at exactly 10 minutes, #176/#175/#173/#168).
 PI_MODEL_WAIT_DEAD_SECONDS = 1800.0
 
 

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -493,9 +493,11 @@ def test_load_config_defaults_model_wait_dead_seconds_to_thirty_minutes(
     tmp_path,
 ):
     """Issue #228: omitted -> 1800 seconds (30 minutes): a slow local
-    model (Qwen 27B, ~17 tokens/s, llama-server request timeout 1200 s)
-    must not be killed merely because one complete assistant message
-    takes more than 10 minutes."""
+    model (27B Q4 GGUF, llama-server request timeout 1200 s — ~57
+    tokens/s at 12K context on an RX 7900 XTX with all layers on GPU,
+    well under 20 tokens/s on partial GPU offload or CPU-only) must
+    not be killed merely because one complete assistant message takes
+    more than 10 minutes."""
     config_path = tmp_path / "orbi.toml"
     config_path.write_text('source_repos = ["owner/repo"]\n', encoding="utf-8")
     config = runner.load_config(config_path)
@@ -9156,10 +9158,12 @@ def test_stream_pi_hung_model_request_killed_when_upstream_gone(
 
 def test_stream_pi_model_wait_dead_default_is_thirty_minutes():
     # Issue #228: the default dead-request threshold is 30 minutes
-    # (1800 s) — a slow local model (Qwen 27B, ~17 tokens/s,
-    # llama-server request timeout 1200 s) must survive a 10-minute
-    # complete-message silence under the default; a genuinely frozen
-    # request is still bounded and releases the slot.
+    # (1800 s) — a slow local model (27B Q4 GGUF, llama-server request
+    # timeout 1200 s: ~57 tokens/s at 12K context on an RX 7900 XTX
+    # with all layers on GPU, well under 20 tokens/s on partial GPU
+    # offload or CPU-only) must survive a 10-minute complete-message
+    # silence under the default; a genuinely frozen request is still
+    # bounded and releases the slot.
     assert runner.PI_MODEL_WAIT_DEAD_SECONDS == 1800.0
 
 


### PR DESCRIPTION
<!-- orbi:run=277a6f57 -->

Fixes #752

文档里的本地模型速度 ~17 tokens/s 已过时：实测 57–94 tok/s，6 处需更新 (run_id=277a6f57)
