### PR TITLE
失败评论把原始 JSONL 与覆盖率表倒进正文：GitHub 上无法阅读

### DIFF
--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -7275,11 +7275,11 @@ def _publish_test_milestone(publisher: ProgressPublisher,
 
 
 def _failure_detail(exc: BaseException) -> str:
-    """One-line failure description; keeps subprocess stderr visible."""
+    """One-line failure description; keeps bounded subprocess stderr visible."""
     detail = str(exc)
     stderr = getattr(exc, "stderr", None)
     if isinstance(stderr, str) and stderr.strip() and stderr.strip() not in detail:
-        detail = f"{detail} stderr={stderr.strip()}"
+        detail = f"{detail} stderr={stderr.strip()[:1000]}"
     return detail
 
 
@@ -7303,12 +7303,119 @@ def _tail_text(path: Path, *, lines: int = 20, chars: int = 4000) -> str:
     return tail[-chars:] if len(tail) > chars else tail
 
 
+def _latest_session_file(worktree: Path | None) -> Path | None:
+    """The most recent pi session log in the worktree, or None."""
+    if worktree is None:
+        return None
+    session_files = sorted(
+        (p for p in (worktree / ".pi-session").glob("*.jsonl")
+         if p.is_file()),
+        key=lambda p: p.stat().st_mtime,
+    )
+    return session_files[-1] if session_files else None
+
+
+def _fenced(content: str, *, cap: int = 4000) -> str:
+    """One raw-output segment inside a CommonMark code fence (Issue #775).
+
+    GitHub renders fenced content literally and monospaced, so coverage
+    tables and escaped JSONL survive a failure comment unread by the
+    markdown parser. The fence is one backtick longer than every run in
+    the content, so a payload containing markdown fences can never close
+    it; content past `cap` is cut and the cut is noted after the fence.
+    """
+    omitted = 0
+    if len(content) > cap:
+        omitted = len(content) - cap
+        content = content[:cap]
+    fence = "`" * max(
+        3,
+        1 + max((len(run) for run in re.findall(r"`+", content)), default=0),
+    )
+    block = f"{fence}\n{content}\n{fence}"
+    if omitted:
+        block += f"\n_[truncated, {omitted} chars omitted]_"
+    return block
+
+
+# The number of session records a failure comment summarizes (Issue #775).
+SESSION_SUMMARY_LIMIT = 20
+
+
+def _session_summary(session_file: Path,
+                     *, limit: int = SESSION_SUMMARY_LIMIT) -> str:
+    """Structured summary of the last session records (Issue #775).
+
+    One line per parsed record — timestamp, type, role, tool name and
+    content-block kinds; the record text itself never enters the comment
+    (the full log path is named next to the segment). A record whose
+    text blocks repeat the previous record's is skipped: pi logs the
+    final assistant text twice (once inside the full message, once
+    standalone), which used to duplicate whole paragraphs in the
+    comment. Unparsable tail lines are skipped; an unreadable file is
+    the `<unavailable>` placeholder.
+    """
+    try:
+        with session_file.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            window = min(size, 65536)
+            handle.seek(size - window)
+            content = handle.read(window).decode("utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return "<unavailable>"
+    summary: list[str] = []
+    previous_text: str | None = None
+    for line in reversed(content.splitlines()):
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        message = record.get("message")
+        message = message if isinstance(message, dict) else {}
+        blocks = message.get("content")
+        blocks = blocks if isinstance(blocks, list) else []
+        text = "".join(
+            block.get("text", "") for block in blocks
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+        if text and text == previous_text:
+            continue
+        previous_text = text or None
+        parts = [str(record.get("type", "?"))]
+        if message.get("role"):
+            parts.append(f"role={message['role']}")
+        if message.get("toolName"):
+            parts.append(f"tool={message['toolName']}")
+        kinds = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            kind = str(block.get("type", "?"))
+            if kind == "toolCall" and block.get("name"):
+                kind = f"toolCall:{block['name']}"
+            kinds.append(kind)
+        if kinds:
+            parts.append(f"content={','.join(kinds)}")
+        summary.append(f"{record.get('timestamp', '-')} {' '.join(parts)}")
+        if len(summary) >= limit:
+            break
+    if not summary:
+        return "<unparsable>"
+    return "\n".join(reversed(summary))
+
+
 def _failure_evidence(worktree: Path | None, exc: BaseException) -> str:
     """Render the bounded evidence that survives terminal worktree cleanup.
 
     Pi subprocess streams come from ``CalledProcessError``. The session and
-    test log are read before cleanup and only their tails are copied into the
-    failure comment, keeping the GitHub comment useful and bounded.
+    test log are read before cleanup and only bounded, fenced segments are
+    copied into the failure comment: raw output stays literal on GitHub,
+    the session tail is a structural summary whose duplicates are removed,
+    and the full session log is named for the deep-dive (Issue #775). The
+    failure reason itself stays the readable head of the comment.
     """
     stderr = getattr(exc, "stderr", None)
     stdout = getattr(exc, "output", None)
@@ -7319,26 +7426,24 @@ def _failure_evidence(worktree: Path | None, exc: BaseException) -> str:
     stderr = str(stderr) if stderr else "<empty>"
     stdout = str(stdout) if stdout else "<empty>"
     return_code = getattr(exc, "returncode", None)
-    session = "<unavailable>"
+    session_file = _latest_session_file(worktree)
+    session = (
+        _session_summary(session_file) if session_file else "<unavailable>"
+    )
     test_log = "<unavailable>"
     if worktree is not None:
-        session_files = sorted(
-            (p for p in (worktree / ".pi-session").glob("*.jsonl")
-             if p.is_file()),
-            key=lambda p: p.stat().st_mtime,
-        )
-        if session_files:
-            session = _tail_text(session_files[-1])
         test_path = worktree / ".orbi" / "test.log"
         if test_path.is_file():
             test_log = _tail_text(test_path)
     return (
         "\n\nFailure evidence (captured before cleanup):\n"
         f"exit_code={return_code if return_code is not None else '<unknown>'}\n"
-        f"stderr={stderr[-4000:]}\n"
-        f"stdout_tail={stdout[-4000:]}\n"
-        f"session_last_events={session[-4000:]}\n"
-        f"test_log_tail={test_log[-4000:]}"
+        f"\nstderr_tail:\n{_fenced(stderr)}\n"
+        f"\nstdout_tail:\n{_fenced(stdout)}\n"
+        "\nsession_last_events "
+        f"(last {SESSION_SUMMARY_LIMIT} records; full log: "
+        f"{session_file or '<unavailable>'}):\n{_fenced(session)}\n"
+        f"\ntest_log_tail:\n{_fenced(test_log)}"
     )
 
 
@@ -8374,6 +8479,9 @@ _FIX_NEEDED_PHRASE = (
     "; the Issue stays ai-fix-needed and the next tick resumes the "
     "same run, branch, worktree and PR"
 )
+# Issue #775: the whole failure-comment body is capped well below the
+# GitHub comment limit; the cut is noted with the full session log path.
+FAILURE_COMMENT_MAX_CHARS = 20000
 
 
 def report_delivery_failure(
@@ -8493,6 +8601,17 @@ def report_delivery_failure(
         outcome = "fix needed"
     if evidence:
         body += _failure_evidence(worktree, exc)
+    if len(body) > FAILURE_COMMENT_MAX_CHARS:
+        # Issue #775: the comment body is capped; the cut preserves the
+        # cause-first head and names the full session log for the part
+        # that was dropped.
+        session_file = _latest_session_file(worktree)
+        body = (
+            body[:FAILURE_COMMENT_MAX_CHARS]
+            + f"\n\n_[comment truncated at {FAILURE_COMMENT_MAX_CHARS} "
+            f"chars; full session log: "
+            f"{session_file or '<unavailable>'}]_"
+        )
     if run_id:
         body = f"{run_marker(run_id)}\n{body}"
     comment_issue(number, repo=source_repo, body=body)

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -7817,9 +7817,15 @@ def test_failure_evidence_handles_binary_streams_and_unavailable_files(tmp_path)
     evidence = runner._failure_evidence(tmp_path / "missing", error)
 
     assert "exit_code=2" in evidence
-    assert "stderr=binary stderr" in evidence
-    assert "stdout_tail=binary stdout" in evidence
-    assert "session_last_events=<unavailable>" in evidence
+    assert "stderr_tail:\n```" in evidence
+    assert "stdout_tail:\n```" in evidence
+    assert "binary stderr" in evidence
+    assert "binary stdout" in evidence
+    # Issue #775: raw segments are fenced; a missing file stays a
+    # placeholder inside its fence instead of a raw dump.
+    assert "test_log_tail:\n```\n<unavailable>\n```" in evidence
+    assert "session_last_events (last 20 records; full log: <unavailable>):" \
+        in evidence
     assert runner._tail_text(tmp_path / "missing.log") == "<unavailable>"
 
 
@@ -7827,7 +7833,18 @@ def test_failure_evidence_includes_streams_session_and_test_tail(tmp_path):
     worktree = tmp_path / "wt"
     (worktree / ".pi-session").mkdir(parents=True)
     (worktree / ".pi-session" / "session.jsonl").write_text(
-        "old event\nlatest event\n", encoding="utf-8",
+        json.dumps({
+            "type": "message", "timestamp": "2026-09-12T10:00:00Z",
+            "message": {"role": "user", "content": [
+                {"type": "text", "text": "review the PR"},
+            ]},
+        }) + "\n"
+        + json.dumps({
+            "type": "message", "timestamp": "2026-09-12T10:01:00Z",
+            "message": {"role": "toolResult", "toolName": "Bash",
+                        "isError": False},
+        }) + "\n",
+        encoding="utf-8",
     )
     (worktree / ".orbi").mkdir()
     (worktree / ".orbi" / "test.log").write_text(
@@ -7838,17 +7855,174 @@ def test_failure_evidence_includes_streams_session_and_test_tail(tmp_path):
     evidence = runner._failure_evidence(worktree, error)
 
     assert "exit_code=1" in evidence
-    assert "stderr=<empty>" in evidence
     assert "stdout tail" in evidence
-    assert "latest event" in evidence
     assert "1 failed, 2 passed" in evidence
+    # Issue #775: the session tail is a structural summary, not raw JSONL.
+    assert "2026-09-12T10:00:00Z message role=user content=text" in evidence
+    assert "2026-09-12T10:01:00Z message role=toolResult tool=Bash" in evidence
+    assert f"full log: {worktree / '.pi-session' / 'session.jsonl'}" in evidence
+
+
+def test_failure_evidence_keeps_coverage_table_literal_inside_fence(tmp_path):
+    """Issue #775: the vitest coverage table must render as monospace
+    literal text on GitHub, never parsed as a markdown table."""
+    worktree = tmp_path / "wt"
+    (worktree / ".pi-session").mkdir(parents=True)
+    raw_record = json.dumps({
+        "type": "message", "timestamp": "t1",
+        "message": {"role": "assistant", "content": [
+            {"type": "text", "text": "**bold** | not | a | table"},
+        ]},
+    })
+    (worktree / ".pi-session" / "s.jsonl").write_text(raw_record + "\n")
+    (worktree / ".orbi").mkdir()
+    (worktree / ".orbi" / "test.log").write_text(
+        " src      | stmts |\n"
+        "----------|-------\n"
+        " billing  | 96%   |\n",
+        encoding="utf-8",
+    )
+    error = subprocess.CalledProcessError(1, ["pi"])
+
+    evidence = runner._failure_evidence(worktree, error)
+
+    # Every raw segment opens its fence directly under the label.
+    for label in ("stderr_tail:", "stdout_tail:", "test_log_tail:"):
+        assert f"\n{label}\n```" in evidence
+    # The table separator line survives verbatim inside the test-log
+    # fence (label -> fence -> table row).
+    assert "test_log_tail:\n```\n src      | stmts |\n----------|-------\n" \
+        in evidence
+    # The session record text never enters the comment: the summary
+    # carries the shape, the fence carries the log path.
+    assert "bold" not in evidence
+    assert raw_record not in evidence
+
+
+def test_failure_evidence_dedupes_repeated_session_text_block(tmp_path):
+    """Issue #775: pi logs the final assistant text twice (once inside
+    the full message, once standalone); the summary keeps it once."""
+    worktree = tmp_path / "wt"
+    (worktree / ".pi-session").mkdir(parents=True)
+    final_text = "审查完成。结论：verdict pass"
+    duplicated = [
+        {"type": "message", "timestamp": "2026-09-12T10:44:12.000Z",
+         "message": {"role": "assistant", "content": [
+             {"type": "thinking"}, {"type": "text", "text": final_text},
+         ]}},
+        {"type": "message", "timestamp": "2026-09-12T10:44:12.000Z",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": final_text},
+         ]}},
+    ]
+    (worktree / ".pi-session" / "s.jsonl").write_text(
+        "".join(json.dumps(record) + "\n" for record in duplicated),
+        encoding="utf-8",
+    )
+
+    evidence = runner._failure_evidence(
+        worktree, subprocess.CalledProcessError(1, ["pi"]),
+    )
+
+    assert evidence.count("role=assistant") == 1
+    assert final_text not in evidence
+
+
+def test_session_summary_skips_malformed_records_and_respects_limit(tmp_path):
+    """Defensive edges: malformed lines, messages and blocks are skipped,
+    the toolCall kind carries its name, the limit keeps the LAST records,
+    and an all-unparsable log degrades to the placeholder."""
+    good = {"type": "message", "timestamp": "t", "message": {
+        "role": "assistant",
+        "content": [{"type": "toolCall", "name": "Bash"}, "junk", 3],
+    }}
+    path = tmp_path / "s.jsonl"
+    path.write_text(
+        "not json\n"
+        "[1, 2]\n"
+        + json.dumps({"type": "x", "message": "not-a-dict"}) + "\n"
+        + json.dumps(good) + "\n",
+        encoding="utf-8",
+    )
+
+    assert runner._session_summary(path, limit=1) == (
+        "t message role=assistant content=toolCall:Bash"
+    )
+
+    many = tmp_path / "many.jsonl"
+    many.write_text("".join(
+        json.dumps({"type": f"r{i}", "timestamp": f"t{i}"}) + "\n"
+        for i in range(5)
+    ), encoding="utf-8")
+    assert runner._session_summary(many, limit=2) == "t3 r3\nt4 r4"
+
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text("nope\n[1]\n", encoding="utf-8")
+    assert runner._session_summary(bad) == "<unparsable>"
+
+    # An unreadable/missing file is the placeholder (also the race path
+    # where the session vanishes between the glob and this read).
+    assert runner._session_summary(tmp_path / "missing.jsonl") == "<unavailable>"
+
+
+def test_failure_evidence_truncates_oversized_segment_with_note(tmp_path):
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    evidence = runner._failure_evidence(
+        worktree,
+        subprocess.CalledProcessError(1, ["pi"], stderr="x" * 9000),
+    )
+
+    assert "[truncated, 5000 chars omitted]" in evidence
+
+
+def test_report_delivery_failure_caps_comment_and_names_session_log(
+    monkeypatch, tmp_path,
+):
+    """Issue #775: an oversized body is cut at the cap, the cut names
+    the full session log path, and the failure reason stays first."""
+    posted = []
+    monkeypatch.setattr(runner, "apply_label_patch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(runner, "issue_labels", lambda *args, **kwargs: set())
+    monkeypatch.setattr(
+        runner, "comment_issue",
+        lambda number, *, repo, body: posted.append(body),
+    )
+    error = subprocess.CalledProcessError(1, ["pi"])
+    worktree = tmp_path / "wt"
+    session_file = worktree / ".pi-session" / "s.jsonl"
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text("{}\n", encoding="utf-8")
+
+    outcome = runner.report_delivery_failure(
+        error, issue={"number": 775, "title": "t", "labels": []},
+        source_repo="orbi-build/orbi", run_id=None, pr_url=None,
+        worktree=worktree, branch="b", role=runner.ROLE_IMPLEMENT,
+        cause="x" * 25000,
+        classify=False, evidence=True,
+    )
+
+    assert outcome == "blocked"
+    body = posted[0]
+    # The cause-first head survives the cut; the oversize cause itself
+    # legitimately fills the whole window and pushes the evidence out.
+    assert body.startswith("Orbi failed:")
+    assert len(body) <= runner.FAILURE_COMMENT_MAX_CHARS + 300
+    assert f"full session log: {session_file}" in body
 
 
 def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_path):
     calls = []
     (tmp_path / "wt" / ".pi-session").mkdir(parents=True)
     (tmp_path / "wt" / ".pi-session" / "session.jsonl").write_text(
-        "assistant event\n", encoding="utf-8",
+        json.dumps({
+            "type": "message", "timestamp": "2026-08-25T02:30:00Z",
+            "message": {"role": "assistant", "content": [
+                {"type": "text", "text": "assistant event"},
+            ]},
+        }) + "\n",
+        encoding="utf-8",
     )
     (tmp_path / "wt" / ".orbi").mkdir()
     (tmp_path / "wt" / ".orbi" / "test.log").write_text(
@@ -7901,7 +8075,11 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     assert "result=ok" in failure_body
     assert "exit_code=1" in failure_body
     assert "stderr=boom" in failure_body
-    assert "assistant event" in failure_body
+    # Issue #775: the session tail appears as its structured summary
+    # line inside a fence, not as raw session text.
+    assert "2026-08-25T02:30:00Z message role=assistant content=text" \
+        in failure_body
+    assert "assistant event" not in failure_body
     assert "1 failed" in failure_body
     # The full scene on the failure comment carries the debug entry.
     assert f"worktree={tmp_path / 'wt'}" in failure_body

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -282,7 +282,9 @@ def test_wait_for_delivery_recoverable_review_failure_stays_fix_needed(
     assert "session=" in body
     assert "phase=" in body
     assert "last_activity=" in body
-    assert "stderr=<empty>" in body
+    # Issue #775: raw evidence segments are fenced; the empty stderr is
+    # the placeholder inside its fence.
+    assert "stderr_tail:\n```\n<empty>\n```" in body
     if isinstance(exc, subprocess.CalledProcessError):
         assert "exit_code=1" in body
     # The SAME failure comment is written to the PR (Issue #50: the


### PR DESCRIPTION
<!-- orbi:run=e72d05a0 -->

Fixes #775

失败评论把原始 JSONL 与覆盖率表倒进正文：GitHub 上无法阅读 (run_id=e72d05a0)
