### PR TITLE
上手指南的 Groq 示例与模板/provider 指南不一致：仍是 qwen3.8-27b（8K TPM），应统一为 groq/compound（70K TPM）

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -353,10 +353,10 @@ it references an environment variable):
       "apiKey": "$GROQ_API_KEY",
       "models": [
         {
-          "id": "qwen/qwen3.8-27b",
-          "name": "Qwen 3.8 27B",
+          "id": "groq/compound",
+          "name": "Groq Compound",
           "contextWindow": 131072,
-          "maxTokens": 16384
+          "maxTokens": 8192
         }
       ]
     }
@@ -393,13 +393,39 @@ A local `llama.cpp` server (OpenAI-compatible routes at `/v1`, default
 ```
 
 Then select the provider and model in `orbi.toml` (the Runner
-passes them to Pi as `--provider groq --model qwen/qwen3.8-27b`, and
+passes them to Pi as `--provider groq --model groq/compound`, and
 `--thinking <level>` when `pi_thinking` is set):
 
 ```toml
 pi_providers = ".orbi/pi-providers.json"
 pi_provider = "groq"
-pi_model = "qwen/qwen3.8-27b"
+pi_model = "groq/compound"
+```
+
+#### Why `groq/compound` and not `qwen/qwen3.8-27b`
+
+Both models sit on Groq's Free Plan, and `qwen/qwen3.8-27b` even
+carries the higher request quota (1K RPD vs 250 RPD) — but the
+deciding quota for delivery-scale work is tokens, not requests. Per
+Groq account-page rate-limit data (provided by a user on 2026-09-12,
+not an Orbi measurement — re-check the official
+[rate-limit table](https://console.groq.com/docs/rate-limits) before
+relying on it), `groq/compound` is **70K TPM with no daily token
+cap**, while `qwen/qwen3.8-27b` is **8K TPM / 200K TPD**.
+
+At this repository's delivery scale the difference is one of kind, not
+degree: the median across this repo's own ~47 real deliveries is
+≈ 2.2M tokens per delivery, implement and review combined (a Python
+repository with CI and structured Issues — unverified on other
+repositories), so the 200K TPD cap cannot fund even one median
+delivery per day, and the 8K TPM alone means hours of rate-limit
+waiting. The token wall arrives long before the request wall, which
+is why the higher RPD never helps. The template, the
+[provider guide](/providers) and this guide therefore pin
+`groq/compound` — whose low TPM still makes short, bounded coding
+Issues a better fit than long-context repository analysis. These are
+account limits, not an Orbi guarantee; real Groq requests, usage
+metering, and 429 responses remain untested here.
 ```
 
 #### Keeping the API key out of the repo and the docs

--- a/docs/zh/getting-started.mdx
+++ b/docs/zh/getting-started.mdx
@@ -304,10 +304,10 @@ provider）保持原样，解析出的值只存在于 gitignored 的 per-run 目
       "apiKey": "$GROQ_API_KEY",
       "models": [
         {
-          "id": "qwen/qwen3.8-27b",
-          "name": "Qwen 3.8 27B",
+          "id": "groq/compound",
+          "name": "Groq Compound",
           "contextWindow": 131072,
-          "maxTokens": 16384
+          "maxTokens": 8192
         }
       ]
     }
@@ -344,13 +344,35 @@ provider）保持原样，解析出的值只存在于 gitignored 的 per-run 目
 ```
 
 然后在 `orbi.toml` 里选择 provider 和 model（Runner 会以
-`--provider groq --model qwen/qwen3.8-27b` 传给 Pi；设置
+`--provider groq --model groq/compound` 传给 Pi；设置
 `pi_thinking` 时再传 `--thinking <level>`）：
 
 ```toml
 pi_providers = ".orbi/pi-providers.json"
 pi_provider = "groq"
