### PR TITLE
release 声明的 version_file 默认 pyproject.toml，非 Python 仓不写就在打 tag 阶段才炸

### DIFF
--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -244,7 +244,12 @@ DAG, no priority numbers, no separate queues:
      line) — it is never executed. Missing, duplicated or unknown
      fields fail fast.
   2. Freeze the base — the release commit is exactly
-     `origin/<base_branch>` (fetched under the base-sync lock).
+     `origin/<base_branch>` (fetched under the base-sync lock). Before
+     any gate wait, the declared (or defaulted) `version_file` is
+     proven to exist at the root of that frozen tree (Issue #740): a
+     mismatch fails fast at claim time, naming the supported ecosystem
+     files that DO exist there and the `none` option, never as a late
+     FileNotFoundError after the gates and the scope verification.
   3. Enforce the pre-release gates: no leftover open `ai-in-progress` /
      `ai-pr-opened` / `ai-fix-needed` Issues **in the release's
      Milestone** (Issue #671; the release Issue itself excluded; without

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -200,7 +200,11 @@ PR 验收时校验该关键词，缺失即 fail fast。
      接受但忽略（记一行 evidence），永不执行。字段缺失、重复或未知
      都 fail fast。
   2. 冻结 base——release commit 就是 `origin/<base_branch>`（在
-     base-sync 锁下 fetch）。
+     base-sync 锁下 fetch）。在任何门禁等待之前，校验声明（或默认）
+     的 `version_file` 确实存在于该冻结树的根目录（Issue #740）：
+     不匹配在认领瞬间 fail fast，错误信息列出根目录实际存在的受支持
+     文件和 `none` 选项，不会在烧完门禁和范围核验后才以
+     FileNotFoundError 失败。
   3. 执行发布前门禁：**release 所属 Milestone 内**无遗留 open 的
      `ai-in-progress` / `ai-pr-opened` / `ai-fix-needed` Issue
      （Issue #671；release Issue 本身除外；无 Milestone 时仍按全仓

--- a/src/orbi/release.py
+++ b/src/orbi/release.py
@@ -77,6 +77,16 @@ from orbi.runner import (
 )
 
 
+# Supported `version_file` declaration values: the ecosystem metadata
+# files (written by `prepare_release_version`) plus `none` — skip version
+# metadata changes and tag the frozen base HEAD directly.
+RELEASE_VERSION_FILE_OPTIONS = (
+    "pyproject.toml", "package.json", "pom.xml", "build.gradle",
+    "build.gradle.kts", "gradle.properties", "Cargo.toml",
+    "composer.json", "pubspec.yaml", "none",
+)
+
+
 def parse_release_declaration(body: str) -> dict:
     """Strictly parse the `## Release` section of a release Issue body.
 
@@ -110,7 +120,9 @@ def parse_release_declaration(body: str) -> dict:
     `release_test_command_ignored` evidence line at run time) and never
     executed. `scope` lists the Issue/PR numbers verified one by one.
     Optional `version_file` selects a supported ecosystem metadata file
-    (the default is `pyproject.toml`) or `none` to skip version metadata changes.
+    (the default is `pyproject.toml`) or `none` to skip version metadata
+    changes; its existence in the frozen release tree is verified at
+    claim time by `verify_release_version_file` (Issue #740).
     Exactly one of `scope` / `scope_from_milestone` must be present:
     both (conflict) or neither fails fast. `scope_from_milestone` is
     the Milestone TITLE (no spaces); its scope is derived later by
@@ -248,11 +260,7 @@ def parse_release_declaration(body: str) -> dict:
                 "not contain spaces"
             )
     version_file = fields.get("version_file", "pyproject.toml")
-    if version_file not in (
-        "pyproject.toml", "package.json", "pom.xml", "build.gradle",
-        "build.gradle.kts", "gradle.properties", "Cargo.toml",
-        "composer.json", "pubspec.yaml", "none",
-    ):
+    if version_file not in RELEASE_VERSION_FILE_OPTIONS:
         raise ValueError(
             "release declaration field `version_file` is not supported"
         )
@@ -265,6 +273,45 @@ def parse_release_declaration(body: str) -> dict:
         "scope_from_milestone": fields.get("scope_from_milestone"),
         "version_file": version_file,
     }
+
+
+def verify_release_version_file(repo_dir: Path, release_commit: str,
+                                version_file: str) -> None:
+    """Prove the declared `version_file` exists in the frozen base (Issue #740).
+
+    `version_file` is an optional declaration field that silently defaults
+    to the Python ecosystem's `pyproject.toml`; a repository without that
+    file used to discover the mismatch only at the version-write step —
+    after the gates and the scope verification had already run — and
+    burned the ticket `ai-blocked` with a bare FileNotFoundError
+    (orbi-cloud#246). The check probes the ROOT of the frozen release
+    commit's tree (`git ls-tree --name-only` — the exact content the
+    version write will see) and runs at claim time, before any gate wait.
+    A mismatch fails fast with an actionable message: the supported
+    ecosystem files that DO exist at the repository root (the value to
+    declare), and `none` for a repository with no version metadata file
+    at all.
+    """
+    if version_file == "none":
+        return
+    root_entries = set(run_command(
+        ["git", "ls-tree", "--name-only", release_commit],
+        cwd=repo_dir,
+    ).splitlines())
+    if version_file in root_entries:
+        return
+    existing = [
+        name for name in RELEASE_VERSION_FILE_OPTIONS
+        if name != "none" and name in root_entries
+    ]
+    raise RuntimeError(
+        f"release version_file {version_file!r} does not exist at the "
+        f"root of the release tree {release_commit} — supported files "
+        f"present at the repository root: "
+        f"{', '.join(existing) if existing else '(none)'}; declare one "
+        "of those as `- version_file: <file>`, or `- version_file: "
+        "none` to skip version metadata changes"
+    )
 
 
 def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
@@ -767,12 +814,7 @@ def prepare_release_version(worktree: Path, tag: str,
             f"release version {tag!r} must be a v-prefixed numeric tag"
         )
     version = match.group(1)
-    supported_files = {
-        "pyproject.toml", "package.json", "pom.xml", "build.gradle",
-        "build.gradle.kts", "gradle.properties", "Cargo.toml",
-        "composer.json", "pubspec.yaml", "none",
-    }
-    if version_file not in supported_files:
+    if version_file not in RELEASE_VERSION_FILE_OPTIONS:
         raise ValueError("release version_file is not supported")
     if version_file == "none":
         return run_command(["git", "rev-parse", "HEAD"], cwd=worktree).strip()
@@ -1579,6 +1621,11 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
        Issue #569).
     2. Freeze the base — the release commit is exactly
        `origin/<base_branch>` (fetched under the base-sync lock).
+    2b. Prove the declared (or defaulted) `version_file` exists at the
+       root of the frozen release tree (`verify_release_version_file`,
+       Issue #740) — before any gate wait, so a declaration/repo
+       mismatch fails fast at claim time with the supported files that
+       do exist, never as a late FileNotFoundError after the gates.
     3. Enforce the pre-release gates (`check_release_gates`).
     4. When `scope_from_milestone` is declared, derive the scope from
        the Milestone (`derive_release_scope_from_milestone`): closed
@@ -1712,6 +1759,15 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             ),
         )
         release_commit = freeze_base(config["repo_dir"], base_branch)
+        # Issue #740: the declared (or defaulted) version_file is proven
+        # to exist in the frozen release tree BEFORE any gate wait — a
+        # mismatch used to surface only at the version-write step, after
+        # the gates and the scope verification, and burned the ticket
+        # ai-blocked with a bare FileNotFoundError.
+        verify_release_version_file(
+            config["repo_dir"], release_commit,
+            declaration["version_file"],
+        )
         wait_started: float | None = None
         # Waiting is persisted in the auditable Issue comment, so a later
         # tick can enforce one bounded waiting window without local state.

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -16174,6 +16174,62 @@ def test_parse_release_declaration_scope_from_milestone():
     }
 
 
+# Issue #740: the declared (or defaulted) `version_file` is proven to
+# exist in the frozen release tree at claim time — a mismatch used to
+# surface only at the version-write step, AFTER the gates and the scope
+# verification, burning the ticket ai-blocked with a bare
+# FileNotFoundError.
+
+def test_verify_release_version_file_passes_when_the_file_exists(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        release, "run_command",
+        lambda command, **kwargs: commands.append((command, kwargs))
+        or "pyproject.toml\npackage.json\n",
+    )
+    release.verify_release_version_file(Path("/r"), "abc123", "pyproject.toml")
+    assert commands == [(["git", "ls-tree", "--name-only", "abc123"],
+                         {"cwd": Path("/r")})]
+
+
+def test_verify_release_version_file_skips_none_without_probing(monkeypatch):
+    monkeypatch.setattr(
+        release, "run_command",
+        lambda command, **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"unexpected command: {command}")),
+    )
+    release.verify_release_version_file(Path("/r"), "abc123", "none")
+
+
+def test_verify_release_version_file_lists_existing_supported_files(monkeypatch):
+    monkeypatch.setattr(
+        release, "run_command",
+        lambda command, **kwargs: "package.json\nCargo.toml\nREADME.md\n",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        release.verify_release_version_file(
+            Path("/r"), "abc123", "pyproject.toml",
+        )
+    message = str(excinfo.value)
+    assert "pyproject.toml" in message
+    assert "abc123" in message
+    assert "package.json" in message
+    assert "Cargo.toml" in message
+    assert "version_file: none" in message
+
+
+def test_verify_release_version_file_without_supported_file_points_at_none(monkeypatch):
+    monkeypatch.setattr(
+        release, "run_command", lambda command, **kwargs: "README.md\n",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        release.verify_release_version_file(
+            Path("/r"), "abc123", "package.json",
+        )
+    assert "package.json" in str(excinfo.value)
+    assert "version_file: none" in str(excinfo.value)
+
+
 def test_parse_release_declaration_manual_scope_has_no_milestone():
     decl = release.parse_release_declaration(RELEASE_DECLARATION_BODY)
     assert decl["scope_from_milestone"] is None
@@ -18113,7 +18169,8 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
                              tag_commit=None, release_url="https://github.com/o/r/releases/tag/v0.3.0",
                              in_progress=False, existing_run_id=None,
                              check_run_pages=None, milestone_items=None,
-                             leftover_labels=None, leftover_milestones=None):
+                             leftover_labels=None, leftover_milestones=None,
+                             release_tree_files=("pyproject.toml", "package.json")):
     """Full fake environment for `process_release`.
 
     Returns a dict of captured state: edit_issue / comment_issue calls,
@@ -18234,6 +18291,10 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             return "[]"
         if command[:2] == ["git", "fetch"]:
             return ""
+        if command[:3] == ["git", "ls-tree", "--name-only"]:
+            # Issue #740: the frozen release tree the version_file check
+            # probes — root entries, one per line.
+            return "".join(name + "\n" for name in release_tree_files)
         if command[:2] == ["git", "tag"]:
             return ""
         if command[:3] == ["git", "merge-base", "--is-ancestor"]:
@@ -18411,6 +18472,62 @@ def test_process_release_uses_declared_package_version_file(monkeypatch):
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
     release.process_release(issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r")
     assert seen == [(Path("/wt"), "v0.3.0", "main", "package.json")]
+
+
+def test_process_release_blocks_at_claim_when_default_version_file_missing(monkeypatch):
+    """Issue #740 (the orbi-cloud#246 scene): a TypeScript repo declares no
+    `version_file`, the default `pyproject.toml` does not exist. The claim
+    fails fast BEFORE the gates and the scope verification, and the
+    failure comment names the missing file plus a supported file that
+    exists and the `none` option."""
+    state = make_release_process_env(
+        monkeypatch, release_tree_files=["package.json"],
+    )
+    seen = []
+    monkeypatch.setattr(
+        release, "prepare_release_version",
+        lambda *args: seen.append(args) or "abc123",
+    )
+    issue = {"number": 99, "title": "Release v0.3.0",
+             "body": RELEASE_DECLARATION_BODY,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    result = release.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert result == ""
+    assert seen == []
+    # Nothing ran between the frozen base and the check: no gate, no
+    # scope verification, no version write.
+    assert [c for c, _ in state["commands"]] == [
+        ["git", "ls-tree", "--name-only", "abc123"],
+    ]
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+    failure = [k["body"] for n, k in state["comments"]
+               if n == 99 and "ai-blocked" in k["body"]]
+    assert failure and "pyproject.toml" in failure[0]
+    assert "package.json" in failure[0]
+    assert "version_file: none" in failure[0]
+
+
+def test_process_release_blocks_when_declared_version_file_missing(monkeypatch):
+    state = make_release_process_env(
+        monkeypatch, release_tree_files=["pyproject.toml"],
+    )
+    body = RELEASE_DECLARATION_BODY.replace(
+        "- version: v0.3.0\n", "- version: v0.3.0\n- version_file: package.json\n",
+    )
+    issue = {"number": 99, "title": "Release v0.3.0", "body": body,
+             "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
+    result = release.process_release(
+        issue, {"repo_dir": Path("/r"), "base_branch": "main"}, "o/r",
+    )
+    assert result == ""
+    assert state["edits"][-1] == (99, {"repo": "o/r", "add": "ai-blocked",
+                                       "remove": "ai-in-progress"})
+    failure = [k["body"] for n, k in state["comments"]
+               if n == 99 and "ai-blocked" in k["body"]]
+    assert failure and "package.json" in failure[0]
 
 
 def test_process_release_success_end_to_end(monkeypatch):


### PR DESCRIPTION
<!-- orbi:run=375e1490 -->

Fixes #740

release 声明的 version_file 默认 pyproject.toml，非 Python 仓不写就在打 tag 阶段才炸 (run_id=375e1490)
