### PR TITLE
待办：迁移到 config-as-code——三个源仓库补 .github/orbi.toml，优先补上三处全缺的 test_command

### DIFF
--- a/.github/orbi.toml
+++ b/.github/orbi.toml
@@ -1,0 +1,6 @@
+# Repository delivery policy (config-as-code, orbi-build/orbi#527).
+# Whitelisted policy keys only — everything else (identity, credentials,
+# scheduling such as max_concurrency) is host-only and blocks the claim.
+# This is the first migrated key (orbi-build/orbi#731): the coverage-gated
+# test contract from AGENTS.md, as one command.
+test_command = "COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage run --branch -m pytest tests/ -q && COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 -m coverage report --show-missing && COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/coverage_gate.py .orbi/.coverage && COVERAGE_FILE=.orbi/.coverage /usr/bin/python3 tools/diff_coverage_gate.py origin/main"

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ dist/
 # boundary, so deliver_pr's dirty-worktree gate must never see it.
 .pi/
 .worktrees/
-orbi.toml
+# The local ROOT-level host-style engine config only (Issue #731): the
+# bare pattern also matched the tracked `.github/orbi.toml` policy file
+# and made it undeliverable — anchor this to the repository root.
+/orbi.toml
 # Per-run artifacts written into the task worktree (prompt.md steps 2
 # and 5): never version-controlled, so a new worktree created from the
 # frozen base never inherits the previous run's plan or test log.

--- a/docs/workflow.mdx
+++ b/docs/workflow.mdx
@@ -391,7 +391,10 @@ Every other key is rejected: an unknown key, a host-only
 identity/security key (see [Security](/security)), invalid TOML or a
 wrong type fails the claim fast with the offending key names and the
 Issue becomes `ai-blocked` — one repository's bad file never affects
-another pool. `dispatch_label` must not be a delivery lifecycle label
+another pool. The host-only set also owns host scheduling:
+`max_concurrency` can never be delegated to a repository file — the
+concurrency slot pool belongs to the deployment host.
+`dispatch_label` must not be a delivery lifecycle label
 (`ai-in-progress`, `ai-merged`, …): those stay host constants. The block
 lands on the Issue the claim selected; a repository whose
 `dispatch_label` is not `ai-ready` has no `ai-ready` candidate to block

--- a/docs/zh/workflow.mdx
+++ b/docs/zh/workflow.mdx
@@ -315,7 +315,9 @@ context_files = ["AGENTS.md"]
 其他键一律拒绝：未知键、host-only 身份/安全键（见
 [安全](/zh/security)）、坏 TOML 或类型错误都会让 claim fail-fast 并
 在错误里列出违规键，Issue 进入 `ai-blocked`——一个仓库的坏文件绝不
-影响其他池。`dispatch_label` 不得是交付生命周期标签
+影响其他池。host-only 集合同样包括宿主调度：`max_concurrency`
+永远不能下放到仓库文件——并发 slot 池属于部署宿主。
+`dispatch_label` 不得是交付生命周期标签
 （`ai-in-progress`、`ai-merged` 等）：那些恒为宿主常量。阻塞落在
 claim 选中的那个 Issue 上；`dispatch_label` 不是 `ai-ready` 的仓库在
 文件本身坏掉时没有 `ai-ready` 候选 Issue 可阻塞，此时 fail-fast 原因

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -945,3 +945,41 @@ def test_repo_policies_are_isolated_per_repository(monkeypatch):
     assert good["policy"] == {"base_branch": "beta"}
     with pytest.raises(repo_config.RepoConfigError):
         runner.load_repo_policy({"repositories": []}, "owner/bad")
+
+
+# --- this repository's own policy file (Issue #731) -------------------------
+
+def test_this_repositorys_own_orbi_toml_is_valid_and_declares_test_command():
+    """Orbi dogfoods its own config-as-code (Issue #731): the file this
+    repository carries at `.github/orbi.toml` must pass the strict claim
+    schema and declare the test command the implementer prompt injects —
+    a broken file here would block every claim of this repository with
+    `repo_config_invalid`."""
+    path = Path(__file__).resolve().parents[1] / ".github" / "orbi.toml"
+    assert path.is_file(), (
+        "the repository must carry .github/orbi.toml (Issue #731)"
+    )
+    policy = repo_config.parse_repo_config(
+        path.read_text(encoding="utf-8"),
+    )
+    test_command = policy.get("test_command")
+    assert isinstance(test_command, str) and test_command.strip()
+
+
+def test_this_repositorys_own_orbi_toml_is_not_gitignored():
+    """The policy file must be deliverable (Issue #731): the tracked
+    .gitignore ignores the local ROOT-level `orbi.toml` (host-style
+    engine config), and the bare pattern must not reach into `.github/`
+    — an ignored `.github/orbi.toml` could never reach the default
+    branch, so every claim would keep falling back to the host config."""
+    root = Path(__file__).resolve().parents[1]
+
+    def ignored(relative: str) -> bool:
+        proc = subprocess.run(
+            ["git", "check-ignore", "-q", relative],
+            cwd=root, capture_output=True,
+        )
+        return proc.returncode == 0
+
+    assert not ignored(".github/orbi.toml")
+    assert ignored("orbi.toml")


### PR DESCRIPTION
<!-- orbi:run=8fa45a3d -->

Fixes #731

待办：迁移到 config-as-code——三个源仓库补 .github/orbi.toml，优先补上三处全缺的 test_command (run_id=8fa45a3d)