-pi_model = "qwen/qwen3.8-27b"
+pi_model = "groq/compound"
+```
+
+#### 为什么选 `groq/compound` 而不是 `qwen/qwen3.8-27b`
+
+两个模型都在 Groq 免费档上，`qwen/qwen3.8-27b` 的请求数配额甚至更高
+（1K RPD 对 250 RPD）——但对交付量级的工作，起决定作用的是 token
+配额，不是请求数。按 Groq 账号页面的限流数据（用户于 2026-09-12
+提供，不是 Orbi 实测——依赖前请重新核对
+[官方限流表](https://console.groq.com/docs/rate-limits)），
+`groq/compound` 是 **70K TPM、无日 token 上限**，`qwen/qwen3.8-27b`
+是 **8K TPM / 200K TPD**。
+
+在本仓库的交付量级下，这是性质之别，不是程度之别：本仓库自身约 47
+次真实交付的中位数约为每次交付 220 万 token（implement 与 review
+合计；来源是一个带 CI、有 Issue 规范的 Python 仓库——对其他仓库
+未验证），所以 200K TPD 连一天一次的中位交付都覆盖不了，8K TPM
+本身就意味着数小时的限流等待。token 墙先于请求墙到来，这正是更高
+的 RPD 在这里不起作用的原因。因此模板、
+[provider 指南](/zh/providers)与本指南统一钉在 `groq/compound`
+上——它的 TPM 同样偏低，仍然只适合短小、边界清晰的 coding Issue，
+不适合长上下文仓库分析。这些是账号限额，不是 Orbi 承诺；真实的
+Groq 请求、usage 计量与 429 响应在本文中仍未实测。
 ```
 
 #### 让 API key 不进仓库、不进文档

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -419,6 +419,59 @@ def test_docs_document_groq_free_plan_configuration_and_limits():
         assert "GROQ_API_KEY" in text
 
 
+def test_docs_getting_started_groq_example_matches_the_provider_template():
+    """Issue #776: both getting-started pages must configure the same Groq
+    model the provider template, the provider guide, and the weekly CI
+    catalog check pin — `groq/compound` with the template's 8,192-token
+    maximum completion — never the 8K-TPM `qwen/qwen3.8-27b`, and must
+    explain the choice on token quota (TPM/TPD), not the higher request
+    quota, with sourced numbers and without any new "tested" claim."""
+    for slug in ("getting-started", "zh/getting-started"):
+        text = page_text(slug)
+        # No fenced example (JSON/TOML/bash) configures the weak model;
+        # the prose comparison names it, the configuration never does.
+        blocks = re.findall(r"```[a-z]*\n(.*?)```", text, re.DOTALL)
+        assert blocks, f"{slug} must carry fenced examples"
+        for block in blocks:
+            assert "qwen/qwen3.8-27b" not in block, (
+                f"{slug} must not configure qwen/qwen3.8-27b anywhere"
+            )
+        # The example is the template's model, with the template's limits.
+        assert '"id": "groq/compound"' in text, (
+            f"{slug} must define the groq provider on groq/compound"
+        )
+        assert '"name": "Groq Compound"' in text, (
+            f"{slug} must carry the template's model name"
+        )
+        assert '"maxTokens": 8192' in text, (
+            f"{slug} must align maxTokens with templates/pi-providers/groq.json"
+        )
+        assert "--model groq/compound" in text, (
+            f"{slug} must document the real Pi launch flag"
+        )
+        assert 'pi_model = "groq/compound"' in text, (
+            f"{slug} must select groq/compound in orbi.toml"
+        )
+        # The why: token quota decides, not the higher request quota —
+        # with the source date and the evidence scope kept honest.
+        for fact in (
+            "qwen/qwen3.8-27b", "70K", "8K", "TPD", "RPD",
+            "2026-09-12",
+        ):
+            assert fact in text, f"{slug} must explain the model choice ({fact})"
+        assert (
+            "未实测" in text
+            or "not tested" in text.lower()
+            or "untested" in text.lower()
+        ), f"{slug} must keep the untested boundary, no new availability claim"
+        assert (
+            "未验证" in text
+            or "未经验证" in text
+            or "not verified" in text.lower()
+            or "unverified" in text.lower()
+        ), f"{slug} must scope the delivery-token evidence to this repository"
+
+
 def test_docs_document_openrouter_free_models_with_honest_limits():
     """Issue #316: the OpenRouter guide must be runnable and distinguish
     catalog facts from measurements that were not performed."""


### PR DESCRIPTION
<!-- orbi:run=d4f72001 -->

Fixes #776

上手指南的 Groq 示例与模板/provider 指南不一致：仍是 qwen3.8-27b（8K TPM），应统一为 groq/compound（70K TPM） (run_id=d4f72001)
