### PR TITLE
调研型票撞交付判据：票面写「先调研不要写实现」，agent 照做却被判 no commit 烧成 ai-blocked

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -51,7 +51,11 @@ gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 ```
 
 A good body states the background, the expected behavior, the acceptance
-criteria, and (for bugs) the reproduction. Before changing anything Orbi
+criteria, and (for bugs) the reproduction. A research-only ticket
+("research/design first, do NOT implement yet") is dispatched as an ops
+ticket instead — `ai-ready` + `ai-ops-only`: a dev ticket whose agent
+correctly delivers no commit fails the delivery criterion and is burned
+`ai-blocked` (see the workflow page). Before changing anything Orbi
 reads the Issue, the repository's `AGENTS.md`, the files it will change
 plus their callers, and the related tests — the README and the rest of
 the repository only when the task is actually about them (Issue #180).

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -154,6 +154,19 @@ Ops semantics (Issue #537):
   removing `ai-in-progress` — no PR. Committed code takes the normal PR
   path with review and merge.
 
+Research-only tickets (Issue #739): a ticket whose body demands
+investigation only — "research/design first, do NOT implement yet" —
+is an ops ticket at dispatch time: give it `ai-ready` +
+`ai-ops-only`. A dev ticket cannot carry that instruction: the dev
+delivery criterion is a commit on the task branch, so an agent that
+correctly follows it delivers no commit and the run fails with
+`the agent delivered no commit` — the Issue is burned `ai-blocked`.
+The ops playbook's evidence discipline (real commands, verbatim
+output, unverified items labeled as such) IS the research
+deliverable; a no-commit ops run completes normally (the Issue is
+closed, `ai-in-progress` removed), and research that continues into
+code still takes the normal PR ceremony.
+
 Before Issue #537 the label `ai-ops-only` dispatched the content agent
 (the #530 rename never changed the behavior — the name promised ops,
 the mode was content-only); the content path dispatches on

--- a/docs/zh/contributing.mdx
+++ b/docs/zh/contributing.mdx
@@ -44,7 +44,10 @@ gh issue create --repo OWNER/PILOT-REPO --title "task title" --body "task body"
 gh issue edit <number> --repo OWNER/PILOT-REPO --add-label ai-ready
 ```
 
-好的 body 写清背景、期望行为、验收标准，（bug 时）复现步骤。Orbi 在
+好的 body 写清背景、期望行为、验收标准，（bug 时）复现步骤。调研型票
+（「先调研，不要直接写实现」）改派为 ops 票——`ai-ready` +
+`ai-ops-only`：dev 票照办不提交会撞交付判据、被烧成 `ai-blocked`
+（见 workflow 页）。Orbi 在
 改任何东西之前会读 Issue、仓库的 `AGENTS.md`、要改的文件及其调用方和
 相关测试——README 和仓库其余部分只在任务确实相关时才读（Issue #180）。
 

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -127,6 +127,14 @@ ops 语义（Issue #537）：
   （无 commit）以 Runner 关闭 Issue 并摘除 `ai-in-progress` 收尾——
   无 PR。附带代码 commit 则照常走 PR 路径（审查 + 合并）。
 
+调研型票（Issue #739）：票面要求只调研/设计——「先调研，不要直接写
+实现」——的票，派发时就是 ops 票：打 `ai-ready` + `ai-ops-only`。
+dev 票带不动这个指令：dev 的交付判据是 task branch 上有新提交，
+照办不提交的 agent 会以 `the agent delivered no commit` 失败，票被
+烧成 `ai-blocked`。ops 剧本的证据纪律（真实命令、原文输出、未验证项
+如实标注）就是调研交付物本身；无 commit 的 ops 运行正常收尾（关票、
+摘除 `ai-in-progress`），调研后继续落地的代码仍走正常 PR 流程。
+
 Issue #537 之前，`ai-ops-only` 标签派发的是内容代理（#530 只改了名，
 模式未变——名字承诺 ops，模式仍是纯内容）；现在 content 路径派发到
 `ai-content-only`，`ai-ops-only` 是完整执行的 ops 路径。

--- a/labels.toml
+++ b/labels.toml
@@ -66,4 +66,4 @@ description = "Content-only task: the content agent delivers text to the Issue �
 [[label]]
 name = "ai-ops-only"
 color = "0e8a16"
-description = "Ops task: full execution session (ops playbook) — evidence on the Issue, code changes via PR"
+description = "Ops/research task: full execution session (ops playbook) — evidence on the Issue, code via PR"

--- a/tests/test_docs_i18n.py
+++ b/tests/test_docs_i18n.py
@@ -367,6 +367,20 @@ def test_chinese_workflow_documents_the_full_issue_to_merge_chain():
     assert not unknown, f"Chinese workflow references unknown labels: {sorted(unknown)}"
 
 
+def test_chinese_workflow_documents_research_only_dispatch():
+    """Issue #739: the Chinese workflow page carries the same
+    research-only dispatch facts as the English page — a research-only
+    ticket is dispatched as ops (`ai-ready` + `ai-ops-only`); a dev
+    ticket whose agent correctly delivers no commit fails with `the
+    agent delivered no commit` and burns `ai-blocked`, while a
+    no-commit ops run completes normally."""
+    text = zh_page_text("workflow")
+    assert "调研型票" in text
+    assert "`ai-ready` + `ai-ops-only`" in text
+    assert "the agent delivered no commit" in text
+    assert "ai-blocked" in text
+
+
 def test_chinese_operations_documents_the_real_commands_and_recovery():
     """The Chinese operations page must carry the real operations facts:
     the 5-minute timer, the journal, the CLI commands, the worktree and

--- a/tests/test_docs_labels.py
+++ b/tests/test_docs_labels.py
@@ -74,6 +74,21 @@ def test_workflow_documents_all_labels_with_meaning():
     )
 
 
+def test_workflow_documents_research_only_dispatch():
+    """Issue #739: the dispatch section tells the ticket author that a
+    research-only ticket ("research/design first, do NOT implement
+    yet") is an ops ticket at dispatch time (`ai-ready` +
+    `ai-ops-only`): a dev ticket whose agent correctly follows the
+    instruction delivers no commit, fails with `the agent delivered no
+    commit` and burns `ai-blocked`, while a no-commit ops run
+    completes normally and committed code still takes the PR path."""
+    text = docs_page("workflow")
+    assert "Research-only tickets" in text
+    assert "`ai-ready` + `ai-ops-only`" in text
+    assert "the agent delivered no commit" in text
+    assert "ai-blocked" in text
+
+
 def test_setup_documents_label_initialization():
     """Issue #49/#241: GitHub labels are external state — a commit
     never creates them. docs/setup.mdx documents the initialization:


### PR DESCRIPTION
<!-- orbi:run=bded3c33 -->

Fixes #739

调研型票撞交付判据：票面写「先调研不要写实现」，agent 照做却被判 no commit 烧成 ai-blocked (run_id=bded3c33)
