### PR TITLE
假警报：缺少 .github/orbi.toml 时每 tick 刷 ERROR command_failed，而该 404 是设计内的 no-op

### DIFF
--- a/src/orbi/repo_config.py
+++ b/src/orbi/repo_config.py
@@ -254,6 +254,16 @@ def _is_not_found(exc: Exception) -> bool:
     return '"status":"404"' in stdout.replace(" ", "") or "HTTP 404" in stderr
 
 
+def _command_output_detail(exc: Exception) -> str:
+    """One-line stdout/stderr detail of a failed read (empty when absent)."""
+    parts = []
+    for name in ("stdout", "stderr"):
+        text = (getattr(exc, name, "") or "").strip().replace("\n", "\\n")
+        if text:
+            parts.append(f"{name}={text}")
+    return (" " + " ".join(parts)) if parts else ""
+
+
 def read_repo_config(repo: str, *, path: str = REPO_CONFIG_PATH,
                      run_command: Callable[..., str]) -> dict | None:
     """Read `<repo>@<default-branch>` `path` through the contents API.
@@ -262,16 +272,25 @@ def read_repo_config(repo: str, *, path: str = REPO_CONFIG_PATH,
     repository has no such file (the 404) or the read failed for any other
     transport reason. A file that exists but violates the schema raises
     :class:`RepoConfigError` — the caller blocks the claim.
+
+    The 404 is the designed no-op (a `None` return, not a failure): the
+    read passes `failure_log_level=logging.DEBUG` so `run_command`'s
+    generic `command_failed` line never reaches the INFO journal, and this
+    handler owns the real outcome — silent for the 404, an ERROR carrying
+    the command output for any other failure (Issue #730).
     """
     endpoint = f"repos/{repo}/contents/{path}"
     try:
-        raw = run_command(["gh", "api", endpoint], timeout=30)
+        raw = run_command(
+            ["gh", "api", endpoint], timeout=30,
+            failure_log_level=logging.DEBUG,
+        )
     except Exception as exc:
         if not _is_not_found(exc):
-            LOGGER.warning(
-                "repo_config_read_failed repo=%s path=%s error=%s "
+            LOGGER.error(
+                "repo_config_read_failed repo=%s path=%s error=%s%s "
                 "(falling back to the host config)",
-                repo, path, exc,
+                repo, path, exc, _command_output_detail(exc),
             )
         return None
     try:

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -7,6 +7,7 @@ change-visibility audit, and the runner wiring at the claim scan and claim.
 """
 import base64
 import json
+import logging
 import subprocess
 from pathlib import Path
 
@@ -238,6 +239,53 @@ def test_read_repo_config_read_failure_fails_open(caplog):
         "owner/repo", run_command=broken,
     ) is None
     assert "repo_config_read_failed" in caplog.text
+
+
+def test_read_repo_config_missing_file_logs_no_journal_error(
+    caplog, monkeypatch,
+):
+    """Issue #730: the designed 404 no-op is a `None` return, not a failure —
+    the real `run_command` (as wired by `load_repo_policy`) must not emit a
+    journal-visible (>= INFO) `command_failed` line for it."""
+    def not_found(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command,
+            output='{"message":"Not Found","status":"404"}',
+            stderr="gh: Not Found (HTTP 404)",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", not_found)
+    with caplog.at_level(logging.DEBUG, logger="orbi.bootstrap"):
+        assert repo_config.read_repo_config(
+            "owner/repo", run_command=runner.run_command,
+        ) is None
+    journal_visible = [
+        record for record in caplog.records
+        if record.levelno >= logging.INFO
+        and "command_failed" in record.getMessage()
+    ]
+    assert journal_visible == []
+
+
+def test_read_repo_config_read_failure_logs_error_with_detail(caplog):
+    """Issue #730: a real read failure (network/permission/rate limit) keeps
+    an ERROR line carrying the command output, not just the bare exit code."""
+    def denied(command, **kwargs):
+        raise subprocess.CalledProcessError(
+            1, command,
+            stderr="gh: API rate limit exceeded for installation 1234",
+        )
+
+    with caplog.at_level(logging.DEBUG, logger="orbi.bootstrap"):
+        assert repo_config.read_repo_config(
+            "owner/repo", run_command=denied,
+        ) is None
+    error_lines = [
+        record.getMessage() for record in caplog.records
+        if record.levelno >= logging.ERROR
+        and "repo_config_read_failed" in record.getMessage()
+    ]
+    assert any("rate limit exceeded" in line for line in error_lines)
 
 
 def test_read_repo_config_non_file_response_is_none():


### PR DESCRIPTION
<!-- orbi:run=c6e7c018 -->

Fixes #730

假警报：缺少 .github/orbi.toml 时每 tick 刷 ERROR command_failed，而该 404 是设计内的 no-op (run_id=c6e7c018)
