### PR TITLE
架构重构 1/5:新建 github.py / gitops.py 叶子模块,消灭抽离模块对 runner 的反向依赖

### DIFF
--- a/src/orbi/cli_source.py
+++ b/src/orbi/cli_source.py
@@ -142,3 +142,180 @@ def drift_line(source: dict) -> str | None:
         f"expected={quote_value(str(source['expected']))} "
         f"fix={quote_value(source['fix'])}"
     )
+
+
+# --- the editable CLI install refresh (moved from `orbi.runner`,
+# --- Issue #785: the install domain belongs to the CLI-source module) ---
+
+import fcntl  # noqa: E402
+import hashlib  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import os  # noqa: E402
+
+from orbi.gitops import acquire_base_sync_lock  # noqa: E402
+
+CLI_INSTALL_LOGGER = logging.getLogger("orbi.cli_install")
+
+# The uv install timeout (seconds): a local editable build of this
+# zero-dependency package takes seconds; a hang (a wedged uv or a
+# full disk) must fail the start, never block it forever (Issue #95:
+# blocking commands carry a timeout).
+UV_INSTALL_TIMEOUT_SECONDS = 300
+
+
+class CliInstallError(RuntimeError):
+    """The editable CLI install refresh failed (fail fast)."""
+
+
+def packaging_fingerprint(repo_dir: Path) -> str:
+    """The sha256 of the checkout's `pyproject.toml`.
+
+    `pyproject.toml` is the packaging input that decides the editable
+    metadata (the entry points, the version, the dependencies) — so
+    its content hash is the refresh trigger. Ordinary Python source
+    content is NOT part of it: since the src layout (Issue #168) the
+    editable finder maps the WHOLE `src/orbi/` package
+    directory, so a newly added package module needs no reinstall
+    (the whole point of the editable install, Issue #152). A checkout
+    without `pyproject.toml` cannot be tool-installed: fail fast,
+    never guess a fingerprint.
+    """
+    pyproject = Path(repo_dir) / "pyproject.toml"
+    if not pyproject.is_file():
+        raise CliInstallError(
+            f"packaging file missing: {pyproject} (the deployment "
+            "checkout must carry the packaging input of the editable "
+            "install)"
+        )
+    return hashlib.sha256(pyproject.read_bytes()).hexdigest()
+
+
+def install_state_path(repo_dir: Path) -> Path:
+    """The last-install fingerprint record in the shared state dir.
+
+    `<repo_dir>/.orbi/cli-install.json` — the EXISTING shared
+    state dir (gitignored, next to `base-sync.lock` and the slots;
+    it survives the `git merge --ff-only` checkout sync). Not a second
+    release state and not a per-process temp file.
+    """
+    return Path(repo_dir) / ".orbi" / "cli-install.json"
+
+
+def read_install_state(repo_dir: Path) -> str | None:
+    """The stored last-install fingerprint, or None.
+
+    Missing file (first install / fresh checkout) -> None. A
+    malformed file (a torn write) is treated as "no state" and heals
+    in the SAFE direction: one extra idempotent `--force
+    --reinstall` runs — never a wedged start.
+    """
+    path = install_state_path(repo_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    fingerprint = data.get("pyproject_sha256") if isinstance(data, dict) else None
+    if not isinstance(fingerprint, str) or not fingerprint:
+        return None
+    return fingerprint
+
+
+def write_install_state(repo_dir: Path, fingerprint: str) -> None:
+    """Record the last-install fingerprint (atomic: tmp + replace).
+
+    Only called AFTER a successful install, under the base-sync flock
+    (no concurrent writer; the atomic replace guards a torn write on
+    a crash mid-install).
+    """
+    path = install_state_path(repo_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(
+        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
+    )
+    os.replace(str(tmp), str(path))
+
+
+def refresh_cli_install(
+    repo_dir: Path, *, run_command,
+    lock_timeout_seconds: float = 300.0,
+    lock_repo_dir: Path | None = None,
+) -> str:
+    """Refresh the editable CLI install when the packaging inputs
+    changed; return `"unchanged"` or `"installed"`. ``repo_dir`` is
+    the checkout to install; ``lock_repo_dir`` optionally names the
+    shared deployment checkout whose base-sync lock also protects the
+    tool environment.
+
+    The pre-start gate (called by the Runner tick before any slot or
+    claim):
+
+    - the current packaging fingerprint equals the stored last-install
+      fingerprint -> `"unchanged"` and NO uv call (no per-tick
+      reinstall);
+    - otherwise (changed, or no state yet — the first install): take
+      the base-sync flock (the SAME lock the service template's
+      `ExecStartPre` and the checkout sync use), re-check the state
+      UNDER the lock (a concurrent instance may have refreshed while
+      we waited — reuse its result, never run a second install), run
+      the exact verified editable force reinstall from
+      `cli_source.reinstall_args`, and record the fingerprint only
+      after success.
+
+    A failing install logs the structured `cli_install_failed` line
+    (reason + the exact fix command) and raises `CliInstallError`:
+    the service does not start (fail fast), no state is recorded (the
+    next start retries) and the lock is released (success or
+    failure).
+    """
+    repo_dir = Path(repo_dir)
+    lock_repo_dir = (
+        Path(lock_repo_dir) if lock_repo_dir is not None else repo_dir
+    )
+    fingerprint = packaging_fingerprint(repo_dir)
+    if read_install_state(repo_dir) == fingerprint:
+        CLI_INSTALL_LOGGER.info(
+            "cli_install_unchanged repo_dir=%s pyproject_sha256=%s",
+            repo_dir, fingerprint,
+        )
+        return "unchanged"
+    fd = acquire_base_sync_lock(lock_repo_dir, lock_timeout_seconds)
+    try:
+        # Re-check UNDER the lock: a concurrent instance may have
+        # refreshed the tool env while we waited for the flock —
+        # reuse its result, never run a second install.
+        if read_install_state(repo_dir) == fingerprint:
+            CLI_INSTALL_LOGGER.info(
+                "cli_install_reused repo_dir=%s pyproject_sha256=%s",
+                repo_dir, fingerprint,
+            )
+            return "unchanged"
+        reason = "first_install" if (
+            read_install_state(repo_dir) is None
+        ) else "packaging_changed"
+        try:
+            run_command(
+                reinstall_args(repo_dir),
+                timeout=UV_INSTALL_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            CLI_INSTALL_LOGGER.error(
+                "cli_install_failed repo_dir=%s reason=%s fix=%s",
+                repo_dir, quote_value(str(exc)),
+                quote_value(reinstall_command(repo_dir)),
+            )
+            raise CliInstallError(
+                f"editable CLI install failed for {repo_dir}: {exc} "
+                f"(fix: {reinstall_command(repo_dir)})"
+            ) from exc
+        write_install_state(repo_dir, fingerprint)
+        CLI_INSTALL_LOGGER.info(
+            "cli_install_refreshed repo_dir=%s reason=%s "
+            "pyproject_sha256=%s",
+            repo_dir, reason, fingerprint,
+        )
+        return "installed"
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)

--- a/src/orbi/github.py
+++ b/src/orbi/github.py
@@ -214,12 +214,17 @@ def milestone_issues(repo: str, milestone_number: int,
             if isinstance(item, dict)]
 
 
-def list_milestones(repo: str) -> list[dict]:
-    """List ALL Milestones of the repo (open and closed), all pages."""
+def list_milestones(repo: str, *, timeout: int | None = None) -> list[dict]:
+    """List ALL Milestones of the repo (open and closed), all pages.
+
+    ``timeout`` keeps the caller's bound (Issue #95: a network wait is
+    a blocking command): the idle milestone-advance sweep bounded this
+    read at 30 s before the move into this module.
+    """
     raw = run_gh_read_command([
         "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
         "--paginate", "--slurp",
-    ])
+    ], timeout=timeout)
     return parse_paginated_issue_array(raw)
 
 

--- a/src/orbi/github.py
+++ b/src/orbi/github.py
@@ -1,0 +1,776 @@
+"""GitHub read/write data access at the `gh` command line.
+
+One function per GitHub read/write, with the `gh` argument assembly, the
+`--json` field sets, the JSON shape validation, and the read-only retry
+of `run_gh_read_command` all in this one leaf (Issue #785) — no call site
+assembles a `gh` command for the shared contracts anymore, and the
+extracted modules consume GitHub through these typed functions instead of
+importing `runner`.
+
+The only seam is `orbi.journal.run_command` (Article 3.4). The argv each
+function emits is byte-identical to the call site it replaces — the
+command line is the contract (Article 5.2), including the two distinct
+milestone issue-list orders the sweep and the release scope derivation
+pin separately.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from orbi.delivery_labels import (
+    IN_PROGRESS_LABEL,
+    P0_LABEL,
+    label_patch,
+)
+from orbi.journal import LOGGER, run_command, single_line
+from orbi.progress import format_status_comment
+
+GH_READ_MAX_ATTEMPTS = 3
+GH_READ_BACKOFF_SECONDS = 1
+# gh prints its own HTTP failures as `HTTP <code>: <text> (<url>)` — the
+# transient classes of Issue #738 are the 401 keyring race, the rate
+# limits (429 / the API's "rate limit" messages) and GitHub-side 5xx.
+GH_TRANSIENT_ERROR_RE = re.compile(
+    r"http 401|http 429|http 5\d\d|bad credentials|rate limit",
+    re.IGNORECASE,
+)
+# The read-only gh subcommand surface (the maintainer comment's
+# enumerated read table). A verb missing from the set simply gets no
+# retry — today's behavior — while a write verb can never classify as
+# retryable, so a retried write can never duplicate a side effect.
+GH_READ_SUBCOMMANDS = {
+    ("issue", "list"), ("issue", "view"),
+    ("pr", "list"), ("pr", "view"),
+    ("release", "view"),
+    ("repo", "view"),
+    ("label", "list"),
+    ("auth", "status"), ("auth", "token"),
+}
+RESUME_PR_STATE_TIMEOUT_SECONDS = 30
+
+
+def _is_readonly_gh_command(command: list[str]) -> bool:
+    """Return whether a gh command is provably read-only.
+
+    `gh api` is a read only when it carries no non-GET `--method`/`-X`
+    override and no request parameter: per gh's own semantics the
+    default method is GET normally and POST if any `-f`/`-F` parameter
+    was added, so only an explicit `--method GET` keeps parameters on
+    the query string — the flags are gh's read/write semantics, not a
+    call-site list. Every other subcommand is a read only when its verb
+    is in the fixed read set.
+    """
+    if command[:1] != ["gh"] or len(command) < 3:
+        return False
+    if command[1] == "api":
+        args = command[2:]
+        method_get = False
+        has_parameter = False
+        for index, argument in enumerate(args):
+            if argument in {"-X", "--method"} and index + 1 < len(args):
+                if args[index + 1].upper() != "GET":
+                    return False
+                method_get = True
+            elif argument.startswith("--method="):
+                if argument.split("=", 1)[1].upper() != "GET":
+                    return False
+                method_get = True
+            elif (
+                argument in {"-f", "-F", "--raw-field", "--field"}
+                or argument.startswith(("--raw-field=", "--field="))
+                or (argument.startswith(("-f", "-F")) and len(argument) > 2)
+            ):
+                has_parameter = True
+        return method_get or not has_parameter
+    return (command[1], command[2]) in GH_READ_SUBCOMMANDS
+
+
+def run_gh_read_command(
+    command: list[str], *, cwd: Path | None = None,
+    timeout: int | None = None,
+    command_runner: Callable[..., str] | None = None,
+) -> str:
+    """Run one read-only gh command with bounded transient-failure retries.
+
+    Issue #738: a keyring race (HTTP 401), a rate limit (429) or a
+    GitHub-side 5xx used to crash a whole tick that was only reading.
+    Only provably read-only commands (`_is_readonly_gh_command`) that
+    failed with a transient error are retried, so no write path can ever
+    reach the retry loop; every retry logs a structured `gh_read_retry`
+    line, and the last error is re-raised unchanged so the existing
+    failure handling keeps its stderr.
+    """
+    execute = command_runner or run_command
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            # Forward only the set options: None is run_command's own
+            # default, and passing it explicitly would change the call
+            # observed by the run_command fakes and probes.
+            if timeout is None:
+                if cwd is None:
+                    return execute(command)
+                return execute(command, cwd=cwd)
+            if cwd is None:
+                return execute(command, timeout=timeout)
+            return execute(command, cwd=cwd, timeout=timeout)
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or "").strip()
+            retryable = (
+                _is_readonly_gh_command(command)
+                and GH_TRANSIENT_ERROR_RE.search(detail) is not None
+            )
+            if attempt >= GH_READ_MAX_ATTEMPTS or not retryable:
+                raise
+        delay = GH_READ_BACKOFF_SECONDS * (2 ** (attempt - 1))
+        LOGGER.warning(
+            "gh_read_retry command=%s attempt=%s max_attempts=%s "
+            "delay_seconds=%s stderr=%s",
+            single_line(" ".join(command)), attempt + 1,
+            GH_READ_MAX_ATTEMPTS, delay, single_line(detail),
+        )
+        time.sleep(delay)
+
+
+def parse_issue_array(raw: str) -> list[dict]:
+    """Return the issue array from gh's JSON output."""
+    issues = json.loads(raw)
+    if not isinstance(issues, list):
+        raise ValueError("issue list must be a JSON array")
+    return issues
+
+
+def parse_issue_list(raw: str) -> dict | None:
+    """Return the first issue from gh's JSON array, or None when idle."""
+    issues = parse_issue_array(raw)
+    return issues[0] if issues else None
+
+
+def parse_paginated_issue_array(raw: str) -> list[dict]:
+    """Flatten the JSON array emitted by ``gh api --paginate --slurp``."""
+    pages = json.loads(raw)
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise ValueError("paginated issue list must be an array of arrays")
+    if any(not isinstance(item, dict) for page in pages for item in page):
+        raise ValueError("paginated issue list contains a non-object item")
+    return [item for page in pages for item in page]
+
+
+def list_issues(repo: str, *, state: str | None = None,
+                label: str | None = None, milestone: str | None = None,
+                search: str | None = None, json_fields: str, limit: int,
+                timeout: int | None = None) -> list[dict]:
+    """Run one ``gh issue list`` query and return the parsed JSON array.
+
+    Issue #299: every ``gh issue list`` call site shares this single
+    command builder. The flag order mirrors the call sites it replaces
+    (``--label``/``--state``/``--search`` before ``--json``/``--limit``,
+    with ``--milestone`` appended last, exactly as the release gate did),
+    so the emitted ``gh`` command is byte-for-byte unchanged.
+    """
+    command = ["gh", "issue", "list", "--repo", repo]
+    if label is not None:
+        command += ["--label", label]
+    if state is not None:
+        command += ["--state", state]
+    if search is not None:
+        command += ["--search", search]
+    command += ["--json", json_fields, "--limit", str(limit)]
+    if milestone is not None:
+        command += ["--milestone", milestone]
+    return parse_issue_array(run_gh_read_command(command, timeout=timeout))
+
+
+def milestone_open_issues(repo: str, milestone_number: int) -> list[dict]:
+    """List open Issues for one exact Milestone number, including all pages."""
+    raw = run_gh_read_command([
+        "gh", "api",
+        f"repos/{repo}/issues?milestone={milestone_number}&state=open&per_page=100",
+        "--paginate", "--slurp",
+    ])
+    return parse_paginated_issue_array(raw)
+
+
+def milestone_issues(repo: str, milestone_number: int,
+                     state: str) -> list[dict]:
+    """List Issues of one Milestone in one explicit state, all pages.
+
+    The release scope derivation pins THIS query order
+    (`state=` before `milestone=`); the tick sweep reads the open state
+    through `milestone_open_issues`, whose order its own contract pins.
+    """
+    raw = run_gh_read_command([
+        "gh", "api",
+        f"repos/{repo}/issues?state={state}&milestone={milestone_number}&per_page=100",
+        "--paginate", "--slurp",
+    ])
+    return [item for item in parse_paginated_issue_array(raw)
+            if isinstance(item, dict)]
+
+
+def list_milestones(repo: str) -> list[dict]:
+    """List ALL Milestones of the repo (open and closed), all pages."""
+    raw = run_gh_read_command([
+        "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
+        "--paginate", "--slurp",
+    ])
+    return parse_paginated_issue_array(raw)
+
+
+def milestone_open_issue_count(repo: str, milestone_title: str) -> int:
+    """Return the Open-Issue count of one Milestone (Issue #663).
+
+    A single `gh api` call reads GitHub's own `open_issues` counter —
+    the authority on whether the Milestone still has unfinished work.
+    Unlike the search-based ready scans it does not depend on the search
+    index and it is not affected by a delivery-state label, so an Issue
+    temporarily outside the ready queue (`ai-blocked`, `ai-pr-opened`,
+    or not yet indexed) still counts. The title-filtered `--jq` is the
+    command documented in the Issue, verified against the live API. An
+    empty result means the Milestone could not be found: that is a
+    failed check, never a silent 0 (the caller must not release on it).
+    """
+    raw = run_gh_read_command(
+        [
+            "gh", "api", f"repos/{repo}/milestones",
+            "--jq",
+            f'.[] | select(.title=="{milestone_title}") | .open_issues',
+        ],
+        timeout=30,
+    )
+    if not raw:
+        raise RuntimeError(
+            f"Milestone {milestone_title!r} not found in {repo}"
+        )
+    return int(raw)
+
+
+def close_milestone(repo: str, number: int) -> None:
+    """Close one Milestone by number (the release completion step)."""
+    run_command([
+        "gh", "api", f"repos/{repo}/milestones/{number}",
+        "--method", "PATCH", "-f", "state=closed",
+    ])
+
+
+def close_issue(number: int, *, repo: str) -> None:
+    """Close one Issue by number (the reconciliation/cleanup step)."""
+    run_command(["gh", "issue", "close", str(number), "--repo", repo])
+
+
+def issue_view(number: int, fields: str, *, repo: str | None = None,
+               cwd: Path | None = None, timeout: int | None = None) -> dict:
+    """Read one Issue's JSON fields through `gh issue view`.
+
+    Without ``repo`` the query runs in the checkout ``cwd`` points at
+    (its `gh` repo context), byte-identical to the repo-free call sites.
+    """
+    command = ["gh", "issue", "view", str(number)]
+    if repo is not None:
+        command += ["--repo", repo]
+    command += ["--json", fields]
+    data = json.loads(run_gh_read_command(command, cwd=cwd, timeout=timeout))
+    if not isinstance(data, dict):
+        raise ValueError("issue view must be a JSON object")
+    return data
+
+
+def pr_view(number: int, fields: str, *, repo: str | None = None,
+            cwd: Path | None = None, timeout: int | None = None) -> dict:
+    """Read one PR's JSON fields through `gh pr view` (same repo rule)."""
+    command = ["gh", "pr", "view", str(number)]
+    if repo is not None:
+        command += ["--repo", repo]
+    command += ["--json", fields]
+    data = json.loads(run_gh_read_command(command, cwd=cwd, timeout=timeout))
+    if not isinstance(data, dict):
+        raise ValueError("pr view must be a JSON object")
+    return data
+
+
+def commit_check_runs(repo: str, commit: str) -> list:
+    """Read one commit's GitHub check runs (the CI gate evidence)."""
+    checks = json.loads(run_gh_read_command([
+        "gh", "api", f"repos/{repo}/commits/{commit}/check-runs",
+        "--jq", ".check_runs",
+    ]))
+    if not isinstance(checks, list):
+        raise ValueError("check-runs response must be an array")
+    return checks
+
+
+def release_view(repo: str, tag: str, fields: str) -> dict:
+    """Read one GitHub Release's JSON fields by tag."""
+    data = json.loads(run_gh_read_command([
+        "gh", "release", "view", tag, "--repo", repo,
+        "--json", fields,
+    ]))
+    if not isinstance(data, dict):
+        raise ValueError("release view must be a JSON object")
+    return data
+
+
+def release_edit_notes(repo: str, tag: str, *, notes: str) -> None:
+    """Replace one GitHub Release's notes."""
+    run_command([
+        "gh", "release", "edit", tag, "--repo", repo,
+        "--notes", notes,
+    ])
+
+
+def release_create(repo: str, *, tag: str, version: str,
+                   notes: str) -> None:
+    """Publish one GitHub Release from an existing tag."""
+    run_command([
+        "gh", "release", "create", tag, "--repo", repo,
+        "--verify-tag", "--title", version, "--notes", notes,
+    ])
+
+
+def issue_priority(issue: dict) -> str:
+    """Return the pickup priority of one issue (Issue #101).
+
+    `p0` when the issue carries the `p0` label, `normal` otherwise.
+    The ready/in-flight/resumable scans fetch `labels` (verified
+    against `gh issue list --help`: `labels` is a supported JSON
+    field, an array of `{name, ...}` nodes), so this is a pure
+    function of the scanned issue — no extra gh call. A missing or
+    malformed `labels` field fails to `normal` (like the blockedBy
+    field fails open): a P0 misread as normal only loses its ordering
+    for one run, never the delivery.
+    """
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return "normal"
+    for label in labels:
+        if isinstance(label, dict) and label.get("name") == P0_LABEL:
+            return "p0"
+    return "normal"
+
+
+def epic_issue_with_blockers(repo: str, issue: dict) -> dict:
+    """Add the native blocker field omitted by the REST issue listing."""
+    if isinstance(issue.get("blockedBy"), dict):
+        return issue
+    number = issue.get("number")
+    if not isinstance(number, int) or isinstance(number, bool):
+        raise ValueError("Epic number is missing or invalid")
+    raw = run_gh_read_command([
+        "gh", "issue", "view", str(number), "--repo", repo,
+        "--json", "number,body,labels,blockedBy",
+    ])
+    details = json.loads(raw)
+    if not isinstance(details, dict):
+        raise ValueError(f"Epic #{number} details are not an object")
+    return details
+
+
+def open_blocker_numbers(issue: dict) -> list[int]:
+    """Return the numbers of the issue's OPEN native GitHub blockers.
+
+    `gh issue list --json blockedBy` (gh 2.94+) carries the native
+    dependency relation as `{"nodes": [...], "totalCount": N}`. GitHub
+    keeps a relation listed after its blocker closes (the node then
+    carries `state: "CLOSED"` and is inert — verified against the live
+    API, Issue #54), so only OPEN blockers actually block: a closed
+    blocker clears the dependency without any runner-side bookkeeping,
+    and the next tick claims the Issue. A node without an explicit
+    `state` counts as open (claiming a possibly-blocked Issue costs a
+    full run; waiting one tick does not). A missing or malformed field
+    means "no known blockers" (fail open): an API shape change must
+    never deadlock the queue.
+    """
+    blocked_by = issue.get("blockedBy")
+    if not isinstance(blocked_by, dict):
+        return []
+    nodes = blocked_by.get("nodes")
+    if not isinstance(nodes, list):
+        return []
+    numbers: list[int] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        number = node.get("number")
+        if not isinstance(number, int) or isinstance(number, bool):
+            continue
+        if node.get("state", "OPEN") != "OPEN":
+            continue
+        numbers.append(number)
+    return numbers
+
+
+def _verify_epic_complete(repo: str, listed_epic: dict) -> list[str]:
+    """Verify native sub-issues and blockers; otherwise fail closed.
+
+    Live API shape (measured 2026-09-09 against #305):
+    ``GET /repos/{owner}/{repo}/issues/{number}/sub_issues`` returns a JSON
+    array (``[]`` for no children), paginates with the standard ``--paginate``
+    contract, and Issue items include ``repository.full_name`` and no
+    ``pull_request`` key.  The endpoint is paginated with ``per_page=100``;
+    a cross-repository item is identified by its ``repository.full_name`` and
+    is rejected.  A PR-shaped item is identified by a non-null
+    ``pull_request`` field and is checked through the PR endpoint.
+    """
+    epic = epic_issue_with_blockers(repo, listed_epic)
+    number = epic.get("number")
+    if not isinstance(number, int) or isinstance(number, bool):
+        raise ValueError("Epic number is missing or invalid")
+    blockers = epic.get("blockedBy")
+    # Live API check (Issue #552): `gh issue view --json blockedBy` returns
+    # {"blockedBy":{"nodes":[],"totalCount":0}} for zero dependencies.
+    # Missing/malformed blockedBy is not equivalent to that empty set.
+    if not isinstance(blockers, dict) or not isinstance(blockers.get("nodes"), list):
+        raise ValueError("native blocker/dependency state is unavailable")
+    for node in blockers["nodes"]:
+        if (not isinstance(node, dict)
+                or not isinstance(node.get("number"), int)
+                or isinstance(node.get("number"), bool)
+                or ("state" in node and node["state"] not in {"OPEN", "CLOSED"})):
+            raise ValueError("native blocker/dependency state is malformed")
+    open_blockers = open_blocker_numbers(epic)
+    if open_blockers:
+        raise ValueError("open blockers: " + ", ".join(f"#{n}" for n in open_blockers))
+    raw = run_gh_read_command([
+        "gh", "api", f"repos/{repo}/issues/{number}/sub_issues?per_page=100",
+        "--paginate", "--slurp",
+    ])
+    children = parse_paginated_issue_array(raw)
+    if not children:
+        raise ValueError("Epic child scope is missing or empty")
+    child_evidence: list[str] = []
+    for child in children:
+        child_number = child.get("number")
+        if not isinstance(child_number, int) or isinstance(child_number, bool):
+            raise ValueError("Epic child scope contains an invalid number")
+        child_repo = child.get("repository")
+        if not isinstance(child_repo, dict) or not isinstance(child_repo.get("full_name"), str):
+            raise ValueError(f"child #{child_number} repository state is malformed")
+        if child_repo["full_name"].lower() != repo.lower():
+            raise ValueError(f"cross-repository child #{child_number}")
+        if child.get("state") not in {"open", "closed"}:
+            raise ValueError(f"child #{child_number} state is malformed")
+        kind = "pr" if child.get("pull_request") is not None else "issue"
+        child_evidence.append(_epic_child_evidence(repo, kind, child_number))
+    return child_evidence
+
+
+def _epic_child_evidence(repo: str, kind: str, number: int) -> str:
+    """Verify one child against GitHub's live Issue/PR state."""
+    raw = run_gh_read_command(["gh", "api", f"repos/{repo}/issues/{number}"])
+    item = json.loads(raw)
+    if not isinstance(item, dict):
+        raise ValueError(f"child #{number} response is not an object")
+    is_pr = "pull_request" in item
+    if kind == "issue" and is_pr:
+        raise ValueError(f"child #{number} declared as Issue but is a PR")
+    if kind == "pr" and not is_pr:
+        raise ValueError(f"child #{number} declared as PR but is an Issue")
+    if is_pr:
+        pr = json.loads(run_gh_read_command(["gh", "api", f"repos/{repo}/pulls/{number}"]))
+        if not isinstance(pr, dict) or pr.get("merged") is not True:
+            raise ValueError(f"child PR #{number} is not merged")
+        return f"PR #{number} merged"
+    if item.get("state") != "closed":
+        raise ValueError(f"child Issue #{number} is not closed")
+    return f"Issue #{number} closed"
+
+
+def _epic_audit(child_evidence: list[str], version: str | None = None) -> str:
+    prefix = f" for {version}" if version else ""
+    return (f"Epic reconciliation{prefix}: complete; "
+            f"children: {', '.join(child_evidence)}; "
+            "no open native blockers/dependencies.")
+
+
+# Only comments posted by a repo maintainer are trusted to carry the
+# recovery scene: a public comment (authorAssociation=NONE) must never
+# steer the runner into an arbitrary local worktree, branch or PR
+# (Issue #45 review, BLOCKER). A missing association is never trusted.
+TRUSTED_COMMENT_ASSOCIATIONS = frozenset({
+    "OWNER", "MAINTAINER", "MEMBER", "COLLABORATOR",
+})
+
+
+def edit_issue(number: int, *, repo: str, add: str | None = None,
+               remove: str | None = None) -> None:
+    command = ["gh", "issue", "edit", str(number), "--repo", repo]
+    if add:
+        command += ["--add-label", add]
+    if remove:
+        command += ["--remove-label", remove]
+    run_command(command)
+
+
+def apply_label_patch(number: int, *, repo: str, event: str,
+                      current_labels) -> None:
+    """Compute the deterministic label patch for `event` and apply it.
+
+    `current_labels` is the Issue's current label names (read once by the
+    caller). The patch comes from `delivery_labels.label_patch` — the
+    single source of truth for the transition rules (Issue #175) — so the
+    same current labels and event always produce the same idempotent
+    patch. The patch is applied through `edit_issue`: one call for the
+    add plus the first remove, then one call per extra remove (the exact
+    same `edit_issue` kwargs the pre-#175 code emitted). A no-op patch
+    (nothing to add or remove) applies nothing.
+    """
+    to_add, to_remove = label_patch(event, current_labels)
+    if not to_add and not to_remove:
+        return
+    first_remove = to_remove[0] if to_remove else None
+    kwargs: dict = {"repo": repo}
+    if to_add:
+        kwargs["add"] = to_add[0]
+    if first_remove is not None:
+        kwargs["remove"] = first_remove
+    edit_issue(number, **kwargs)
+    for label in to_remove[1:]:
+        edit_issue(number, repo=repo, remove=label)
+
+
+def comment_issue(number: int, *, repo: str, body: str) -> None:
+    run_command(["gh", "issue", "comment", str(number), "--repo", repo,
+                 "--body", format_status_comment(body)])
+
+
+def issue_comments(number: int, *, repo: str) -> list[dict]:
+    """Return the Issue's comment history (oldest first) from GitHub.
+
+    ``gh issue view --json comments`` returns a top-level object with a
+    ``comments`` array; each comment carries the author and the
+    ``authorAssociation`` of the viewer, which is how the runner tells
+    its own trusted comments apart from public ones (Issue #45).
+    """
+    raw = run_gh_read_command([
+        "gh", "issue", "view", str(number), "--repo", repo,
+        "--json", "comments",
+    ], timeout=30)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("issue view must be a JSON object")
+    comments = data.get("comments")
+    if not isinstance(comments, list):
+        raise ValueError("issue comments must be a JSON array")
+    return comments
+
+
+def pr_comments(number: int, *, repo: str) -> list[dict]:
+    """Return the PR's comment history (oldest first) from GitHub.
+
+    The PR-side twin of `issue_comments`: a PR's comments are read
+    through `gh pr view --json comments` (`gh issue view` rejects PR
+    numbers), the same top-level object with a `comments` array — and
+    the same 30 s bound (#745 bounded the issue-side read; an
+    unbounded comments read is the same hang on the PR side).
+    """
+    raw = run_gh_read_command([
+        "gh", "pr", "view", str(number), "--repo", repo,
+        "--json", "comments",
+    ], timeout=30)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("pr view must be a JSON object")
+    comments = data.get("comments")
+    if not isinstance(comments, list):
+        raise ValueError("pr comments must be a JSON array")
+    return comments
+
+
+def trusted_issue_comments_block(comments: list[dict], limit: int) -> str:
+    """Render the {{ISSUE_COMMENTS}} prompt block (Issue #745).
+
+    Only trusted authors enter the task context — the same
+    `authorAssociation` trust set as the recovery-scene parser (Issue
+    #45; a public repo lets anyone comment, and an unfiltered injection
+    would be a prompt-injection surface). The input order is preserved
+    (oldest first, the natural timeline read). Over `limit` the OLDEST
+    trusted comments are dropped — the newest carry the latest decision
+    — and the omission is stated inside the block: the agent must know
+    it did not see the full history, never a silent truncation. Zero
+    trusted comments produce an explicit marker, not an empty string.
+    """
+    trusted = [
+        comment for comment in comments if _comment_is_trusted(comment)
+    ]
+    kept = trusted[-limit:]
+    omitted = len(trusted) - len(kept)
+    if not kept:
+        return "(no trusted comments)"
+    lines = []
+    if omitted:
+        noun = "comment" if omitted == 1 else "comments"
+        lines.append(
+            f"({omitted} older trusted {noun} omitted; showing the "
+            f"{len(kept)} most recent)"
+        )
+    for comment in kept:
+        author = comment.get("author")
+        login = author.get("login") if isinstance(author, dict) else None
+        lines.append(
+            f"- {login or 'unknown'} "
+            f"({comment.get('authorAssociation') or '-'}) "
+            f"at {comment.get('createdAt') or '-'}:\n\n"
+            f"{str(comment.get('body') or '').rstrip()}"
+        )
+    return "\n\n".join(lines)
+
+
+def _authenticated_github_login() -> str:
+    """Return the login represented by the active ``gh`` credential.
+
+    ``gh api installation`` is unavailable with installation tokens, while
+    ``gh auth status`` reports the account selected in gh's credential store.
+    Read that local status instead of guessing a bot name or making an API
+    request that cannot identify this credential shape.
+    """
+    try:
+        # The comments being verified come from github.com.  Restrict the
+        # status query to that host so an active account on another configured
+        # GitHub Enterprise host cannot be mistaken for this credential.
+        status = run_gh_read_command([
+            "gh", "auth", "status", "--hostname", "github.com",
+        ])
+    except Exception as exc:
+        raise ValueError(
+            "GitHub identity resolution failed: `gh auth status` could not "
+            f"read the active account: {exc}; run `gh auth login` or fix "
+            "the GitHub credentials"
+        ) from exc
+
+    account: str | None = None
+    active_account: str | None = None
+    for line in status.splitlines():
+        match = re.search(r"\baccount\s+(\S+)", line)
+        if match:
+            account = match.group(1)
+        if re.search(r"Active account:\s*true\b", line, re.IGNORECASE):
+            if account:
+                active_account = account
+
+    if not active_account:
+        raise ValueError(
+            "GitHub identity resolution failed: `gh auth status` did not "
+            "report an active account; run `gh auth login` or select an "
+            "active github.com account with `gh auth switch`"
+        )
+    return active_account
+
+
+def _strip_bot_suffix(login: str) -> str:
+    """Drop the optional ``[bot]`` suffix from an App login.
+
+    ``gh issue view --json comments`` reads comments through GraphQL and
+    reports ``author.login`` without the ``[bot]`` suffix, while REST's
+    ``user.login`` keeps it (Issue #655). Both shapes name the same App
+    credential, so the suffix is normalized away before comparison.
+    """
+    return login[:-5] if login.endswith("[bot]") else login
+
+
+def _comment_is_trusted(comment: object) -> bool:
+    """True when the comment is from a maintainer or this runner's App bot."""
+    if not isinstance(comment, dict):
+        return False
+    if comment.get("authorAssociation") in TRUSTED_COMMENT_ASSOCIATIONS:
+        return True
+    author = comment.get("author")
+    login = author.get("login") if isinstance(author, dict) else None
+    if not isinstance(login, str):
+        return False
+    # A copied run marker is not sufficient: the author must be the account
+    # represented by the currently authenticated installation token. The
+    # optional `[bot]` suffix is normalized on both sides because GraphQL
+    # drops it and REST keeps it (Issue #655).
+    return _strip_bot_suffix(login) == _strip_bot_suffix(
+        _authenticated_github_login()
+    )
+
+
+def open_pr_for_branch(repo_dir: Path, branch: str) -> dict | None:
+    """Return the sole open PR for a branch, or None when absent."""
+    raw = run_gh_read_command([
+        "gh", "pr", "list", "--state", "open", "--head", branch,
+        "--json", "number,url,baseRefName,headRefName,headRefOid",
+        "--limit", "2",
+    ], cwd=repo_dir, timeout=RESUME_PR_STATE_TIMEOUT_SECONDS)
+    prs = json.loads(raw) if raw.strip() else []
+    if not isinstance(prs, list):
+        raise RuntimeError("open PR query must return an array")
+    if len(prs) > 1:
+        raise RuntimeError(
+            f"multiple open PRs for stable delivery branch {branch}"
+        )
+    return prs[0] if prs else None
+
+
+def issue_labels(number: int, repo: str) -> list[str]:
+    """Return the current label names of one Issue."""
+    data = issue_view(number, "labels", repo=repo)
+    labels = data.get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("issue labels must be a JSON array")
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def has_in_progress_label(number: int, repo: str) -> bool:
+    """True while the Issue carries `ai-in-progress` (the live claim state).
+
+    Read via `gh issue view` — a direct, strongly consistent read. The
+    pre-#658 implementation used `gh issue list --search`, the same
+    eventually-consistent index the pickup scan reads, so it could not
+    see a label another instance added seconds ago — exactly the moment
+    this check exists to catch (the pre-claim race guard).
+    """
+    labels = issue_view(number, "labels", repo=repo).get("labels")
+    if not isinstance(labels, list):
+        raise ValueError("issue view labels must be a JSON array")
+    return any(
+        isinstance(label, dict) and label.get("name") == IN_PROGRESS_LABEL
+        for label in labels
+    )
+
+
+def _pr_number(pr_url: str) -> int:
+    """Extract the PR number from its URL (the last path segment)."""
+    return int(pr_url.rstrip("/").rsplit("/", 1)[-1])
+
+
+def pr_delivery_status(pr_url: str, source_repo: str) -> tuple[str, list[str]]:
+    """Return PR state and CI summaries for delivery-wait evidence."""
+    number = _pr_number(pr_url)
+    data = pr_view(number, "state,statusCheckRollup", repo=source_repo)
+    state = data.get("state")
+    if state not in ("OPEN", "MERGED", "CLOSED"):
+        raise ValueError(f"unexpected PR state: {state!r}")
+    rollup = data.get("statusCheckRollup")
+    if rollup is None:
+        rollup = []
+    if not isinstance(rollup, list):
+        raise ValueError("pr statusCheckRollup must be a JSON array")
+    summaries = []
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        name = check.get("name", check.get("context", "check"))
+        status = check.get("status", check.get("state", "UNKNOWN"))
+        conclusion = check.get("conclusion")
+        detail = str(status)
+        if conclusion:
+            detail += f"/{conclusion}"
+        summaries.append(f"{name}={detail}")
+    return state, summaries
+
+
+def pr_state(pr_url: str, source_repo: str) -> str:
+    """Return a PR's state from the configured source repository."""
+    return pr_delivery_status(pr_url, source_repo)[0]

--- a/src/orbi/gitops.py
+++ b/src/orbi/gitops.py
@@ -1,0 +1,325 @@
+"""Git data operations: delivery naming, worktrees, fetch, ancestor checks.
+
+One leaf for the git data operations the Runner and the extracted modules
+share (Issue #785): the stable delivery naming (`task_branch`,
+`worktree_path`, `latest_run_id`), worktree creation, the base fetch that
+freezes `origin/<base>`, the ancestor checks of the delivery gates, and
+the base-sync lock every fetch that updates the shared remote-tracking
+ref must hold (Issue #171).
+
+The only seam is `orbi.journal.run_command` (Article 3.4); this module
+imports no other `orbi` module besides `journal`.
+"""
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from orbi.journal import (
+    GIT_NETWORK_TIMEOUT_SECONDS,
+    LOGGER,
+    run_command,
+    run_git_network_command,
+)
+
+LOGGER = logging.getLogger("orbi.gitops")
+
+BASE_SYNC_LOCK_NAME = "base-sync.lock"
+
+
+class BaseSyncLockError(RuntimeError):
+    """The base-sync flock could not be taken within the timeout.
+
+    The lock orders every writer of the shared remote-tracking ref
+    ``refs/remotes/origin/<base>`` and of the deployment tool env
+    (Issue #171); a timeout means another Runner instance or the
+    ExecStartPre preflight is syncing right now — fail fast, no retry.
+    """
+
+    def __init__(self, lock_path: Path, lock_timeout_seconds: float):
+        super().__init__(
+            f"could not take the base-sync lock {lock_path} "
+            f"within {lock_timeout_seconds}s (another Runner "
+            "instance or the ExecStartPre preflight is syncing "
+            "the deployment checkout)"
+        )
+
+
+def task_branch(source_repo: str, number: int, run_id: str | None = None) -> str:
+    """Return the stable remote delivery identity for one Issue.
+
+    ``run_id`` remains accepted for callers and compatibility, but is not
+    part of the branch identity: retries must converge on one GitHub branch
+    and therefore one open PR.
+    """
+    return f"orbi/{source_repo.replace('/', '-')}-issue-{number}"
+
+
+def worktree_path(repo_dir: Path, source_repo: str, number: int,
+                  run_id: str) -> Path:
+    """Task worktrees live in the configured repo's .worktrees/ directory."""
+    slug = source_repo.replace("/", "-")
+    return (
+        repo_dir / ".worktrees"
+        / f"orbi-{slug}-issue-{number}-{run_id}"
+    )
+
+
+def latest_run_id(repo_dir: Path, source_repo: str, number: int) -> str | None:
+    """Return the run id of the newest task worktree for the issue.
+
+    The worktree directory name carries the run id — the state the
+    release state machine (Issue #98) reuses to resume the same run
+    after a restart. Development runs use the stricter state-file
+    discovery (`worktree_resume_scene`, Issue #219) instead.
+    """
+    slug = source_repo.replace("/", "-")
+    pattern = f".worktrees/orbi-{slug}-issue-{number}-*"
+    candidates = [
+        path for path in repo_dir.glob(pattern) if path.is_dir()
+    ]
+    if not candidates:
+        return None
+    newest = max(candidates, key=lambda path: path.stat().st_mtime)
+    return newest.name.rsplit("-", 1)[-1]
+
+
+def _is_ancestor(commit: str, base: str, *, cwd: Path) -> bool:
+    """Return whether *commit* is reachable from *base*.
+
+    Git uses exit code 1 for the normal negative answer. Any other failure
+    means the check itself could not be performed and must be surfaced.
+    """
+    try:
+        run_command(
+            ["git", "merge-base", "--is-ancestor", commit, base], cwd=cwd,
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode != 1:
+            raise
+        return False
+    return True
+
+
+def stable_branch_exists(repo_dir: Path, branch: str) -> bool:
+    """Return whether the stable delivery branch exists on origin."""
+    raw = run_command(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        cwd=repo_dir, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
+    )
+    return bool(raw.strip())
+
+
+def create_worktree(repo_dir: Path, source_repo: str, number: int,
+                    run_id: str, base_sha: str,
+                    existing: Path | None = None,
+                    existing_branch: bool = False,
+                    branch: str | None = None) -> Path:
+    """Create the task worktree from the frozen base SHA, never HEAD.
+
+    An existing path is reused: only a resumed run (same run id after a
+    process restart) reaches that state, and its worktree is the scene
+    the run continues in (Issue #18). `existing` is the VERIFIED resume
+    scene (Issue #219): after a repo rename the scene's path carries
+    the OLD slug, so the derived path would miss it and a second
+    worktree would be created — the verified scene is returned as-is.
+
+    `branch` overrides the stable delivery branch name: an EXTERNAL
+    takeover (Issue #608) checks out the contributor's own head branch,
+    the identity the takeover PR is frozen on. With `existing_branch`
+    the named branch is fetched and reused (a local branch is reused
+    with `--force`, never a second `-b` — the exit-255 claim failure of
+    Issue #608); without it the branch is created from the frozen base.
+
+    A local branch that already exists (the orphan a SIGKILLed run
+    leaves with no worktree and no remote counterpart, Issue #662) is
+    reused as-is rather than re-created with `-b`: git exits 255 on an
+    existing branch, which used to burn the re-claimed Issue into
+    terminal `ai-blocked`.
+    """
+    if existing is not None and existing.is_dir():
+        return existing
+    path = worktree_path(repo_dir, source_repo, number, run_id)
+    if path.exists():
+        return path
+    branch = branch or task_branch(source_repo, number, run_id)
+    if existing_branch:
+        # The branch is the delivery identity.  Fetch it, then create the
+        # run-isolated worktree from its remote HEAD rather than the base.
+        run_git_network_command(
+            ["git", "fetch", "origin", branch], cwd=repo_dir,
+        )
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            run_command([
+                "git", "worktree", "add", "--force", str(path), branch,
+            ], cwd=repo_dir)
+        else:
+            run_command([
+                "git", "worktree", "add", "-b", branch, str(path),
+                f"origin/{branch}",
+            ], cwd=repo_dir)
+    else:
+        # Issue #662 (the #655 incident): a SIGKILLed run can leave the
+        # stable branch behind with no worktree and no remote counterpart
+        # (a pure orphan).  `worktree add -b` cannot re-create it — git
+        # exits 255 (`fatal: a branch named ... already exists`) and the
+        # claim used to be burned into terminal `ai-blocked`.  The branch
+        # is the delivery identity, so a local one is reused as-is; only
+        # a missing branch is created from the frozen base SHA.
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            run_command([
+                "git", "worktree", "add", str(path), branch,
+            ], cwd=repo_dir)
+        else:
+            run_command([
+                "git", "worktree", "add", "-b", branch, str(path), base_sha,
+            ], cwd=repo_dir)
+    return path
+
+
+def create_release_worktree(repo_dir: Path, source_repo: str, number: int,
+                            run_id: str, release_commit: str) -> Path:
+    """Prepare the release worktree at this attempt's verified commit.
+
+    Release worktrees have no resumable session semantics.  A failed release
+    may leave the stable branch checked out in an older, run-specific
+    worktree, so reusing ``create_worktree(..., existing_branch=True)`` would
+    incorrectly preserve that old position.  Find that worktree when it is
+    registered, otherwise create one from the local stable branch (or the
+    release commit), then hard-reset it to the commit whose gates just passed.
+    """
+    branch = task_branch(source_repo, number, run_id)
+    listing = run_command(
+        ["git", "worktree", "list", "--porcelain"], cwd=repo_dir,
+    )
+    current_path: Path | None = None
+    current_branch = f"branch refs/heads/{branch}"
+    for block in listing.split("\n\n"):
+        lines = block.splitlines()
+        if current_branch in lines and lines:
+            current_path = Path(lines[0].removeprefix("worktree "))
+            break
+    if current_path is None:
+        local = run_command(
+            ["git", "branch", "--list", branch], cwd=repo_dir,
+        )
+        if local.strip():
+            current_path = worktree_path(
+                repo_dir, source_repo, number, run_id,
+            )
+            run_command([
+                "git", "worktree", "add", "--force", str(current_path),
+                branch,
+            ], cwd=repo_dir)
+        else:
+            current_path = create_worktree(
+                repo_dir, source_repo, number, run_id, release_commit,
+            )
+    run_command(["git", "reset", "--hard", release_commit], cwd=current_path)
+    return current_path
+
+
+def base_sync_lock_path(repo_dir: Path) -> Path:
+    """The lock file serializing ALL writers of the deployment base
+    checkout and its tool env.
+
+    Two timer instances may start in the same tick, so the service
+    template's `ExecStartPre` wraps the fetch + fast-forward in a
+    short-lived `flock` on this SAME file, and the Python-side
+    checkout sync and the CLI install refresh take the same lock: the
+    main worktree and the tool env are never written concurrently.
+    The lock lives in the shared state dir (next to the slot files),
+    never in a per-process temp dir.
+
+    Issue #171 extended the same lock to EVERY fetch that updates the
+    shared remote-tracking ref ``refs/remotes/origin/<base>``: task
+    worktrees share the deployment checkout's common dir, so an
+    unlocked concurrent fetch (Runner verify/gate/confirm, the Pi
+    prompt-side fetch) races on that one ref and fails with
+    ``cannot lock ref ... is at <X> but expected <Y>``.
+    """
+    return Path(repo_dir) / ".orbi" / BASE_SYNC_LOCK_NAME
+
+
+def acquire_base_sync_lock(
+    repo_dir: Path, lock_timeout_seconds: float,
+) -> int:
+    """Take the base-sync flock; fail fast when it is still held after
+    the timeout. The kernel releases an flock when its holder exits,
+    so a dead holder can never wedge the lock."""
+    lock_path = base_sync_lock_path(repo_dir)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    deadline = time.monotonic() + lock_timeout_seconds
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except (BlockingIOError, InterruptedError, PermissionError):
+            if time.monotonic() >= deadline:
+                os.close(fd)
+                LOGGER.error(
+                    "base_sync_lock_timeout repo_dir=%s lock=%s "
+                    "timeout_seconds=%s",
+                    repo_dir, lock_path, lock_timeout_seconds,
+                )
+                raise BaseSyncLockError(lock_path, lock_timeout_seconds) from None
+            time.sleep(0.1)
+
+
+def fetch_base_ref(repo_dir: Path, base_branch: str,
+                   *, cwd: Path | None = None,
+                   lock_timeout_seconds: float = 300.0,
+                   command_runner: Callable[[list[str]], str] | None = None,
+                   ) -> None:
+    """Fetch ``origin/<base>`` under the base-sync lock (Issue #171).
+
+    Every command that updates the shared remote-tracking ref
+    ``refs/remotes/origin/<base>`` must run under the SAME lock in the
+    deployment checkout's shared state dir (the one the ExecStartPre
+    flock and ``sync_base_checkout`` use): worktrees share the common
+    dir, so an unlocked concurrent fetch races on the ref and fails
+    the session. ``repo_dir`` is the deployment checkout (the lock
+    location); ``cwd`` is where the fetch runs (the task worktree for
+    the Runner verify/gate/confirm paths, the checkout itself by
+    default). ``command_runner`` overrides the command executor (the
+    setup entry injects its own); by default the module's
+    ``run_command`` is used. A lock timeout or a fetch error fails
+    fast — no retry, no lock bypass.
+    """
+    if command_runner is None:
+        command_runner = run_command
+    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
+    try:
+        run_git_network_command(
+            ["git", "fetch", "origin", base_branch],
+            cwd=cwd if cwd is not None else repo_dir,
+            command_runner=command_runner,
+        )
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def freeze_base(repo_dir: Path, base_branch: str) -> str:
+    """Fetch the remote and freeze the exact SHA of origin/<base_branch>.
+
+    The fetch runs under the base-sync lock (Issue #171): it updates
+    the shared remote-tracking ref, so it must not race the other
+    Runner/Pi fetches on that ref.
+    """
+    fetch_base_ref(repo_dir, base_branch)
+    return run_command(
+        ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,
+    )

--- a/src/orbi/journal.py
+++ b/src/orbi/journal.py
@@ -1,0 +1,273 @@
+"""Runner journal kernel: logging, run binding, and the subprocess seam.
+
+Every journal line of a task attempt starts with `[run_id]` (Issue #41);
+this module owns the logger that enforces it, the run-id binding the
+filter reads, and the in-flight delivery scene the stop handler reports.
+It also owns the ONE subprocess seam of Article 3.4: ``run_command`` and
+its bounded git network retry.
+
+This module imports nothing from the `orbi` package — it is the lowest
+leaf, so `github` / `gitops` / `progress` / the extracted modules can all
+share one seam and one logger without importing `runner` (Issue #785).
+"""
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+LOGGER = logging.getLogger("orbi.bootstrap")
+
+# Run correlation (Issue #41): one task attempt generates one run_id and
+# every journal line of the attempt starts with `[run_id]`, so a single
+# grep reconstructs the whole timeline. The filter rewrites the message in
+# place, so every handler (journal, caplog) sees the same prefixed text.
+RUN_ID_PATTERN = re.compile(r"[0-9a-f]{8}")
+_CURRENT_RUN_ID: str | None = None
+
+
+def validate_run_id(run_id: object) -> str:
+    """Fail fast unless ``run_id`` identifies exactly one task attempt."""
+    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
+        raise ValueError(f"invalid run id: {run_id!r}")
+    return run_id
+
+
+class RunIdFilter(logging.Filter):
+    """Prefix every log message with the current `[run_id]`, if bound."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if _CURRENT_RUN_ID is not None:
+            record.msg = f"[{_CURRENT_RUN_ID}] {record.msg}"
+        return True
+
+
+LOGGER.addFilter(RunIdFilter())
+
+
+def set_run_id(run_id: str) -> None:
+    """Bind one task attempt: every later journal line carries `[run_id]`."""
+    global _CURRENT_RUN_ID
+    _CURRENT_RUN_ID = validate_run_id(run_id)
+
+
+def current_run_id() -> str | None:
+    """Return the run id bound to this tick, or None before the claim."""
+    return _CURRENT_RUN_ID
+
+
+def new_run_id() -> str:
+    """Return a unique short run identifier for one task attempt."""
+    return uuid.uuid4().hex[:8]
+
+
+def issue_context(source_repo: str, number: int) -> str:
+    """Issue reference used on every journal line: `owner/repo#number`."""
+    return f"{source_repo}#{number}"
+
+
+def log_format() -> str:
+    """Journal log format without a Python timestamp (Issue #40).
+
+    systemd journal already provides time, host and process on every
+    line; printing `%(asctime)s` again only duplicates information.
+    """
+    return "%(levelname)s %(message)s"
+
+
+def single_line(value: str) -> str:
+    """Flatten a log value to one journal line (Issue #143).
+
+    A command argument may carry line breaks (the multi-line progress
+    comment body behind `gh api ... --field body=...`); emitted verbatim,
+    they split one `command=` log into several systemd journal lines with
+    the same timestamp and PID. Escape each line break to the visible
+    two-character sequence `\\n` so the field content stays readable on
+    one line. This only changes the log display — the real command is
+    never modified.
+    """
+    return value.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
+
+
+def quote_value(value: str) -> str:
+    """Double-quote a key=value field value when it needs quoting.
+
+    Values containing spaces or double quotes are quoted; embedded double
+    quotes are escaped as ``\\"`` so the field stays parseable as a single
+    ``key=value`` token.
+    """
+    if " " in value or '"' in value:
+        return '"' + value.replace('"', '\\"') + '"'
+    return value
+
+
+def run_command(command: list[str], *, cwd: Path | None = None,
+                timeout: int | None = None,
+                log_command: list[str] | None = None,
+                log_stdout: bool = False,
+                failure_log_level: int = logging.ERROR) -> str:
+    """Run one external command; log context and fail fast on any error.
+
+    ``failure_log_level`` is INFO for probes whose failure is an expected
+    status result, such as an optional component health check. The command
+    still raises, so callers retain control over whether the failure blocks.
+    """
+    LOGGER.info(
+        "command=%s cwd=%s",
+        single_line(" ".join(log_command or command)), cwd or Path.cwd(),
+    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.CalledProcessError as exc:
+        LOGGER.log(
+            failure_log_level,
+            "command_failed returncode=%s stdout=%s stderr=%s",
+            exc.returncode, (exc.stdout or "").rstrip(),
+            (exc.stderr or "").rstrip(),
+        )
+        raise
+    except subprocess.TimeoutExpired as exc:
+        LOGGER.log(
+            failure_log_level,
+            "command_timeout timeout=%s stdout=%s stderr=%s",
+            timeout, (exc.stdout or "").rstrip(),
+            (exc.stderr or "").rstrip(),
+        )
+        raise
+    except OSError as exc:
+        LOGGER.log(failure_log_level, "command_spawn_failed error=%s", exc)
+        raise
+    if result.stderr:
+        LOGGER.info("stderr=%s", result.stderr.rstrip())
+    if log_stdout and result.stdout:
+        LOGGER.info("stdout=%s", result.stdout.rstrip())
+    return result.stdout.strip()
+
+
+GIT_NETWORK_MAX_ATTEMPTS = 3
+GIT_NETWORK_TIMEOUT_SECONDS = 30
+GIT_NETWORK_BACKOFF_SECONDS = 1
+GIT_TRANSIENT_ERROR_MARKERS = (
+    "connection timed out",
+    "operation timed out",
+    "connection reset",
+    "connection refused",
+    "temporary failure in name resolution",
+    "network is unreachable",
+    "network unreachable",
+)
+
+
+def _is_retryable_git_network_failure(
+    command: list[str], exc: subprocess.CalledProcessError,
+) -> bool:
+    """Return whether a Git fetch/push failed with a known transient error."""
+    if len(command) < 2 or command[:1] != ["git"]:
+        return False
+    if command[1] not in {"fetch", "push"}:
+        return False
+    stderr = (exc.stderr or "").lower()
+    return any(marker in stderr for marker in GIT_TRANSIENT_ERROR_MARKERS)
+
+
+def _is_git_network_command(command: list[str]) -> bool:
+    return (
+        len(command) >= 2
+        and command[:1] == ["git"]
+        and command[1] in {"fetch", "push"}
+    )
+
+
+def run_git_network_command(
+    command: list[str], *, cwd: Path | str | None = None,
+    command_runner: Callable[..., str] | None = None,
+) -> str:
+    """Run an Orbi-controlled Git fetch/push with bounded network retries.
+
+    Only explicitly recognized transient network messages are retried. The
+    last ``CalledProcessError`` is re-raised unchanged so its stderr remains
+    available to the existing failure handling.
+    """
+    execute = command_runner or run_command
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return execute(
+                command, cwd=cwd, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            retryable = _is_git_network_command(command)
+            detail = f"command timed out after {GIT_NETWORK_TIMEOUT_SECONDS}s"
+            if attempt >= GIT_NETWORK_MAX_ATTEMPTS or not retryable:
+                raise
+        except subprocess.CalledProcessError as exc:
+            retryable = _is_retryable_git_network_failure(command, exc)
+            detail = (exc.stderr or "").strip()
+            if attempt >= GIT_NETWORK_MAX_ATTEMPTS or not retryable:
+                raise
+        delay = GIT_NETWORK_BACKOFF_SECONDS * (2 ** (attempt - 1))
+        LOGGER.warning(
+            "git_network_retry command=%s attempt=%s max_attempts=%s "
+            "delay_seconds=%s stderr=%s",
+            single_line(" ".join(command)), attempt + 1,
+            GIT_NETWORK_MAX_ATTEMPTS, delay, single_line(detail),
+        )
+        time.sleep(delay)
+
+
+# Stop scene (Issue #48): when systemd (or any caller) stops the Runner
+# with SIGTERM, the journal must show which Issue context was active
+# BEFORE systemd's generic "Stopped" line, and the live Pi child must be
+# shut down (no orphan Pi). The context is bound while a delivery is in
+# flight (after the claim, or after a resumed scene is bound) and cleared
+# when the delivery ends. It carries no new id: the run id is the
+# existing `_CURRENT_RUN_ID`, and the phase/session come from the
+# existing activity snapshot of the worktree's `.pi-session`.
+_ACTIVE_RUN: dict | None = None
+
+
+def set_active_run(issue: int, title: str, branch: str, worktree: str) -> None:
+    """Bind the in-flight delivery scene for the stop handler (Issue #48)."""
+    global _ACTIVE_RUN
+    _ACTIVE_RUN = {
+        "issue": int(issue),
+        "title": title,
+        "branch": branch,
+        "worktree": worktree,
+        "pi": None,
+    }
+
+
+def set_active_pi(process: subprocess.Popen | None) -> None:
+    """Track the live Pi child of the in-flight delivery (Issue #48).
+
+    `stream_pi` calls it after the child is spawned (and again with None
+    after the child is reaped), so the stop handler signals exactly the
+    child that is alive — never an already-exited process. Without a
+    bound run (unit tests call `stream_pi` directly) it is a no-op.
+    """
+    if _ACTIVE_RUN is not None:
+        _ACTIVE_RUN["pi"] = process
+
+
+def clear_active_run() -> None:
+    """No delivery in flight anymore (Issue #48)."""
+    global _ACTIVE_RUN
+    _ACTIVE_RUN = None
+
+
+def active_run() -> dict | None:
+    """The in-flight delivery scene, or None (the stop handler reads it)."""
+    return _ACTIVE_RUN

--- a/src/orbi/pi_activity.py
+++ b/src/orbi/pi_activity.py
@@ -30,7 +30,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
-from orbi.progress import quote_value
+from orbi.journal import quote_value
 
 MAX_SUMMARY_LENGTH = 200
 

--- a/src/orbi/pi_process.py
+++ b/src/orbi/pi_process.py
@@ -29,6 +29,7 @@ from orbi.pi_activity import (
     session_state,
 )
 from orbi.progress import quote_value
+from orbi.journal import RunIdFilter, issue_context, set_active_pi
 from orbi.pi_recovery import (
     clk_tck,
     find_idle_descendants,
@@ -42,6 +43,8 @@ from orbi.pi_recovery import (
 )
 
 LOGGER = logging.getLogger("orbi.pi_process")
+
+LOGGER.addFilter(RunIdFilter())
 
 # Live activity polling while Pi runs (Issue #24): every poll the journal
 # gets either an `activity` line (something changed) or a `heartbeat` line
@@ -999,11 +1002,6 @@ def stream_pi(
     activity field. The first new session event resets the whole
     recovery state (`pi_resumed`).
     """
-    # Issue #300: the issue-ref formatting lives in `runner`; import it
-    # lazily so this module never imports `runner` at module load (the
-    # runner imports this module — Issue #266 circular-import rule).
-    from orbi.runner import issue_context
-
     # The raw pi command embeds the full prompt and Issue body; only the
     # redacted form may ever reach the journal or an exception message.
     safe_command = log_command or ["<redacted>"]
@@ -1139,11 +1137,6 @@ def _stream_pi_once(
     raises `ProviderRateLimitedError` so the `stream_pi` retry loop can
     back off and re-spawn; every other failure raises exactly as
     before. The full streamer contract lives on `stream_pi`."""
-    # Issue #300: the stop-handler state `_ACTIVE_RUN` lives in `runner`;
-    # import it lazily so this module never imports `runner` at module
-    # load (the runner imports this module — Issue #266 rule).
-    from orbi.runner import set_active_pi
-
     watcher = SessionWatcher(session_dir, known_files=known_files)
     start = time.monotonic()
     # The initial state is what run_start already reported; activity lines

--- a/src/orbi/progress.py
+++ b/src/orbi/progress.py
@@ -10,21 +10,32 @@ ready, tests passed/failed, review findings, merged, blocked) are
 published as short standalone comments so GitHub Mobile pushes a
 notification for each one.
 
-All GitHub traffic goes through the reused `runner.run_command`
-(`gh api`), which logs the command and fails fast on any error. There is
-no fallback or retry.
+All GitHub traffic goes through the single subprocess seam
+(`orbi.journal.run_command`, `gh api`), which logs the command and fails
+fast on any error. There is no fallback or retry.
 """
 from __future__ import annotations
 
 import json
 import re
 import subprocess
+import time
 from importlib import metadata
 from pathlib import Path
 from typing import Callable
 
+from orbi.journal import (
+    LOGGER,
+    RUN_ID_PATTERN,
+    issue_context,
+    quote_value,
+    validate_run_id,
+)
+from orbi.pi_activity import activity_snapshot, sanitize
+
 # One marker per run: hidden in the rendered comment, exact for lookup.
-RUN_ID_PATTERN = re.compile(r"[0-9a-f]{8}")
+# The run-id pattern and its validator live in `orbi.journal` (the run
+# binding owns the contract); they are re-exported here for callers.
 RUN_MARKER_PATTERN = re.compile(r"<!-- orbi:run=([0-9a-f]{8}) -->")
 RUN_MARKER_TEMPLATE = "<!-- orbi:run={run_id} -->"
 RUNNER_MARKER_TEMPLATE = "<!-- runner={fingerprint} -->"
@@ -83,18 +94,6 @@ def _without_runner_marker(body: str) -> str:
     return _RUNNER_MARKER_PATTERN.sub("", body).rstrip()
 
 
-def quote_value(value: str) -> str:
-    """Double-quote a key=value field value when it needs quoting.
-
-    Values containing spaces or double quotes are quoted; embedded double
-    quotes are escaped as ``\\"`` so the field stays parseable as a single
-    ``key=value`` token.
-    """
-    if " " in value or '"' in value:
-        return '"' + value.replace('"', '\\"') + '"'
-    return value
-
-
 def field_block(run_id: str, headline: str, fields: dict[str, object]) -> str:
     """Render a marker-first status comment with one field per line."""
     lines = [run_marker(run_id), headline]
@@ -137,13 +136,6 @@ def format_status_comment(body: str) -> str:
             if marker else rendered
         )
     return _with_runner_marker((marker + "\n" + body) if marker else body)
-
-
-def validate_run_id(run_id: object) -> str:
-    """Fail fast unless ``run_id`` identifies exactly one task attempt."""
-    if not isinstance(run_id, str) or not RUN_ID_PATTERN.fullmatch(run_id):
-        raise ValueError(f"invalid run id: {run_id!r}")
-    return run_id
 
 
 def run_marker(run_id: object) -> str:
@@ -417,3 +409,185 @@ class ProgressPublisher:
             self.ensure(body)
             return
         self.patch(body)
+
+
+# --- test evidence and run-scene helpers (moved from `orbi.runner`,
+# --- Issue #785: the progress state belongs to the progress module) ----
+
+
+# pytest's final summary line: `1 failed, 155 passed in 4.43s` (the
+# counts and the `in <seconds>` part are optional; the line is NOT
+# wrapped in `=` section padding).
+_Pytest_SUMMARY_RE = re.compile(
+    r"^\d+ (?:failed|passed|error|errors|skipped|xfailed|xpassed"
+    r"|deselected)(?:, \d+ \w+)*(?: in [\d.]+s)?$")
+
+
+def _is_section_header(line: str) -> bool:
+    """True for pytest section headers like `=== FAILURES ===`.
+
+    A header is `=`-delimited at both ends (padding may be absent on
+    one side for short titles) and its title carries no digits; the
+    real summary line (`1 failed, 155 passed in 4.43s`, bare or
+    `=`-padded) and the `FAILED`/`ERROR` evidence lines never match.
+    """
+    if not line.startswith("="):
+        return False
+    core = line.strip("=").strip()
+    return core == "" or not any(ch.isdigit() for ch in core)
+
+
+# A pytest summary line reports an outcome only when its FIRST count
+# category is failed/passed/error(s): pytest orders the counts
+# failed, passed, skipped, errors, xfailed, xpassed, deselected, so a
+# run that collected tests always leads with failed or passed (or a
+# collection error). `no tests ran in 0.01s` matches no summary regex
+# at all; `3 deselected in 0.02s` / `2 skipped in 0.01s` match but
+# carry no outcome — reporting them as a pass is a false notification
+# (review round 3, PR #42).
+_OUTCOME_FIRST_RE = re.compile(
+    r"^\d+ (?:failed|passed|error|errors)\b",
+)
+_NO_TESTS_RE = re.compile(r"no tests (?:ran|collected)")
+
+
+def _is_no_result(line: str) -> bool:
+    """True for pytest lines that verified nothing (no tests ran)."""
+    if _NO_TESTS_RE.search(line):
+        return True
+    stripped = line.strip("=").strip()
+    return bool(_Pytest_SUMMARY_RE.match(stripped)) \
+        and not _OUTCOME_FIRST_RE.match(stripped)
+
+
+def read_test_result(worktree: Path) -> str | None:
+    """Summarize the worktree's `.orbi/test.log`, or None when it does
+    not exist (Issue #302: the contract test command writes the log
+    into the excluded run dir, never at the worktree root).
+
+    Prefers the pytest summary line (`1 failed, 155 passed in 4.43s`):
+    the LAST one with an outcome when the log holds several runs (TDD
+    red, then green), so the progress comment and the `tests
+    passed/failed` milestone report the most recent run that actually
+    collected tests. Section headers (`=== FAILURES ===`) are never
+    reported: the fallback takes the first `FAILED`/`ERROR` evidence
+    line or the last non-empty line instead, and a log holding nothing
+    but headers yields None (no result info to report). Lines that
+    verified nothing (`no tests ran`, `N deselected`, `N skipped`) are
+    never reported either: a run that collected no tests is no result,
+    and posting `tests passed` for it is a false notification (review
+    round 3, PR #42).
+    """
+    path = worktree / ".orbi" / "test.log"
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for line in reversed(lines):
+        # The summary line is bare in pytest 9; some runners wrap it in
+        # `=` padding, so the stripped form is matched as well.
+        stripped = line.strip("=").strip()
+        if _Pytest_SUMMARY_RE.match(line) \
+                or _Pytest_SUMMARY_RE.match(stripped):
+            if _is_no_result(line):
+                # No tests collected in this run: keep looking for an
+                # earlier run that did (or report nothing at all).
+                continue
+            return sanitize(stripped)
+    for line in lines:
+        if _is_section_header(line) or _is_no_result(line):
+            continue
+        if line.startswith(("FAILED", "ERROR")) or "passed" in line:
+            return sanitize(line)
+    last = lines[-1] if lines else None
+    if last is not None and (_is_section_header(last)
+                             or _is_no_result(last)):
+        return None
+    return sanitize(last) if last is not None else None
+
+
+def _run_info_fields(run_info: str) -> dict[str, str]:
+    """Extract the runner-owned key/value fields for comment rendering."""
+    return dict(
+        part.split("=", 1) for part in run_info.split()
+        if "=" in part
+    )
+
+
+def _progress_state(*, issue: int, title: str, run_id: str, role: str,
+                    branch: str, worktree: Path, started: float,
+                    pr_url: str | None, review_round: int, priority: str,
+                    activity: dict | None = None) -> dict:
+    """Collect the current run state for the GitHub progress comment.
+
+    `title` is the issue's GitHub title (Issue #100): the progress
+    comment's issue line shows `#<number> <title>` in every scene. It
+    is required — the GitHub issue data contract guarantees a
+    non-empty string title (every runner scan fetches it), and a
+    missing title fails fast in `progress.issue_field` instead of
+    fabricating one.
+    `priority` is the pickup priority of the issue (`p0` or `normal`,
+    Issue #101), derived from the issue's labels at claim/resume time.
+    `activity` is the live state from the `stream_pi` watcher while a Pi
+    session runs (fresh and already read); without it the newest session
+    file is full-scanned. Activity snapshotting is best-effort
+    observability: a read failure is logged and reported as "no session
+    yet", it never blocks the task.
+    """
+    if activity is None:
+        try:
+            activity = activity_snapshot(worktree / ".pi-session")
+        except Exception:
+            LOGGER.exception("issue=%s activity snapshot failed", issue)
+            activity = None
+    return {
+        "run_id": run_id,
+        "issue": issue,
+        "issue_title": title,
+        "role": role,
+        "priority": priority,
+        "phase": (activity or {}).get("phase") or "starting",
+        "elapsed": format_elapsed(time.monotonic() - started),
+        "last_activity": (activity or {}).get("last_activity"),
+        "last_action": (activity or {}).get("action"),
+        "tests": read_test_result(worktree),
+        "review_round": review_round,
+        "branch": branch,
+        "pr": pr_url,
+        "session": (activity or {}).get("session_id"),
+        # Idle-stall recovery state (Issue #94): `term` / `kill` while
+        # the runner recovers a stalled session, absent/None otherwise
+        # (the body renders the line only while it is active).
+        "recovery": (activity or {}).get("recovery"),
+    }
+
+
+def _progress_body(state: dict, *, outcome: str | None = None) -> str:
+    """Render the progress body, optionally with a final outcome header."""
+    body = progress_body(state)
+    if outcome is None:
+        return body
+    return f"{outcome}\n\n{body}"
+
+
+def _safe_publish(*, run_id: str, issue: int, source_repo: str,
+                  role: str, action: Callable[[], None]) -> None:
+    """Run one progress-publishing step as a pure bypass (Issue #79).
+
+    The main delivery path is claim -> worktree -> Pi -> verify PR ->
+    review -> fix -> merge; the GitHub progress comment is observability
+    on the side. A publishing failure (404, rate limit, API shape
+    change) is logged as `progress_publish_failed` and never fails the
+    delivery, never marks the Issue `ai-blocked`, and never skips
+    `run_pi` / `wait_for_delivery`. This is the same semantics as the
+    in-stream live-PATCH callback; Issue #60 already applied it to the
+    post-PR record, Issue #79 extends it to the whole
+    `ProgressPublisher` path (ensure / milestone / finish).
+    """
+    try:
+        action()
+    except Exception:
+        LOGGER.exception(
+            "progress_publish_failed run=%s issue=%s role=%s",
+            run_id, issue_context(source_repo, issue), role,
+        )

--- a/src/orbi/release.py
+++ b/src/orbi/release.py
@@ -3,11 +3,11 @@
 The deterministic release state machine the Runner executes for an
 `ai-release` Issue: declaration parsing, scope verification, gates,
 version preparation, tag, GitHub Release publish, docs sync, Milestone
-close, and the `process_release` orchestration. It imports the generic
-runner primitives; the ONLY runner-side entry is the dispatch in
-`orbi.runner.process_issue`, which imports this module lazily (this
-module imports `orbi.runner` back, so a module-level reverse import
-would be circular).
+close, and the `process_release` orchestration. Its GitHub and git data
+access goes through the `orbi.github` / `orbi.gitops` leaves and the
+`orbi.journal` seam (Issue #785); the runner-side entry is the dispatch
+in `orbi.runner.process_issue`, and `runner` imports this module at
+module level for the release constants.
 """
 from __future__ import annotations
 
@@ -24,6 +24,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from orbi.delivery_labels import (
+    EPIC_LABEL,
     EVENT_BLOCKED,
     EVENT_CLAIM,
     EVENT_MERGED,
@@ -38,43 +39,88 @@ from orbi.progress import (
     progress_body,
     run_marker,
 )
-from orbi.runner import (
-    LOGGER,
-    RELEASE_CI_POLL_INTERVAL,
-    RELEASE_CI_WAIT_SECONDS,
-    RELEASE_DELIVERIES_WAIT_SECONDS,
-    RELEASE_SECTION,
-    ROLE_RELEASE,
-    ReleaseDeliveriesWaiting,
+from orbi.cli_source import refresh_cli_install
+from orbi.github import (
     _comment_is_trusted,
-    _is_ancestor,
-    _progress_body,
-    _progress_state,
-    _run_info_fields,
-    _safe_publish,
-    acquire_base_sync_lock,
+    _verify_epic_complete,
+    _epic_audit,
     apply_label_patch,
+    close_issue,
+    close_milestone,
+    commit_check_runs,
     comment_issue,
-    create_release_worktree,
-    freeze_base,
     has_in_progress_label,
     issue_comments,
     issue_priority,
-    latest_run_id,
+    issue_view,
     list_issues,
+    list_milestones,
+    milestone_issues,
     milestone_open_issues,
+    pr_view,
+    release_create,
+    release_edit_notes,
+    release_view,
+)
+from orbi.gitops import (
+    _is_ancestor,
+    acquire_base_sync_lock,
+    create_release_worktree,
+    freeze_base,
+    latest_run_id,
+    task_branch,
+    worktree_path,
+)
+from orbi.journal import (
+    LOGGER,
     new_run_id,
-    parse_paginated_issue_array,
-    reconcile_release_epics,
-    refresh_cli_install,
-    release_target_milestone,
     run_command,
     run_git_network_command,
     set_active_run,
     set_run_id,
-    task_branch,
-    worktree_path,
 )
+from orbi.progress import (
+    ProgressPublisher,
+    _progress_body,
+    _progress_state,
+    _run_info_fields,
+    _safe_publish,
+    field_block,
+    progress_body,
+    run_marker,
+)
+
+
+# --- release-domain constants, scene and gates (moved from
+# --- `orbi.runner`, Issue #785: the release contract lives here) --------
+
+# The machine-readable section a release Issue body must carry (Issue
+# #98): `- version:`, `- base_branch:` and `- scope:` (or
+# `- scope_from_milestone:`). Parsed strictly — a missing or malformed
+# declaration fails fast, never guessed. The declaration carries NO
+# local test contract (Issue #569): test acceptance is the GitHub
+# Actions CI result on the release commit (the #268 CI-wait gate).
+# The Pi role of a release run (Issue #41/#82): the delivery state
+# machine executes it, never a Pi session.
+ROLE_RELEASE = "release"
+
+RELEASE_SECTION = "## Release"
+# Release CI wait (Issue #268): the release commit is born from the last
+# delivery PR merge, so its CI is almost always still running when the
+# gate checks it — a pending check (queued/in_progress) is an
+# intermediate state, not a failure. The gate waits for completion up to
+# this limit and decides on the FINAL conclusions; a wait timeout is its
+# own failure reason, never reported as a CI failure. The TOML field
+# `release_ci_wait_seconds` overrides the default (the #228 pattern).
+RELEASE_CI_WAIT_SECONDS = 1800
+# Release delivery wait (Issue #381): an early release ticket yields the
+# slot while other deliveries finish. The limit applies to one gate attempt;
+# the next tick retries the same ready release ticket.
+RELEASE_DELIVERIES_WAIT_SECONDS = 1800
+# Poll cadence while waiting: one `release_waiting_ci` journal line plus
+# one progress-comment PATCH per poll — the same 30s GitHub cadence as
+# the live progress heartbeat (PI_HEARTBEAT_SECONDS).
+RELEASE_CI_POLL_INTERVAL = 30.0
 
 
 # Supported `version_file` declaration values: the ecosystem metadata
@@ -339,16 +385,12 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
     evidence: list[str] = []
     for number in scope:
         try:
-            raw = run_command([
-                "gh", "pr", "view", str(number), "--repo", repo,
-                "--json", "number,state,mergeCommit",
-            ])
+            pr = pr_view(number, "number,state,mergeCommit", repo=repo)
         except subprocess.CalledProcessError as exc:
             if "Could not resolve to a PullRequest" not in (exc.stderr or ""):
                 raise
-            raw = None
-        if raw is not None:
-            pr = json.loads(raw)
+            pr = None
+        if pr is not None:
             state = pr.get("state")
             if state != "MERGED":
                 raise RuntimeError(
@@ -371,10 +413,7 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
             )
             continue
         try:
-            raw = run_command([
-                "gh", "issue", "view", str(number), "--repo", repo,
-                "--json", "number,state,stateReason",
-            ])
+            issue = issue_view(number, "number,state,stateReason", repo=repo)
         except subprocess.CalledProcessError as exc:
             if "Could not resolve to an Issue" not in (exc.stderr or ""):
                 raise
@@ -382,7 +421,6 @@ def verify_release_scope(repo: str, scope: list[int], repo_dir: Path,
                 f"release scope item #{number} is neither a PR nor an "
                 "Issue"
             ) from exc
-        issue = json.loads(raw)
         state = issue.get("state")
         if state != "CLOSED":
             raise RuntimeError(
@@ -426,11 +464,7 @@ def derive_release_scope_from_milestone(repo: str,
     propagates unchanged — a scope that cannot be derived is a failed
     release, never a guessed one.
     """
-    raw = run_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
-        "--paginate", "--slurp",
-    ])
-    milestones = parse_paginated_issue_array(raw)
+    milestones = list_milestones(repo)
     matches = [
         m for m in milestones
         if isinstance(m, dict) and m.get("title") == milestone_title
@@ -450,13 +484,7 @@ def derive_release_scope_from_milestone(repo: str,
     number = matches[0].get("number")
 
     def issues(state: str) -> list[dict]:
-        raw = run_command([
-            "gh", "api",
-            f"repos/{repo}/issues?state={state}&milestone={number}&per_page=100",
-            "--paginate", "--slurp",
-        ])
-        return [item for item in parse_paginated_issue_array(raw)
-                if isinstance(item, dict)]
+        return milestone_issues(repo, int(number), state)
 
     closed_issues = [item for item in issues("closed")
                      if "pull_request" not in item]
@@ -633,10 +661,7 @@ def build_release_changelog(repo: str, scope: list[int]) -> str:
                 )
             # Issue #707: an unmerged PR is not released content — its
             # link never enters the release notes.
-            pr_state = json.loads(run_command([
-                "gh", "pr", "view", str(pr_number), "--repo", repo,
-                "--json", "state",
-            ])).get("state")
+            pr_state = pr_view(pr_number, "state", repo=repo).get("state")
             if pr_state != "MERGED":
                 LOGGER.info(
                     "release_changelog_pr_link_dropped issue=%d pr=%d "
@@ -787,12 +812,8 @@ def check_release_gates(repo: str, base_branch: str, release_commit: str,
         f"{IN_PROGRESS_LABEL} / {PR_OPENED_LABEL} / {FIX_NEEDED_LABEL}"
     )
     def fetch_check_runs() -> list[dict]:
-        command = [
-            "gh", "api", f"repos/{repo}/commits/{release_commit}/check-runs",
-            "--jq", ".check_runs",
-        ]
         try:
-            return json.loads(run_command(command))
+            return commit_check_runs(repo, release_commit)
         except subprocess.CalledProcessError as error:
             output = "\n".join(
                 str(value) for value in (error.stdout, error.stderr)
@@ -1170,29 +1191,15 @@ def publish_release(*, repo: str, tag: str, version: str,
         f"run_id={run_id}",
     ])
     try:
-        raw = run_command([
-            "gh", "release", "view", tag, "--repo", repo,
-            "--json", "tagName,url,body",
-        ])
-        release = json.loads(raw)
+        release = release_view(repo, tag, fields="tagName,url,body")
         if changelog not in release.get("body", ""):
-            run_command([
-                "gh", "release", "edit", tag, "--repo", repo,
-                "--notes", notes,
-            ])
+            release_edit_notes(repo, tag, notes=notes)
         return release["url"]
     except subprocess.CalledProcessError as exc:
         if "not found" not in (exc.stderr or ""):
             raise
-    run_command([
-        "gh", "release", "create", tag, "--repo", repo,
-        "--verify-tag", "--title", version, "--notes", notes,
-    ])
-    raw = run_command([
-        "gh", "release", "view", tag, "--repo", repo,
-        "--json", "tagName,url",
-    ])
-    return json.loads(raw)["url"]
+    release_create(repo, tag=tag, version=version, notes=notes)
+    return release_view(repo, tag, fields="tagName,url")["url"]
 
 
 # Issue #754: the GitHub issue index is eventually consistent —
@@ -1236,11 +1243,7 @@ def close_release_milestone(repo: str, version: str, *, run_id: str | None = Non
     unchanged — like the release gates, a check that cannot be made
     is a failed check.
     """
-    raw = run_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
-        "--paginate", "--slurp",
-    ])
-    milestones = parse_paginated_issue_array(raw)
+    milestones = list_milestones(repo)
     matches = [
         m for m in milestones
         if isinstance(m, dict) and m.get("title") == version
@@ -1294,10 +1297,7 @@ def close_release_milestone(repo: str, version: str, *, run_id: str | None = Non
             f"has {len(open_issues)} open issue(s) — closing it would hide "
             f"unfinished work; open issues: {listing}"
         )
-    run_command([
-        "gh", "api", f"repos/{repo}/milestones/{number}",
-        "--method", "PATCH", "-f", "state=closed",
-    ])
+    close_milestone(repo, int(number))
     epic_suffix = f"; {'; '.join(epic_evidence)}" if epic_evidence else ""
     return (
         f"Milestone #{number} ({html_url}) closed after release "
@@ -1513,11 +1513,8 @@ def sync_release_docs(*, source_repo: str, repo_dir: Path,
     if not docs_config.is_file():
         return "docs sync skipped (no Mintlify docs in repo)"
 
-    raw = run_command([
-        "gh", "release", "view", tag, "--repo", source_repo,
-        "--json", "tagName,publishedAt,url,body",
-    ])
-    release = json.loads(raw)
+    release = release_view(source_repo, tag,
+                           fields="tagName,publishedAt,url,body")
     body = release.get("body")
     if not isinstance(body, str) or not body.strip():
         raise RuntimeError(
@@ -2075,9 +2072,7 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
                 number, repo=source_repo, event=EVENT_MERGED,
                 current_labels={IN_PROGRESS_LABEL},
             )
-            run_command(
-                ["gh", "issue", "close", str(number), "--repo", source_repo],
-            )
+            close_issue(int(number), repo=source_repo)
         except Exception:
             # The tag and GitHub Release are already published at this
             # point. The ai-merged transition and the Issue close are
@@ -2170,3 +2165,64 @@ def process_release(issue: dict, config: dict, source_repo: str) -> str:
             action=lambda: publisher.finish(progress_body(progress())),
         )
         return ""
+
+
+class ReleaseDeliveriesWaiting(RuntimeError):
+    """Gate 1 found deliveries still in flight; retry next tick."""
+
+    def __init__(self, issue_numbers: list[int], waited: float, limit: float):
+        self.issue_numbers = issue_numbers
+        self.waited = waited
+        self.limit = limit
+        super().__init__(
+            "release gate: waiting for open deliveries "
+            f"{issue_numbers} (waited {int(waited)}s / {int(limit)}s)"
+        )
+
+
+def release_target_milestone(
+    issue: dict, active_milestone: str | None = None,
+) -> str | None:
+    """Return the Milestone a release Issue releases (Issue #663).
+
+    The completeness gate judges the Milestone the release belongs to:
+    the Issue's own GitHub Milestone is authoritative, and the configured
+    `active_milestone` is the fallback (the release fallback scan is
+    already scoped to it). Without any Milestone there is nothing to
+    check and the release keeps the pre-#663 behavior, so the function
+    returns None and the caller skips the gate.
+    """
+    milestone = issue.get("milestone")
+    if isinstance(milestone, dict):
+        title = milestone.get("title")
+        if isinstance(title, str) and title:
+            return title
+    if isinstance(active_milestone, str) and active_milestone:
+        return active_milestone
+    return None
+
+
+def reconcile_release_epics(repo: str, milestone_number: int, version: str,
+                            run_id: str) -> list[str]:
+    """Close only provably complete open Epics in this exact Milestone."""
+    issues = milestone_open_issues(repo, milestone_number)
+    evidence: list[str] = []
+    for listed_epic in issues:
+        labels = listed_epic.get("labels", [])
+        names = {label.get("name") for label in labels if isinstance(label, dict)}
+        if EPIC_LABEL not in names:
+            continue
+        number = listed_epic.get("number")
+        try:
+            child_evidence = _verify_epic_complete(repo, listed_epic)
+        except (ValueError, json.JSONDecodeError) as exc:
+            evidence.append(f"Epic #{number} kept open: {exc}")
+            continue
+        audit = _epic_audit(child_evidence, version)
+        comments = issue_comments(int(number), repo=repo)
+        if not any(audit in str(comment.get("body", "")) for comment in comments):
+            comment_issue(int(number), repo=repo,
+                         body=f"<!-- orbi:run={run_id} -->\n{audit}\nrun_id={run_id}")
+        close_issue(int(number), repo=repo)
+        evidence.append(f"Epic #{number} closed after verification ({'; '.join(child_evidence)})")
+    return evidence

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -47,18 +47,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NamedTuple
 
-# NOTE (Issue #158, root-caused by Issue #168): the editable CLI
-# install refresh below lives in THIS module: the bootstrap chain
-# (`orbi.cli` -> `orbi.runner`) must still LOAD in a
-# tool env whose installed editable finder predates a packaging
-# change. Since the src layout (Issue #168) the finder maps the WHOLE
-# package directory `src/orbi/`, so a newly added package
-# module is importable WITHOUT any reinstall — the #158 incident
-# class is fixed at the root. The refresh remains the safety net for
-# packaging-metadata changes (version, dependencies, entry points in
-# `pyproject.toml`). The former thin re-export module
-# `orbi.cli_install` is deleted (Issue #295): the tests import these
-# symbols directly from this module.
+# NOTE (Issue #158, root-caused by Issue #168): the editable finder maps
+# the WHOLE package directory `src/orbi/`, so a newly added package
+# module is importable WITHOUT any reinstall — the #158 incident class
+# is fixed at the root. `refresh_cli_install` lives in `orbi.cli_source`
+# since Issue #785; `runner` imports it like any caller and the
+# preflight stubs keep patching the module global below.
 from orbi import engine_source
 from orbi.engine_source import EngineSourceError
 from orbi.git_transport import TransportError, check_transport
@@ -108,11 +102,16 @@ from orbi.repo_config import (
 from orbi.progress import (
     RUN_MARKER_PATTERN,
     ProgressPublisher,
+    _progress_body,
+    _progress_state,
+    _run_info_fields,
+    _safe_publish,
     field_block,
     format_status_comment,
     format_elapsed,
     progress_body,
     quote_value,
+    read_test_result,
     run_marker,
     validate_run_id,
 )
@@ -142,7 +141,88 @@ from orbi.pi_process import (
     stream_pi,
 )
 
-LOGGER = logging.getLogger("orbi.bootstrap")
+# Issue #785: the shared primitives live in the leaf modules now — the
+# journal kernel (logger, run binding, subprocess seam), the GitHub
+# data-access layer, the git operations layer, and the CLI-install domain.
+# `runner` consumes them like any other caller; only `cli` and
+# `pilot_setup` import `runner` itself.
+from orbi import github, gitops, journal, release
+from orbi.cli_source import CliInstallError, refresh_cli_install
+from orbi.github import (
+    RESUME_PR_STATE_TIMEOUT_SECONDS,
+    TRUSTED_COMMENT_ASSOCIATIONS,
+    run_gh_read_command,
+    _comment_is_trusted,
+    _pr_number,
+    _epic_audit,
+    _verify_epic_complete,
+    apply_label_patch,
+    close_issue,
+    close_milestone,
+    commit_check_runs,
+    comment_issue,
+    edit_issue,
+    epic_issue_with_blockers,
+    has_in_progress_label,
+    issue_comments,
+    issue_labels,
+    issue_priority,
+    issue_view,
+    list_issues,
+    list_milestones,
+    milestone_issues,
+    milestone_open_issue_count,
+    milestone_open_issues,
+    open_blocker_numbers,
+    open_pr_for_branch,
+    parse_issue_array,
+    parse_issue_list,
+    parse_paginated_issue_array,
+    pr_comments,
+    pr_delivery_status,
+    pr_state,
+    pr_view,
+    trusted_issue_comments_block,
+)
+from orbi.gitops import (
+    acquire_base_sync_lock,
+    base_sync_lock_path,
+    create_release_worktree,
+    create_worktree,
+    fetch_base_ref,
+    freeze_base,
+    latest_run_id,
+    stable_branch_exists,
+    task_branch,
+    worktree_path,
+    _is_ancestor,
+)
+from orbi.journal import (
+    LOGGER,
+    RunIdFilter,
+    clear_active_run,
+    current_run_id,
+    issue_context,
+    log_format,
+    new_run_id,
+    run_command,
+    run_git_network_command,
+    set_active_pi,
+    set_active_run,
+    set_run_id,
+    single_line,
+    validate_run_id,
+)
+from orbi.release import (
+    RELEASE_CI_POLL_INTERVAL,
+    RELEASE_CI_WAIT_SECONDS,
+    RELEASE_DELIVERIES_WAIT_SECONDS,
+    RELEASE_SECTION,
+    ROLE_RELEASE,
+    ReleaseDeliveriesWaiting,
+    release_target_milestone,
+)
+
 
 # Machine-readable verdict line the reviewer session must end with, and the
 # bounded size of the review/fix loop (see review-fix-loop skill: max 5 rounds).
@@ -167,61 +247,15 @@ STOP_CHILD_GRACE_SECONDS = 15.0
 # Non-implement Pi session roles (Issue #41/#82). `ROLE_IMPLEMENT` is the
 # default role of a delivery Pi session and lives in `orbi.pi_process`.
 ROLE_REVIEW = "review"
-ROLE_RELEASE = "release"
 ROLE_TICKET = "ticket"
 
-# Run correlation (Issue #41): one task attempt generates one run_id and
-# every journal line of the attempt starts with `[run_id]`, so a single
-# grep reconstructs the whole timeline. The filter rewrites the message in
-# place, so every handler (journal, caplog) sees the same prefixed text.
-# Run marker validation and rendering live in progress.py so every caller
-# enforces the same strict eight-hex-digit contract.
-_CURRENT_RUN_ID: str | None = None
 
-# GitHub labels are the only state store (Issue #45). The delivery
-# lifecycle states (`ai-in-progress`, `ai-pr-opened`, `ai-fix-needed`,
-# `ai-merged`, `ai-blocked`), the scheduling-metadata labels (`p0`,
-# `bug`, `ai-epic`, `ai-release`, `ai-ops-only`), the event → label
-# patch transition rules, and the pickup/resume/human-intervention
-# decisions all live in `orbi.delivery_labels` (Issue #175) — the single
-# source of truth. They are imported above; `p0`/`bug`/`ai-epic` are
-# scheduling metadata, never delivery lifecycle states.
-# The machine-readable section a release Issue body must carry (Issue
-# #98): `- version:`, `- base_branch:` and `- scope:` (or
-# `- scope_from_milestone:`). Parsed strictly — a missing or malformed
-# declaration fails fast, never guessed. The declaration carries NO
-# local test contract (Issue #569): test acceptance is the GitHub
-# Actions CI result on the release commit (the #268 CI-wait gate).
-RELEASE_SECTION = "## Release"
-# Release CI wait (Issue #268): the release commit is born from the last
-# delivery PR merge, so its CI is almost always still running when the
-# gate checks it — a pending check (queued/in_progress) is an
-# intermediate state, not a failure. The gate waits for completion up to
-# this limit and decides on the FINAL conclusions; a wait timeout is its
-# own failure reason, never reported as a CI failure. The TOML field
-# `release_ci_wait_seconds` overrides the default (the #228 pattern).
-RELEASE_CI_WAIT_SECONDS = 1800
-# Release delivery wait (Issue #381): an early release ticket yields the
-# slot while other deliveries finish. The limit applies to one gate attempt;
-# the next tick retries the same ready release ticket.
-RELEASE_DELIVERIES_WAIT_SECONDS = 1800
-# Poll cadence while waiting: one `release_waiting_ci` journal line plus
-# one progress-comment PATCH per poll — the same 30s GitHub cadence as
-# the live progress heartbeat (PI_HEARTBEAT_SECONDS).
-RELEASE_CI_POLL_INTERVAL = 30.0
 # Mergeability is recomputed asynchronously after a push. Poll the PR after
 # its checks settle instead of treating the transient UNKNOWN value as a
 # conflict.
 MERGEABLE_WAIT_SECONDS = 120.0
 MERGEABLE_POLL_INTERVAL = 5.0
 
-# Only comments posted by a repo maintainer are trusted to carry the
-# recovery scene: a public comment (authorAssociation=NONE) must never
-# steer the runner into an arbitrary local worktree, branch or PR
-# (Issue #45 review, BLOCKER). A missing association is never trusted.
-TRUSTED_COMMENT_ASSOCIATIONS = frozenset({
-    "OWNER", "MAINTAINER", "MEMBER", "COLLABORATOR",
-})
 
 # Issue #745: {{ISSUE_COMMENTS}} injects the Issue's trusted-comment
 # timeline into the implementer/review prompt. This cap bounds how many
@@ -250,19 +284,6 @@ _WORKTREE_INFLIGHT_LABELS = frozenset({
 _WORKTREE_NAME_PATTERN = re.compile(
     r"^orbi-(?P<slug>.+)-issue-(?P<number>\d+)-(?P<run_id>[0-9a-f]{8})$",
 )
-
-
-class ReleaseDeliveriesWaiting(RuntimeError):
-    """Gate 1 found deliveries still in flight; retry next tick."""
-
-    def __init__(self, issue_numbers: list[int], waited: float, limit: float):
-        self.issue_numbers = issue_numbers
-        self.waited = waited
-        self.limit = limit
-        super().__init__(
-            "release gate: waiting for open deliveries "
-            f"{issue_numbers} (waited {int(waited)}s / {int(limit)}s)"
-        )
 
 
 class RecoverableMergeGateError(RuntimeError):
@@ -339,73 +360,9 @@ def is_unrecoverable_failure(exc: BaseException) -> bool:
     )
 
 
-class RunIdFilter(logging.Filter):
-    """Prefix every log message with the current `[run_id]`, if bound."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if _CURRENT_RUN_ID is not None:
-            record.msg = f"[{_CURRENT_RUN_ID}] {record.msg}"
-        return True
-
-
-LOGGER.addFilter(RunIdFilter())
 # Issue #266: the health check's journal lines carry the same `[run_id]`
 # prefix as every other Runner line (the RunIdFilter is attached per
 # logger; the health module must not import this one — circular).
-runner_health.LOGGER.addFilter(RunIdFilter())
-pi_process.LOGGER.addFilter(RunIdFilter())
-
-
-def set_run_id(run_id: str) -> None:
-    """Bind one task attempt: every later journal line carries `[run_id]`."""
-    global _CURRENT_RUN_ID
-    _CURRENT_RUN_ID = validate_run_id(run_id)
-
-
-def current_run_id() -> str | None:
-    """Return the run id bound to this tick, or None before the claim."""
-    return _CURRENT_RUN_ID
-
-
-# Stop scene (Issue #48): when systemd (or any caller) stops the Runner
-# with SIGTERM, the journal must show which Issue context was active
-# BEFORE systemd's generic "Stopped" line, and the live Pi child must be
-# shut down (no orphan Pi). The context is bound while a delivery is in
-# flight (after the claim, or after a resumed scene is bound) and cleared
-# when the delivery ends. It carries no new id: the run id is the
-# existing `_CURRENT_RUN_ID`, and the phase/session come from the
-# existing activity snapshot of the worktree's `.pi-session`.
-_ACTIVE_RUN: dict | None = None
-
-
-def set_active_run(issue: int, title: str, branch: str, worktree: str) -> None:
-    """Bind the in-flight delivery scene for the stop handler (Issue #48)."""
-    global _ACTIVE_RUN
-    _ACTIVE_RUN = {
-        "issue": int(issue),
-        "title": title,
-        "branch": branch,
-        "worktree": worktree,
-        "pi": None,
-    }
-
-
-def set_active_pi(process: subprocess.Popen | None) -> None:
-    """Track the live Pi child of the in-flight delivery (Issue #48).
-
-    `stream_pi` calls it after the child is spawned (and again with None
-    after the child is reaped), so the stop handler signals exactly the
-    child that is alive — never an already-exited process. Without a
-    bound run (unit tests call `stream_pi` directly) it is a no-op.
-    """
-    if _ACTIVE_RUN is not None:
-        _ACTIVE_RUN["pi"] = process
-
-
-def clear_active_run() -> None:
-    """No delivery in flight anymore (Issue #48)."""
-    global _ACTIVE_RUN
-    _ACTIVE_RUN = None
 
 
 def _stop_delivery(signum: int) -> None:
@@ -421,7 +378,7 @@ def _stop_delivery(signum: int) -> None:
     exits with 128+signum (143 for SIGTERM) — the same value systemd
     records for a signal-caused stop.
     """
-    run = _ACTIVE_RUN
+    run = journal.active_run()
     if run is None:
         LOGGER.info("run_stopped result=idle")
     else:
@@ -1718,360 +1675,6 @@ def sync_active_milestone_variable(
         LOGGER.exception("active_milestone_variable_sync_failed repo=%s", repo)
 
 
-def single_line(value: str) -> str:
-    """Flatten a log value to one journal line (Issue #143).
-
-    A command argument may carry line breaks (the multi-line progress
-    comment body behind `gh api ... --field body=...`); emitted verbatim,
-    they split one `command=` log into several systemd journal lines with
-    the same timestamp and PID. Escape each line break to the visible
-    two-character sequence `\\n` so the field content stays readable on
-    one line. This only changes the log display — the real command is
-    never modified.
-    """
-    return value.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")
-
-
-def run_command(command: list[str], *, cwd: Path | None = None,
-                timeout: int | None = None,
-                log_command: list[str] | None = None,
-                log_stdout: bool = False,
-                failure_log_level: int = logging.ERROR) -> str:
-    """Run one external command; log context and fail fast on any error.
-
-    ``failure_log_level`` is INFO for probes whose failure is an expected
-    status result, such as an optional component health check. The command
-    still raises, so callers retain control over whether the failure blocks.
-    """
-    LOGGER.info(
-        "command=%s cwd=%s",
-        single_line(" ".join(log_command or command)), cwd or Path.cwd(),
-    )
-    try:
-        result = subprocess.run(
-            command,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=timeout,
-        )
-    except subprocess.CalledProcessError as exc:
-        LOGGER.log(
-            failure_log_level,
-            "command_failed returncode=%s stdout=%s stderr=%s",
-            exc.returncode, (exc.stdout or "").rstrip(),
-            (exc.stderr or "").rstrip(),
-        )
-        raise
-    except subprocess.TimeoutExpired as exc:
-        LOGGER.log(
-            failure_log_level,
-            "command_timeout timeout=%s stdout=%s stderr=%s",
-            timeout, (exc.stdout or "").rstrip(),
-            (exc.stderr or "").rstrip(),
-        )
-        raise
-    except OSError as exc:
-        LOGGER.log(failure_log_level, "command_spawn_failed error=%s", exc)
-        raise
-    if result.stderr:
-        LOGGER.info("stderr=%s", result.stderr.rstrip())
-    if log_stdout and result.stdout:
-        LOGGER.info("stdout=%s", result.stdout.rstrip())
-    return result.stdout.strip()
-
-
-GIT_NETWORK_MAX_ATTEMPTS = 3
-GIT_NETWORK_TIMEOUT_SECONDS = 30
-RESUME_PR_STATE_TIMEOUT_SECONDS = 30
-GIT_NETWORK_BACKOFF_SECONDS = 1
-GIT_TRANSIENT_ERROR_MARKERS = (
-    "connection timed out",
-    "operation timed out",
-    "connection reset",
-    "connection refused",
-    "temporary failure in name resolution",
-    "network is unreachable",
-    "network unreachable",
-)
-
-
-def _is_retryable_git_network_failure(
-    command: list[str], exc: subprocess.CalledProcessError,
-) -> bool:
-    """Return whether a Git fetch/push failed with a known transient error."""
-    if len(command) < 2 or command[:1] != ["git"]:
-        return False
-    if command[1] not in {"fetch", "push"}:
-        return False
-    stderr = (exc.stderr or "").lower()
-    return any(marker in stderr for marker in GIT_TRANSIENT_ERROR_MARKERS)
-
-
-def _is_git_network_command(command: list[str]) -> bool:
-    return (
-        len(command) >= 2
-        and command[:1] == ["git"]
-        and command[1] in {"fetch", "push"}
-    )
-
-
-def run_git_network_command(
-    command: list[str], *, cwd: Path | str | None = None,
-    command_runner: Callable[..., str] | None = None,
-) -> str:
-    """Run an Orbi-controlled Git fetch/push with bounded network retries.
-
-    Only explicitly recognized transient network messages are retried. The
-    last ``CalledProcessError`` is re-raised unchanged so its stderr remains
-    available to the existing failure handling.
-    """
-    execute = command_runner or run_command
-    attempt = 0
-    while True:
-        attempt += 1
-        try:
-            return execute(
-                command, cwd=cwd, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
-            )
-        except subprocess.TimeoutExpired as exc:
-            retryable = _is_git_network_command(command)
-            detail = f"command timed out after {GIT_NETWORK_TIMEOUT_SECONDS}s"
-            if attempt >= GIT_NETWORK_MAX_ATTEMPTS or not retryable:
-                raise
-        except subprocess.CalledProcessError as exc:
-            retryable = _is_retryable_git_network_failure(command, exc)
-            detail = (exc.stderr or "").strip()
-            if attempt >= GIT_NETWORK_MAX_ATTEMPTS or not retryable:
-                raise
-        delay = GIT_NETWORK_BACKOFF_SECONDS * (2 ** (attempt - 1))
-        LOGGER.warning(
-            "git_network_retry command=%s attempt=%s max_attempts=%s "
-            "delay_seconds=%s stderr=%s",
-            single_line(" ".join(command)), attempt + 1,
-            GIT_NETWORK_MAX_ATTEMPTS, delay, single_line(detail),
-        )
-        time.sleep(delay)
-
-
-GH_READ_MAX_ATTEMPTS = 3
-GH_READ_BACKOFF_SECONDS = 1
-# gh prints its own HTTP failures as `HTTP <code>: <text> (<url>)` — the
-# transient classes of Issue #738 are the 401 keyring race, the rate
-# limits (429 / the API's "rate limit" messages) and GitHub-side 5xx.
-GH_TRANSIENT_ERROR_RE = re.compile(
-    r"http 401|http 429|http 5\d\d|bad credentials|rate limit",
-    re.IGNORECASE,
-)
-# The read-only gh subcommand surface (the maintainer comment's
-# enumerated read table). A verb missing from the set simply gets no
-# retry — today's behavior — while a write verb can never classify as
-# retryable, so a retried write can never duplicate a side effect.
-GH_READ_SUBCOMMANDS = {
-    ("issue", "list"), ("issue", "view"),
-    ("pr", "list"), ("pr", "view"),
-    ("release", "view"),
-    ("repo", "view"),
-    ("label", "list"),
-    ("auth", "status"), ("auth", "token"),
-}
-
-
-def _is_readonly_gh_command(command: list[str]) -> bool:
-    """Return whether a gh command is provably read-only.
-
-    `gh api` is a read only when it carries no non-GET `--method`/`-X`
-    override and no request parameter: per gh's own semantics the
-    default method is GET normally and POST if any `-f`/`-F` parameter
-    was added, so only an explicit `--method GET` keeps parameters on
-    the query string — the flags are gh's read/write semantics, not a
-    call-site list. Every other subcommand is a read only when its verb
-    is in the fixed read set.
-    """
-    if command[:1] != ["gh"] or len(command) < 3:
-        return False
-    if command[1] == "api":
-        args = command[2:]
-        method_get = False
-        has_parameter = False
-        for index, argument in enumerate(args):
-            if argument in {"-X", "--method"} and index + 1 < len(args):
-                if args[index + 1].upper() != "GET":
-                    return False
-                method_get = True
-            elif argument.startswith("--method="):
-                if argument.split("=", 1)[1].upper() != "GET":
-                    return False
-                method_get = True
-            elif (
-                argument in {"-f", "-F", "--raw-field", "--field"}
-                or argument.startswith(("--raw-field=", "--field="))
-                or (argument.startswith(("-f", "-F")) and len(argument) > 2)
-            ):
-                has_parameter = True
-        return method_get or not has_parameter
-    return (command[1], command[2]) in GH_READ_SUBCOMMANDS
-
-
-def run_gh_read_command(
-    command: list[str], *, cwd: Path | None = None,
-    timeout: int | None = None,
-    command_runner: Callable[..., str] | None = None,
-) -> str:
-    """Run one read-only gh command with bounded transient-failure retries.
-
-    Issue #738: a keyring race (HTTP 401), a rate limit (429) or a
-    GitHub-side 5xx used to crash a whole tick that was only reading.
-    Only provably read-only commands (`_is_readonly_gh_command`) that
-    failed with a transient error are retried, so no write path can ever
-    reach the retry loop; every retry logs a structured `gh_read_retry`
-    line, and the last error is re-raised unchanged so the existing
-    failure handling keeps its stderr.
-    """
-    execute = command_runner or run_command
-    attempt = 0
-    while True:
-        attempt += 1
-        try:
-            # Forward only the set options: None is run_command's own
-            # default, and passing it explicitly would change the call
-            # observed by the run_command fakes and probes.
-            if timeout is None:
-                if cwd is None:
-                    return execute(command)
-                return execute(command, cwd=cwd)
-            if cwd is None:
-                return execute(command, timeout=timeout)
-            return execute(command, cwd=cwd, timeout=timeout)
-        except subprocess.CalledProcessError as exc:
-            detail = (exc.stderr or "").strip()
-            retryable = (
-                _is_readonly_gh_command(command)
-                and GH_TRANSIENT_ERROR_RE.search(detail) is not None
-            )
-            if attempt >= GH_READ_MAX_ATTEMPTS or not retryable:
-                raise
-        delay = GH_READ_BACKOFF_SECONDS * (2 ** (attempt - 1))
-        LOGGER.warning(
-            "gh_read_retry command=%s attempt=%s max_attempts=%s "
-            "delay_seconds=%s stderr=%s",
-            single_line(" ".join(command)), attempt + 1,
-            GH_READ_MAX_ATTEMPTS, delay, single_line(detail),
-        )
-        time.sleep(delay)
-
-
-def parse_issue_array(raw: str) -> list[dict]:
-    """Return the issue array from gh's JSON output."""
-    issues = json.loads(raw)
-    if not isinstance(issues, list):
-        raise ValueError("issue list must be a JSON array")
-    return issues
-
-
-def list_issues(repo: str, *, state: str | None = None,
-                label: str | None = None, milestone: str | None = None,
-                search: str | None = None, json_fields: str, limit: int,
-                timeout: int | None = None) -> list[dict]:
-    """Run one ``gh issue list`` query and return the parsed JSON array.
-
-    Issue #299: every ``gh issue list`` call site shares this single
-    command builder. The flag order mirrors the call sites it replaces
-    (``--label``/``--state``/``--search`` before ``--json``/``--limit``,
-    with ``--milestone`` appended last, exactly as the release gate did),
-    so the emitted ``gh`` command is byte-for-byte unchanged.
-    """
-    command = ["gh", "issue", "list", "--repo", repo]
-    if label is not None:
-        command += ["--label", label]
-    if state is not None:
-        command += ["--state", state]
-    if search is not None:
-        command += ["--search", search]
-    command += ["--json", json_fields, "--limit", str(limit)]
-    if milestone is not None:
-        command += ["--milestone", milestone]
-    return parse_issue_array(run_gh_read_command(command, timeout=timeout))
-
-
-def parse_issue_list(raw: str) -> dict | None:
-    """Return the first issue from gh's JSON array, or None when idle."""
-    issues = parse_issue_array(raw)
-    return issues[0] if issues else None
-
-
-def parse_paginated_issue_array(raw: str) -> list[dict]:
-    """Flatten the JSON array emitted by ``gh api --paginate --slurp``."""
-    pages = json.loads(raw)
-    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
-        raise ValueError("paginated issue list must be an array of arrays")
-    if any(not isinstance(item, dict) for page in pages for item in page):
-        raise ValueError("paginated issue list contains a non-object item")
-    return [item for page in pages for item in page]
-
-
-def milestone_open_issues(repo: str, milestone_number: int) -> list[dict]:
-    """List open Issues for one exact Milestone number, including all pages."""
-    raw = run_gh_read_command([
-        "gh", "api",
-        f"repos/{repo}/issues?milestone={milestone_number}&state=open&per_page=100",
-        "--paginate", "--slurp",
-    ])
-    return parse_paginated_issue_array(raw)
-
-
-def epic_issue_with_blockers(repo: str, issue: dict) -> dict:
-    """Add the native blocker field omitted by the REST issue listing."""
-    if isinstance(issue.get("blockedBy"), dict):
-        return issue
-    number = issue.get("number")
-    if not isinstance(number, int) or isinstance(number, bool):
-        raise ValueError("Epic number is missing or invalid")
-    raw = run_gh_read_command([
-        "gh", "issue", "view", str(number), "--repo", repo,
-        "--json", "number,body,labels,blockedBy",
-    ])
-    details = json.loads(raw)
-    if not isinstance(details, dict):
-        raise ValueError(f"Epic #{number} details are not an object")
-    return details
-
-
-def open_blocker_numbers(issue: dict) -> list[int]:
-    """Return the numbers of the issue's OPEN native GitHub blockers.
-
-    `gh issue list --json blockedBy` (gh 2.94+) carries the native
-    dependency relation as `{"nodes": [...], "totalCount": N}`. GitHub
-    keeps a relation listed after its blocker closes (the node then
-    carries `state: "CLOSED"` and is inert — verified against the live
-    API, Issue #54), so only OPEN blockers actually block: a closed
-    blocker clears the dependency without any runner-side bookkeeping,
-    and the next tick claims the Issue. A node without an explicit
-    `state` counts as open (claiming a possibly-blocked Issue costs a
-    full run; waiting one tick does not). A missing or malformed field
-    means "no known blockers" (fail open): an API shape change must
-    never deadlock the queue.
-    """
-    blocked_by = issue.get("blockedBy")
-    if not isinstance(blocked_by, dict):
-        return []
-    nodes = blocked_by.get("nodes")
-    if not isinstance(nodes, list):
-        return []
-    numbers: list[int] = []
-    for node in nodes:
-        if not isinstance(node, dict):
-            continue
-        number = node.get("number")
-        if not isinstance(number, int) or isinstance(number, bool):
-            continue
-        if node.get("state", "OPEN") != "OPEN":
-            continue
-        numbers.append(number)
-    return numbers
-
-
 # Ready scans (Issue #71/#101): P0 urgent Issues are claimed before
 # bugs, bugs before new features — if the delivery loop is broken,
 # claiming enhancements only piles up unreviewed PRs, and a production
@@ -2145,77 +1748,6 @@ def release_fallback_search(active_milestone: str | None = None,
     )
 
 
-def milestone_open_issue_count(repo: str, milestone_title: str) -> int:
-    """Return the Open-Issue count of one Milestone (Issue #663).
-
-    A single `gh api` call reads GitHub's own `open_issues` counter —
-    the authority on whether the Milestone still has unfinished work.
-    Unlike the search-based ready scans it does not depend on the search
-    index and it is not affected by a delivery-state label, so an Issue
-    temporarily outside the ready queue (`ai-blocked`, `ai-pr-opened`,
-    or not yet indexed) still counts. The title-filtered `--jq` is the
-    command documented in the Issue, verified against the live API. An
-    empty result means the Milestone could not be found: that is a
-    failed check, never a silent 0 (the caller must not release on it).
-    """
-    raw = run_gh_read_command(
-        [
-            "gh", "api", f"repos/{repo}/milestones",
-            "--jq",
-            f'.[] | select(.title=="{milestone_title}") | .open_issues',
-        ],
-        timeout=30,
-    )
-    if not raw:
-        raise RuntimeError(
-            f"Milestone {milestone_title!r} not found in {repo}"
-        )
-    return int(raw)
-
-
-def release_target_milestone(
-    issue: dict, active_milestone: str | None = None,
-) -> str | None:
-    """Return the Milestone a release Issue releases (Issue #663).
-
-    The completeness gate judges the Milestone the release belongs to:
-    the Issue's own GitHub Milestone is authoritative, and the configured
-    `active_milestone` is the fallback (the release fallback scan is
-    already scoped to it). Without any Milestone there is nothing to
-    check and the release keeps the pre-#663 behavior, so the function
-    returns None and the caller skips the gate.
-    """
-    milestone = issue.get("milestone")
-    if isinstance(milestone, dict):
-        title = milestone.get("title")
-        if isinstance(title, str) and title:
-            return title
-    if isinstance(active_milestone, str) and active_milestone:
-        return active_milestone
-    return None
-
-
-def issue_priority(issue: dict) -> str:
-    """Return the pickup priority of one issue (Issue #101).
-
-    `p0` when the issue carries the `p0` label, `normal` otherwise.
-    The ready/in-flight/resumable scans fetch `labels` (verified
-    against `gh issue list --help`: `labels` is a supported JSON
-    field, an array of `{name, ...}` nodes), so this is a pure
-    function of the scanned issue — no extra gh call. A missing or
-    malformed `labels` field fails to `normal` (like the blockedBy
-    field fails open): a P0 misread as normal only loses its ordering
-    for one run, never the delivery.
-    """
-    labels = issue.get("labels")
-    if not isinstance(labels, list):
-        return "normal"
-    for label in labels:
-        if isinstance(label, dict) and label.get("name") == P0_LABEL:
-            return "p0"
-    return "normal"
-
-
 def is_epic(issue: dict) -> bool:
     """Return True when one issue carries the `ai-epic` label (Issue #93).
 
@@ -2253,132 +1785,6 @@ def is_release(issue: dict) -> bool:
     return False
 
 
-def _is_ancestor(commit: str, base: str, *, cwd: Path) -> bool:
-    """Return whether *commit* is reachable from *base*.
-
-    Git uses exit code 1 for the normal negative answer. Any other failure
-    means the check itself could not be performed and must be surfaced.
-    """
-    try:
-        run_command(
-            ["git", "merge-base", "--is-ancestor", commit, base], cwd=cwd,
-        )
-    except subprocess.CalledProcessError as exc:
-        if exc.returncode != 1:
-            raise
-        return False
-    return True
-
-
-def _epic_child_evidence(repo: str, kind: str, number: int) -> str:
-    """Verify one child against GitHub's live Issue/PR state."""
-    raw = run_gh_read_command(["gh", "api", f"repos/{repo}/issues/{number}"])
-    item = json.loads(raw)
-    if not isinstance(item, dict):
-        raise ValueError(f"child #{number} response is not an object")
-    is_pr = "pull_request" in item
-    if kind == "issue" and is_pr:
-        raise ValueError(f"child #{number} declared as Issue but is a PR")
-    if kind == "pr" and not is_pr:
-        raise ValueError(f"child #{number} declared as PR but is an Issue")
-    if is_pr:
-        pr = json.loads(run_gh_read_command(["gh", "api", f"repos/{repo}/pulls/{number}"]))
-        if not isinstance(pr, dict) or pr.get("merged") is not True:
-            raise ValueError(f"child PR #{number} is not merged")
-        return f"PR #{number} merged"
-    if item.get("state") != "closed":
-        raise ValueError(f"child Issue #{number} is not closed")
-    return f"Issue #{number} closed"
-
-
-def _verify_epic_complete(repo: str, listed_epic: dict) -> list[str]:
-    """Verify native sub-issues and blockers; otherwise fail closed.
-
-    Live API shape (measured 2026-09-09 against #305):
-    ``GET /repos/{owner}/{repo}/issues/{number}/sub_issues`` returns a JSON
-    array (``[]`` for no children), paginates with the standard ``--paginate``
-    contract, and Issue items include ``repository.full_name`` and no
-    ``pull_request`` key.  The endpoint is paginated with ``per_page=100``;
-    a cross-repository item is identified by its ``repository.full_name`` and
-    is rejected.  A PR-shaped item is identified by a non-null
-    ``pull_request`` field and is checked through the PR endpoint.
-    """
-    epic = epic_issue_with_blockers(repo, listed_epic)
-    number = epic.get("number")
-    if not isinstance(number, int) or isinstance(number, bool):
-        raise ValueError("Epic number is missing or invalid")
-    blockers = epic.get("blockedBy")
-    # Live API check (Issue #552): `gh issue view --json blockedBy` returns
-    # {"blockedBy":{"nodes":[],"totalCount":0}} for zero dependencies.
-    # Missing/malformed blockedBy is not equivalent to that empty set.
-    if not isinstance(blockers, dict) or not isinstance(blockers.get("nodes"), list):
-        raise ValueError("native blocker/dependency state is unavailable")
-    for node in blockers["nodes"]:
-        if (not isinstance(node, dict)
-                or not isinstance(node.get("number"), int)
-                or isinstance(node.get("number"), bool)
-                or ("state" in node and node["state"] not in {"OPEN", "CLOSED"})):
-            raise ValueError("native blocker/dependency state is malformed")
-    open_blockers = open_blocker_numbers(epic)
-    if open_blockers:
-        raise ValueError("open blockers: " + ", ".join(f"#{n}" for n in open_blockers))
-    raw = run_gh_read_command([
-        "gh", "api", f"repos/{repo}/issues/{number}/sub_issues?per_page=100",
-        "--paginate", "--slurp",
-    ])
-    children = parse_paginated_issue_array(raw)
-    if not children:
-        raise ValueError("Epic child scope is missing or empty")
-    child_evidence: list[str] = []
-    for child in children:
-        child_number = child.get("number")
-        if not isinstance(child_number, int) or isinstance(child_number, bool):
-            raise ValueError("Epic child scope contains an invalid number")
-        child_repo = child.get("repository")
-        if not isinstance(child_repo, dict) or not isinstance(child_repo.get("full_name"), str):
-            raise ValueError(f"child #{child_number} repository state is malformed")
-        if child_repo["full_name"].lower() != repo.lower():
-            raise ValueError(f"cross-repository child #{child_number}")
-        if child.get("state") not in {"open", "closed"}:
-            raise ValueError(f"child #{child_number} state is malformed")
-        kind = "pr" if child.get("pull_request") is not None else "issue"
-        child_evidence.append(_epic_child_evidence(repo, kind, child_number))
-    return child_evidence
-
-
-def _epic_audit(child_evidence: list[str], version: str | None = None) -> str:
-    prefix = f" for {version}" if version else ""
-    return (f"Epic reconciliation{prefix}: complete; "
-            f"children: {', '.join(child_evidence)}; "
-            "no open native blockers/dependencies.")
-
-
-def reconcile_release_epics(repo: str, milestone_number: int, version: str,
-                            run_id: str) -> list[str]:
-    """Close only provably complete open Epics in this exact Milestone."""
-    issues = milestone_open_issues(repo, milestone_number)
-    evidence: list[str] = []
-    for listed_epic in issues:
-        labels = listed_epic.get("labels", [])
-        names = {label.get("name") for label in labels if isinstance(label, dict)}
-        if EPIC_LABEL not in names:
-            continue
-        number = listed_epic.get("number")
-        try:
-            child_evidence = _verify_epic_complete(repo, listed_epic)
-        except (ValueError, json.JSONDecodeError) as exc:
-            evidence.append(f"Epic #{number} kept open: {exc}")
-            continue
-        audit = _epic_audit(child_evidence, version)
-        comments = issue_comments(int(number), repo=repo)
-        if not any(audit in str(comment.get("body", "")) for comment in comments):
-            comment_issue(int(number), repo=repo,
-                         body=f"<!-- orbi:run={run_id} -->\n{audit}\nrun_id={run_id}")
-        run_command(["gh", "issue", "close", str(number), "--repo", repo])
-        evidence.append(f"Epic #{number} closed after verification ({'; '.join(child_evidence)})")
-    return evidence
-
-
 def reconcile_open_epics(repo: str, run_id: str) -> list[str]:
     """Sweep open Epics once per tick; ordinary pickup must not depend on it."""
     epics = list_issues(
@@ -2400,7 +1806,7 @@ def reconcile_open_epics(repo: str, run_id: str) -> list[str]:
         if not any(audit in str(comment.get("body", "")) for comment in comments):
             comment_issue(int(number), repo=repo,
                          body=f"<!-- orbi:run={run_id} -->\n{audit}\nrun_id={run_id}")
-        run_command(["gh", "issue", "close", str(number), "--repo", repo])
+        close_issue(int(number), repo=repo)
         LOGGER.info("epic_closed issue=%s repo=%s", number, repo)
         evidence.append(f"Epic #{number} closed after verification ({'; '.join(child_evidence)})")
     return evidence
@@ -2413,11 +1819,7 @@ def reconcile_release_milestones(repo: str, run_id: str) -> list[str]:
     Milestone title are independent GitHub facts, so a late-closing Issue is
     reconciled on a later tick without requiring a new release run.
     """
-    raw = run_gh_read_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
-        "--paginate", "--slurp",
-    ])
-    all_milestones = parse_paginated_issue_array(raw)
+    all_milestones = list_milestones(repo)
     milestones = [m for m in all_milestones if m.get("state") == "open"]
     for milestone in all_milestones:
         if not isinstance(milestone, dict) or milestone.get("state") not in {"open", "closed"}:
@@ -2454,10 +1856,7 @@ def reconcile_release_milestones(repo: str, run_id: str) -> list[str]:
         if open_issues:
             LOGGER.info("milestone_kept_open number=%s repo=%s reason=open issues", number, repo)
             continue
-        run_command([
-            "gh", "api", f"repos/{repo}/milestones/{number}",
-            "--method", "PATCH", "-f", "state=closed",
-        ])
+        close_milestone(repo, int(number))
         LOGGER.info("milestone_closed number=%s repo=%s", number, repo)
         evidence.append(f"Milestone #{number} ({title}) closed")
     return evidence
@@ -2510,11 +1909,7 @@ def reconcile_orphan_prs(repo: str, run_id: str) -> list[str]:
         issue_number = orphan_pr_branch_issue(pr.get("headRefName"))
         if not isinstance(pr_number, int) or issue_number is None:
             continue
-        raw = run_gh_read_command([
-            "gh", "issue", "view", str(issue_number), "--repo", repo,
-            "--json", "state",
-        ], timeout=30)
-        details = json.loads(raw)
+        details = issue_view(issue_number, "state", repo=repo, timeout=30)
         state = details.get("state") if isinstance(details, dict) else None
         if state == "OPEN":
             continue
@@ -2772,172 +2167,6 @@ def pick_next_issue(
     return None
 
 
-def edit_issue(number: int, *, repo: str, add: str | None = None,
-               remove: str | None = None) -> None:
-    command = ["gh", "issue", "edit", str(number), "--repo", repo]
-    if add:
-        command += ["--add-label", add]
-    if remove:
-        command += ["--remove-label", remove]
-    run_command(command)
-
-
-def apply_label_patch(number: int, *, repo: str, event: str,
-                      current_labels) -> None:
-    """Compute the deterministic label patch for `event` and apply it.
-
-    `current_labels` is the Issue's current label names (read once by the
-    caller). The patch comes from `delivery_labels.label_patch` — the
-    single source of truth for the transition rules (Issue #175) — so the
-    same current labels and event always produce the same idempotent
-    patch. The patch is applied through `edit_issue`: one call for the
-    add plus the first remove, then one call per extra remove (the exact
-    same `edit_issue` kwargs the pre-#175 code emitted). A no-op patch
-    (nothing to add or remove) applies nothing.
-    """
-    to_add, to_remove = label_patch(event, current_labels)
-    if not to_add and not to_remove:
-        return
-    first_remove = to_remove[0] if to_remove else None
-    kwargs: dict = {"repo": repo}
-    if to_add:
-        kwargs["add"] = to_add[0]
-    if first_remove is not None:
-        kwargs["remove"] = first_remove
-    edit_issue(number, **kwargs)
-    for label in to_remove[1:]:
-        edit_issue(number, repo=repo, remove=label)
-
-
-def comment_issue(number: int, *, repo: str, body: str) -> None:
-    run_command(["gh", "issue", "comment", str(number), "--repo", repo,
-                 "--body", format_status_comment(body)])
-
-
-def issue_comments(number: int, *, repo: str) -> list[dict]:
-    """Return the Issue's comment history (oldest first) from GitHub.
-
-    ``gh issue view --json comments`` returns a top-level object with a
-    ``comments`` array; each comment carries the author and the
-    ``authorAssociation`` of the viewer, which is how the runner tells
-    its own trusted comments apart from public ones (Issue #45).
-    """
-    raw = run_gh_read_command([
-        "gh", "issue", "view", str(number), "--repo", repo,
-        "--json", "comments",
-    ], timeout=30)
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ValueError("issue view must be a JSON object")
-    comments = data.get("comments")
-    if not isinstance(comments, list):
-        raise ValueError("issue comments must be a JSON array")
-    return comments
-
-
-def pr_comments(number: int, *, repo: str) -> list[dict]:
-    """Return the PR's comment history (oldest first) from GitHub.
-
-    The PR-side twin of `issue_comments`: a PR's comments are read
-    through `gh pr view --json comments` (`gh issue view` rejects PR
-    numbers), the same top-level object with a `comments` array — and
-    the same 30 s bound (#745 bounded the issue-side read; an
-    unbounded comments read is the same hang on the PR side).
-    """
-    raw = run_gh_read_command([
-        "gh", "pr", "view", str(number), "--repo", repo,
-        "--json", "comments",
-    ], timeout=30)
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ValueError("pr view must be a JSON object")
-    comments = data.get("comments")
-    if not isinstance(comments, list):
-        raise ValueError("pr comments must be a JSON array")
-    return comments
-
-
-def trusted_issue_comments_block(comments: list[dict], limit: int) -> str:
-    """Render the {{ISSUE_COMMENTS}} prompt block (Issue #745).
-
-    Only trusted authors enter the task context — the same
-    `authorAssociation` trust set as the recovery-scene parser (Issue
-    #45; a public repo lets anyone comment, and an unfiltered injection
-    would be a prompt-injection surface). The input order is preserved
-    (oldest first, the natural timeline read). Over `limit` the OLDEST
-    trusted comments are dropped — the newest carry the latest decision
-    — and the omission is stated inside the block: the agent must know
-    it did not see the full history, never a silent truncation. Zero
-    trusted comments produce an explicit marker, not an empty string.
-    """
-    trusted = [
-        comment for comment in comments if _comment_is_trusted(comment)
-    ]
-    kept = trusted[-limit:]
-    omitted = len(trusted) - len(kept)
-    if not kept:
-        return "(no trusted comments)"
-    lines = []
-    if omitted:
-        noun = "comment" if omitted == 1 else "comments"
-        lines.append(
-            f"({omitted} older trusted {noun} omitted; showing the "
-            f"{len(kept)} most recent)"
-        )
-    for comment in kept:
-        author = comment.get("author")
-        login = author.get("login") if isinstance(author, dict) else None
-        lines.append(
-            f"- {login or 'unknown'} "
-            f"({comment.get('authorAssociation') or '-'}) "
-            f"at {comment.get('createdAt') or '-'}:\n\n"
-            f"{str(comment.get('body') or '').rstrip()}"
-        )
-    return "\n\n".join(lines)
-
-
-def new_run_id() -> str:
-    """Return a unique short run identifier for one task attempt."""
-    return uuid.uuid4().hex[:8]
-
-
-def issue_context(source_repo: str, number: int) -> str:
-    """Issue reference used on every journal line: `owner/repo#number`."""
-    return f"{source_repo}#{number}"
-
-
-def log_format() -> str:
-    """Journal log format without a Python timestamp (Issue #40).
-
-    systemd journal already provides time, host and process on every
-    line; printing `%(asctime)s` again only duplicates information.
-    """
-    return "%(levelname)s %(message)s"
-
-
-def freeze_base(repo_dir: Path, base_branch: str) -> str:
-    """Fetch the remote and freeze the exact SHA of origin/<base_branch>.
-
-    The fetch runs under the base-sync lock (Issue #171): it updates
-    the shared remote-tracking ref, so it must not race the other
-    Runner/Pi fetches on that ref.
-    """
-    fetch_base_ref(repo_dir, base_branch)
-    return run_command(
-        ["git", "rev-parse", f"origin/{base_branch}"], cwd=repo_dir,
-    )
-
-
-def task_branch(source_repo: str, number: int, run_id: str | None = None) -> str:
-    """Return the stable remote delivery identity for one Issue.
-
-    ``run_id`` remains accepted for callers and compatibility, but is not
-    part of the branch identity: retries must converge on one GitHub branch
-    and therefore one open PR.
-    """
-    return f"orbi/{source_repo.replace('/', '-')}-issue-{number}"
-
-
 def claim_route(labels: set[str], *, branch_exists: bool,
                 open_pr: bool, ready_label: str = READY_LABEL) -> str:
     """Choose the fresh-claim action from the physical GitHub scene.
@@ -2954,32 +2183,6 @@ def claim_route(labels: set[str], *, branch_exists: bool,
     # An existing branch without an open PR is resumed by implementation;
     # a missing branch is the same implementation path.
     return "implement"
-
-
-def stable_branch_exists(repo_dir: Path, branch: str) -> bool:
-    """Return whether the stable delivery branch exists on origin."""
-    raw = run_command(
-        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
-        cwd=repo_dir, timeout=GIT_NETWORK_TIMEOUT_SECONDS,
-    )
-    return bool(raw.strip())
-
-
-def open_pr_for_branch(repo_dir: Path, branch: str) -> dict | None:
-    """Return the sole open PR for a branch, or None when absent."""
-    raw = run_gh_read_command([
-        "gh", "pr", "list", "--state", "open", "--head", branch,
-        "--json", "number,url,baseRefName,headRefName,headRefOid",
-        "--limit", "2",
-    ], cwd=repo_dir, timeout=RESUME_PR_STATE_TIMEOUT_SECONDS)
-    prs = json.loads(raw) if raw.strip() else []
-    if not isinstance(prs, list):
-        raise RuntimeError("open PR query must return an array")
-    if len(prs) > 1:
-        raise RuntimeError(
-            f"multiple open PRs for stable delivery branch {branch}"
-        )
-    return prs[0] if prs else None
 
 
 # Issue #608: the triage workflow embeds this hidden marker in the bug
@@ -3039,14 +2242,6 @@ def external_takeover_pr(repo_dir: Path, body: str | None,
         number, pr.get("headRefName"),
     )
     return pr
-
-
-def _run_info_fields(run_info: str) -> dict[str, str]:
-    """Extract the runner-owned key/value fields for comment rendering."""
-    return dict(
-        part.split("=", 1) for part in run_info.split()
-        if "=" in part
-    )
 
 
 def started_pi_comment_body(run_id: str, run_info: str, branch: str,
@@ -3608,11 +2803,7 @@ def advance_active_milestone_on_idle(
     *, auto_next_milestone: bool = True,
 ) -> tuple[str, str | None]:
     """Check and advance a configured milestone after no_ready_issue."""
-    raw = run_gh_read_command([
-        "gh", "api", f"repos/{repo}/milestones?state=all&per_page=100",
-        "--paginate", "--slurp",
-    ], timeout=30)
-    milestones = parse_paginated_issue_array(raw)
+    milestones = list_milestones(repo)
     matches = [
         milestone for milestone in milestones
         if isinstance(milestone, dict)
@@ -3807,131 +2998,6 @@ def _pick_issue_with_repo_policy(
     return pick_issue(repo, milestone, dispatch_label=dispatch_label)
 
 
-def worktree_path(repo_dir: Path, source_repo: str, number: int,
-                  run_id: str) -> Path:
-    """Task worktrees live in the configured repo's .worktrees/ directory."""
-    slug = source_repo.replace("/", "-")
-    return (
-        repo_dir / ".worktrees"
-        / f"orbi-{slug}-issue-{number}-{run_id}"
-    )
-
-
-def create_worktree(repo_dir: Path, source_repo: str, number: int,
-                    run_id: str, base_sha: str,
-                    existing: Path | None = None,
-                    existing_branch: bool = False,
-                    branch: str | None = None) -> Path:
-    """Create the task worktree from the frozen base SHA, never HEAD.
-
-    An existing path is reused: only a resumed run (same run id after a
-    process restart) reaches that state, and its worktree is the scene
-    the run continues in (Issue #18). `existing` is the VERIFIED resume
-    scene (Issue #219): after a repo rename the scene's path carries
-    the OLD slug, so the derived path would miss it and a second
-    worktree would be created — the verified scene is returned as-is.
-
-    `branch` overrides the stable delivery branch name: an EXTERNAL
-    takeover (Issue #608) checks out the contributor's own head branch,
-    the identity the takeover PR is frozen on. With `existing_branch`
-    the named branch is fetched and reused (a local branch is reused
-    with `--force`, never a second `-b` — the exit-255 claim failure of
-    Issue #608); without it the branch is created from the frozen base.
-
-    A local branch that already exists (the orphan a SIGKILLed run
-    leaves with no worktree and no remote counterpart, Issue #662) is
-    reused as-is rather than re-created with `-b`: git exits 255 on an
-    existing branch, which used to burn the re-claimed Issue into
-    terminal `ai-blocked`.
-    """
-    if existing is not None and existing.is_dir():
-        return existing
-    path = worktree_path(repo_dir, source_repo, number, run_id)
-    if path.exists():
-        return path
-    branch = branch or task_branch(source_repo, number, run_id)
-    if existing_branch:
-        # The branch is the delivery identity.  Fetch it, then create the
-        # run-isolated worktree from its remote HEAD rather than the base.
-        run_git_network_command(
-            ["git", "fetch", "origin", branch], cwd=repo_dir,
-        )
-        local = run_command(
-            ["git", "branch", "--list", branch], cwd=repo_dir,
-        )
-        if local.strip():
-            run_command([
-                "git", "worktree", "add", "--force", str(path), branch,
-            ], cwd=repo_dir)
-        else:
-            run_command([
-                "git", "worktree", "add", "-b", branch, str(path),
-                f"origin/{branch}",
-            ], cwd=repo_dir)
-    else:
-        # Issue #662 (the #655 incident): a SIGKILLed run can leave the
-        # stable branch behind with no worktree and no remote counterpart
-        # (a pure orphan).  `worktree add -b` cannot re-create it — git
-        # exits 255 (`fatal: a branch named ... already exists`) and the
-        # claim used to be burned into terminal `ai-blocked`.  The branch
-        # is the delivery identity, so a local one is reused as-is; only
-        # a missing branch is created from the frozen base SHA.
-        local = run_command(
-            ["git", "branch", "--list", branch], cwd=repo_dir,
-        )
-        if local.strip():
-            run_command([
-                "git", "worktree", "add", str(path), branch,
-            ], cwd=repo_dir)
-        else:
-            run_command([
-                "git", "worktree", "add", "-b", branch, str(path), base_sha,
-            ], cwd=repo_dir)
-    return path
-
-
-def create_release_worktree(repo_dir: Path, source_repo: str, number: int,
-                            run_id: str, release_commit: str) -> Path:
-    """Prepare the release worktree at this attempt's verified commit.
-
-    Release worktrees have no resumable session semantics.  A failed release
-    may leave the stable branch checked out in an older, run-specific
-    worktree, so reusing ``create_worktree(..., existing_branch=True)`` would
-    incorrectly preserve that old position.  Find that worktree when it is
-    registered, otherwise create one from the local stable branch (or the
-    release commit), then hard-reset it to the commit whose gates just passed.
-    """
-    branch = task_branch(source_repo, number, run_id)
-    listing = run_command(
-        ["git", "worktree", "list", "--porcelain"], cwd=repo_dir,
-    )
-    current_path: Path | None = None
-    current_branch = f"branch refs/heads/{branch}"
-    for block in listing.split("\n\n"):
-        lines = block.splitlines()
-        if current_branch in lines and lines:
-            current_path = Path(lines[0].removeprefix("worktree "))
-            break
-    if current_path is None:
-        local = run_command(
-            ["git", "branch", "--list", branch], cwd=repo_dir,
-        )
-        if local.strip():
-            current_path = worktree_path(
-                repo_dir, source_repo, number, run_id,
-            )
-            run_command([
-                "git", "worktree", "add", "--force", str(current_path),
-                branch,
-            ], cwd=repo_dir)
-        else:
-            current_path = create_worktree(
-                repo_dir, source_repo, number, run_id, release_commit,
-            )
-    run_command(["git", "reset", "--hard", release_commit], cwd=current_path)
-    return current_path
-
-
 def run_state_path(worktree: Path) -> Path:
     """The run state file of one task worktree (Issue #219).
 
@@ -4117,25 +3183,6 @@ def resume_run_id(repo_dir: Path, source_repo: str,
     return scene[0] if scene is not None else None
 
 
-def latest_run_id(repo_dir: Path, source_repo: str, number: int) -> str | None:
-    """Return the run id of the newest task worktree for the issue.
-
-    The worktree directory name carries the run id — the state the
-    release state machine (Issue #98) reuses to resume the same run
-    after a restart. Development runs use the stricter state-file
-    discovery (`worktree_resume_scene`, Issue #219) instead.
-    """
-    slug = source_repo.replace("/", "-")
-    pattern = f".worktrees/orbi-{slug}-issue-{number}-*"
-    candidates = [
-        path for path in repo_dir.glob(pattern) if path.is_dir()
-    ]
-    if not candidates:
-        return None
-    newest = max(candidates, key=lambda path: path.stat().st_mtime)
-    return newest.name.rsplit("-", 1)[-1]
-
-
 def _tree_size(path: Path) -> int:
     """The byte size of one worktree tree (informational `freed=` field).
 
@@ -4192,7 +3239,7 @@ def reclaim_released_worktrees(config: dict, *,
     }
     # (slug, issue number, path) per orbi-named registered worktree.
     candidates: list[tuple[str, int, Path]] = []
-    active = _ACTIVE_RUN or {}
+    active = journal.active_run() or {}
     listing = run_command(
         ["git", "worktree", "list", "--porcelain"], cwd=repo_dir,
     )
@@ -4274,36 +3321,6 @@ def reclaim_released_worktrees(config: dict, *,
         freed += size
     if removed:
         LOGGER.info("worktree_reclaimed count=%d freed=%d", removed, freed)
-
-
-def has_in_progress_label(number: int, repo: str) -> bool:
-    """True when the Issue still carries `ai-in-progress`.
-
-    The label is added at claim time and removed only by the success or
-    failure path, so it is the marker of a run that is (or was, when
-    the runner died) in flight — as opposed to the preserved worktrees
-    of completed runs (Issue #18).
-
-    Read via `gh issue view` — a direct, strongly consistent read. The
-    pre-#658 implementation used `gh issue list --search`, the same
-    eventually-consistent index the pickup scan reads, so it could not
-    see a label another instance added seconds ago — exactly the moment
-    this check exists to catch (the pre-claim race guard).
-    """
-    raw = run_gh_read_command([
-        "gh", "issue", "view", str(number), "--repo", repo,
-        "--json", "labels",
-    ])
-    details = json.loads(raw)
-    if not isinstance(details, dict):
-        raise ValueError("issue view must return a JSON object")
-    labels = details.get("labels")
-    if not isinstance(labels, list):
-        raise ValueError("issue view labels must be a JSON array")
-    return any(
-        isinstance(label, dict) and label.get("name") == IN_PROGRESS_LABEL
-        for label in labels
-    )
 
 
 def _another_live_runner(slot_dir: Path, max_concurrency: int) -> bool:
@@ -4445,7 +3462,7 @@ def process_ticket_only(issue: dict, config: dict, source_repo: str) -> str:
                   f"Orbi ticket-only delivery (run_id={run_id}):\n\n"
                   f"{output}"),
         )
-        run_command(["gh", "issue", "close", str(number), "--repo", source_repo])
+        close_issue(int(number), repo=source_repo)
         # The ticket-only delivery never enters the PR/review states: it
         # clears the claim label directly (no `ai-merged` terminal state —
         # the Issue is closed, not merged).
@@ -5204,11 +4221,8 @@ def deliver_pr(worktree: Path, branch: str, base_branch: str,
     # stays on the branch for the human) and BEFORE the PR creation.
     # `gh issue view` is a direct, strongly consistent read — the same
     # property `has_in_progress_label` relies on.
-    raw = run_gh_read_command([
-        "gh", "issue", "view", str(issue), "--repo", source_repo,
-        "--json", "state",
-    ], cwd=worktree, timeout=30)
-    details = json.loads(raw)
+    details = issue_view(issue, "state", repo=source_repo,
+                         cwd=worktree, timeout=30)
     state = details.get("state") if isinstance(details, dict) else None
     if state not in ("OPEN", "CLOSED"):
         raise ValueError("issue view state must be OPEN or CLOSED")
@@ -5702,10 +4716,7 @@ def _raise_if_preexisting_ci_failure(
     """Raise a fast, explicit error when base has the same failed check."""
     if not base_commit:
         return
-    base_checks = json.loads(run_gh_read_command([
-        "gh", "api", f"repos/{repo}/commits/{base_commit}/check-runs",
-        "--jq", ".check_runs",
-    ]))
+    base_checks = commit_check_runs(repo, base_commit)
     base_failures = {
         check.get("name") for check in base_checks
         if check.get("status") == "completed"
@@ -5731,10 +4742,7 @@ def check_review_ci(repo: str, commit: str, *, wait_seconds: float) -> str:
     wait configuration and cadence.
     """
     def fetch() -> list[dict]:
-        return json.loads(run_gh_read_command([
-            "gh", "api", f"repos/{repo}/commits/{commit}/check-runs",
-            "--jq", ".check_runs",
-        ]))
+        return commit_check_runs(repo, commit)
 
     waited = 0.0
     check_runs = fetch()
@@ -5815,13 +4823,10 @@ def merge_gate(worktree: Path, pr: dict, base_branch: str,
             f"remote base origin/{base_branch}; absorb the latest base, rerun "
             "tests and review, then retry"
         )
-    view_command = [
-        "gh", "pr", "view", str(pr["number"]),
-        "--json", "state,mergeable,headRefOid,statusCheckRollup",
-    ]
-
     def fetch_state() -> dict:
-        return json.loads(run_gh_read_command(view_command, cwd=worktree))
+        return pr_view(pr["number"],
+                       "state,mergeable,headRefOid,statusCheckRollup",
+                       cwd=worktree)
 
     def check_rollup(state: dict) -> tuple[list[str], list[str]]:
         rollup = state.get("statusCheckRollup") or []
@@ -5927,11 +4932,7 @@ def confirm_merged(worktree: Path, pr: dict, base_branch: str,
     under the base-sync lock (Issue #171) with the deployment checkout
     as the lock location.
     """
-    raw = run_gh_read_command([
-        "gh", "pr", "view", str(pr["number"]),
-        "--json", "state,mergedAt,mergeCommit",
-    ], cwd=worktree)
-    state = json.loads(raw)
+    state = pr_view(pr["number"], "state,mergedAt,mergeCommit", cwd=worktree)
     if state.get("state") != "MERGED" or not state.get("mergedAt"):
         LOGGER.error("confirm_merged_not_merged pr=%s state=%s",
                      pr["number"], state.get("state"))
@@ -6036,12 +5037,7 @@ def log_recovery_ci_status(pr: dict, repo: str) -> None:
     whether the recovered review runs (Issue #79).
     """
     try:
-        checks = json.loads(run_gh_read_command([
-            "gh", "api", f"repos/{repo}/commits/{pr['head_oid']}/check-runs",
-            "--jq", ".check_runs",
-        ]))
-        if not isinstance(checks, list):
-            raise ValueError("PR check-runs response must be an array")
+        checks = commit_check_runs(repo, pr["head_oid"])
         summary = [
             f"{check.get('name', '?')}={check.get('status', '?')}/"
             f"{check.get('conclusion', '?')}"
@@ -6056,313 +5052,6 @@ def log_recovery_ci_status(pr: dict, repo: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Editable CLI install refresh (Issue #158)
-# ---------------------------------------------------------------------------
-#
-# The official local deployment is the EDITABLE uv tool install (Issue
-# #152): the tool env imports the runtime package directly from the
-# deployment checkout through a setuptools editable finder. Since the
-# src layout (Issue #168) the finder maps the WHOLE package directory
-# `src/orbi/` — a newly added package module needs NO reinstall
-# (the #158 stale-module-list incident class is gone at the root). The
-# remaining packaging inputs come from the checkout's `pyproject.toml`
-# (entry points, version, dependencies): when THEY change the installed
-# tool env is STALE and the next CLI process can die before the Runner
-# starts (the #158 incident shape: `cli_source` merged to main, the
-# installed finder still mapped the pre-#152 module set, the systemd
-# start failed).
-#
-# This section refreshes the editable install at the Runner start,
-# BEFORE any slot or claim:
-#
-# - the packaging fingerprint (sha256 of the checkout's
-#   `pyproject.toml` — the packaging input that decides the editable
-#   metadata) is compared against the fingerprint of the LAST
-#   successful install, stored in the shared state dir
-#   (`.orbi/cli-install.json` — the same gitignored dir as
-#   `base-sync.lock` and the slots, which survives the
-#   `git merge --ff-only` checkout sync). It is NOT a second release
-#   state: it only records which packaging input the installed tool
-#   env was built from;
-# - unchanged: NO uv call at all (no per-tick reinstall);
-# - changed, or no state yet (first install): ONE lock-protected
-#   `uv tool install --force --reinstall --editable --python
-#   /usr/bin/python3 <repo_dir>` (the exact verified argv from
-#   `cli_source.reinstall_args`);
-# - two instances starting in the same tick: the SAME base-sync flock
-#   (the lock file the service template's `ExecStartPre` also takes)
-#   serializes them; the second instance re-reads the state UNDER the
-#   lock and reuses the first's result — no concurrent uv install, no
-#   corrupted tool env;
-# - a failing install fails fast with the structured
-#   `cli_install_failed` line (reason + the exact fix command) and
-#   records NO state (the next start retries).
-#
-# The implementation lives in `runner` itself (see the NOTE at the top
-# of this file): the bootstrap chain must stay loadable in a tool env
-# whose installed finder predates the packaging change. `cli_source` is
-# imported lazily inside `refresh_cli_install`: the reinstall argv is
-# the single cross-module dependency (Issue #152's verified command).
-
-CLI_INSTALL_LOGGER = logging.getLogger("orbi.cli_install")
-
-# The uv install timeout (seconds): a local editable build of this
-# zero-dependency package takes seconds; a hang (a wedged uv or a
-# full disk) must fail the start, never block it forever (Issue #95:
-# blocking commands carry a timeout).
-UV_INSTALL_TIMEOUT_SECONDS = 300
-
-# The base-sync lock: one home for the concurrency primitive — the
-# checkout sync, the ExecStartPre preflight and the CLI install
-# refresh all serialize on the SAME lock file.
-BASE_SYNC_LOCK_NAME = "base-sync.lock"
-
-
-class CliInstallError(RuntimeError):
-    """The editable CLI install refresh failed (fail fast)."""
-
-
-def base_sync_lock_path(repo_dir: Path) -> Path:
-    """The lock file serializing ALL writers of the deployment base
-    checkout and its tool env.
-
-    Two timer instances may start in the same tick, so the service
-    template's `ExecStartPre` wraps the fetch + fast-forward in a
-    short-lived `flock` on this SAME file, and the Python-side
-    checkout sync and the CLI install refresh take the same lock: the
-    main worktree and the tool env are never written concurrently.
-    The lock lives in the shared state dir (next to the slot files),
-    never in a per-process temp dir.
-
-    Issue #171 extended the same lock to EVERY fetch that updates the
-    shared remote-tracking ref ``refs/remotes/origin/<base>``: task
-    worktrees share the deployment checkout's common dir, so an
-    unlocked concurrent fetch (Runner verify/gate/confirm, the Pi
-    prompt-side fetch) races on that one ref and fails with
-    ``cannot lock ref ... is at <X> but expected <Y>``.
-    """
-    return Path(repo_dir) / ".orbi" / BASE_SYNC_LOCK_NAME
-
-
-def acquire_base_sync_lock(
-    repo_dir: Path, lock_timeout_seconds: float,
-) -> int:
-    """Take the base-sync flock; fail fast when it is still held after
-    the timeout. The kernel releases an flock when its holder exits,
-    so a dead holder can never wedge the lock."""
-    lock_path = base_sync_lock_path(repo_dir)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
-    deadline = time.monotonic() + lock_timeout_seconds
-    while True:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return fd
-        except (BlockingIOError, InterruptedError, PermissionError):
-            if time.monotonic() >= deadline:
-                os.close(fd)
-                CLI_INSTALL_LOGGER.error(
-                    "base_sync_lock_timeout repo_dir=%s lock=%s "
-                    "timeout_seconds=%s",
-                    repo_dir, lock_path, lock_timeout_seconds,
-                )
-                raise CliInstallError(
-                    f"could not take the base-sync lock {lock_path} "
-                    f"within {lock_timeout_seconds}s (another Runner "
-                    "instance or the ExecStartPre preflight is syncing "
-                    "the deployment checkout)"
-                ) from None
-            time.sleep(0.1)
-
-
-def fetch_base_ref(repo_dir: Path, base_branch: str,
-                   *, cwd: Path | None = None,
-                   lock_timeout_seconds: float = 300.0,
-                   command_runner: Callable[[list[str]], str] | None = None,
-                   ) -> None:
-    """Fetch ``origin/<base>`` under the base-sync lock (Issue #171).
-
-    Every command that updates the shared remote-tracking ref
-    ``refs/remotes/origin/<base>`` must run under the SAME lock in the
-    deployment checkout's shared state dir (the one the ExecStartPre
-    flock and ``sync_base_checkout`` use): worktrees share the common
-    dir, so an unlocked concurrent fetch races on the ref and fails
-    the session. ``repo_dir`` is the deployment checkout (the lock
-    location); ``cwd`` is where the fetch runs (the task worktree for
-    the Runner verify/gate/confirm paths, the checkout itself by
-    default). ``command_runner`` overrides the command executor (the
-    setup entry injects its own); by default the module's
-    ``run_command`` is used. A lock timeout or a fetch error fails
-    fast — no retry, no lock bypass.
-    """
-    if command_runner is None:
-        command_runner = run_command
-    fd = acquire_base_sync_lock(repo_dir, lock_timeout_seconds)
-    try:
-        run_git_network_command(
-            ["git", "fetch", "origin", base_branch],
-            cwd=cwd if cwd is not None else repo_dir,
-            command_runner=command_runner,
-        )
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
-
-
-def packaging_fingerprint(repo_dir: Path) -> str:
-    """The sha256 of the checkout's `pyproject.toml`.
-
-    `pyproject.toml` is the packaging input that decides the editable
-    metadata (the entry points, the version, the dependencies) — so
-    its content hash is the refresh trigger. Ordinary Python source
-    content is NOT part of it: since the src layout (Issue #168) the
-    editable finder maps the WHOLE `src/orbi/` package
-    directory, so a newly added package module needs no reinstall
-    (the whole point of the editable install, Issue #152). A checkout
-    without `pyproject.toml` cannot be tool-installed: fail fast,
-    never guess a fingerprint.
-    """
-    pyproject = Path(repo_dir) / "pyproject.toml"
-    if not pyproject.is_file():
-        raise CliInstallError(
-            f"packaging file missing: {pyproject} (the deployment "
-            "checkout must carry the packaging input of the editable "
-            "install)"
-        )
-    return hashlib.sha256(pyproject.read_bytes()).hexdigest()
-
-
-def install_state_path(repo_dir: Path) -> Path:
-    """The last-install fingerprint record in the shared state dir.
-
-    `<repo_dir>/.orbi/cli-install.json` — the EXISTING shared
-    state dir (gitignored, next to `base-sync.lock` and the slots;
-    it survives the `git merge --ff-only` checkout sync). Not a second
-    release state and not a per-process temp file.
-    """
-    return Path(repo_dir) / ".orbi" / "cli-install.json"
-
-
-def read_install_state(repo_dir: Path) -> str | None:
-    """The stored last-install fingerprint, or None.
-
-    Missing file (first install / fresh checkout) -> None. A
-    malformed file (a torn write) is treated as "no state" and heals
-    in the SAFE direction: one extra idempotent `--force
-    --reinstall` runs — never a wedged start.
-    """
-    path = install_state_path(repo_dir)
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    fingerprint = data.get("pyproject_sha256") if isinstance(data, dict) else None
-    if not isinstance(fingerprint, str) or not fingerprint:
-        return None
-    return fingerprint
-
-
-def write_install_state(repo_dir: Path, fingerprint: str) -> None:
-    """Record the last-install fingerprint (atomic: tmp + replace).
-
-    Only called AFTER a successful install, under the base-sync flock
-    (no concurrent writer; the atomic replace guards a torn write on
-    a crash mid-install).
-    """
-    path = install_state_path(repo_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(
-        json.dumps({"pyproject_sha256": fingerprint}), encoding="utf-8",
-    )
-    os.replace(str(tmp), str(path))
-
-
-def refresh_cli_install(
-    repo_dir: Path, *, run_command,
-    lock_timeout_seconds: float = 300.0,
-    lock_repo_dir: Path | None = None,
-) -> str:
-    """Refresh the editable CLI install when the packaging inputs
-    changed; return `"unchanged"` or `"installed"`. ``repo_dir`` is
-    the checkout to install; ``lock_repo_dir`` optionally names the
-    shared deployment checkout whose base-sync lock also protects the
-    tool environment.
-
-    The pre-start gate (called by the Runner tick before any slot or
-    claim):
-
-    - the current packaging fingerprint equals the stored last-install
-      fingerprint -> `"unchanged"` and NO uv call (no per-tick
-      reinstall);
-    - otherwise (changed, or no state yet — the first install): take
-      the base-sync flock (the SAME lock the service template's
-      `ExecStartPre` and the checkout sync use), re-check the state
-      UNDER the lock (a concurrent instance may have refreshed while
-      we waited — reuse its result, never run a second install), run
-      the exact verified editable force reinstall from
-      `cli_source.reinstall_args`, and record the fingerprint only
-      after success.
-
-    A failing install logs the structured `cli_install_failed` line
-    (reason + the exact fix command) and raises `CliInstallError`:
-    the service does not start (fail fast), no state is recorded (the
-    next start retries) and the lock is released (success or
-    failure).
-    """
-    repo_dir = Path(repo_dir)
-    lock_repo_dir = (
-        Path(lock_repo_dir) if lock_repo_dir is not None else repo_dir
-    )
-    fingerprint = packaging_fingerprint(repo_dir)
-    if read_install_state(repo_dir) == fingerprint:
-        CLI_INSTALL_LOGGER.info(
-            "cli_install_unchanged repo_dir=%s pyproject_sha256=%s",
-            repo_dir, fingerprint,
-        )
-        return "unchanged"
-    fd = acquire_base_sync_lock(lock_repo_dir, lock_timeout_seconds)
-    try:
-        # Re-check UNDER the lock: a concurrent instance may have
-        # refreshed the tool env while we waited for the flock —
-        # reuse its result, never run a second install.
-        if read_install_state(repo_dir) == fingerprint:
-            CLI_INSTALL_LOGGER.info(
-                "cli_install_reused repo_dir=%s pyproject_sha256=%s",
-                repo_dir, fingerprint,
-            )
-            return "unchanged"
-        reason = "first_install" if (
-            read_install_state(repo_dir) is None
-        ) else "packaging_changed"
-        from orbi import cli_source  # lazy: the single cross-module dependency
-        try:
-            run_command(
-                cli_source.reinstall_args(repo_dir),
-                timeout=UV_INSTALL_TIMEOUT_SECONDS,
-            )
-        except Exception as exc:
-            CLI_INSTALL_LOGGER.error(
-                "cli_install_failed repo_dir=%s reason=%s fix=%s",
-                repo_dir, quote_value(str(exc)),
-                quote_value(cli_source.reinstall_command(repo_dir)),
-            )
-            raise CliInstallError(
-                f"editable CLI install failed for {repo_dir}: {exc} "
-                f"(fix: {cli_source.reinstall_command(repo_dir)})"
-            ) from exc
-        write_install_state(repo_dir, fingerprint)
-        CLI_INSTALL_LOGGER.info(
-            "cli_install_refreshed repo_dir=%s reason=%s "
-            "pyproject_sha256=%s",
-            repo_dir, reason, fingerprint,
-        )
-        return "installed"
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
-
-
 # Startup source freshness (Issue #525): the 2026-09-07 incident — the
 # editable install resolved into an OLD issue worktree while the
 # ExecStartPre preflight kept the deployment checkout fresh — showed
@@ -7077,99 +5766,6 @@ def _pr_head_repo(pr: dict) -> str:
     return f"{login}/{name}"
 
 
-
-
-# pytest's final summary line: `1 failed, 155 passed in 4.43s` (the
-# counts and the `in <seconds>` part are optional; the line is NOT
-# wrapped in `=` section padding).
-_Pytest_SUMMARY_RE = re.compile(
-    r"^\d+ (?:failed|passed|error|errors|skipped|xfailed|xpassed"
-    r"|deselected)(?:, \d+ \w+)*(?: in [\d.]+s)?$")
-
-
-def _is_section_header(line: str) -> bool:
-    """True for pytest section headers like `=== FAILURES ===`.
-
-    A header is `=`-delimited at both ends (padding may be absent on
-    one side for short titles) and its title carries no digits; the
-    real summary line (`1 failed, 155 passed in 4.43s`, bare or
-    `=`-padded) and the `FAILED`/`ERROR` evidence lines never match.
-    """
-    if not line.startswith("="):
-        return False
-    core = line.strip("=").strip()
-    return core == "" or not any(ch.isdigit() for ch in core)
-
-
-# A pytest summary line reports an outcome only when its FIRST count
-# category is failed/passed/error(s): pytest orders the counts
-# failed, passed, skipped, errors, xfailed, xpassed, deselected, so a
-# run that collected tests always leads with failed or passed (or a
-# collection error). `no tests ran in 0.01s` matches no summary regex
-# at all; `3 deselected in 0.02s` / `2 skipped in 0.01s` match but
-# carry no outcome — reporting them as a pass is a false notification
-# (review round 3, PR #42).
-_OUTCOME_FIRST_RE = re.compile(
-    r"^\d+ (?:failed|passed|error|errors)\b",
-)
-_NO_TESTS_RE = re.compile(r"no tests (?:ran|collected)")
-
-
-def _is_no_result(line: str) -> bool:
-    """True for pytest lines that verified nothing (no tests ran)."""
-    if _NO_TESTS_RE.search(line):
-        return True
-    stripped = line.strip("=").strip()
-    return bool(_Pytest_SUMMARY_RE.match(stripped)) \
-        and not _OUTCOME_FIRST_RE.match(stripped)
-
-
-def read_test_result(worktree: Path) -> str | None:
-    """Summarize the worktree's `.orbi/test.log`, or None when it does
-    not exist (Issue #302: the contract test command writes the log
-    into the excluded run dir, never at the worktree root).
-
-    Prefers the pytest summary line (`1 failed, 155 passed in 4.43s`):
-    the LAST one with an outcome when the log holds several runs (TDD
-    red, then green), so the progress comment and the `tests
-    passed/failed` milestone report the most recent run that actually
-    collected tests. Section headers (`=== FAILURES ===`) are never
-    reported: the fallback takes the first `FAILED`/`ERROR` evidence
-    line or the last non-empty line instead, and a log holding nothing
-    but headers yields None (no result info to report). Lines that
-    verified nothing (`no tests ran`, `N deselected`, `N skipped`) are
-    never reported either: a run that collected no tests is no result,
-    and posting `tests passed` for it is a false notification (review
-    round 3, PR #42).
-    """
-    path = worktree / ".orbi" / "test.log"
-    if not path.is_file():
-        return None
-    text = path.read_text(encoding="utf-8", errors="replace")
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
-    for line in reversed(lines):
-        # The summary line is bare in pytest 9; some runners wrap it in
-        # `=` padding, so the stripped form is matched as well.
-        stripped = line.strip("=").strip()
-        if _Pytest_SUMMARY_RE.match(line) \
-                or _Pytest_SUMMARY_RE.match(stripped):
-            if _is_no_result(line):
-                # No tests collected in this run: keep looking for an
-                # earlier run that did (or report nothing at all).
-                continue
-            return sanitize(stripped)
-    for line in lines:
-        if _is_section_header(line) or _is_no_result(line):
-            continue
-        if line.startswith(("FAILED", "ERROR")) or "passed" in line:
-            return sanitize(line)
-    last = lines[-1] if lines else None
-    if last is not None and (_is_section_header(last)
-                             or _is_no_result(last)):
-        return None
-    return sanitize(last) if last is not None else None
-
-
 def delivery_head_advanced(worktree: Path, base_sha: str) -> bool:
     """True when the task branch has commits beyond the frozen base."""
     head = run_command(["git", "rev-parse", "HEAD"], cwd=worktree)
@@ -7235,62 +5831,6 @@ def _human_review_column2(worktree: Path, config: dict) -> list[str]:
         changed_files=delivered_changed_files(worktree, base),
         test_command=config.get("test_command"),
     )["column2"]
-
-
-def _progress_state(*, issue: int, title: str, run_id: str, role: str,
-                    branch: str, worktree: Path, started: float,
-                    pr_url: str | None, review_round: int, priority: str,
-                    activity: dict | None = None) -> dict:
-    """Collect the current run state for the GitHub progress comment.
-
-    `title` is the issue's GitHub title (Issue #100): the progress
-    comment's issue line shows `#<number> <title>` in every scene. It
-    is required — the GitHub issue data contract guarantees a
-    non-empty string title (every runner scan fetches it), and a
-    missing title fails fast in `progress.issue_field` instead of
-    fabricating one.
-    `priority` is the pickup priority of the issue (`p0` or `normal`,
-    Issue #101), derived from the issue's labels at claim/resume time.
-    `activity` is the live state from the `stream_pi` watcher while a Pi
-    session runs (fresh and already read); without it the newest session
-    file is full-scanned. Activity snapshotting is best-effort
-    observability: a read failure is logged and reported as "no session
-    yet", it never blocks the task.
-    """
-    if activity is None:
-        try:
-            activity = activity_snapshot(worktree / ".pi-session")
-        except Exception:
-            LOGGER.exception("issue=%s activity snapshot failed", issue)
-            activity = None
-    return {
-        "run_id": run_id,
-        "issue": issue,
-        "issue_title": title,
-        "role": role,
-        "priority": priority,
-        "phase": (activity or {}).get("phase") or "starting",
-        "elapsed": format_elapsed(time.monotonic() - started),
-        "last_activity": (activity or {}).get("last_activity"),
-        "last_action": (activity or {}).get("action"),
-        "tests": read_test_result(worktree),
-        "review_round": review_round,
-        "branch": branch,
-        "pr": pr_url,
-        "session": (activity or {}).get("session_id"),
-        # Idle-stall recovery state (Issue #94): `term` / `kill` while
-        # the runner recovers a stalled session, absent/None otherwise
-        # (the body renders the line only while it is active).
-        "recovery": (activity or {}).get("recovery"),
-    }
-
-
-def _progress_body(state: dict, *, outcome: str | None = None) -> str:
-    """Render the progress body, optionally with a final outcome header."""
-    body = progress_body(state)
-    if outcome is None:
-        return body
-    return f"{outcome}\n\n{body}"
 
 
 def _publish_plan_milestone(publisher: ProgressPublisher, worktree: Path) -> None:
@@ -7489,29 +6029,6 @@ def _failure_evidence(worktree: Path | None, exc: BaseException) -> str:
         f"{session_file or '<unavailable>'}):\n{_fenced(session)}\n"
         f"\ntest_log_tail:\n{_fenced(test_log)}"
     )
-
-
-def _safe_publish(*, run_id: str, issue: int, source_repo: str,
-                  role: str, action: Callable[[], None]) -> None:
-    """Run one progress-publishing step as a pure bypass (Issue #79).
-
-    The main delivery path is claim -> worktree -> Pi -> verify PR ->
-    review -> fix -> merge; the GitHub progress comment is observability
-    on the side. A publishing failure (404, rate limit, API shape
-    change) is logged as `progress_publish_failed` and never fails the
-    delivery, never marks the Issue `ai-blocked`, and never skips
-    `run_pi` / `wait_for_delivery`. This is the same semantics as the
-    in-stream live-PATCH callback; Issue #60 already applied it to the
-    post-PR record, Issue #79 extends it to the whole
-    `ProgressPublisher` path (ensure / milestone / finish).
-    """
-    try:
-        action()
-    except Exception:
-        LOGGER.exception(
-            "progress_publish_failed run=%s issue=%s role=%s",
-            run_id, issue_context(source_repo, issue), role,
-        )
 
 
 def _live_progress(publisher: ProgressPublisher, *, issue: int,
@@ -8361,67 +6878,6 @@ def process_issue(issue: dict, config: dict, source_repo: str,
         # the next tick's restart-resume scan recovers it — no crash
         # needed for either outcome.
         return IssueResult("failed", None)
-
-
-def _pr_number(pr_url: str) -> int:
-    """Extract the PR number from its URL (the last path segment)."""
-    return int(pr_url.rstrip("/").rsplit("/", 1)[-1])
-
-
-def pr_delivery_status(pr_url: str, source_repo: str) -> tuple[str, list[str]]:
-    """Return PR state and CI summaries for delivery-wait evidence."""
-    number = _pr_number(pr_url)
-    raw = run_gh_read_command([
-        "gh", "pr", "view", str(number), "--repo", source_repo,
-        "--json", "state,statusCheckRollup",
-    ])
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ValueError("pr view must be a JSON object")
-    state = data.get("state")
-    if state not in ("OPEN", "MERGED", "CLOSED"):
-        raise ValueError(f"unexpected PR state: {state!r}")
-    rollup = data.get("statusCheckRollup")
-    if rollup is None:
-        rollup = []
-    if not isinstance(rollup, list):
-        raise ValueError("pr statusCheckRollup must be a JSON array")
-    summaries = []
-    for check in rollup:
-        if not isinstance(check, dict):
-            continue
-        name = check.get("name", check.get("context", "check"))
-        status = check.get("status", check.get("state", "UNKNOWN"))
-        conclusion = check.get("conclusion")
-        detail = str(status)
-        if conclusion:
-            detail += f"/{conclusion}"
-        summaries.append(f"{name}={detail}")
-    return state, summaries
-
-
-def pr_state(pr_url: str, source_repo: str) -> str:
-    """Return a PR's state from the configured source repository."""
-    return pr_delivery_status(pr_url, source_repo)[0]
-
-
-def issue_labels(number: int, repo: str) -> list[str]:
-    """Return the current label names of one Issue."""
-    raw = run_gh_read_command([
-        "gh", "issue", "view", str(number), "--repo", repo,
-        "--json", "labels",
-    ])
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ValueError("issue view must be a JSON object")
-    labels = data.get("labels")
-    if not isinstance(labels, list):
-        raise ValueError("issue labels must be a JSON array")
-    names: list[str] = []
-    for label in labels:
-        if isinstance(label, dict) and isinstance(label.get("name"), str):
-            names.append(label["name"])
-    return names
 
 
 def _finish_progress_body(*, number: int, title: str, run_id: str,

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -2803,7 +2803,7 @@ def advance_active_milestone_on_idle(
     *, auto_next_milestone: bool = True,
 ) -> tuple[str, str | None]:
     """Check and advance a configured milestone after no_ready_issue."""
-    milestones = list_milestones(repo)
+    milestones = list_milestones(repo, timeout=30)
     matches = [
         milestone for milestone in milestones
         if isinstance(milestone, dict)

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -152,7 +152,6 @@ from orbi import github, gitops, journal, release
 from orbi.cli_source import CliInstallError, refresh_cli_install
 from orbi.github import (
     RESUME_PR_STATE_TIMEOUT_SECONDS,
-    TRUSTED_COMMENT_ASSOCIATIONS,
     run_gh_read_command,
     _comment_is_trusted,
     _pr_number,
@@ -2412,77 +2411,6 @@ def parse_pr_comment(body: str) -> dict | None:
     # required-field check: its absence is normal, never an error.
     scene["external"] = fields.get("external", "")
     return scene
-
-
-def _authenticated_github_login() -> str:
-    """Return the login represented by the active ``gh`` credential.
-
-    ``gh api installation`` is unavailable with installation tokens, while
-    ``gh auth status`` reports the account selected in gh's credential store.
-    Read that local status instead of guessing a bot name or making an API
-    request that cannot identify this credential shape.
-    """
-    try:
-        # The comments being verified come from github.com.  Restrict the
-        # status query to that host so an active account on another configured
-        # GitHub Enterprise host cannot be mistaken for this credential.
-        status = run_gh_read_command([
-            "gh", "auth", "status", "--hostname", "github.com",
-        ])
-    except Exception as exc:
-        raise ValueError(
-            "GitHub identity resolution failed: `gh auth status` could not "
-            f"read the active account: {exc}; run `gh auth login` or fix "
-            "the GitHub credentials"
-        ) from exc
-
-    account: str | None = None
-    active_account: str | None = None
-    for line in status.splitlines():
-        match = re.search(r"\baccount\s+(\S+)", line)
-        if match:
-            account = match.group(1)
-        if re.search(r"Active account:\s*true\b", line, re.IGNORECASE):
-            if account:
-                active_account = account
-
-    if not active_account:
-        raise ValueError(
-            "GitHub identity resolution failed: `gh auth status` did not "
-            "report an active account; run `gh auth login` or select an "
-            "active github.com account with `gh auth switch`"
-        )
-    return active_account
-
-
-def _strip_bot_suffix(login: str) -> str:
-    """Drop the optional ``[bot]`` suffix from an App login.
-
-    ``gh issue view --json comments`` reads comments through GraphQL and
-    reports ``author.login`` without the ``[bot]`` suffix, while REST's
-    ``user.login`` keeps it (Issue #655). Both shapes name the same App
-    credential, so the suffix is normalized away before comparison.
-    """
-    return login[:-5] if login.endswith("[bot]") else login
-
-
-def _comment_is_trusted(comment: object) -> bool:
-    """True when the comment is from a maintainer or this runner's App bot."""
-    if not isinstance(comment, dict):
-        return False
-    if comment.get("authorAssociation") in TRUSTED_COMMENT_ASSOCIATIONS:
-        return True
-    author = comment.get("author")
-    login = author.get("login") if isinstance(author, dict) else None
-    if not isinstance(login, str):
-        return False
-    # A copied run marker is not sufficient: the author must be the account
-    # represented by the currently authenticated installation token. The
-    # optional `[bot]` suffix is normalized on both sides because GraphQL
-    # drops it and REST keeps it (Issue #655).
-    return _strip_bot_suffix(login) == _strip_bot_suffix(
-        _authenticated_github_login()
-    )
 
 
 def resume_scene(comments: list[dict]) -> dict:

--- a/src/orbi/runner_health.py
+++ b/src/orbi/runner_health.py
@@ -39,10 +39,13 @@ import time
 from pathlib import Path
 
 from orbi.delivery_labels import READY_LABEL
+from orbi.journal import RunIdFilter
 from orbi.progress import format_status_comment, run_marker
 from orbi.systemd_deploy import service_instances
 
 LOGGER = logging.getLogger("orbi.health")
+
+LOGGER.addFilter(RunIdFilter())
 
 STATE_FILENAME = "health.json"
 CRASH_WINDOW_MINUTES = 60

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ over this default).
 import pytest
 
 import orbi.runner as runner
+from seam import seam
 
 
 @pytest.fixture(autouse=True)
@@ -27,14 +28,12 @@ def _default_cli_install_preflight(monkeypatch):
     patches ITS module global — the call `main()` makes."""
     import orbi.release as release
 
-    monkeypatch.setattr(
-        runner, "refresh_cli_install", lambda *a, **k: "unchanged",
+    monkeypatch.setattr(seam, "refresh_cli_install", lambda *a, **k: "unchanged",
     )
     # Issue #286: `process_release` now lives in `orbi.release` and reads
     # the refresh through the release module global — stub that binding
     # with the same default no-op.
-    monkeypatch.setattr(
-        release, "refresh_cli_install", lambda *a, **k: "unchanged",
+    monkeypatch.setattr(seam, "refresh_cli_install", lambda *a, **k: "unchanged",
     )
 
 

--- a/tests/seam.py
+++ b/tests/seam.py
@@ -1,0 +1,39 @@
+"""Fan-out patch target for the subprocess seam (Issue #785).
+
+Since Issue #785 the seam primitives (`run_command`,
+`run_git_network_command`, `run_gh_read_command`) live in `orbi.journal`
+/ `orbi.github` / `orbi.gitops`, and every module binds them into its own
+namespace. A fake must therefore replace the name in EVERY module that
+binds it, so it intercepts the seam no matter which module executes the
+function under test. ``monkeypatch.setattr(seam, "run_command", fake)``
+does exactly that: reading resolves the current binding (monkeypatch's
+old-value capture) and writing fans the value out to all bindings, so
+monkeypatch's teardown fans the original back.
+"""
+import orbi.cli_source as cli_source
+import orbi.github as github
+import orbi.gitops as gitops
+import orbi.journal as journal
+import orbi.progress as progress
+import orbi.release as release
+import orbi.runner as runner
+
+_MODULES = (journal, github, gitops, progress, cli_source, release, runner)
+
+
+class Seam:
+    """Set/read a seam name across every module that binds it."""
+
+    def __getattr__(self, name: str):
+        for module in _MODULES:
+            if name in vars(module):
+                return vars(module)[name]
+        raise AttributeError(name)
+
+    def __setattr__(self, name: str, value) -> None:
+        for module in _MODULES:
+            if name in vars(module):
+                setattr(module, name, value)
+
+
+seam = Seam()

--- a/tests/test_apply_label_patch.py
+++ b/tests/test_apply_label_patch.py
@@ -1,4 +1,4 @@
-"""Direct unit tests for `runner.apply_label_patch` (Issue #175).
+"""Direct unit tests for `github.apply_label_patch` (Issue #175).
 
 `apply_label_patch` computes the deterministic label patch via
 `delivery_labels.label_patch` and applies it through `edit_issue`. These
@@ -6,13 +6,20 @@ tests cover the branches the delivery-flow tests do not reach: the no-op
 patch (nothing to add or remove), the add-only patch, the remove-only
 patch, and the multi-remove patch (one `edit_issue` call per extra remove).
 """
-import orbi.runner as runner
+from orbi import github
+from orbi.delivery_labels import (
+    EVENT_BLOCKED,
+    EVENT_CLAIM,
+    EVENT_FIX_NEEDED,
+    EVENT_MERGED,
+    EVENT_PR_OPENED,
+)
+from seam import seam
 
 
 def test_apply_label_patch_no_op_patch_applies_nothing(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
     # `label_patch` never returns an empty patch for a known event, so
@@ -20,11 +27,11 @@ def test_apply_label_patch_no_op_patch_applies_nothing(monkeypatch):
     # (nothing to add, nothing to remove) — `apply_label_patch` must
     # apply nothing (no `edit_issue` call).
     monkeypatch.setattr(
-        runner, "label_patch",
+        github, "label_patch",
         lambda event, current_labels: ([], []),
     )
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_BLOCKED,
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_BLOCKED,
         current_labels={"ai-ready", "ai-blocked"},
     )
     assert calls == []
@@ -34,14 +41,13 @@ def test_apply_label_patch_blocked_with_only_non_delivery_labels_is_add_only(
         monkeypatch,
 ):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
     # `ai-blocked` is not a delivery-state label, so the remove list is
     # empty: one add-only call.
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_BLOCKED,
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_BLOCKED,
         current_labels={"ai-ready", "ai-blocked"},
     )
     assert calls == [
@@ -51,12 +57,11 @@ def test_apply_label_patch_blocked_with_only_non_delivery_labels_is_add_only(
 
 def test_apply_label_patch_add_only_patch(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_CLAIM, current_labels=(),
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_CLAIM, current_labels=(),
     )
     assert calls == [
         ((7,), {"repo": "o/r", "add": "ai-in-progress"}),
@@ -65,12 +70,11 @@ def test_apply_label_patch_add_only_patch(monkeypatch):
 
 def test_apply_label_patch_single_remove_patch(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_PR_OPENED, current_labels=(),
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_PR_OPENED, current_labels=(),
     )
     assert calls == [
         ((7,), {"repo": "o/r", "add": "ai-pr-opened",
@@ -80,18 +84,17 @@ def test_apply_label_patch_single_remove_patch(monkeypatch):
 
 def test_apply_label_patch_remove_only_patch(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
     # A remove-only patch (nothing to add) must emit a single remove-only
     # `edit_issue` call — no `add` kwarg.
     monkeypatch.setattr(
-        runner, "label_patch",
+        github, "label_patch",
         lambda event, current_labels: ([], ["ai-in-progress"]),
     )
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_BLOCKED,
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_BLOCKED,
         current_labels={"ai-in-progress"},
     )
     assert calls == [
@@ -101,14 +104,13 @@ def test_apply_label_patch_remove_only_patch(monkeypatch):
 
 def test_apply_label_patch_multi_remove_patch_one_call_per_remove(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
     # A blocked patch with two present delivery-state labels produces
     # one add+first-remove call, then one remove-only call per extra.
-    runner.apply_label_patch(
-        7, repo="o/r", event=runner.EVENT_BLOCKED,
+    github.apply_label_patch(
+        7, repo="o/r", event=EVENT_BLOCKED,
         current_labels={"ai-pr-opened", "ai-fix-needed"},
     )
     assert calls == [

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -4847,7 +4847,7 @@ def test_trusted_issue_comments_block_filters_untrusted_and_keeps_order(
     # authenticated-login fallback; pin it so the test never depends on
     # the host's real gh login state (CI runs unauthenticated).
     monkeypatch.setattr(
-        runner, "_authenticated_github_login", lambda: "ci-runner[bot]"
+        seam, "_authenticated_github_login", lambda: "ci-runner[bot]"
     )
     comments = [
         {"author": {"login": "alice"}, "authorAssociation": "OWNER",
@@ -4898,7 +4898,7 @@ def test_trusted_issue_comments_block_states_when_nothing_is_trusted(
     an empty string — the agent can tell an empty timeline apart from a
     missing section."""
     monkeypatch.setattr(
-        runner, "_authenticated_github_login", lambda: "ci-runner[bot]"
+        seam, "_authenticated_github_login", lambda: "ci-runner[bot]"
     )
     block = runner.trusted_issue_comments_block([
         {"author": {"login": "mallory"}, "authorAssociation": "NONE",
@@ -4939,7 +4939,7 @@ def test_run_pi_injects_trusted_issue_comments_into_the_prompt(
     # fallback; pin it so the test never depends on the host's real gh
     # login state (CI runs unauthenticated).
     monkeypatch.setattr(
-        runner, "_authenticated_github_login", lambda: "ci-runner[bot]"
+        seam, "_authenticated_github_login", lambda: "ci-runner[bot]"
     )
     calls = []
     monkeypatch.setattr(
@@ -5024,7 +5024,7 @@ def test_run_review_injects_trusted_issue_comments_into_the_prompt(
     # fallback; pin it so the test never depends on the host's real gh
     # login state (CI runs unauthenticated).
     monkeypatch.setattr(
-        runner, "_authenticated_github_login", lambda: "ci-runner[bot]"
+        seam, "_authenticated_github_login", lambda: "ci-runner[bot]"
     )
     calls = []
     monkeypatch.setattr(

--- a/tests/test_bootstrap_runner.py
+++ b/tests/test_bootstrap_runner.py
@@ -18,8 +18,11 @@ import pytest
 
 import orbi.runner as runner
 import orbi.release as release
+import orbi.github as github
 from orbi import pi_activity, pi_process, progress
 from tests.test_progress_wiring import make_fake_gh
+import orbi.journal as journal
+from seam import seam
 
 
 def test_runner_main_config_failure_is_one_structured_log_line(
@@ -62,7 +65,7 @@ def test_list_issues_builds_each_parameter_combination(monkeypatch):
         calls.append((command, kwargs))
         return json.dumps([{"number": 1}])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
     # state + search: the common ready/in-flight scan shape.
     assert runner.list_issues(
@@ -1381,7 +1384,7 @@ def test_run_command_logs_multiline_body_as_one_journal_line(
         "gh", "api", "repos/xqliu/orbi/issues/143/comments",
         "--method", "POST", "--field", f"body={body}",
     ]
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     completed = Mock(stdout='{"id": 1}', stderr="")
     monkeypatch.setattr(runner.subprocess, "run", Mock(return_value=completed))
     with caplog.at_level("INFO"):
@@ -1422,7 +1425,7 @@ def test_pick_issue_uses_github_queue(monkeypatch):
             return json.dumps([])
         return json.dumps([issue])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi-backlog") == issue
     # Issue #101: the P0 scan runs first, then the bug scan (Issue
     # #71); with nothing in either queue the plain ready scan decides.
@@ -1507,8 +1510,7 @@ def test_pick_issue_skips_blocked_issue_and_claims_next(monkeypatch, caplog):
         "number": 55, "title": "free task", "body": "",
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([blocked, ready]),
     )
     with caplog.at_level("INFO"):
@@ -1530,8 +1532,7 @@ def test_pick_issue_returns_none_when_all_ready_issues_blocked(
         "number": 2, "title": "b", "body": "",
         "blockedBy": {"nodes": [{"number": 8}], "totalCount": 1},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([blocked_a, blocked_b]),
     )
     with caplog.at_level("INFO"):
@@ -1550,8 +1551,7 @@ def test_pick_issue_claims_issue_whose_blocker_is_closed(monkeypatch):
             {"number": 31, "state": "CLOSED", "title": "done"},
         ], "totalCount": 1},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([issue]),
     )
     assert runner.pick_issue("xqliu/orbi") == issue
@@ -1562,8 +1562,7 @@ def test_pick_issue_claims_issue_with_empty_blocked_by(monkeypatch):
         "number": 54, "title": "free task", "body": "",
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([issue]),
     )
     assert runner.pick_issue("xqliu/orbi") == issue
@@ -1577,8 +1576,7 @@ def test_pick_issue_stays_blocked_while_any_blocker_is_open(monkeypatch):
             {"number": 32, "state": "OPEN", "title": "pending"},
         ], "totalCount": 2},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([blocked]),
     )
     assert runner.pick_issue("xqliu/orbi") is None
@@ -1588,8 +1586,7 @@ def test_pick_issue_fails_open_when_blocked_by_field_missing(monkeypatch):
     # Older gh versions or a changed API shape omit the field: the
     # Issue must still be claimable (fail open, Issue #54).
     issue = {"number": 9, "title": "task", "body": "body"}
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([issue]),
     )
     assert runner.pick_issue("xqliu/orbi") == issue
@@ -1604,8 +1601,7 @@ def test_pick_issue_fails_open_when_blocked_by_query_fails(
     error = subprocess.CalledProcessError(
         1, ["gh"], output="boom", stderr="rate limited",
     )
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(error),
     )
     # Issue #738: the read now retries the transient stderr; skip the
@@ -1641,7 +1637,7 @@ def test_pick_issue_scopes_all_three_ready_scans_to_active_milestone(
             return json.dumps([])
         return json.dumps([issue])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue(
         "xqliu/orbi-backlog", active_milestone="v0.2.0",
     ) == issue
@@ -1735,8 +1731,7 @@ def test_pick_issue_keeps_epic_and_blocked_by_guards_with_milestone(
         "labels": [{"name": "ai-ready"}],
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([epic, blocked, ready]),
     )
     with caplog.at_level("INFO"):
@@ -1757,8 +1752,7 @@ def test_pick_issue_fails_open_when_milestone_query_fails(
     error = subprocess.CalledProcessError(
         1, ["gh"], output="boom", stderr="rate limited",
     )
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(error),
     )
     # Issue #738: the read now retries the transient stderr; skip the
@@ -1792,7 +1786,7 @@ def test_pick_issue_prefers_bug_labeled_issues(monkeypatch):
             return json.dumps([bug])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == bug
     # The P0 scan ran first and found nothing; the bug scan found the
     # bug: the plain ready scan never ran.
@@ -1819,7 +1813,7 @@ def test_pick_issue_bug_scan_keeps_existing_exclusions(monkeypatch):
             return json.dumps([bug])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == bug
     assert searches[0] == (
         "label:ai-ready label:p0 -label:ai-in-progress "
@@ -1849,7 +1843,7 @@ def test_pick_issue_falls_back_to_ready_scan_when_no_bug(monkeypatch):
             return json.dumps([])
         return json.dumps([feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == feature
     assert len(searches) == 3
     assert "label:p0" in searches[0]
@@ -1882,7 +1876,7 @@ def test_pick_issue_bug_blocked_by_open_blocker_falls_back(monkeypatch):
             return json.dumps([blocked_bug])
         return json.dumps([feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == feature
     assert len(searches) == 3
 
@@ -1892,8 +1886,7 @@ def test_pick_issue_bug_scan_failure_fails_open(monkeypatch, caplog):
     (Issue #54) — the tick claims nothing from this repo, the error is
     logged, never raised."""
     error = subprocess.CalledProcessError(1, ["gh"], output="boom")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(error),
     )
     with caplog.at_level("INFO"):
@@ -1933,7 +1926,7 @@ def test_pick_issue_prefers_p0_over_bug_and_plain(monkeypatch, caplog):
         # scan that runs) sees them all and must pick the P0.
         return json.dumps([p0, bug, feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == p0
     # The P0 scan ran first and found the P0: the bug and plain ready
@@ -1964,7 +1957,7 @@ def test_pick_issue_p0_scan_keeps_existing_exclusions(monkeypatch):
         # exact exclusions.
         return json.dumps([p0])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == p0
     assert searches[0] == (
         "label:ai-ready label:p0 -label:ai-in-progress "
@@ -2025,7 +2018,7 @@ def test_release_issue_not_claimed_when_ordinary_delivery_exists(
         # fallback scan never runs (only three searches).
         return json.dumps([release, feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == feature
     assert len(searches) == 3
@@ -2052,7 +2045,7 @@ def test_release_issue_claimed_when_no_ordinary_delivery(
             return json.dumps([release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == release
     # Three ordinary scans + one release fallback scan.
@@ -2084,7 +2077,7 @@ def test_release_fallback_scoped_to_active_milestone(monkeypatch):
             return json.dumps([release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue(
         "xqliu/orbi", active_milestone="v0.3.0",
     ) == release
@@ -2119,7 +2112,7 @@ def test_release_fallback_excludes_epic_and_blocked(
             return json.dumps([epic_release, blocked_release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert "epic_not_claimed" in caplog.text
@@ -2138,7 +2131,7 @@ def test_release_fallback_scan_failure_fails_open(monkeypatch, caplog):
             raise error
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert "blocked_by_check_failed" in caplog.text
@@ -2157,7 +2150,7 @@ def test_milestone_open_issue_count_reads_github_counter(monkeypatch):
         commands.append(command)
         return "3"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.milestone_open_issue_count("xqliu/orbi", "v0.4.2") == 3
     assert commands == [[
         "gh", "api", "repos/xqliu/orbi/milestones",
@@ -2168,7 +2161,7 @@ def test_milestone_open_issue_count_reads_github_counter(monkeypatch):
 def test_milestone_open_issue_count_missing_milestone_raises(monkeypatch):
     """Issue #663: an empty result (the Milestone is gone) is a failed
     check, not a silent zero — the caller must never claim on it."""
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "")
     with pytest.raises(RuntimeError, match="v0.4.2"):
         runner.milestone_open_issue_count("xqliu/orbi", "v0.4.2")
 
@@ -2223,7 +2216,7 @@ def test_release_not_claimed_when_milestone_incomplete(monkeypatch, caplog):
     sees. The gate reads GitHub's own `open_issues` counter, so a
     temporarily un-claimable Issue (ai-blocked / ai-pr-opened / not yet
     indexed) can no longer let the release run ahead."""
-    monkeypatch.setattr(runner, "run_command", _release_scan_fake("3"))
+    monkeypatch.setattr(seam, "run_command", _release_scan_fake("3"))
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert "release_milestone_incomplete" in caplog.text
@@ -2238,7 +2231,7 @@ def test_release_claimed_when_milestone_only_has_the_release(
 ):
     """Issue #663: with only the release ticket itself left
     (`open_issues=1`) the release is claimed exactly as before."""
-    monkeypatch.setattr(runner, "run_command", _release_scan_fake("1"))
+    monkeypatch.setattr(seam, "run_command", _release_scan_fake("1"))
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == RELEASE_663
     assert "picked issue=254" in caplog.text
@@ -2249,7 +2242,7 @@ def test_release_not_claimed_when_milestone_check_fails(monkeypatch, caplog):
     claims — a bad release is irreversible, so the check fails safe and
     the next tick retries (recoverable, never `ai-blocked`)."""
     error = subprocess.CalledProcessError(1, ["gh"], output="boom")
-    monkeypatch.setattr(runner, "run_command", _release_scan_fake(error))
+    monkeypatch.setattr(seam, "run_command", _release_scan_fake(error))
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert "release_milestone_check_failed" in caplog.text
@@ -2275,7 +2268,7 @@ def test_release_without_milestone_claimed_without_api_call(
             return json.dumps([release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == release
     assert not [c for c in commands_seen if c[1] == "api"]
@@ -2304,7 +2297,7 @@ def test_release_milestone_falls_back_to_active_milestone(
             return json.dumps([release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue(
             "xqliu/orbi", active_milestone="v0.3.0",
@@ -2332,7 +2325,7 @@ def test_release_fallback_scan_fetches_milestone(monkeypatch):
             return json.dumps([release])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("xqliu/orbi") == release
     fields = scans[-1][scans[-1].index("--json") + 1]
     assert "milestone" in fields.split(",")
@@ -2364,7 +2357,7 @@ def test_pick_issue_p0_blocked_by_open_blocker_falls_back_to_bug(
             return json.dumps([blocked_p0])
         return json.dumps([bug])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == bug
     # The blocked P0 was skipped with the structured blocked_by line;
@@ -2381,8 +2374,7 @@ def test_pick_issue_p0_scan_failure_fails_open(monkeypatch, caplog):
     (Issue #54) — the tick claims nothing from this repo, the error is
     logged, never raised."""
     error = subprocess.CalledProcessError(1, ["gh"], output="boom")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(error),
     )
     with caplog.at_level("INFO"):
@@ -2408,7 +2400,7 @@ def test_pick_issue_logs_priority_normal_for_plain_pickup(
             return json.dumps([])
         return json.dumps([feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == feature
     assert "priority=normal" in caplog.text
@@ -2479,8 +2471,7 @@ def test_pick_issue_skips_epic_and_claims_next(monkeypatch, caplog):
         "labels": [{"name": "ai-ready"}],
         "blockedBy": {"nodes": [], "totalCount": 0},
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([epic, ready]),
     )
     with caplog.at_level("INFO"):
@@ -2522,7 +2513,7 @@ def test_pick_issue_returns_none_when_only_epics_are_ready(
             return json.dumps([])
         return json.dumps([epic_a, epic_b])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") is None
     assert caplog.text.count("epic_not_claimed") == 2
@@ -2542,8 +2533,7 @@ def test_pick_issue_epic_check_precedes_blocker_check(monkeypatch, caplog):
             "nodes": [{"number": 9}, {"number": 10}], "totalCount": 2,
         },
     }
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([epic]),
     )
     with caplog.at_level("INFO"):
@@ -2586,7 +2576,7 @@ def test_pick_issue_skips_epic_in_p0_and_bug_scans(monkeypatch, caplog):
             return json.dumps([epic_bug])
         return json.dumps([feature])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.pick_issue("xqliu/orbi") == feature
     assert caplog.text.count("epic_not_claimed") == 2
@@ -2605,7 +2595,7 @@ def test_pick_in_progress_issue_scan_excludes_epics(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
     ) is None
@@ -2647,7 +2637,7 @@ def test_main_epic_only_queue_ends_idle_without_process_issue(
             return json.dumps([epic])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not issue-list traffic.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
@@ -2680,7 +2670,7 @@ def test_pick_in_progress_issue_scan_fetches_labels(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps([issue])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # No slot dir yet: every slot is free, so the scan runs.
     assert runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
@@ -2712,7 +2702,7 @@ def test_pick_in_progress_issue_scan_fetches_milestone(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps([issue])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     resumed = runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
     )
@@ -2745,7 +2735,7 @@ def test_pick_in_progress_issue_scans_in_flight_issues(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps([issue])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # No slot dir yet: every slot is free, so the scan runs.
     assert runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
@@ -2773,7 +2763,7 @@ def test_pick_in_progress_issue_uses_the_repo_dispatch_label(
         calls.append(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
         dispatch_label="repo-ready",
@@ -2791,8 +2781,7 @@ def test_pick_in_progress_issue_uses_the_repo_dispatch_label(
 def test_pick_in_progress_issue_returns_none_when_idle(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(
-        runner, "run_command", lambda command, **kwargs: "[]",
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]",
     )
     assert runner.pick_in_progress_issue(
         "xqliu/orbi", tmp_path / "slots", 1,
@@ -2807,8 +2796,7 @@ def test_pick_in_progress_issue_skips_when_another_runner_is_live(
     flight, not orphaned, so no second Pi may be started for it. This
     runner's own slot (its own PID) does not block the scan."""
     gh_calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: gh_calls.append(command) or "[]",
     )
     monkeypatch.setattr(runner, "slot_occupancy",
@@ -2946,7 +2934,7 @@ def test_pick_next_issue_returns_none_when_all_sources_empty(monkeypatch):
 
 def test_edit_issue_builds_add_and_remove_command(monkeypatch):
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append(command))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append(command))
     runner.edit_issue(3, repo="xqliu/orbi-backlog", add="ai-in-progress", remove="ai-ready")
     assert calls == [[
         "gh", "issue", "edit", "3", "--repo", "xqliu/orbi-backlog",
@@ -2956,7 +2944,7 @@ def test_edit_issue_builds_add_and_remove_command(monkeypatch):
 
 def test_edit_issue_allows_no_label_change(monkeypatch):
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append(command))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append(command))
     runner.edit_issue(3, repo="xqliu/orbi-backlog")
     assert calls == [["gh", "issue", "edit", "3", "--repo", "xqliu/orbi-backlog"]]
 
@@ -2992,14 +2980,14 @@ def test_run_marker_is_shared_with_progress_formatter():
 
 
 def test_set_run_id_binds_the_attempt_and_current_run_id_reads_it(monkeypatch):
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     assert runner.current_run_id() is None
     runner.set_run_id("e07383c2")
     assert runner.current_run_id() == "e07383c2"
 
 
 def test_set_run_id_fails_fast_on_invalid_run_id(monkeypatch):
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     with pytest.raises(ValueError, match="invalid run id"):
         runner.set_run_id("run1")
     assert runner.current_run_id() is None
@@ -3012,13 +3000,13 @@ def test_run_id_filter_prefixes_messages_when_run_is_bound(caplog):
             runner.LOGGER.info("hello %s", "world")
         assert caplog.messages[-1] == "[e07383c2] hello world"
     finally:
-        runner._CURRENT_RUN_ID = None
+        journal._CURRENT_RUN_ID = None
 
 
 def test_run_id_filter_leaves_messages_untouched_without_bound_run(
     monkeypatch, caplog,
 ):
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     with caplog.at_level("INFO"):
         runner.LOGGER.info("hello")
     assert caplog.messages[-1] == "hello"
@@ -3031,12 +3019,12 @@ def test_freeze_base_fetches_remote_and_returns_exact_sha(monkeypatch, tmp_path)
         calls.append((command, kwargs))
         return "abc123def456"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.freeze_base(tmp_path, "main") == "abc123def456"
     assert calls == [(
         ["git", "fetch", "origin", "main"], {
             "cwd": tmp_path,
-            "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS,
+            "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS,
         },
     ), (
         ["git", "rev-parse", "origin/main"], {"cwd": tmp_path},
@@ -3072,7 +3060,7 @@ def test_freeze_base_fetches_under_the_base_sync_lock(
             held.append(not _probe_lock_free(tmp_path))
         return "abc123def456"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.freeze_base(tmp_path, "main") == "abc123def456"
     assert held == [True]
     assert _probe_lock_free(tmp_path) is True
@@ -3083,8 +3071,7 @@ def test_freeze_base_fails_fast_when_remote_base_is_missing(monkeypatch, tmp_pat
         128, ["git", "rev-parse", "origin/main"],
         stderr="fatal: ambiguous argument",
     )
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(error),
     )
     with pytest.raises(subprocess.CalledProcessError):
@@ -3100,8 +3087,7 @@ def test_create_worktree_reuses_existing_path_for_a_resumed_run(
     existing = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-run1"
     existing.mkdir(parents=True)
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command),
     )
     assert runner.create_worktree(
@@ -3113,8 +3099,7 @@ def test_create_worktree_reuses_existing_path_for_a_resumed_run(
 def test_create_worktree_adds_branch_from_frozen_base_sha(monkeypatch, tmp_path):
     path = tmp_path / ".worktrees" / "orbi-owner-repo-issue-3-run1"
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "",
     )
     assert runner.create_worktree(tmp_path, "owner/repo", 3, "run1", "abc123def456") == path
@@ -3141,7 +3126,7 @@ def test_create_worktree_reuses_orphan_local_branch_never_exits_255(
             return "orbi/owner-repo-issue-3"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_worktree(
         tmp_path, "owner/repo", 3, "run1", "base",
     ) == path
@@ -3207,12 +3192,12 @@ def test_create_worktree_reuses_existing_remote_branch(monkeypatch, tmp_path):
             return ""
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_worktree(
         tmp_path, "owner/repo", 3, "run1", "base", existing_branch=True,
     ) == path
     assert calls == [
-        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path, "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS}),
+        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path, "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS}),
         (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
         (["git", "worktree", "add", "-b", "orbi/owner-repo-issue-3", str(path), "origin/orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
     ]
@@ -3234,12 +3219,12 @@ def test_create_worktree_existing_local_branch_is_reused_never_re_created(
             return "orbi/owner-repo-issue-3"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_worktree(
         tmp_path, "owner/repo", 3, "run1", "base", existing_branch=True,
     ) == path
     assert calls == [
-        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path, "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS}),
+        (["git", "fetch", "origin", "orbi/owner-repo-issue-3"], {"cwd": tmp_path, "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS}),
         (["git", "branch", "--list", "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
         (["git", "worktree", "add", "--force", str(path), "orbi/owner-repo-issue-3"], {"cwd": tmp_path}),
     ]
@@ -3259,13 +3244,13 @@ def test_create_worktree_branch_override_checks_out_the_external_head(
             return ""
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_worktree(
         tmp_path, "owner/repo", 3, "run1", "base",
         existing_branch=True, branch="fix/outer",
     ) == path
     assert calls == [
-        (["git", "fetch", "origin", "fix/outer"], {"cwd": tmp_path, "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS}),
+        (["git", "fetch", "origin", "fix/outer"], {"cwd": tmp_path, "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS}),
         (["git", "branch", "--list", "fix/outer"], {"cwd": tmp_path}),
         (["git", "worktree", "add", "-b", "fix/outer", str(path), "origin/fix/outer"], {"cwd": tmp_path}),
     ]
@@ -3337,7 +3322,7 @@ def test_create_release_worktree_resets_leftover_worktree_to_current_commit(
             return f"worktree {old_worktree}\nHEAD old\nbranch refs/heads/{branch}\n"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_release_worktree(
         tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
     ) == old_worktree
@@ -3363,7 +3348,7 @@ def test_create_release_worktree_handles_leftover_local_branch(
             return "  orbi/owner-repo-issue-3"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.create_release_worktree(
         tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
     ) == path
@@ -3389,8 +3374,8 @@ def test_create_release_worktree_creates_from_release_commit_when_branch_is_new(
             return ""
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "create_worktree",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "create_worktree",
                         lambda *args: expected)
     assert runner.create_release_worktree(
         tmp_path, "owner/repo", 3, "newrun", "new-release-commit",
@@ -3542,7 +3527,7 @@ def test_changed_files_lists_uncommitted_changes(tmp_path, monkeypatch):
         # The third line has a blank XY column: it is not a change.
         return " M src/a.py\n?? src/b.py\n   src/c.py\n"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.changed_files(tmp_path) == ["src/a.py", "src/b.py"]
     assert calls == [(
         ["git", "status", "--porcelain"], {"cwd": tmp_path},
@@ -3552,7 +3537,7 @@ def test_changed_files_lists_uncommitted_changes(tmp_path, monkeypatch):
 def test_resume_context_is_none_for_a_fresh_worktree(tmp_path, monkeypatch):
     """No uncommitted changes and no previous session: the agent starts
     from the Issue alone (the exact pre-#219 prompt)."""
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "")
     monkeypatch.setattr(runner, "activity_snapshot", lambda *a, **k: None)
     assert runner.resume_context(tmp_path) is None
 
@@ -3563,8 +3548,7 @@ def test_resume_context_carries_changes_and_session_progress(
     """The new session starts from the existing work: the instruction to
     continue, the previous session's progress and the changed files —
     never a fresh redo (Issue #219)."""
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: " M src/a.py\n?? src/b.py\n",
     )
     monkeypatch.setattr(
@@ -3593,7 +3577,7 @@ def test_resume_context_without_changes_carries_the_session_progress(
 ):
     """A clean worktree with a previous session (the agent committed
     mid-run before the interruption) still continues the same run."""
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "")
     monkeypatch.setattr(
         runner, "activity_snapshot",
         lambda *a, **k: {
@@ -3721,7 +3705,7 @@ def test_has_in_progress_label_checks_the_issue_label(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps({"labels": [{"name": "ai-in-progress"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.has_in_progress_label(4, "owner/repo") is True
     assert calls == [[
         "gh", "issue", "view", "4", "--repo", "owner/repo",
@@ -3730,8 +3714,7 @@ def test_has_in_progress_label_checks_the_issue_label(monkeypatch, tmp_path):
 
 
 def test_has_in_progress_label_is_false_without_the_label(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps(
             {"labels": [{"name": "ai-fix-needed"}]},
         ),
@@ -3740,16 +3723,17 @@ def test_has_in_progress_label_is_false_without_the_label(monkeypatch):
 
 
 def test_has_in_progress_label_fails_fast_on_malformed_output(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
-    with pytest.raises(ValueError, match="issue view must return a JSON object"):
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]")
+    # Issue #785: the shared `issue_view` validates the object shape, so
+    # the message wording is the view's ("must be"), not the caller's.
+    with pytest.raises(ValueError, match="issue view must be a JSON object"):
         runner.has_in_progress_label(4, "owner/repo")
 
 
 def test_has_in_progress_label_fails_fast_on_malformed_labels(monkeypatch):
     """view 返回 JSON 对象但 labels 字段不是数组（Issue #658）：解析
     失败必须 fail-fast，绝不落入默认 False（那会让竞态守卫失明）。"""
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps({"labels": "ai-in-progress"}),
     )
     with pytest.raises(ValueError, match="labels must be a JSON array"):
@@ -3770,7 +3754,7 @@ def test_has_in_progress_label_reads_directly_not_via_the_search_index(
             return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     assert runner.has_in_progress_label(4, "owner/repo") is True
     # The fixed path reads the Issue directly — the search index (which
     # has not ingested the other instance's claim yet) is never queried.
@@ -3796,23 +3780,20 @@ def _claim_race_deps(monkeypatch, tmp_path, *, freeze_side_effect=None,
         seq = list(stable_branch_seq)
         # Exactly two probes consume the sequence: the scan-time probe
         # and the pre-claim guard (Issue #658).
-        monkeypatch.setattr(
-            runner, "stable_branch_exists",
+        monkeypatch.setattr(seam, "stable_branch_exists",
             lambda repo_dir, branch: seq.pop(0),
         )
     if freeze_side_effect is not None:
         def fake_freeze_base(repo_dir, base_branch):
             freeze_side_effect()
             return "0123456789abcdef0123456789abcdef01234567"
-        monkeypatch.setattr(runner, "freeze_base", fake_freeze_base)
+        monkeypatch.setattr(seam, "freeze_base", fake_freeze_base)
     else:
-        monkeypatch.setattr(
-            runner, "freeze_base",
+        monkeypatch.setattr(seam, "freeze_base",
             lambda repo_dir, base_branch:
                 "0123456789abcdef0123456789abcdef01234567",
         )
-    monkeypatch.setattr(
-        runner, "new_run_id", lambda: "feedface",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "feedface",
     )
     # create_worktree/run_pi stay REAL: on the fixed path the guard
     # yields before either is reached, and a regression that skips the
@@ -3849,7 +3830,7 @@ def make_claim_race_gh(monkeypatch, state):
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return fake_run_command
 
 
@@ -3931,7 +3912,7 @@ def _release_race_deps(monkeypatch, in_progress: bool, live_holders: list):
             return json.dumps({"labels": labels})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     monkeypatch.setattr(
         runner, "slot_occupancy", lambda *a, **k: list(live_holders),
     )
@@ -4106,24 +4087,21 @@ def test_process_issue_resumes_existing_run_and_same_progress_comment(
             return head
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append(("edit", args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "freeze_base",
+    monkeypatch.setattr(seam, "freeze_base",
         lambda repo_dir, base_branch: "abc123def456",
     )
     # The fresh id would be different: the resume must override it with
     # the newest worktree's run id.
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     monkeypatch.setattr(
         runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
         ("a1b2c3d4", tmp_path / "wt"),
     )
-    monkeypatch.setattr(
-        runner, "create_worktree",
+    monkeypatch.setattr(seam, "create_worktree",
         lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
@@ -4220,20 +4198,18 @@ def test_process_issue_second_tick_behind_the_index_resumes_not_reclaims(
             return head
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(
-        runner, "freeze_base",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "freeze_base",
         lambda repo_dir, base_branch: "abc123def456",
     )
     # If a regression makes this tick a FRESH claim, the fresh id leaks
     # into the scene comments and the assertions below catch it.
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     monkeypatch.setattr(
         runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
         ("a1b2c3d4", tmp_path / "wt"),
     )
-    monkeypatch.setattr(
-        runner, "create_worktree",
+    monkeypatch.setattr(seam, "create_worktree",
         lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
@@ -4310,20 +4286,18 @@ def test_process_issue_binds_run_id_before_the_resume_scan(
             return head
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123",
     )
     # The fresh id differs from the reused one: both are valid run ids
     # of this attempt (generated, then replaced by the resumed run).
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     monkeypatch.setattr(
         runner, "worktree_resume_scene", lambda repo_dir, source_repo, number:
         ("a1b2c3d4", tmp_path / "wt"),
     )
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     with caplog.at_level("INFO"):
@@ -4383,19 +4357,17 @@ def test_process_issue_starts_fresh_run_when_the_label_is_gone(
             return head
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     scene_calls = []
     monkeypatch.setattr(
         runner, "worktree_resume_scene",
         lambda repo_dir, source_repo, number: scene_calls.append(1) or None,
     )
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     runner.process_issue(
@@ -4452,16 +4424,14 @@ def test_process_issue_keeps_fresh_run_when_no_worktree_survived(
             return head
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     # The label is on, but no task worktree survived the kill.
     monkeypatch.setattr(runner, "worktree_resume_scene", lambda *a: None)
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     with caplog.at_level("INFO"):
@@ -4521,12 +4491,11 @@ def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
             return branch
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "ffffeeee")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "ffffeeee")
     worktree = tmp_path / "wt"
     worktree.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(
@@ -4536,8 +4505,7 @@ def _resume_wiring_setup(monkeypatch, tmp_path, *, in_progress: bool,
             if latest_run_id_result else None
         ),
     )
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: worktree,
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: worktree,
     )
     return gh_calls, posted, worktree, comment_bodies
 
@@ -4656,8 +4624,7 @@ def test_process_issue_fails_fast_when_the_run_state_is_missing(
         lambda *args, **kwargs: run_pi_calls.append(1) or "done",
     )
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
     caplog.set_level("INFO")
@@ -4728,12 +4695,11 @@ def test_claim_route_decision_table():
 def test_open_pr_for_branch_rejects_malformed_and_ambiguous_results(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: "{}")
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: "{}")
     with pytest.raises(RuntimeError, match="must return an array"):
         runner.open_pr_for_branch(tmp_path, "orbi/owner-repo-issue-3")
 
-    monkeypatch.setattr(
-        runner, "run_command", lambda *args, **kwargs: "[{}, {}]",
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: "[{}, {}]",
     )
     with pytest.raises(RuntimeError, match="multiple open PRs"):
         runner.open_pr_for_branch(tmp_path, "orbi/owner-repo-issue-3")
@@ -4741,7 +4707,7 @@ def test_open_pr_for_branch_rejects_malformed_and_ambiguous_results(
 
 def test_comment_issue_runs_gh_comment(monkeypatch):
     calls = []
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append(command))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append(command))
     runner.comment_issue(3, repo="xqliu/orbi-backlog", body="done")
     assert calls == [[
         "gh", "issue", "comment", "3", "--repo", "xqliu/orbi-backlog",
@@ -5024,7 +4990,7 @@ def test_run_pi_injects_trusted_issue_comments_into_the_prompt(
         fetches.append((number, repo))
         return comments
 
-    monkeypatch.setattr(runner, "issue_comments", fake_issue_comments)
+    monkeypatch.setattr(seam, "issue_comments", fake_issue_comments)
     # mallory's NONE-association comment reaches the authenticated-login
     # fallback; pin it so the test never depends on the host's real gh
     # login state (CI runs unauthenticated).
@@ -5082,8 +5048,7 @@ def test_run_pi_skips_the_comment_fetch_without_the_placeholder(
     prompt_path = tmp_path / "prompt.md"
     prompt_path.write_text("SYSTEM {{ISSUE_BODY}}", encoding="utf-8")
     fetches = []
-    monkeypatch.setattr(
-        runner, "issue_comments",
+    monkeypatch.setattr(seam, "issue_comments",
         lambda *args, **kwargs: fetches.append((args, kwargs)),
     )
     calls = []
@@ -5131,7 +5096,7 @@ def test_run_review_injects_trusted_issue_comments_into_the_prompt(
         fetches.append((number, repo))
         return comments
 
-    monkeypatch.setattr(runner, "issue_comments", fake_issue_comments)
+    monkeypatch.setattr(seam, "issue_comments", fake_issue_comments)
     # mallory's NONE-association comment reaches the authenticated-login
     # fallback; pin it so the test never depends on the host's real gh
     # login state (CI runs unauthenticated).
@@ -5172,8 +5137,7 @@ def test_run_review_skips_the_comment_fetch_without_the_placeholder(
     prompt_path = tmp_path / "prompt_review.md"
     prompt_path.write_text("REVIEW {{BASE_SYNC_LOCK}}", encoding="utf-8")
     fetches = []
-    monkeypatch.setattr(
-        runner, "issue_comments",
+    monkeypatch.setattr(seam, "issue_comments",
         lambda *args, **kwargs: fetches.append((args, kwargs)),
     )
     calls = []
@@ -5367,7 +5331,7 @@ def test_run_pi_appends_the_resume_context_to_the_context_argument(
 
 
 def test_verify_pr_rejects_wrong_branch(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "other-branch")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "other-branch")
     with pytest.raises(RuntimeError, match="Pi changed branch"):
         runner.verify_pr(
             tmp_path, "orbi/issue-4", "main", "e07383c2", issue=4, repo_dir=tmp_path,
@@ -5421,7 +5385,7 @@ def test_verify_pr_rejects_delivery_behind_latest_remote_base(monkeypatch, tmp_p
             raise subprocess.CalledProcessError(1, command, stderr="not an ancestor")
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="behind latest remote base",
     ):
@@ -5441,7 +5405,7 @@ def test_verify_pr_rejects_missing_pr(monkeypatch, tmp_path):
     outputs = iter([
         f"orbi/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA, "[]",
     ])
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5453,7 +5417,7 @@ def test_verify_pr_rejects_non_array(monkeypatch, tmp_path):
     outputs = iter([
         f"orbi/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA, "{}",
     ])
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5468,7 +5432,7 @@ def test_verify_pr_returns_url_when_delivery_contains_latest_base(monkeypatch, t
         calls.append(command)
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -5483,7 +5447,7 @@ def test_verify_pr_requires_the_repo_dir_lock_location(
     # Issue #171: the verify fetch updates the shared remote-tracking
     # ref, so the lock location (the deployment checkout's shared state
     # dir) must be explicit — there is no bypass path.
-    monkeypatch.setattr(runner, "run_command", fake_verify_run)
+    monkeypatch.setattr(seam, "run_command", fake_verify_run)
     with pytest.raises(TypeError):
         runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5504,7 +5468,7 @@ def test_verify_pr_fetches_under_the_base_sync_lock(
             held.append(not _probe_lock_free(tmp_path))
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
         FAKE_RUN_ID, issue=4, repo_dir=tmp_path,
@@ -5520,7 +5484,7 @@ def test_verify_pr_rejects_pr_without_url(monkeypatch, tmp_path):
         f"orbi/issue-4-{FAKE_RUN_ID}", "", "", FAKE_HEAD_SHA,
         json.dumps([{"baseRefName": "main"}]),
     ])
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: next(outputs))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: next(outputs))
     with pytest.raises(RuntimeError, match="open PR has no URL"):
         runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5534,7 +5498,7 @@ def test_verify_pr_rejects_pr_based_on_wrong_branch(monkeypatch, tmp_path):
             return fake_verify_pr_payload(baseRefName="develop")
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(
         RuntimeError, match="PR base is develop, expected main",
     ):
@@ -5563,7 +5527,7 @@ def test_verify_pr_rejects_diverged_remote_pr_head(monkeypatch, tmp_path,
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError,
         match="PR head deadbeef.* is not local HEAD 01234567.*diverged",
@@ -5595,7 +5559,7 @@ def test_verify_pr_passes_through_when_local_head_ahead_of_pr_head(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         url = runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5613,7 +5577,7 @@ def test_verify_pr_rejects_pr_body_without_run_marker(monkeypatch, tmp_path, cap
             return fake_verify_pr_payload(body="no run marker here")
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="missing the stable run marker",
     ):
@@ -5630,7 +5594,7 @@ def test_verify_pr_rejects_pr_body_missing_field(monkeypatch, tmp_path):
             return fake_verify_pr_payload(body=None)
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(
         RuntimeError, match="missing the stable run marker",
     ):
@@ -5653,7 +5617,7 @@ def test_verify_pr_accepts_pr_body_with_fixes_keyword(monkeypatch, tmp_path):
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -5671,7 +5635,7 @@ def test_verify_pr_accepts_hash_and_hashless_fixes_reference(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -5690,7 +5654,7 @@ def test_verify_pr_rejects_pr_body_without_fixes_keyword(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match=r"missing `Fixes #4`",
     ):
@@ -5717,7 +5681,7 @@ def test_verify_pr_rejects_pr_body_with_wrong_issue_number(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match=r"missing `Fixes #4`",
     ):
@@ -5743,7 +5707,7 @@ def test_verify_pr_rejects_pr_body_with_longer_issue_number(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match=r"missing `Fixes #4`",
     ):
@@ -5771,7 +5735,7 @@ def test_verify_pr_external_mode_skips_marker_and_fixes_checks(
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, "fix/outer", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path, external_pr=True,
@@ -5788,7 +5752,7 @@ def test_verify_pr_normal_mode_still_requires_marker_and_fixes(
             return fake_verify_pr_payload(body="please review my fix")
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="run marker"):
         runner.verify_pr(
             tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main",
@@ -5798,8 +5762,7 @@ def test_verify_pr_normal_mode_still_requires_marker_and_fixes(
 
 def _fake_takeover_view(monkeypatch, payload):
     """Fake the `gh pr view` of `external_takeover_pr` with `payload`."""
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps(payload),
     )
 
@@ -5871,8 +5834,7 @@ def test_external_takeover_pr_ignores_a_pr_against_another_base(
 def test_external_takeover_pr_returns_none_without_a_marker(monkeypatch,
                                                             tmp_path):
     """A body without the triage marker never reaches `gh pr view`."""
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: (_ for _ in ()).throw(
             AssertionError("no marker: gh must not be called"),
         ),
@@ -5917,7 +5879,7 @@ def test_verify_pr_queries_base_head_and_accepts_matching_pr(
         calls.append(command)
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -5939,7 +5901,7 @@ def test_verify_pr_queries_base_head_and_accepts_matching_pr(
 
 
 def test_verify_pr_accepts_pr_in_expected_repo_and_url(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", fake_verify_run)
+    monkeypatch.setattr(seam, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path, pr_repo=FAKE_PR_REPO, expected_url=FAKE_PR_URL,
@@ -5955,7 +5917,7 @@ def test_verify_pr_rejects_pr_head_in_another_repo(monkeypatch, tmp_path, caplog
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="PR head repo is attacker/other, expected "
                             "orbi-build/orbi",
@@ -5975,7 +5937,7 @@ def test_verify_pr_rejects_pr_head_repo_missing_fields(monkeypatch, tmp_path):
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(
         RuntimeError, match="PR head repo is <missing>, expected "
                             "orbi-build/orbi",
@@ -5994,7 +5956,7 @@ def test_verify_pr_rejects_pr_head_repo_empty_fields(monkeypatch, tmp_path):
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(
         RuntimeError, match="PR head repo is <missing>, expected "
                             "orbi-build/orbi",
@@ -6022,7 +5984,7 @@ def test_verify_pr_skips_repo_check_when_pr_repo_not_given(monkeypatch,
             }])
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -6037,7 +5999,7 @@ def test_verify_pr_rejects_url_different_from_expected(monkeypatch, tmp_path, ca
             )
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match=(
             "PR URL https://github.com/orbi-build/orbi/pull/99 is "
@@ -6055,7 +6017,7 @@ def test_verify_pr_rejects_url_different_from_expected(monkeypatch, tmp_path, ca
 def test_verify_pr_skips_url_check_when_expected_url_not_given(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(runner, "run_command", fake_verify_run)
+    monkeypatch.setattr(seam, "run_command", fake_verify_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path,
@@ -6074,7 +6036,7 @@ def test_verify_pr_skips_latest_base_check_when_not_required(
         calls.append(command)
         return fake_verify_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.verify_pr(
         tmp_path, f"orbi/issue-4-{FAKE_RUN_ID}", "main", FAKE_RUN_ID,
         issue=4, repo_dir=tmp_path, require_latest_base=False,
@@ -6128,11 +6090,11 @@ def test_process_issue_success_records_base_and_run_in_comment(monkeypatch, tmp_
         # git fetch / git merge-base: no output needed.
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     issue = {"number": 4, "title": "Fix", "body": "Body"}
     config = {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}
@@ -6190,13 +6152,13 @@ def _gh_api(command, posted):
 
 
 def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, caplog):
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "deliver_pr", lambda *args, **kwargs: "https://github.com/orbi-build/orbi/pull/4")
-    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None)
     gh_calls, posted = make_fake_gh(monkeypatch)
 
     def fake_run(command, **kwargs):
@@ -6209,7 +6171,7 @@ def test_process_issue_success_logs_run_end_with_commit(monkeypatch, tmp_path, c
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         runner.process_issue(
             {"number": 4, "title": "Fix", "body": "Body"},
@@ -6232,10 +6194,10 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
     an already-handled failure; the tick ends cleanly and `main` skips
     the delivery wait."""
     calls = []
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
     gh_calls, posted = make_fake_gh(monkeypatch)
 
@@ -6250,7 +6212,7 @@ def test_process_issue_failure_marks_blocked_and_ends_cleanly(monkeypatch, tmp_p
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The failure is terminal: `process_issue` returns `None` (no PR) and
     # does NOT re-raise — the service must not crash on it (Issue #239).
     assert runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/orbi-backlog").kind == "failed"
@@ -6286,18 +6248,15 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
     not crash on the unhandled `RuntimeError` (the #239 scene). The
     Runner never auto-commits or expands the agent's commit boundary."""
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append(kwargs),
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     worktree = tmp_path / "wt"
     worktree.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: worktree,
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: worktree,
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     no_commit = RuntimeError(
@@ -6325,7 +6284,7 @@ def test_process_issue_delivery_no_commit_marks_blocked_without_crashing(
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The failure is terminal: `process_issue` returns `None` (no PR) and
     # does NOT re-raise — the service must not crash on it.
     assert runner.process_issue(
@@ -6373,16 +6332,13 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
     the SAME run (same run id, branch, worktree, progress comment). No
     terminal label, no fallback."""
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append(kwargs),
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m: "
@@ -6410,7 +6366,7 @@ def test_process_issue_model_wait_dead_failure_stays_in_progress(
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The failure is recoverable: `process_issue` returns `None` (no PR)
     # and does NOT re-raise — the service must not crash on it (Issue
     # #239), and the Issue must NOT be marked `ai-blocked` (Issue #227).
@@ -6467,15 +6423,12 @@ def test_process_issue_model_wait_failure_records_health_attempt(
     same dead end) must reach health.json exactly like the terminal
     failure branch, or the repeated-failure health check is blind to
     the most common repeat-failure scene."""
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None,
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m"
@@ -6500,7 +6453,7 @@ def test_process_issue_model_wait_failure_records_health_attempt(
             return "[]"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.process_issue(
         {"number": 218, "title": "Model wait dead", "body": ""},
         {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
@@ -6525,15 +6478,12 @@ def test_process_issue_three_recoverable_failures_raise_health_finding(
     repeated-failure health check must see the streak (before the fix
     none of these runs ever reached health.json)."""
     from orbi import runner_health
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None,
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m"
@@ -6557,7 +6507,7 @@ def test_process_issue_three_recoverable_failures_raise_health_finding(
             return "[]"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     for _ in range(3):
         assert runner.process_issue(
             {"number": 218, "title": "Model wait dead", "body": ""},
@@ -6582,21 +6532,18 @@ def test_process_issue_success_records_health_streak_break(
     outcome="pr_opened") has always expected from production: a
     failure -> success -> failure sequence must NOT read as a streak."""
     from orbi import runner_health
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(
         runner, "deliver_pr",
         lambda *args, **kwargs: "https://github.com/orbi-build/orbi/pull/4",
     )
-    monkeypatch.setattr(
-        runner, "comment_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None,
     )
     gh_calls, posted = make_fake_gh(monkeypatch)
 
@@ -6609,7 +6556,7 @@ def test_process_issue_success_records_health_streak_break(
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     result = runner.process_issue(
         {"number": 4, "title": "Fix", "body": "Body"},
         {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
@@ -6639,15 +6586,12 @@ def test_process_issue_recoverable_health_record_failure_is_bypassed(
     state-write failure logs and never changes the recoverable outcome
     (the Issue stays `failed`-recoverable, never `ai-blocked`)."""
     from orbi import runner_health
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None,
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m"
@@ -6671,7 +6615,7 @@ def test_process_issue_recoverable_health_record_failure_is_bypassed(
             return "[]"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner_health, "record_run_attempt",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -6695,21 +6639,18 @@ def test_process_issue_success_health_record_failure_is_bypassed(
     """The delivery path's health record is a pure bypass: a
     state-write failure logs and the PR result is returned unchanged."""
     from orbi import runner_health
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(
         runner, "deliver_pr",
         lambda *args, **kwargs: "https://github.com/orbi-build/orbi/pull/4",
     )
-    monkeypatch.setattr(
-        runner, "comment_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None,
     )
     gh_calls, posted = make_fake_gh(monkeypatch)
 
@@ -6722,7 +6663,7 @@ def test_process_issue_success_health_record_failure_is_bypassed(
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner_health, "record_run_attempt",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -6751,16 +6692,13 @@ def test_process_issue_model_wait_dead_comment_failure_stays_in_progress(
     Issue `ai-blocked` — exactly the unrecoverable state Issue #227
     forbids for the model_wait recovery."""
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append(kwargs),
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     model_wait_dead = runner.ModelWaitDeadError(
         "Pi is stuck in model_wait with a frozen session for 10m: "
@@ -6796,7 +6734,7 @@ def test_process_issue_model_wait_dead_comment_failure_stays_in_progress(
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.process_issue(
         {"number": 218, "title": "Model wait dead", "body": ""},
         {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md",
@@ -6834,16 +6772,13 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
     's `finally` (Issue #239: the handled failure never re-raises to
     crash the service). No special handling, no fallback."""
     calls = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: calls.append(kwargs),
     )
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", Mock(return_value=tmp_path),
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(return_value=tmp_path),
     )
     idle_recovery = RuntimeError(
         "Pi session stayed idle for 15m after idle recovery (TERM/KILL "
@@ -6870,7 +6805,7 @@ def test_process_issue_idle_recovery_failure_marks_blocked(
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The failure is terminal: `process_issue` returns `None` (no PR) and
     # does NOT re-raise — the service must not crash on it (Issue #239).
     assert runner.process_issue(
@@ -6915,13 +6850,12 @@ def test_process_issue_ends_cleanly_when_reporting_fails(monkeypatch, tmp_path, 
     degraded, not fatal."""
     edit_calls = []
 
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edit_calls.append(kwargs),
     )
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", Mock(side_effect=RuntimeError("git failed")))
     gh_calls, posted = make_fake_gh(monkeypatch)
 
     def fake_run(command, **kwargs):
@@ -6944,7 +6878,7 @@ def test_process_issue_ends_cleanly_when_reporting_fails(monkeypatch, tmp_path, 
             return "[]"
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not issue-comment/list traffic.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
@@ -7012,7 +6946,7 @@ def test_advance_active_milestone_pending_creates_one_p0_ready_issue(
             return "[]"
         return json.dumps([milestones])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.advance_active_milestone_on_idle(
             "owner/repo", "v0.3.0", config, auto_next_milestone=False,
@@ -7032,8 +6966,7 @@ def test_advance_active_milestone_manual_notification_is_not_pickupable(
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or (
             "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([[
                 {"title": "v0.3.0", "state": "closed"},
@@ -7070,7 +7003,7 @@ def test_advance_active_milestone_closes_old_manual_notification_after_manual_mo
             ])
         return json.dumps([[{"title": "v0.4.0", "state": "open"}]])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.advance_active_milestone_on_idle(
         "owner/repo", "v0.4.0", config, auto_next_milestone=False,
     ) == ("open", None)
@@ -7092,7 +7025,7 @@ def test_advance_active_milestone_close_failure_is_bypassed(
             return json.dumps([[{"title": "v0.4.0", "state": "open"}]])
         raise RuntimeError("GitHub unavailable")
 
-    monkeypatch.setattr(runner, "run_command", fail_close)
+    monkeypatch.setattr(seam, "run_command", fail_close)
     with caplog.at_level("ERROR"):
         assert runner.advance_active_milestone_on_idle(
             "owner/repo", "v0.4.0", config,
@@ -7106,8 +7039,7 @@ def test_advance_active_milestone_closure_is_idempotent_on_repeated_tick(
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.4.0"\n', encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or (
             "[]" if command[:3] == ["gh", "issue", "list"] else json.dumps([[
                 {"title": "v0.4.0", "state": "open"},
@@ -7137,7 +7069,7 @@ def test_advance_active_milestone_pending_issue_failure_is_bypassed(
             {"title": "v0.3.1", "state": "open", "open_issues": 2},
         ]])
 
-    monkeypatch.setattr(runner, "run_command", fail_pending)
+    monkeypatch.setattr(seam, "run_command", fail_pending)
     with caplog.at_level("ERROR"):
         assert runner.advance_active_milestone_on_idle(
             "owner/repo", "v0.3.0", config, auto_next_milestone=False,
@@ -7159,8 +7091,7 @@ def test_advance_active_milestone_pending_is_idempotent(
         ]]),
         '[{"number": 436}]',
     ]
-    monkeypatch.setattr(
-        runner, "run_command", lambda command, **kwargs: calls.append(command) or responses.pop(0),
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append(command) or responses.pop(0),
     )
     runner.advance_active_milestone_on_idle(
         "owner/repo", "v0.3.0", config, auto_next_milestone=False,
@@ -7173,8 +7104,7 @@ def test_advance_active_milestone_sorts_double_digit_versions_numerically(
 ):
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.9.0"\n', encoding="utf-8")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([[
             {"title": "v0.9.0", "state": "closed"},
             {"title": "v0.10.0", "state": "open"},
@@ -7198,8 +7128,7 @@ def test_advance_active_milestone_selects_smallest_higher_open(
         {"title": "v0.3.1", "state": "open", "open_issues": 8},
         {"title": "not-a-version", "state": "open", "open_issues": 1},
     ]
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([milestones]),
     )
     with caplog.at_level("INFO"):
@@ -7216,8 +7145,7 @@ def test_advance_active_milestone_open_reconciles_notifications_without_write(
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or json.dumps([[
             {"title": "v0.3.0", "state": "open"},
         ]]),
@@ -7233,8 +7161,7 @@ def test_advance_active_milestone_closed_without_candidate_logs_and_keeps_value(
 ):
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.0", "state": "closed"},
             {"title": "v0.2.0", "state": "open", "open_issues": 1},
@@ -7252,8 +7179,7 @@ def test_advance_active_milestone_closed_without_candidate_logs_and_keeps_value(
 def test_advance_active_milestone_missing_lists_open_milestones(monkeypatch, tmp_path):
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.1", "state": "open", "open_issues": 8},
         ]]),
@@ -7265,8 +7191,7 @@ def test_advance_active_milestone_missing_lists_open_milestones(monkeypatch, tmp
 def test_advance_active_milestone_rejects_duplicate_title(monkeypatch, tmp_path):
     config = tmp_path / "orbi.toml"
     config.write_text('active_milestone = "v0.3.0"\n', encoding="utf-8")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([[
             {"title": "v0.3.0", "state": "closed", "number": 1},
             {"title": "v0.3.0", "state": "closed", "number": 2},
@@ -7287,7 +7212,7 @@ def test_arm_release_ticket_adds_ready_to_matching_open_issue(
             return json.dumps([{"number": 385}])
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         runner.arm_release_ticket("owner/repo", "v0.4.0")
 
@@ -7308,8 +7233,7 @@ def test_arm_release_ticket_adds_ready_to_matching_open_issue(
 
 def test_arm_release_ticket_does_nothing_when_no_ticket_matches(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or "[]",
     )
 
@@ -7319,8 +7243,7 @@ def test_arm_release_ticket_does_nothing_when_no_ticket_matches(monkeypatch):
 
 
 def test_arm_release_ticket_rejects_malformed_issue_number(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: '[{"number": "385"}]',
     )
 
@@ -7665,7 +7588,7 @@ def test_main_routes_fix_needed_resume_to_delivery_wait(
     lines and comments carry it (Issue #41). Issue #89: the wait
     receives the URL the resume verification returned, never the raw
     comment string."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
@@ -7711,7 +7634,7 @@ def test_main_routes_awaiting_review_resume_to_delivery_wait(
     lines and comments carry it (Issue #41). Issue #89: the wait
     receives the URL the resume verification returned, never the raw
     comment string."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
     config.write_text("source_repos = [\"owner/repo\"]\n", encoding="utf-8")
@@ -7775,10 +7698,10 @@ def test_process_issue_failure_without_session_still_carries_scene(
     monkeypatch, tmp_path,
 ):
     calls = []
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("pi died")),
@@ -7800,7 +7723,7 @@ def test_process_issue_failure_without_session_still_carries_scene(
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # Issue #239: the failure is terminal — `process_issue` returns `None`
     # instead of re-raising; the scene assertions below are unchanged.
     assert runner.process_issue({"number": 8, "title": "Fail", "body": ""}, {"repo_dir": tmp_path, "prompt": tmp_path / "prompt.md", "base_branch": "main"}, "xqliu/orbi-backlog").kind == "failed"
@@ -7987,10 +7910,9 @@ def test_report_delivery_failure_caps_comment_and_names_session_log(
     """Issue #775: an oversized body is cut at the cap, the cut names
     the full session log path, and the failure reason stays first."""
     posted = []
-    monkeypatch.setattr(runner, "apply_label_patch", lambda *args, **kwargs: None)
-    monkeypatch.setattr(runner, "issue_labels", lambda *args, **kwargs: set())
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "apply_label_patch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "issue_labels", lambda *args, **kwargs: set())
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, *, repo, body: posted.append(body),
     )
     error = subprocess.CalledProcessError(1, ["pi"])
@@ -8032,10 +7954,10 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
     (tmp_path / "wt" / ".orbi" / "test.log").write_text(
         "coverage output\n1 failed\n", encoding="utf-8",
     )
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -8058,7 +7980,7 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: {
         "session_id": "sess-9",
         "session_file": str(tmp_path / "wt" / ".pi-session" / "s.jsonl"),
@@ -8092,10 +8014,10 @@ def test_process_issue_failure_comment_includes_session_scene(monkeypatch, tmp_p
 
 def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, caplog):
     calls = []
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
-    monkeypatch.setattr(runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: calls.append(("edit", args, kwargs)))
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(
         runner, "run_pi",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("git failed")),
@@ -8116,7 +8038,7 @@ def test_process_issue_isolates_scene_lookup_failure(monkeypatch, tmp_path, capl
         calls.append(("comment", (), {"body": command[-1]}))
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The main-path resume-context read (Issue #219) succeeds; the
     # failure-scene lookup is the one that dies on the disk error.
     snapshot_calls = []
@@ -8355,7 +8277,7 @@ def test_stream_pi_high_frequency_lines_carry_run_id_exactly_once(
     single grep still reconstructs the whole timeline. The run is
     bound like in the real journal (`process_issue` binds it before
     starting Pi)."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     records = fake_session_records() + [
         (0.5, {"type": "message", "id": "r1",
                "timestamp": fresh_timestamp(2),
@@ -8401,7 +8323,7 @@ def test_stream_pi_idle_lines_carry_run_id_exactly_once(
 ):
     """Issue #57: `pi_idle` / `pi_resumed` repeat the same rule as the
     other high-frequency lines: prefix only, no `run=` field."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     # a1 is 4s stale when it is polled, so the idle warning fires;
     # a2 arrives later with a fresh timestamp, so the resume does not
     # re-trigger the warning.
@@ -8444,7 +8366,7 @@ def test_stream_pi_scene_lines_keep_run_field_for_parse_scene(
     keep `run=` so `pi_activity.parse_scene` still returns the run id
     from the lines that need to be parsed. The run is bound like in
     the real journal."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     command = make_fake_pi(
         tmp_path, session_records=fake_session_records(),
         stderr="pi exploded", exit_code=3,
@@ -12140,7 +12062,7 @@ def _fake_preflight_run(monkeypatch, installed: Path) -> list:
             return "0123456789abcdef0123456789abcdef01234567"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return calls
 
 
@@ -12287,7 +12209,7 @@ def test_main_unit_drift_auto_sync_failure_blocks_claim(
             raise subprocess.CalledProcessError(1, command, stderr="nope")
         return ""
 
-    monkeypatch.setattr(runner, "run_command", failing_run)
+    monkeypatch.setattr(seam, "run_command", failing_run)
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
     config.write_text(
@@ -12531,7 +12453,7 @@ def test_main_cli_install_refresh_runs_before_slot_and_claim(
         ).exists()
         return "unchanged"
 
-    monkeypatch.setattr(runner, "refresh_cli_install", fake_refresh)
+    monkeypatch.setattr(seam, "refresh_cli_install", fake_refresh)
     _write_prompts(tmp_path)
     config = tmp_path / "orbi.toml"
     config.write_text(
@@ -12564,7 +12486,7 @@ def test_main_cli_refresh_uses_deploy_home_not_repo_dir(
         seen["repo_dir"] = Path(repo_dir)
         return "unchanged"
 
-    monkeypatch.setattr(runner, "refresh_cli_install", fake_refresh)
+    monkeypatch.setattr(seam, "refresh_cli_install", fake_refresh)
     monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "check_transport",
@@ -12605,8 +12527,7 @@ def test_main_unit_drift_check_uses_deploy_home(
         seen.append(Path(repo_dir))
 
     monkeypatch.setattr(runner, "check_unit_drift", fake_check)
-    monkeypatch.setattr(
-        runner, "refresh_cli_install", lambda *a, **k: "unchanged",
+    monkeypatch.setattr(seam, "refresh_cli_install", lambda *a, **k: "unchanged",
     )
     monkeypatch.setattr(
         runner, "check_transport",
@@ -12659,8 +12580,7 @@ def test_main_cli_install_failure_fails_fast_before_slot_and_claim(
         AssertionError, match="must not run on cli install failure",
     ):
         fail_if_called()
-    monkeypatch.setattr(
-        runner, "refresh_cli_install",
+    monkeypatch.setattr(seam, "refresh_cli_install",
         lambda *a, **k: (_ for _ in ()).throw(
             runner.CliInstallError(
                 "editable CLI install failed for /repo: uv exploded "
@@ -12703,7 +12623,7 @@ def fake_pr_view(monkeypatch, state: str) -> tuple[list, object]:
             return json.dumps({"state": state, "statusCheckRollup": []})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return seen, fake_run
 
 
@@ -12735,14 +12655,13 @@ def test_pr_state_fails_fast_on_non_object_json(monkeypatch):
     def fake_run(command, **kwargs):
         return json.dumps(["OPEN"])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(ValueError, match="pr view must be a JSON object"):
         runner.pr_state(PR_URL, "owner/repo")
 
 
 def test_pr_delivery_status_rejects_non_array_check_rollup(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: json.dumps({"state": "OPEN", "statusCheckRollup": {}}),
     )
     with pytest.raises(ValueError, match="statusCheckRollup must be a JSON array"):
@@ -12750,8 +12669,7 @@ def test_pr_delivery_status_rejects_non_array_check_rollup(monkeypatch):
 
 
 def test_pr_delivery_status_ignores_malformed_check_entry(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: json.dumps({
             "state": "OPEN", "statusCheckRollup": [None],
         }),
@@ -12763,8 +12681,7 @@ def test_finish_progress_blocked_is_a_noop_without_run_id(monkeypatch):
     """Without a bound run id there is no tracked comment to update
     (the failure comment simply carries no marker)."""
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or "[]",
     )
     runner._finish_progress(
@@ -12792,7 +12709,7 @@ def test_finish_progress_blocked_creates_the_comment_when_missing(
         return json.dumps({"id": 78, "body": body[len("body="):],
                            "url": "https://x/78"})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner._finish_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
         "the failure", "the next step", title="Blocked task",
@@ -12829,7 +12746,7 @@ def test_finish_progress_carries_the_actual_role_and_round(
         return json.dumps({"id": 78, "body": body[len("body="):],
                            "url": "https://x/78"})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner._finish_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
         "the failure", "the next step", title="Blocked task",
@@ -12859,7 +12776,7 @@ def test_finish_progress_defaults_to_review_round_zero(monkeypatch):
         return json.dumps({"id": 78, "body": body[len("body="):],
                            "url": "https://x/78"})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner._finish_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
         "the failure", "the next step", title="Blocked task",
@@ -12889,7 +12806,7 @@ def test_finish_progress_renders_the_fix_needed_scene(monkeypatch):
         return json.dumps({"id": 78, "body": body[len("body="):],
                            "url": "https://x/78"})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner._finish_progress(
         39, "a1b2c3d4", "owner/repo", None, None, "https://x/pull/46",
         "the failure",
@@ -12917,7 +12834,7 @@ def test_finish_progress_renders_the_fix_needed_scene(monkeypatch):
 def test_wait_for_delivery_returns_when_pr_merged(monkeypatch, caplog):
     seen, _ = fake_pr_view(monkeypatch, "MERGED")
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(PR_URL, issue, {}, "owner/repo")
     assert len(seen) == 1
@@ -12954,7 +12871,7 @@ def test_wait_for_delivery_keeps_waiting_while_pr_open(
             return "orbi/owner-repo-issue-39"
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", lambda s: None)
     config = {"repo_dir": tmp_path, "base_branch": "main"}
     # The derived worktree exists: a normal resume reaches the review
@@ -13022,7 +12939,7 @@ def test_wait_for_delivery_sleeps_poll_interval_between_review_rounds(
             return "orbi/owner-repo-issue-39"
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "pr", "list"])
@@ -13077,7 +12994,7 @@ def test_wait_for_delivery_auto_merges_on_clean_review(
             return "orbi/owner-repo-issue-39"
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
@@ -13090,7 +13007,7 @@ def test_wait_for_delivery_auto_merges_on_clean_review(
     (tmp_path / ".worktrees"
      / "orbi-owner-repo-issue-39-a1b2c3d4").mkdir(parents=True)
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -13138,7 +13055,7 @@ def test_wait_for_delivery_passes_p0_priority_to_the_review(
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
     def fake_review(*args, **kwargs):
         review_calls.append(kwargs)
@@ -13151,7 +13068,7 @@ def test_wait_for_delivery_passes_p0_priority_to_the_review(
         "number": 39, "title": "p0 task", "body": "",
         "labels": [{"name": "ai-pr-opened"}, {"name": "p0"}],
     }
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -13218,19 +13135,17 @@ def test_wait_for_delivery_marks_blocked_when_review_fails(
             ]})
         return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -13321,19 +13236,17 @@ def test_wait_for_delivery_marks_blocked_when_review_fails_while_fix_needed(
         # next review session).
         return json.dumps({"labels": [{"name": "ai-fix-needed"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -13430,16 +13343,14 @@ def test_wait_for_delivery_blocks_when_scene_base_differs_from_config(
             ]})
         return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", lambda s: None)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     # The independent review must never run: the base mismatch is
@@ -13450,7 +13361,7 @@ def test_wait_for_delivery_blocks_when_scene_base_differs_from_config(
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     # The configured base is main; the scene froze develop.
     runner.wait_for_delivery(
@@ -13561,7 +13472,7 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
             return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
     # The fake rejects anything that is not a pr/issue view or the
     # progress API.
@@ -13569,12 +13480,10 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
         fake_run(["git", "fetch"])
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     # The independent review must never run: the missing worktree is
@@ -13585,7 +13494,7 @@ def test_wait_for_delivery_worktree_missing_stays_fix_needed(
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -13697,15 +13606,13 @@ def test_wait_for_delivery_worktree_missing_while_fix_needed_keeps_label(
         # next review session).
         return json.dumps({"labels": [{"name": "ai-fix-needed"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     reviews: list = []
@@ -13714,7 +13621,7 @@ def test_wait_for_delivery_worktree_missing_while_fix_needed_keeps_label(
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
         "owner/repo",
@@ -13771,7 +13678,7 @@ def test_wait_for_delivery_runs_review_when_fix_needed(
             return "orbi/owner-repo-issue-39"
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", lambda s: None)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
@@ -13789,7 +13696,7 @@ def test_wait_for_delivery_runs_review_when_fix_needed(
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     issue = {"number": 39, "title": "task", "body": "stale body"}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     config = {"repo_dir": tmp_path, "base_branch": "main"}
     runner.wait_for_delivery(PR_URL, issue, config, "owner/repo")
@@ -13817,7 +13724,7 @@ def test_issue_labels_returns_names_and_fails_fast(monkeypatch):
             {"name": "ai-fix-needed"}, {"other": 1},
         ]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.issue_labels(39, "owner/repo") == [
         "ai-ready", "ai-fix-needed",
     ]
@@ -13825,14 +13732,14 @@ def test_issue_labels_returns_names_and_fails_fast(monkeypatch):
     def bad_run(command, **kwargs):
         return json.dumps({"labels": "nope"})
 
-    monkeypatch.setattr(runner, "run_command", bad_run)
+    monkeypatch.setattr(seam, "run_command", bad_run)
     with pytest.raises(ValueError, match="issue labels must be a JSON array"):
         runner.issue_labels(39, "owner/repo")
 
     def bad_run2(command, **kwargs):
         return json.dumps(["ai-ready"])
 
-    monkeypatch.setattr(runner, "run_command", bad_run2)
+    monkeypatch.setattr(seam, "run_command", bad_run2)
     with pytest.raises(ValueError, match="issue view must be a JSON object"):
         runner.issue_labels(39, "owner/repo")
 
@@ -13885,19 +13792,17 @@ def test_wait_for_delivery_marks_blocked_when_pr_closed_unmerged(
                                "url": "https://x/78"})
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     issue = {"number": 39, "title": "task", "body": ""}
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("INFO")
     runner.wait_for_delivery(PR_URL, issue, {}, "owner/repo")
     # The Issue is marked ai-blocked; the blocked patch clears every
@@ -13957,7 +13862,7 @@ def test_wait_for_delivery_review_failure_without_bound_run_id(
 ):
     """When no run id is bound the review-failure comment simply carries
     no marker (the Issue is still marked ai-blocked)."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "pr"] and command[2] == "view":
@@ -13968,18 +13873,16 @@ def test_wait_for_delivery_review_failure_without_bound_run_id(
             return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     issue = {"number": 39, "title": "task", "body": ""}
@@ -14030,8 +13933,8 @@ def test_wait_for_delivery_repairs_in_progress_label_and_logs_ci(
             return json.dumps({"labels": [{"name": "ai-in-progress"}]})
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     monkeypatch.setattr(runner, "review_and_merge_if_clean", lambda *a, **k: True)
     (tmp_path / ".worktrees" /
      "orbi-owner-repo-issue-39-a1b2c3d4").mkdir(parents=True)
@@ -14055,15 +13958,15 @@ def test_wait_for_delivery_blocks_when_in_progress_label_repair_fails(
             return json.dumps({"state": "OPEN", "statusCheckRollup": []})
         return json.dumps({"labels": [{"name": "ai-in-progress"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     patches = []
     def fake_patch(number, **kwargs):
         patches.append(kwargs)
         if kwargs["event"] == runner.EVENT_PR_OPENED:
             raise RuntimeError("label API unavailable")
-    monkeypatch.setattr(runner, "apply_label_patch", fake_patch)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "apply_label_patch", fake_patch)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     runner.wait_for_delivery(
         PR_URL, {"number": 39, "title": "task", "body": ""},
         {}, "owner/repo",
@@ -14093,12 +13996,12 @@ def test_wait_for_delivery_keeps_holding_when_no_delivery_label(
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
     monkeypatch.setattr(runner.time, "sleep", lambda s: None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     issue = {"number": 39, "title": "task", "body": ""}
     caplog.set_level("INFO")
     runner.wait_for_delivery(PR_URL, issue, {}, "owner/repo")
@@ -14111,7 +14014,7 @@ def test_wait_for_delivery_keeps_holding_when_no_delivery_label(
 def test_wait_for_delivery_logs_awaiting_without_bound_run_id(monkeypatch, caplog):
     """When no run id is bound the wait still works: the failure comment
     simply carries no marker."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
     def fake_run(command, **kwargs):
         if command[:2] == ["gh", "pr"] and command[2] == "view":
@@ -14121,14 +14024,13 @@ def test_wait_for_delivery_logs_awaiting_without_bound_run_id(monkeypatch, caplo
             return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The fake rejects anything that is not a pr/issue view.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
     comments: list = []
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     caplog.set_level("INFO")
@@ -14177,18 +14079,16 @@ def _review_round_env(
     # The fake rejects anything it does not implement.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "pr", "list"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     if with_worktree:
         (tmp_path / ".worktrees"
          / "orbi-owner-repo-issue-39-a1b2c3d4").mkdir(parents=True)
     edits: list = []
     comments: list = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: comments.append((args, kwargs)),
     )
     monkeypatch.setattr(
@@ -14202,11 +14102,10 @@ def _review_round_env(
         or review_result,
     )
     publishes: list = []
-    monkeypatch.setattr(
-        runner, "_safe_publish",
+    monkeypatch.setattr(seam, "_safe_publish",
         lambda **kwargs: publishes.append(kwargs),
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     return edits, comments, reviews, publishes
 
 
@@ -15857,8 +15756,8 @@ def test_stop_handler_idle_logs_run_stopped_idle_and_exits(
 ):
     # No run in flight (before the claim): the stop logs result=idle
     # WITHOUT any invented issue fields and exits 143.
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     died = {}
     monkeypatch.setattr(
         runner, "_die_from_signal",
@@ -15884,8 +15783,8 @@ def test_stop_handler_active_run_logs_stopping_then_stopped_and_exits(
     # run_stopped result=interrupted, then the process exits 143.
     worktree = tmp_path / "wt"
     worktree.mkdir()
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.set_active_run(
         48, "Log the stop scene", "orbi/owner-repo-issue-48",
         str(worktree),
@@ -15933,8 +15832,8 @@ def test_stop_handler_active_run_uses_activity_snapshot_for_scene(
     worktree = tmp_path / "wt"
     worktree.mkdir()
     _write_session_file(worktree, session_id="sess-48")
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.set_active_run(48, "t", "b", str(worktree))
     died = {}
     monkeypatch.setattr(
@@ -15957,8 +15856,8 @@ def test_stop_handler_active_run_without_live_child_still_stops(
     # are still logged and the process exits 143.
     worktree = tmp_path / "wt"
     worktree.mkdir()
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.set_active_run(48, "t", "b", str(worktree))
     died = {}
     monkeypatch.setattr(
@@ -15981,12 +15880,11 @@ def test_stop_handler_snapshot_failure_still_logs_and_exits(
 ):
     # A failing activity snapshot never swallows the stop: the scene
     # falls back to `-` for phase/session and the stop still exits.
-    monkeypatch.setattr(
-        runner, "_ACTIVE_RUN",
+    monkeypatch.setattr(journal, "_ACTIVE_RUN",
         {"issue": 48, "title": "t", "branch": "b", "worktree": "/w",
          "pi": None},
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     died = {}
     monkeypatch.setattr(
         runner, "_die_from_signal",
@@ -16015,8 +15913,8 @@ def test_stop_handler_reinstalls_default_disposition_and_raises_signal(
     # disposition and re-raises the signal at itself: the process dies
     # from the ORIGINAL signal (systemd sees a signal-caused stop, exit
     # 143) and a handler crash can never swallow the stop.
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
     monkeypatch.setattr(runner.os, "_exit", lambda code: None)
     raised = {}
     monkeypatch.setattr(
@@ -16029,22 +15927,22 @@ def test_stop_handler_reinstalls_default_disposition_and_raises_signal(
 
 
 def test_set_active_run_binds_scene_and_pi_tracking(monkeypatch):
-    monkeypatch.setattr(runner, "_ACTIVE_RUN", None)
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
     runner.set_active_run(7, "t", "b", "/w")
-    assert runner._ACTIVE_RUN == {
+    assert journal._ACTIVE_RUN == {
         "issue": 7, "title": "t", "branch": "b", "worktree": "/w",
         "pi": None,
     }
     child = object()
     runner.set_active_pi(child)
-    assert runner._ACTIVE_RUN["pi"] is child
+    assert journal._ACTIVE_RUN["pi"] is child
     runner.set_active_pi(None)
-    assert runner._ACTIVE_RUN["pi"] is None
+    assert journal._ACTIVE_RUN["pi"] is None
     runner.clear_active_run()
-    assert runner._ACTIVE_RUN is None
+    assert journal._ACTIVE_RUN is None
     # set_active_pi without a bound run is a no-op (never crashes).
     runner.set_active_pi(child)
-    assert runner._ACTIVE_RUN is None
+    assert journal._ACTIVE_RUN is None
 
 
 def test_main_installs_the_stop_handler(monkeypatch, tmp_path):
@@ -16072,7 +15970,7 @@ def test_main_installs_the_stop_handler(monkeypatch, tmp_path):
         runner, "pick_next_delivery", lambda *args, **kwargs: None,
     )
     monkeypatch.setattr(runner, "acquire_slot", lambda *args: Mock(release=lambda: None))
-    monkeypatch.setattr(runner, "refresh_cli_install", lambda *a, **k: "unchanged")
+    monkeypatch.setattr(seam, "refresh_cli_install", lambda *a, **k: "unchanged")
     monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
     monkeypatch.setattr(runner, "check_transport", lambda *a, **k: {})
     assert runner.main(["--config", str(config_path)]) == 0
@@ -16489,8 +16387,7 @@ def test_parse_release_declaration_scope_from_milestone():
 
 def test_verify_release_version_file_passes_when_the_file_exists(monkeypatch):
     commands = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: commands.append((command, kwargs))
         or "pyproject.toml\npackage.json\n",
     )
@@ -16500,8 +16397,7 @@ def test_verify_release_version_file_passes_when_the_file_exists(monkeypatch):
 
 
 def test_verify_release_version_file_skips_none_without_probing(monkeypatch):
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(
             AssertionError(f"unexpected command: {command}")),
     )
@@ -16509,8 +16405,7 @@ def test_verify_release_version_file_skips_none_without_probing(monkeypatch):
 
 
 def test_verify_release_version_file_lists_existing_supported_files(monkeypatch):
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: "package.json\nCargo.toml\nREADME.md\n",
     )
     with pytest.raises(RuntimeError) as excinfo:
@@ -16526,8 +16421,7 @@ def test_verify_release_version_file_lists_existing_supported_files(monkeypatch)
 
 
 def test_verify_release_version_file_without_supported_file_points_at_none(monkeypatch):
-    monkeypatch.setattr(
-        release, "run_command", lambda command, **kwargs: "README.md\n",
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "README.md\n",
     )
     with pytest.raises(RuntimeError) as excinfo:
         release.verify_release_version_file(
@@ -16586,16 +16480,15 @@ def test_process_issue_routes_release_to_process_release(monkeypatch):
     # Issue #708: the release dispatch now direct-reads the live label
     # state before dispatching (`gh issue view`) — the fresh ticket here
     # answers with no labels, and no slot config means no yield path.
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps({"labels": []}),
     )
     monkeypatch.setattr(release, "process_release",
                         lambda i, c, r: calls.append("release") or "rel-url")
     monkeypatch.setattr(runner, "run_pi", Mock(
         side_effect=AssertionError("run_pi must not run for a release task")))
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "freeze_base", lambda r, b: "abc")
     result = runner.process_issue(issue, {"base_branch": "main"}, "o/r")
     assert result == runner.IssueResult("release", "rel-url")
     assert calls == ["release"]
@@ -16704,17 +16597,17 @@ def test_process_ticket_only_posts_agent_output_without_git_delivery(monkeypatch
     edits = []
     comments = []
     commands = []
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "edit_issue",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda run_id: None)
+    monkeypatch.setattr(seam, "edit_issue",
                         lambda number, **kwargs: edits.append((number, kwargs)))
-    monkeypatch.setattr(runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
                         lambda number, **kwargs: comments.append((number, kwargs)))
     monkeypatch.setattr(runner, "run_ticket_agent",
                         lambda *args, **kwargs: "\u53ef\u4ee5\u76f4\u63a5\u53d1\u5e03\u7684\u5e16\u5b50")
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
-    monkeypatch.setattr(runner, "_safe_publish", lambda **kwargs: None)
-    monkeypatch.setattr(runner, "run_command",
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: None)
+    monkeypatch.setattr(seam, "run_command",
                         lambda command, **kwargs: commands.append(command) or "")
 
     result = runner.process_issue(issue, {"repo_dir": Path("/repo")}, "o/r")
@@ -16734,14 +16627,14 @@ def test_process_ticket_only_rejects_empty_agent_content(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
              "labels": [{"name": "ai-content-only"}]}
     edits = []
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "edit_issue",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda run_id: None)
+    monkeypatch.setattr(seam, "edit_issue",
                         lambda number, **kwargs: edits.append((number, kwargs)))
-    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "run_ticket_agent", lambda *args, **kwargs: "")
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
-    monkeypatch.setattr(runner, "_safe_publish", lambda **kwargs: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: None)
     with pytest.raises(RuntimeError, match="returned no content"):
         runner.process_ticket_only(issue, {"repo_dir": Path("/repo")}, "o/r")
     assert edits[-1][1]["add"] == "ai-blocked"
@@ -16752,16 +16645,16 @@ def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypa
              "labels": [{"name": "ai-content-only"}]}
     edits = []
     comments = []
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "edit_issue",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda run_id: None)
+    monkeypatch.setattr(seam, "edit_issue",
                         lambda number, **kwargs: edits.append((number, kwargs)))
-    monkeypatch.setattr(runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
                         lambda number, **kwargs: comments.append((number, kwargs)))
     monkeypatch.setattr(runner, "run_ticket_agent",
                         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Pi failed")))
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
-    monkeypatch.setattr(runner, "_safe_publish", lambda **kwargs: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: None)
     with pytest.raises(RuntimeError, match="Pi failed"):
         runner.process_ticket_only(issue, {"repo_dir": Path("/repo")}, "o/r")
     assert edits[-1] == (99, {"repo": "o/r", "add": "ai-blocked",
@@ -16773,15 +16666,15 @@ def test_process_ticket_only_failure_marks_blocked_without_git_delivery(monkeypa
 def test_process_ticket_only_keeps_original_error_when_failure_reporting_fails(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
              "labels": [{"name": "ai-content-only"}]}
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(runner, "comment_issue",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda run_id: None)
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "comment_issue",
                         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("comment failed")))
     monkeypatch.setattr(runner, "run_ticket_agent",
                         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Pi failed")))
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
-    monkeypatch.setattr(runner, "_safe_publish", lambda **kwargs: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: None)
     with pytest.raises(RuntimeError, match="Pi failed"):
         runner.process_ticket_only(issue, {"repo_dir": Path("/repo")}, "o/r")
 
@@ -16792,31 +16685,31 @@ def test_process_issue_keeps_normal_flow_without_release_label(
     issue = {"number": 99, "title": "Normal", "body": "",
              "labels": [{"name": "ai-ready"}]}
     monkeypatch.setattr(runner, "is_release", lambda i: False)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
-    monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
-    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "set_active_run", Mock())
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda rid: None)
+    monkeypatch.setattr(seam, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(seam, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(seam, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "set_active_run", Mock())
     # The worktree exists: `create_worktree` always returns a real
     # directory (the run state file is written into it, Issue #219).
     worktree = tmp_path / "wt"
     worktree.mkdir()
-    monkeypatch.setattr(runner, "create_worktree", lambda *a, **kwargs: worktree)
-    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(seam, "create_worktree", lambda *a, **kwargs: worktree)
+    monkeypatch.setattr(seam, "comment_issue", Mock())
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
     monkeypatch.setattr(runner, "run_pi",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
     monkeypatch.setattr(runner, "deliver_pr",
                         lambda *a, **k: "https://github.com/o/r/pull/1")
-    monkeypatch.setattr(runner, "run_command", lambda c, **k: "")
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "")
     monkeypatch.setattr(runner, "wait_for_delivery", Mock())
-    monkeypatch.setattr(runner, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "edit_issue", Mock())
     monkeypatch.setattr(runner, "LOGGER", Mock())
     monkeypatch.setattr(runner, "activity_snapshot", lambda p: None)
-    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **k: None)
     monkeypatch.setattr(runner, "format_end_scene", lambda **k: "end")
-    monkeypatch.setattr(runner, "issue_context", lambda r, n: "#n")
+    monkeypatch.setattr(seam, "issue_context", lambda r, n: "#n")
     monkeypatch.setattr(runner, "format_run_scene", lambda *a, **k: "scene")
     monkeypatch.setattr(runner, "_finish_progress", Mock())
     runner.process_issue(
@@ -16839,19 +16732,19 @@ def _ops_issue_mocks(monkeypatch, tmp_path, *, head_sha: str, dirty: str):
     commands: list[list[str]] = []
     configs: list[dict] = []
     monkeypatch.setattr(runner, "is_release", lambda i: False)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda rid: None)
-    monkeypatch.setattr(runner, "has_in_progress_label", lambda n, r: False)
-    monkeypatch.setattr(runner, "freeze_base", lambda r, b: "abc123")
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "set_active_run", Mock())
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda rid: None)
+    monkeypatch.setattr(seam, "has_in_progress_label", lambda n, r: False)
+    monkeypatch.setattr(seam, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(seam, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "set_active_run", Mock())
     worktree = tmp_path / "wt"
     worktree.mkdir()
-    monkeypatch.setattr(runner, "create_worktree", lambda *a, **k: worktree)
-    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(seam, "create_worktree", lambda *a, **k: worktree)
+    monkeypatch.setattr(seam, "comment_issue", Mock())
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
     monkeypatch.setattr(runner, "activity_snapshot", lambda p: None)
-    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **k: None)
     monkeypatch.setattr(
         runner, "run_pi",
         lambda issue_arg, wt, config, repo, **k: configs.append(config),
@@ -16867,7 +16760,7 @@ def _ops_issue_mocks(monkeypatch, tmp_path, *, head_sha: str, dirty: str):
             return dirty
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return issue, commands, worktree, configs
 
 
@@ -17063,8 +16956,8 @@ def make_scope_gh(monkeypatch, *, pr_state_map=None, issue_state_map=None,
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls
 
 
@@ -17118,8 +17011,8 @@ def test_verify_release_scope_rejects_merged_pr_outside_release_base(
             raise subprocess.CalledProcessError(1, command)
         return original(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", not_an_ancestor)
-    monkeypatch.setattr(runner, "run_command", not_an_ancestor)
+    monkeypatch.setattr(seam, "run_command", not_an_ancestor)
+    monkeypatch.setattr(seam, "run_command", not_an_ancestor)
     with pytest.raises(RuntimeError, match="not contained in release commit"):
         release.verify_release_scope("o/r", [123], Path("/repo"), "release123")
 
@@ -17134,8 +17027,8 @@ def test_verify_release_scope_reraises_git_ancestry_check_failure(
             raise subprocess.CalledProcessError(128, command, stderr="bad object")
         return original(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", git_failure)
-    monkeypatch.setattr(runner, "run_command", git_failure)
+    monkeypatch.setattr(seam, "run_command", git_failure)
+    monkeypatch.setattr(seam, "run_command", git_failure)
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         release.verify_release_scope("o/r", [123], Path("/repo"), "release123")
     assert excinfo.value.stderr == "bad object"
@@ -17169,8 +17062,8 @@ def test_verify_release_scope_reraises_real_gh_failure(monkeypatch):
         raise subprocess.CalledProcessError(
             1, command, stderr="HTTP 403: rate limited",
         )
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     with pytest.raises(subprocess.CalledProcessError):
         release.verify_release_scope("o/r", [123], Path("/repo"), "release123")
 
@@ -17201,8 +17094,8 @@ def test_derive_release_scope_flattens_multi_page_results(monkeypatch):
             return json.dumps([[]])
         return json.dumps([page_one, page_two])
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     scope, open_evidence = release.derive_release_scope_from_milestone(
         "o/r", "v0.9.0",
     )
@@ -17241,8 +17134,8 @@ def make_milestone_gh(monkeypatch, *, milestones=None, items_by_milestone=None):
             return json.dumps([bucket.get(f"issues_{state}", [])])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls
 
 
@@ -17381,10 +17274,10 @@ def make_gate_gh(monkeypatch, *, leftover_labels=None, check_runs=None,
             ])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     # the staying helpers the moved gates call (`list_issues`) resolve
     # the primitive in the runner globals.
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls
 
 
@@ -17428,8 +17321,8 @@ def make_registration_lag_gh(monkeypatch, api_responses):
             ])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return fake_run_command
 
 
@@ -17555,8 +17448,8 @@ def test_check_release_gates_waits_for_pending_ci_then_passes(
             ])
         return "[]"  # the label scans and the open-PR scan
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
     waits = []
     with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
@@ -17596,8 +17489,8 @@ def test_check_release_gates_waits_then_fails_on_final_ci_failure(
             ])
         return "[]"
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
     with pytest.raises(RuntimeError, match="check 'tests' is completed/failure"):
         release.check_release_gates("o/r", "main", "abc123", 99)
@@ -17614,8 +17507,8 @@ def test_check_release_gates_ci_wait_times_out(monkeypatch, caplog):
             ])
         return "[]"
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     monkeypatch.setattr(runner.time, "sleep", lambda _s: None)
     with caplog.at_level(logging.INFO, logger="orbi.bootstrap"), pytest.raises(
         RuntimeError,
@@ -17640,8 +17533,8 @@ def test_check_release_gates_reports_missing_checks_permission(monkeypatch):
             )
         return "[]"
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     with pytest.raises(RuntimeError, match=r"lacks Checks:read"):
         release.check_release_gates("o/r", "main", "abc123", 99)
 
@@ -17749,7 +17642,7 @@ def test_process_release_parse_failure_publishes_final_comment(
     release routing and the failure path are the production ones.
     """
     gh_calls, posted = make_fake_gh(monkeypatch)
-    monkeypatch.setattr(release, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     issue = {
         "number": 467,
         "title": "Release v0.4.2",
@@ -17838,11 +17731,10 @@ def test_prepare_release_version_updates_sources_and_commits(tmp_path, monkeypat
         '__version__ = "0.2.0"\n', encoding="utf-8",
     )
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
 
     assert release.prepare_release_version(
         work, "v0.3.0", "main",
@@ -17856,7 +17748,7 @@ def test_prepare_release_version_updates_sources_and_commits(tmp_path, monkeypat
          {"cwd": work}),
         (["git", "push", "origin", "HEAD:refs/heads/main"], {
             "cwd": work,
-            "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS,
+            "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS,
         }),
         (["git", "rev-parse", "HEAD"], {"cwd": work}),
     ]
@@ -17869,11 +17761,10 @@ def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
         '{\n  "name": "cloud",\n  "version": "0.2.0"\n}\n', encoding="utf-8",
     )
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
 
     assert release.prepare_release_version(
         work, "v0.3.0", "main", "package.json",
@@ -17885,7 +17776,7 @@ def test_prepare_release_version_updates_package_json(tmp_path, monkeypatch):
          {"cwd": work}),
         (["git", "push", "origin", "HEAD:refs/heads/main"], {
             "cwd": work,
-            "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS,
+            "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS,
         }),
         (["git", "rev-parse", "HEAD"], {"cwd": work}),
     ]
@@ -17922,11 +17813,10 @@ def test_prepare_release_version_updates_ecosystem_file(
     work.mkdir()
     (work / version_file).write_text(source, encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "newsha",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "newsha")
 
     assert release.prepare_release_version(
         work, "v0.3.0", "main", version_file,
@@ -17944,11 +17834,10 @@ def test_prepare_release_version_ecosystem_file_is_idempotent(tmp_path, monkeypa
     work.mkdir()
     (work / "gradle.properties").write_text("version=0.3.0\n", encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "head",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
     assert release.prepare_release_version(
         work, "v0.3.0", "main", "gradle.properties",
     ) == "head"
@@ -17973,11 +17862,10 @@ def test_prepare_release_version_rejects_cargo_without_package_version(tmp_path)
 
 def test_prepare_release_version_none_does_not_require_a_file(tmp_path, monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "head",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
     assert release.prepare_release_version(tmp_path, "v0.3.0", "main", "none") == "head"
     assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": tmp_path})]
 
@@ -17994,11 +17882,10 @@ def test_prepare_release_version_package_json_is_idempotent(tmp_path, monkeypatc
         '{"name": "cloud", "version": "0.3.0"}\n', encoding="utf-8",
     )
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "head",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
 
     assert release.prepare_release_version(
         work, "v0.3.0", "main", "package.json",
@@ -18033,11 +17920,10 @@ def test_prepare_release_version_none_does_not_change_files(tmp_path, monkeypatc
     marker = work / "README.md"
     marker.write_text("unchanged\n", encoding="utf-8")
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "head",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
 
     assert release.prepare_release_version(work, "v0.3.0", "main", "none") == "head"
     assert marker.read_text() == "unchanged\n"
@@ -18086,11 +17972,10 @@ def test_prepare_release_version_is_idempotent(tmp_path, monkeypatch):
         '__version__ = "0.3.0"\n', encoding="utf-8",
     )
     calls = []
-    monkeypatch.setattr(
-        release, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append((command, kwargs)) or "head",
     )
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: calls.append((command, kwargs)) or "head")
     assert release.prepare_release_version(work, "v0.3.0", "main") == "head"
     assert calls == [(["git", "rev-parse", "HEAD"], {"cwd": work})]
 
@@ -18117,8 +18002,8 @@ def test_release_tag_commit_reraises_real_fetch_failure(tmp_path, monkeypatch):
     work, _ = make_local_remote_pair(tmp_path)
     def fail(command, **kwargs):
         raise subprocess.CalledProcessError(1, command, stderr="boom")
-    monkeypatch.setattr(release, "run_command", fail)
-    monkeypatch.setattr(runner, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
     with pytest.raises(subprocess.CalledProcessError):
         release.release_tag_commit(work, "v0.1.0")
 
@@ -18136,8 +18021,8 @@ def test_release_tag_commit_never_reads_a_network_failure_as_missing_tag(
         assert command[1] == "ls-remote"
         raise subprocess.CalledProcessError(128, command, stderr="boom")
 
-    monkeypatch.setattr(release, "run_git_network_command", fail_ls_remote)
-    monkeypatch.setattr(runner, "run_git_network_command", fail_ls_remote)
+    monkeypatch.setattr(seam, "run_git_network_command", fail_ls_remote)
+    monkeypatch.setattr(seam, "run_git_network_command", fail_ls_remote)
     with pytest.raises(subprocess.CalledProcessError):
         release.release_tag_commit(work, "v0.1.0")
 
@@ -18151,8 +18036,8 @@ def test_ensure_release_tag_pushed_creates_and_pushes_when_no_local_tag(
     def fake_push(command, **kwargs):
         pushed.append(command)
 
-    monkeypatch.setattr(release, "run_git_network_command", fake_push)
-    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    monkeypatch.setattr(seam, "run_git_network_command", fake_push)
+    monkeypatch.setattr(seam, "run_git_network_command", fake_push)
     release.ensure_release_tag_pushed(work, "v0.1.0", head)
     tag_type = subprocess.run(
         ["git", "-C", str(work), "cat-file", "-t", "v0.1.0"],
@@ -18177,8 +18062,8 @@ def test_ensure_release_tag_pushed_repushes_local_residue(tmp_path, monkeypatch)
     def fake_push(command, **kwargs):
         pushed.append(command)
 
-    monkeypatch.setattr(release, "run_git_network_command", fake_push)
-    monkeypatch.setattr(runner, "run_git_network_command", fake_push)
+    monkeypatch.setattr(seam, "run_git_network_command", fake_push)
+    monkeypatch.setattr(seam, "run_git_network_command", fake_push)
     release.ensure_release_tag_pushed(work, "v0.1.0", head)
     assert pushed == [["git", "push", "origin", "refs/tags/v0.1.0"]]
 
@@ -18230,8 +18115,8 @@ def make_release_gh(monkeypatch, *, release_exists=False,
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls
 
 
@@ -18287,8 +18172,8 @@ def test_build_release_changelog_groups_descriptions_links_and_orders(monkeypatc
         ).split("=", 1)[1])
         return json.dumps({"data": {"repository": {"issue": source[number]}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [30, 10, 20])
     assert changelog == """## Changelog
 
@@ -18335,8 +18220,8 @@ def test_build_release_changelog_skips_not_planned_issues(monkeypatch):
         assert command[:3] == ["gh", "api", "graphql"], command
         return json.dumps({"data": {"repository": {"issue": item}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [702])
     assert "#702" not in changelog
     assert "#705" not in changelog
@@ -18373,8 +18258,8 @@ def test_build_release_changelog_omits_unmerged_pr_links(monkeypatch):
         assert command[:3] == ["gh", "api", "graphql"], command
         return json.dumps({"data": {"repository": {"issue": source[10]}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [10])
     assert "[PR #11](https://github.com/o/r/pull/11)" in changelog
     assert "#705" not in changelog
@@ -18426,8 +18311,8 @@ def test_build_release_changelog_lists_deduped_sorted_contributor_avatars(monkey
         ).split("=", 1)[1])
         return json.dumps({"data": {"repository": {"issue": source[number]}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [10, 20])
     assert changelog == """## Changelog
 
@@ -18463,8 +18348,8 @@ def test_build_release_changelog_without_contributors_has_no_section(monkeypatch
         assert command[:3] == ["gh", "api", "graphql"], command
         return json.dumps({"data": {"repository": {"issue": item}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [10])
     assert changelog == """## Changelog
 
@@ -18499,8 +18384,8 @@ def test_build_release_changelog_unmerged_pr_author_is_not_a_contributor(monkeyp
         assert command[:3] == ["gh", "api", "graphql"], command
         return json.dumps({"data": {"repository": {"issue": item}}})
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     changelog = release.build_release_changelog("o/r", [10])
     assert "alice" in changelog
     assert "bob" not in changelog
@@ -18526,19 +18411,17 @@ def test_build_release_changelog_fails_on_empty_or_malformed_evidence(monkeypatc
         {"__typename": "Issue", "number": 10, "title": "Useful title", "body": "detail", "url": "https://github.com/o/r/issues/10", "stateReason": "COMPLETED", "labels": {"nodes": []}, "closedByPullRequestsReferences": {"nodes": [{"number": "bad", "url": "https://github.com/o/r/pull/20", "author": None}]}},
     ]
     for issue in bad_issues:
-        monkeypatch.setattr(
-            release, "run_command",
+        monkeypatch.setattr(seam, "run_command",
             lambda *args, issue=issue, **kwargs: json.dumps(
                 {"data": {"repository": {"issue": issue}}}),
         )
-        monkeypatch.setattr(
-            runner, "run_command",
+        monkeypatch.setattr(seam, "run_command",
             lambda *args, issue=issue, **kwargs: json.dumps(
                 {"data": {"repository": {"issue": issue}}}),
         )
         with pytest.raises(ValueError, match="release changelog"):
             release.build_release_changelog("o/r", [10])
-    monkeypatch.setattr(release, "run_command", lambda *args, **kwargs: json.dumps({
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: json.dumps({
         "data": {"repository": {"issue": {
             "__typename": "Issue", "number": 10, "title": "",
             "body": "\nConcrete summary\n",
@@ -18547,7 +18430,7 @@ def test_build_release_changelog_fails_on_empty_or_malformed_evidence(monkeypatc
             "closedByPullRequestsReferences": {"nodes": []},
         }}},
     }))
-    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: json.dumps({
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: json.dumps({
         "data": {"repository": {"issue": {
             "__typename": "Issue", "number": 10, "title": "",
             "body": "\nConcrete summary\n",
@@ -18560,7 +18443,7 @@ def test_build_release_changelog_fails_on_empty_or_malformed_evidence(monkeypatc
     # A PR number in scope resolves through the PullRequest branch: no
     # stateReason, no closedBy references (verified against the real
     # GraphQL schema — the field only exists on Issue).
-    monkeypatch.setattr(release, "run_command", lambda *args, **kwargs: json.dumps({
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: json.dumps({
         "data": {"repository": {"issue": {
             "__typename": "PullRequest", "number": 10,
             "title": "Merge direct release work", "body": "",
@@ -18568,7 +18451,7 @@ def test_build_release_changelog_fails_on_empty_or_malformed_evidence(monkeypatc
             "labels": {"nodes": []},
         }}},
     }))
-    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: json.dumps({
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: json.dumps({
         "data": {"repository": {"issue": {
             "__typename": "PullRequest", "number": 10,
             "title": "Merge direct release work", "body": "",
@@ -18645,8 +18528,8 @@ def test_publish_release_reraises_real_gh_failure(monkeypatch):
         raise subprocess.CalledProcessError(
             1, command, stderr="HTTP 403: rate limited",
         )
-    monkeypatch.setattr(release, "run_command", fail)
-    monkeypatch.setattr(runner, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
     with pytest.raises(subprocess.CalledProcessError):
         release.publish_release(
             repo="o/r", tag="v0.3.0", version="v0.3.0",
@@ -18798,35 +18681,34 @@ def make_release_process_env(monkeypatch, *, body=RELEASE_DECLARATION_BODY,
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    monkeypatch.setattr(release, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(release, "set_run_id",
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id",
                         lambda rid: state["run_ids"].append(rid))
-    monkeypatch.setattr(release, "has_in_progress_label",
+    monkeypatch.setattr(seam, "has_in_progress_label",
                         lambda n, r: in_progress)
-    monkeypatch.setattr(release, "latest_run_id",
+    monkeypatch.setattr(seam, "latest_run_id",
                         lambda r, s, n: existing_run_id)
-    monkeypatch.setattr(release, "freeze_base", lambda r, b: "abc123")
-    monkeypatch.setattr(runner, "edit_issue",
+    monkeypatch.setattr(seam, "freeze_base", lambda r, b: "abc123")
+    monkeypatch.setattr(seam, "edit_issue",
                         lambda n, **k: state["edits"].append((n, k)))
-    monkeypatch.setattr(release, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
                         lambda n, **k: state["comments"].append((n, k)))
-    monkeypatch.setattr(runner, "create_worktree",
+    monkeypatch.setattr(seam, "create_worktree",
                         lambda *a: Path("/wt"))
-    monkeypatch.setattr(release, "create_release_worktree",
+    monkeypatch.setattr(seam, "create_release_worktree",
                         lambda *a: Path("/wt"))
     monkeypatch.setattr(release, "ProgressPublisher", Mock())
-    monkeypatch.setattr(release, "_safe_publish", lambda **k: None)
-    monkeypatch.setattr(release, "set_active_run",
+    monkeypatch.setattr(seam, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(seam, "set_active_run",
                         lambda *a: state["active_runs"].append(a))
     monkeypatch.setattr(release, "LOGGER", Mock())
     monkeypatch.setattr(release, "release_tag_commit",
                         lambda r, t: tag_commit)
     monkeypatch.setattr(release, "prepare_release_version",
                         lambda worktree, tag, base_branch: "abc123")
-    monkeypatch.setattr(
-        release, "refresh_cli_install",
+    monkeypatch.setattr(seam, "refresh_cli_install",
         lambda worktree, **kwargs: "installed",
     )
     monkeypatch.setattr(release, "publish_release", lambda **k: release_url)
@@ -18912,7 +18794,7 @@ def test_process_release_wait_timeout_uses_persisted_wait_start(monkeypatch):
     state = make_release_process_env(
         monkeypatch, leftover_labels={"ai-in-progress": [7]},
     )
-    monkeypatch.setattr(release, "issue_comments", lambda *a, **k: [
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [
         {
             "authorAssociation": "MEMBER",
             "body": "<!-- orbi:run=aaaaaaaa -->\n"
@@ -19037,7 +18919,7 @@ def test_process_release_success_end_to_end(monkeypatch):
              "abc123"], {"cwd": Path("/r")}) in state["commands"]
     assert (["git", "push", "origin", "refs/tags/v0.3.0"], {
         "cwd": Path("/r"),
-        "timeout": runner.GIT_NETWORK_TIMEOUT_SECONDS,
+        "timeout": journal.GIT_NETWORK_TIMEOUT_SECONDS,
     }) in state["commands"]
     assert not any("--force" in c or "-f" == c for c in commands)
     # The release Issue is closed.
@@ -19108,7 +18990,7 @@ def test_process_release_refreshes_deployment_cli_after_version_bump(
         assert kwargs["run_command"] is runner.run_command
         return "installed"
 
-    monkeypatch.setattr(release, "refresh_cli_install", refresh)
+    monkeypatch.setattr(seam, "refresh_cli_install", refresh)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19232,7 +19114,7 @@ def test_process_release_waits_for_pending_ci_and_succeeds(monkeypatch):
         # progress-comment wait reflection is actually recorded.
         kwargs["action"]()
 
-    monkeypatch.setattr(release, "_safe_publish", run_publish_actions)
+    monkeypatch.setattr(seam, "_safe_publish", run_publish_actions)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19318,7 +19200,7 @@ def test_process_release_publish_closeout_failure_keeps_release_result(
             raise RuntimeError("GitHub unavailable")
         return real_edit(number, **kwargs)
 
-    monkeypatch.setattr(runner, "edit_issue", failing_edit)
+    monkeypatch.setattr(seam, "edit_issue", failing_edit)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19349,7 +19231,7 @@ def test_process_release_success_comment_failure_keeps_release_result(
         # failing unconditionally fails exactly that comment.
         raise RuntimeError("GitHub unavailable")
 
-    monkeypatch.setattr(release, "comment_issue", failing_comment)
+    monkeypatch.setattr(seam, "comment_issue", failing_comment)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19388,8 +19270,8 @@ def test_process_release_milestone_failure_keeps_release_successful(monkeypatch)
             return json.dumps([[{"number": 101, "title": "leftover"}]])
         return real(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", milestone_failing)
-    monkeypatch.setattr(runner, "run_command", milestone_failing)
+    monkeypatch.setattr(seam, "run_command", milestone_failing)
+    monkeypatch.setattr(seam, "run_command", milestone_failing)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19527,8 +19409,8 @@ def test_process_release_fails_on_tag_mismatch_without_moving_it(monkeypatch):
             )
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", merge_base_failing)
-    monkeypatch.setattr(runner, "run_command", merge_base_failing)
+    monkeypatch.setattr(seam, "run_command", merge_base_failing)
+    monkeypatch.setattr(seam, "run_command", merge_base_failing)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19584,8 +19466,8 @@ def test_process_release_fails_on_scope_violation(monkeypatch):
                 "number": 123, "state": "OPEN", "mergeCommit": None,
             })
         return real(command, **kwargs)
-    monkeypatch.setattr(release, "run_command", scope_failing)
-    monkeypatch.setattr(runner, "run_command", scope_failing)
+    monkeypatch.setattr(seam, "run_command", scope_failing)
+    monkeypatch.setattr(seam, "run_command", scope_failing)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -19634,8 +19516,8 @@ def test_close_release_milestone_closes_an_open_empty_milestone(monkeypatch):
             return json.dumps(_milestone(5, "v0.3.0", "closed", 0))
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     evidence = release.close_release_milestone("o/r", "v0.3.0")
     # The close uses the official REST contract
     # (PATCH /repos/{owner}/{repo}/milestones/{number}, state=closed)
@@ -19662,8 +19544,8 @@ def test_close_release_milestone_is_idempotent_when_already_closed(monkeypatch):
             ]])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     evidence = release.close_release_milestone("o/r", "v0.3.0")
     # Already closed: no mutation at all (no PATCH, no reopen).
     assert calls == [MILESTONE_LIST_COMMAND]
@@ -19684,8 +19566,8 @@ def test_close_release_milestone_fails_fast_without_a_matching_title(monkeypatch
             ]])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="no Milestone with the exact title"):
         release.close_release_milestone("o/r", "v0.3.0")
     # No mutation, no fuzzy match against a different Milestone.
@@ -19708,8 +19590,8 @@ def test_close_release_milestone_fails_fast_when_open_issues_remain(monkeypatch)
                                 {"number": 102, "title": "leftover two"}]])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     sleeps: list[float] = []
     monkeypatch.setattr("time.sleep", sleeps.append)
     with pytest.raises(RuntimeError, match="Milestone #5") as excinfo:
@@ -19751,8 +19633,8 @@ def test_close_release_milestone_retries_the_stale_issue_index_after_close(monke
             return json.dumps(_milestone(5, "v0.3.0", "closed", 0))
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr("time.sleep", sleeps.append)
     evidence = release.close_release_milestone("o/r", "v0.3.0")
     assert "Milestone #5" in evidence
@@ -19780,8 +19662,8 @@ def test_close_release_milestone_fails_after_the_backoff_is_exhausted(monkeypatc
             return json.dumps([[{"number": 101, "title": "leftover one"}]])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr("time.sleep", sleeps.append)
     with pytest.raises(RuntimeError, match="Milestone #5") as excinfo:
         release.close_release_milestone("o/r", "v0.3.0")
@@ -19807,8 +19689,8 @@ def test_close_release_milestone_fails_fast_on_duplicate_titles(monkeypatch):
             ]])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="ambiguous") as excinfo:
         release.close_release_milestone("o/r", "v0.3.0")
     # Both candidates are named; neither is closed.
@@ -19829,7 +19711,7 @@ def test_parse_paginated_issue_array_rejects_malformed_items():
 def test_epic_issue_with_blockers_rejects_invalid_details(monkeypatch):
     with pytest.raises(ValueError, match="number is missing"):
         runner.epic_issue_with_blockers("o/r", {"number": "20"})
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]")
     with pytest.raises(ValueError, match="details are not an object"):
         runner.epic_issue_with_blockers("o/r", {"number": 20})
 
@@ -19860,9 +19742,9 @@ def test_reconcile_release_epics_closes_verified_epic_with_audit(monkeypatch):
         assert number == 20 and repo == "o/r"
         assert "Issue #21 closed" in body
         assert "run_id=abc12345" in body
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "comment_issue", fake_comment)
-    result = runner.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "comment_issue", fake_comment)
+    result = release.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
     assert result == ["Epic #20 closed after verification (Issue #21 closed)"]
     assert ["gh", "issue", "close", "20", "--repo", "o/r"] in commands
     with pytest.raises(AssertionError):
@@ -19888,9 +19770,9 @@ def test_reconcile_release_epics_keeps_open_child_and_bad_scope_open(monkeypatch
         if command == ["gh", "api", "repos/o/r/issues/22/sub_issues?per_page=100", "--paginate", "--slurp"]:
             return json.dumps([[]])
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "comment_issue", lambda **kwargs: calls.append(["comment"]))
-    result = runner.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "comment_issue", lambda **kwargs: calls.append(["comment"]))
+    result = release.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
     assert "Epic #20 kept open: child Issue #21 is not closed" in result
     assert "Epic #22 kept open: Epic child scope is missing or empty" in result
     assert not any(command[:3] == ["gh", "issue", "close"] for command in calls if isinstance(command, list))
@@ -19905,11 +19787,11 @@ def test_reconcile_open_epics_closes_and_deduplicates_audit(monkeypatch, caplog)
     def fake_run(command, **kwargs):
         commands.append(command)
         return json.dumps([epic]) if command[:3] == ["gh", "issue", "list"] else ""
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "_verify_epic_complete", lambda repo, item: ["Issue #21 closed"])
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "_verify_epic_complete", lambda repo, item: ["Issue #21 closed"])
     comments = []
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: comments)
-    monkeypatch.setattr(runner, "comment_issue", lambda number, *, repo, body: comments.append({"body": body}))
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: comments)
+    monkeypatch.setattr(seam, "comment_issue", lambda number, *, repo, body: comments.append({"body": body}))
     result = runner.reconcile_open_epics("o/r", "abc12345")
     assert result == ["Epic #20 closed after verification (Issue #21 closed)"]
     assert len(comments) == 1 and "run_id=abc12345" in comments[0]["body"]
@@ -19924,10 +19806,10 @@ def test_reconcile_open_epics_closes_and_deduplicates_audit(monkeypatch, caplog)
 def test_reconcile_open_epics_keeps_incomplete_without_comment(monkeypatch, caplog):
     caplog.set_level("INFO")
     epic = {"number": 20}
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: json.dumps([epic]))
-    monkeypatch.setattr(runner, "_verify_epic_complete", lambda repo, item: (_ for _ in ()).throw(ValueError("open blockers: #3")))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: json.dumps([epic]))
+    monkeypatch.setattr(seam, "_verify_epic_complete", lambda repo, item: (_ for _ in ()).throw(ValueError("open blockers: #3")))
     comments = []
-    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: comments.append(True))
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: comments.append(True))
     runner.reconcile_open_epics("o/r", "abc12345")
     assert not comments
     assert "epic_kept_open issue=20 repo=o/r reason=open blockers: #3" in caplog.text
@@ -19948,7 +19830,7 @@ def test_reconcile_release_milestones_closes_only_published_empty_milestones(mon
         if command == ["gh", "api", "repos/o/r/milestones/5", "--method", "PATCH", "-f", "state=closed"]:
             return ""
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.reconcile_release_milestones("o/r", "abc12345") == ["Milestone #5 (v0.4.0) closed"]
     assert "milestone_closed number=5 repo=o/r" in caplog.text
     assert calls.index(["gh", "api", "repos/o/r/milestones/5", "--method", "PATCH", "-f", "state=closed"]) > calls.index(["gh", "api", "repos/o/r/issues?milestone=5&state=open&per_page=100", "--paginate", "--slurp"])
@@ -19965,7 +19847,7 @@ def test_reconcile_release_milestones_keeps_open_without_published_release_or_em
         if command == ["gh", "api", "repos/o/r/releases?per_page=100", "--paginate", "--slurp"]:
             return json.dumps([[{"tag_name": "v0.4.0", "draft": True}]])
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.reconcile_release_milestones("o/r", "abc12345") == []
     assert "reason=ambiguous title" in caplog.text
     with pytest.raises(AssertionError):
@@ -19974,9 +19856,9 @@ def test_reconcile_release_milestones_keeps_open_without_published_release_or_em
 
 def test_verify_epic_complete_uses_native_sub_issue_shapes(monkeypatch):
     base = {"number": 20, "blockedBy": {"nodes": []}}
-    monkeypatch.setattr(runner, "epic_issue_with_blockers", lambda repo, issue: {"number": "bad", "blockedBy": {"nodes": []}})
+    monkeypatch.setattr(seam, "epic_issue_with_blockers", lambda repo, issue: {"number": "bad", "blockedBy": {"nodes": []}})
     with pytest.raises(ValueError, match="Epic number is missing"):
-        runner._verify_epic_complete("o/r", base)
+        github._verify_epic_complete("o/r", base)
     cases = [
         ({"number": "bad"}, "invalid number"),
         ({"number": 21, "repository": {}, "state": "closed"}, "repository state is malformed"),
@@ -19984,10 +19866,10 @@ def test_verify_epic_complete_uses_native_sub_issue_shapes(monkeypatch):
         ({"number": 21, "repository": {"full_name": "o/r"}}, "state is malformed"),
     ]
     for child, message in cases:
-        monkeypatch.setattr(runner, "epic_issue_with_blockers", lambda repo, issue: base)
-        monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: json.dumps([[child]]))
+        monkeypatch.setattr(seam, "epic_issue_with_blockers", lambda repo, issue: base)
+        monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: json.dumps([[child]]))
         with pytest.raises(ValueError, match=message):
-            runner._verify_epic_complete("o/r", base)
+            github._verify_epic_complete("o/r", base)
     pr = {"number": 21, "repository": {"full_name": "o/r"},
           "state": "closed", "pull_request": {}}
     def pr_run(command, **kwargs):
@@ -19998,9 +19880,9 @@ def test_verify_epic_complete_uses_native_sub_issue_shapes(monkeypatch):
         if command[-1] == "repos/o/r/pulls/21":
             return json.dumps({"merged": False})
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", pr_run)
+    monkeypatch.setattr(seam, "run_command", pr_run)
     with pytest.raises(ValueError, match="not merged"):
-        runner._verify_epic_complete("o/r", base)
+        github._verify_epic_complete("o/r", base)
     with pytest.raises(AssertionError):
         pr_run(["x", "y", "z"])
 
@@ -20016,7 +19898,7 @@ def test_reconcile_release_milestones_keeps_malformed_or_incomplete_open(monkeyp
         if "issues?milestone=5" in command[2]:
             return json.dumps([[{"number": 9}]])
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.reconcile_release_milestones("o/r", "abc12345") == []
     assert "reason=malformed" in caplog.text
     assert "reason=open issues" in caplog.text
@@ -20043,8 +19925,8 @@ def test_reconcile_orphan_prs_reports_an_open_pr_of_a_closed_issue(monkeypatch, 
             return json.dumps({"state": "CLOSED"})
         raise AssertionError(command)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "pr_comments", lambda number, *, repo: pr_comments)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "pr_comments", lambda number, *, repo: pr_comments)
     monkeypatch.setattr(
         runner, "comment_pr",
         lambda number, *, repo, body: posted.append((number, repo, body)),
@@ -20075,7 +19957,7 @@ def test_reconcile_orphan_prs_rejects_malformed_pr_list_and_state(monkeypatch):
             return json.dumps({"comments": []})
         raise AssertionError(command)
 
-    monkeypatch.setattr(runner, "run_command", pr_list_run)
+    monkeypatch.setattr(seam, "run_command", pr_list_run)
     with pytest.raises(ValueError, match="pr list must return a JSON array"):
         runner.reconcile_orphan_prs("o/r", "abc12345")
     with pytest.raises(AssertionError):
@@ -20088,7 +19970,7 @@ def test_reconcile_orphan_prs_rejects_malformed_pr_list_and_state(monkeypatch):
             return json.dumps({"state": "WEIRD"})
         raise AssertionError(command)
 
-    monkeypatch.setattr(runner, "run_command", weird_state_run)
+    monkeypatch.setattr(seam, "run_command", weird_state_run)
     with pytest.raises(ValueError, match="state must be OPEN or CLOSED"):
         runner.reconcile_orphan_prs("o/r", "abc12345")
     with pytest.raises(AssertionError):
@@ -20098,18 +19980,15 @@ def test_reconcile_orphan_prs_rejects_malformed_pr_list_and_state(monkeypatch):
 def test_pr_comments_reads_and_validates(monkeypatch):
     """`pr_comments` is the PR-side twin of `issue_comments`: same JSON
     shape contract, same fail-fast on a malformed answer."""
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps({"comments": [{"body": "x"}]}),
     )
     assert runner.pr_comments(9, repo="o/r") == [{"body": "x"}]
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: json.dumps([{"comments": []}]),
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: json.dumps([{"comments": []}]),
     )
     with pytest.raises(ValueError, match="pr view must be a JSON object"):
         runner.pr_comments(9, repo="o/r")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: json.dumps({"comments": "bad"}),
     )
     with pytest.raises(ValueError, match="pr comments must be a JSON array"):
@@ -20135,7 +20014,7 @@ def test_reconcile_orphan_prs_skips_open_issues_and_non_delivery_branches(monkey
             return json.dumps({"state": "OPEN"})
         raise AssertionError(command)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: (_ for _ in ()).throw(AssertionError("no comment")))
     assert runner.reconcile_orphan_prs("o/r", "abc12345") == []
     assert read_issues == [4]
@@ -20150,7 +20029,7 @@ def test_reconcile_orphan_prs_failure_is_fail_open(monkeypatch, caplog):
     monkeypatch.setattr(runner, "pick_resumable_delivery", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "pick_in_progress_issue", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "pick_issue", lambda *args: {"number": 1})
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "abc12345")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "abc12345")
     result = runner.pick_next_delivery(["o/r"], Path("/tmp/slots"), 1)
     assert result == ("o/r", {"number": 1}, None)
     assert "orphan_pr_reconcile_failed repo=o/r" in caplog.text
@@ -20163,7 +20042,7 @@ def test_reconcile_open_epics_failure_is_fail_open(monkeypatch, caplog):
     monkeypatch.setattr(runner, "pick_resumable_delivery", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "pick_in_progress_issue", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "pick_issue", lambda *args: {"number": 1})
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "abc12345")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "abc12345")
     result = runner.pick_next_delivery(["o/r"], Path("/tmp/slots"), 1)
     assert result == ("o/r", {"number": 1}, None)
     assert "epic_reconcile_failed repo=o/r" in caplog.text
@@ -20171,8 +20050,8 @@ def test_reconcile_open_epics_failure_is_fail_open(monkeypatch, caplog):
 
 def test_reconcile_open_epics_runs_on_a_fresh_tick(monkeypatch):
     calls = []
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(runner, "reconcile_open_epics", lambda repo, run_id: calls.append((repo, run_id)))
     monkeypatch.setattr(runner, "reconcile_release_milestones", lambda *args, **kwargs: None)
     monkeypatch.setattr(runner, "reconcile_orphan_prs", lambda *args, **kwargs: None)
@@ -20184,16 +20063,16 @@ def test_reconcile_open_epics_runs_on_a_fresh_tick(monkeypatch):
 
 
 def test_verify_epic_complete_rejects_malformed_native_blockers(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *args, **kwargs: json.dumps({
+    monkeypatch.setattr(seam, "run_command", lambda *args, **kwargs: json.dumps({
         "number": 20, "body": "## Children\n- #21",
     }))
     with pytest.raises(ValueError, match="native blocker/dependency state is unavailable"):
-        runner._verify_epic_complete("o/r", {"number": 20})
+        github._verify_epic_complete("o/r", {"number": 20})
 
 
 def test_verify_epic_complete_rejects_malformed_native_blocker_node():
     with pytest.raises(ValueError, match="native blocker/dependency state is malformed"):
-        runner._verify_epic_complete("o/r", {
+        github._verify_epic_complete("o/r", {
             "number": 20, "body": "## Children\n- #21",
             "blockedBy": {"nodes": [{"state": "OPEN"}]},
         })
@@ -20205,21 +20084,21 @@ def test_epic_child_evidence_validates_issue_and_pr_shapes(monkeypatch):
         "repos/o/r/issues/2": json.dumps({"pull_request": {}, "state": "open"}),
         "repos/o/r/pulls/2": json.dumps({"merged": True}),
     }
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: responses[command[-1]])
-    assert runner._epic_child_evidence("o/r", "issue", 1) == "Issue #1 closed"
-    assert runner._epic_child_evidence("o/r", "pr", 2) == "PR #2 merged"
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: responses[command[-1]])
+    assert github._epic_child_evidence("o/r", "issue", 1) == "Issue #1 closed"
+    assert github._epic_child_evidence("o/r", "pr", 2) == "PR #2 merged"
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]")
     with pytest.raises(ValueError, match="not an object"):
-        runner._epic_child_evidence("o/r", "issue", 3)
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: json.dumps({"pull_request": {}}))
+        github._epic_child_evidence("o/r", "issue", 3)
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: json.dumps({"pull_request": {}}))
     with pytest.raises(ValueError, match="declared as Issue"):
-        runner._epic_child_evidence("o/r", "issue", 2)
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: json.dumps({"state": "closed"}))
+        github._epic_child_evidence("o/r", "issue", 2)
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: json.dumps({"state": "closed"}))
     with pytest.raises(ValueError, match="declared as PR"):
-        runner._epic_child_evidence("o/r", "pr", 2)
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: json.dumps({"pull_request": {}}) if "issues" in command[-1] else json.dumps({"merged": False}))
+        github._epic_child_evidence("o/r", "pr", 2)
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: json.dumps({"pull_request": {}}) if "issues" in command[-1] else json.dumps({"merged": False}))
     with pytest.raises(ValueError, match="not merged"):
-        runner._epic_child_evidence("o/r", "pr", 2)
+        github._epic_child_evidence("o/r", "pr", 2)
 
 
 def test_close_release_milestone_reconciles_epics_when_summary_lags(monkeypatch):
@@ -20233,8 +20112,8 @@ def test_close_release_milestone_reconciles_epics_when_summary_lags(monkeypatch)
         if command[-1:] == ["state=closed"]:
             return ""
         raise AssertionError(command)
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(release, "reconcile_release_epics", lambda *args: ["Epic #20 closed"])
     result = release.close_release_milestone("o/r", "v0.4.0", run_id="abc12345")
     assert "Epic #20 closed" in result
@@ -20282,9 +20161,9 @@ def test_reconcile_release_epics_keeps_blocked_and_avoids_duplicate_audit(monkey
         }:
             return ""
         raise AssertionError(command)
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: calls.append(["comment"]))
-    result = runner.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: calls.append(["comment"]))
+    result = release.reconcile_release_epics("o/r", 4, "v0.4.0", "abc12345")
     assert any("Epic #30 closed after verification" in item for item in result)
     assert any("open blockers: #9" in item for item in result)
     assert ["gh", "issue", "close", "34", "--repo", "o/r"] in calls
@@ -20415,8 +20294,8 @@ def fake_gh_release_view(monkeypatch, *, body: str, tag: str = "v0.4.0",
             })
         return real(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", mixed)
-    monkeypatch.setattr(release, "run_command", mixed)
+    monkeypatch.setattr(seam, "run_command", mixed)
+    monkeypatch.setattr(seam, "run_command", mixed)
     return real
 
 
@@ -20658,8 +20537,8 @@ def test_sync_release_docs_resume_after_failed_push_recommits_normally(
     def failing_push(command, **kwargs):
         raise subprocess.CalledProcessError(1, command, stderr="boom")
 
-    monkeypatch.setattr(release, "run_git_network_command", failing_push)
-    monkeypatch.setattr(runner, "run_git_network_command", failing_push)
+    monkeypatch.setattr(seam, "run_git_network_command", failing_push)
+    monkeypatch.setattr(seam, "run_git_network_command", failing_push)
     with pytest.raises(subprocess.CalledProcessError):
         release.sync_release_docs(
             source_repo="o/r", repo_dir=work, worktree=work,
@@ -20674,8 +20553,8 @@ def test_sync_release_docs_resume_after_failed_push_recommits_normally(
     # 重放（对 release_commit 的一条 `git reset --hard`）。
     subprocess.run(["git", "-C", str(work), "reset", "--hard", head],
                    check=True, capture_output=True)
-    monkeypatch.setattr(release, "run_git_network_command", original)
-    monkeypatch.setattr(runner, "run_git_network_command", original)
+    monkeypatch.setattr(seam, "run_git_network_command", original)
+    monkeypatch.setattr(seam, "run_git_network_command", original)
     evidence = release.sync_release_docs(
         source_repo="o/r", repo_dir=work, worktree=work,
         base_branch="main", tag="v0.4.0", release_commit=head,
@@ -20716,8 +20595,8 @@ def test_sync_release_docs_stale_tracking_ref_is_not_a_false_recovery(
     # the fixed world where the push never happens — the assertion below
     # is what fails if it ever does.
     no_push = Mock()
-    monkeypatch.setattr(release, "run_git_network_command", no_push)
-    monkeypatch.setattr(runner, "run_git_network_command", no_push)
+    monkeypatch.setattr(seam, "run_git_network_command", no_push)
+    monkeypatch.setattr(seam, "run_git_network_command", no_push)
     evidence = release.sync_release_docs(
         source_repo="o/r", repo_dir=work, worktree=work,
         base_branch="main", tag="v0.4.0", release_commit=head,
@@ -20758,8 +20637,8 @@ def test_sync_release_docs_resumes_after_a_partial_step(tmp_path, monkeypatch):
             )
         return gh_view(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", crash_before_commit)
-    monkeypatch.setattr(runner, "run_command", crash_before_commit)
+    monkeypatch.setattr(seam, "run_command", crash_before_commit)
+    monkeypatch.setattr(seam, "run_command", crash_before_commit)
     with pytest.raises(subprocess.CalledProcessError):
         release.sync_release_docs(
             source_repo="o/r", repo_dir=work, worktree=work,
@@ -20775,8 +20654,8 @@ def test_sync_release_docs_resumes_after_a_partial_step(tmp_path, monkeypatch):
         git_out(work, "rev-parse", "HEAD")
     # The re-run finishes: marker move is a lenient no-op, the nav is
     # updated, one commit lands on main.
-    monkeypatch.setattr(release, "run_command", gh_view)
-    monkeypatch.setattr(runner, "run_command", gh_view)
+    monkeypatch.setattr(seam, "run_command", gh_view)
+    monkeypatch.setattr(seam, "run_command", gh_view)
     evidence = release.sync_release_docs(
         source_repo="o/r", repo_dir=work, worktree=work,
         base_branch="main", tag="v0.4.0", release_commit=head,
@@ -20897,8 +20776,8 @@ def test_sync_release_docs_fails_fast_when_the_base_advanced(
             })
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", view_v041)
-    monkeypatch.setattr(runner, "run_command", view_v041)
+    monkeypatch.setattr(seam, "run_command", view_v041)
+    monkeypatch.setattr(seam, "run_command", view_v041)
     with pytest.raises(subprocess.CalledProcessError):
         release.sync_release_docs(
             source_repo="o/r", repo_dir=work, worktree=stale,
@@ -21057,8 +20936,8 @@ def test_sync_release_docs_fails_fast_when_the_body_is_not_a_string(
             })
         return real(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", bad_body)
-    monkeypatch.setattr(runner, "run_command", bad_body)
+    monkeypatch.setattr(seam, "run_command", bad_body)
+    monkeypatch.setattr(seam, "run_command", bad_body)
     with pytest.raises(RuntimeError, match="body is empty"):
         release.sync_release_docs(
             source_repo="o/r", repo_dir=work, worktree=work,
@@ -21100,8 +20979,8 @@ def test_sync_release_docs_fails_fast_on_a_real_git_diff_error(
             )
         return real(command, **kwargs)
 
-    monkeypatch.setattr(release, "run_command", diff_failing)
-    monkeypatch.setattr(runner, "run_command", diff_failing)
+    monkeypatch.setattr(seam, "run_command", diff_failing)
+    monkeypatch.setattr(seam, "run_command", diff_failing)
     with pytest.raises(subprocess.CalledProcessError):
         release.sync_release_docs(
             source_repo="o/r", repo_dir=work, worktree=work,
@@ -21158,7 +21037,7 @@ def test_process_release_resumes_after_docs_sync_advanced_the_base(
     # The frozen base is the docs commit (a descendant of the tag commit);
     # the env's fake_run_command answers "ancestor" for the merge-base
     # check.
-    monkeypatch.setattr(release, "freeze_base", lambda r, b: "docs456")
+    monkeypatch.setattr(seam, "freeze_base", lambda r, b: "docs456")
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -21178,8 +21057,8 @@ def test_close_release_milestone_rejects_a_non_array_milestone_list(monkeypatch)
             return json.dumps({"number": 5, "title": "v0.3.0"})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(ValueError, match="must be an array of arrays"):
         release.close_release_milestone("o/r", "v0.3.0")
     with pytest.raises(AssertionError, match="unexpected command"):
@@ -21194,8 +21073,8 @@ def test_close_release_milestone_reraises_a_real_gh_failure(monkeypatch):
             )
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake_run)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(subprocess.CalledProcessError):
         release.close_release_milestone("o/r", "v0.3.0")
     with pytest.raises(AssertionError, match="unexpected command"):
@@ -21260,8 +21139,8 @@ def test_verify_release_scope_reraises_real_issue_gh_failure(monkeypatch):
             )
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fail)
-    monkeypatch.setattr(runner, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         release.verify_release_scope("o/r", [7], Path("/repo"), "release123")
     assert "HTTP 403: rate limited" in str(excinfo.value.stderr)
@@ -21299,7 +21178,7 @@ def test_process_release_publishes_the_release_role_progress_body(
         publishes.append(kwargs)
         kwargs["action"]()
 
-    monkeypatch.setattr(release, "_safe_publish", publish)
+    monkeypatch.setattr(seam, "_safe_publish", publish)
     issue = {"number": 99, "title": "Release v0.3.0",
              "body": RELEASE_DECLARATION_BODY,
              "labels": [{"name": "ai-ready"}, {"name": "ai-release"}]}
@@ -21373,8 +21252,8 @@ def test_release_process_env_fake_answers_the_real_tag_probe(tmp_path,
                     "abc123\trefs/tags/v0.3.0^{}\n")
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(release, "run_command", fake)
-    monkeypatch.setattr(runner, "run_command", fake)
+    monkeypatch.setattr(seam, "run_command", fake)
+    monkeypatch.setattr(seam, "run_command", fake)
     with pytest.raises(AssertionError, match="unexpected command"):
         fake(["git", "fetch", "origin"])
     assert release.release_tag_commit(tmp_path, "v0.3.0") == "abc123"
@@ -21425,7 +21304,7 @@ def test_deliver_pr_rejects_wrong_branch(monkeypatch, tmp_path):
         assert command[:3] == ["git", "branch", "--show-current"], command
         return "other-branch"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="Pi changed branch"):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", FAKE_HEAD_SHA, FAKE_RUN_ID,
@@ -21439,7 +21318,7 @@ def test_deliver_pr_rejects_uncommitted_changes(monkeypatch, tmp_path):
             return " M leaked.py\n?? junk.txt"
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="uncommitted changes"):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21456,7 +21335,7 @@ def test_deliver_pr_rejects_delivery_without_a_commit(monkeypatch, tmp_path):
             return base_sha
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="no commit"):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", base_sha, FAKE_RUN_ID,
@@ -21473,7 +21352,7 @@ def test_deliver_pr_completes_the_closeout(monkeypatch, tmp_path):
         calls.append(command)
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.deliver_pr(
         tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
         issue=4, issue_title="t", repo_dir=tmp_path, source_repo="o/r",
@@ -21521,7 +21400,7 @@ def test_deliver_pr_rolls_back_a_conflicting_base_absorb(
             )
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21550,7 +21429,7 @@ def test_deliver_pr_absorbs_an_advanced_base(monkeypatch, tmp_path, caplog):
             raise subprocess.CalledProcessError(1, command)
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("INFO"):
         assert runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21589,7 +21468,7 @@ def test_deliver_pr_creates_the_pr_when_absent(monkeypatch, tmp_path):
             return FAKE_PR_URL
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.deliver_pr(
         tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
         issue=4, issue_title="Closeout title", repo_dir=tmp_path, source_repo="o/r",
@@ -21618,7 +21497,7 @@ def test_deliver_pr_fails_fast_when_pr_create_fails(monkeypatch, tmp_path):
             )
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(subprocess.CalledProcessError):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21634,7 +21513,7 @@ def test_deliver_pr_rejects_remote_head_mismatch_after_push(
             return "f" * 40
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="remote head"):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21660,7 +21539,7 @@ def test_deliver_pr_verifies_the_pr_with_the_latest_base_check_skipped(
             raise subprocess.CalledProcessError(1, command)
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner.deliver_pr(
         tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
         issue=4, issue_title="t", repo_dir=tmp_path, source_repo="o/r",
@@ -21691,10 +21570,9 @@ def test_deliver_pr_reports_a_closed_issue_and_skips_the_pr(
             return json.dumps({"state": "CLOSED"})
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     comments = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, *, repo, body: comments.append((number, repo, body)),
     )
     monkeypatch.setattr(
@@ -21726,21 +21604,19 @@ def test_process_issue_closed_issue_ends_without_pr_ceremony(
     delivery — no `ai-pr-opened` label patch, no `Orbi opened PR:` scene
     comment; the run ends `issue_closed` and the result kind ends the
     tick before the delivery wait."""
-    monkeypatch.setattr(runner, "freeze_base",
+    monkeypatch.setattr(seam, "freeze_base",
                         lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "create_worktree",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree",
                         lambda *args, **kwargs: tmp_path / "wt")
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(runner, "deliver_pr", lambda *args, **kwargs: None)
     edits: list[tuple] = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
     comments = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, *, repo, body: comments.append(body),
     )
     gh_calls, posted = make_fake_gh(monkeypatch)
@@ -21752,7 +21628,7 @@ def test_process_issue_closed_issue_ends_without_pr_ceremony(
             return json.dumps({"labels": [{"name": "ai-ready"}]})
         return "0123456789abcdef0123456789abcdef01234567"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # Issue #266: the health record is a pure bypass — a failed record
     # never changes the issue-closed outcome (the except branch runs).
     def dead_health(*args, **kwargs):
@@ -21932,7 +21808,7 @@ def test_deliver_pr_repairs_runner_runtime_leftovers(monkeypatch, tmp_path,
             return "?? .orbi/\n" if status_calls["n"] == 1 else ""
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
         url = runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21956,7 +21832,7 @@ def test_deliver_pr_repairs_the_renamed_state_dir_too(monkeypatch, tmp_path,
             return "?? .orbi/\n" if status_calls["n"] == 1 else ""
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
         url = runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -21977,7 +21853,7 @@ def test_deliver_pr_still_fails_on_agent_leftovers_alongside_runner_state(
             return " M src/app.py\n?? .orbi/\n?? foo.py\n"
         return fake_deliver_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="uncommitted changes"):
         runner.deliver_pr(
             tmp_path, DELIVER_BRANCH, "main", "9" * 40, FAKE_RUN_ID,
@@ -22222,16 +22098,14 @@ def test_pick_resumable_routes_marker_ticket_instead_of_blocking(
     且 PR 仍 OPEN 的票必须转投：EVENT_REQUEUE 回 ready 队列，下一个
     fresh claim 的接管探针接手评审。"""
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
     patches = []
-    monkeypatch.setattr(
-        runner, "apply_label_patch",
+    monkeypatch.setattr(seam, "apply_label_patch",
         lambda number, *, repo, event, current_labels:
             patches.append(event),
     )
     comments_posted = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, *, repo, body: comments_posted.append(body),
     )
 
@@ -22248,7 +22122,7 @@ def test_pick_resumable_routes_marker_ticket_instead_of_blocking(
             return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     result = runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 2,
     )
@@ -22267,7 +22141,7 @@ def test_pick_resumable_closes_marker_ticket_when_pr_already_merged(
     修复已交付，triage 票按接管合并的同款簿记关票，而不是 block、
     也不是重做。"""
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
     closes = []
     issue = {"number": 100, "title": "triage", "state": "OPEN",
              "body": "<!-- orbi:external-pr:55 -->\nfix the thing",
@@ -22282,8 +22156,8 @@ def test_pick_resumable_closes_marker_ticket_when_pr_already_merged(
             return closes.append(command) or ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "comment_issue", Mock())
     result = runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 2,
     )
@@ -22330,7 +22204,7 @@ def test_wait_for_delivery_closes_triage_issue_after_auto_merge(
         raise AssertionError(f"unexpected command: {command}")
 
     closes: list = []
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", lambda s: None)
     monkeypatch.setattr(
         runner, "review_and_merge_if_clean",
@@ -22363,9 +22237,8 @@ def test_route_external_pr_probe_failure_falls_through_to_block(
     """Issue #726：接管探针自身失败（gh 异常）时绝不瞎猜路由——落回
     旧的 block 路径，让失败被看见。"""
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([issue])
         if command[:3] == ["gh", "issue", "list"]
         else (_ for _ in ()).throw(RuntimeError("gh down")),
@@ -22391,9 +22264,8 @@ def test_route_external_pr_unknown_state_falls_through_to_block(
     """Issue #726：PR 状态是意外值（非 OPEN/MERGED/CLOSED）时同样落回
     block 路径——路由器只承诺三种已知世界。"""
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([issue])
         if command[:3] == ["gh", "issue", "list"] else (
         json.dumps({"state": "DRAFT"})
@@ -22421,14 +22293,14 @@ def test_route_external_pr_ignores_tickets_without_marker(
     """Issue #726 的边界：body 没有外部标记的普通场景损坏票照走 block
     路径——路由器零介入。"""
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
 
     def fake_run(command, **kwargs):
         if command[:3] == ["gh", "issue", "list"]:
             return json.dumps([issue])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     blocked = []
     monkeypatch.setattr(
         runner, "block_scene_failure",
@@ -22464,7 +22336,7 @@ def test_wait_for_delivery_closes_triage_issue_on_merged_poll(
         raise AssertionError(f"unexpected command: {command}")
 
     closes: list = []
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     issue = {"number": 39, "title": "task", "body": ""}
     runner.wait_for_delivery(
         PR_URL, issue, {"repo_dir": tmp_path, "base_branch": "main"},
@@ -22480,8 +22352,7 @@ def test_close_external_triage_issue_swallows_close_failure(
 ):
     """关票是已合并事实的簿记旁路：失败只记日志，永不改写合并事实、
     永不炸 tick（#608 语义，#726 抽取后必须保持）。"""
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: (_ for _ in ()).throw(RuntimeError("gh down")),
     )
     with caplog.at_level("ERROR"):
@@ -22523,8 +22394,8 @@ def test_process_issue_scan_window_orphan_resumes_when_no_runner_live(
     _claim_race_deps(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "slot_occupancy", lambda *a, **k: [
         (tmp_path / "slot-0", None), (tmp_path / "slot-1", os.getpid())])
-    monkeypatch.setattr(runner, "apply_label_patch", Mock())
-    monkeypatch.setattr(runner, "create_worktree", Mock(
+    monkeypatch.setattr(seam, "apply_label_patch", Mock())
+    monkeypatch.setattr(seam, "create_worktree", Mock(
         side_effect=AssertionError("orphan must resume")))
     issue = {"number": 18, "title": "t", "body": "b",
              "labels": [{"name": "ai-ready"}]}

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -41,14 +41,12 @@ from pathlib import Path
 
 import pytest
 
-from orbi import runner
-from orbi import cli_source
+from orbi import cli_source, gitops, runner
+from seam import seam
 
-# The refresh implementation lives in `orbi.runner` (see the NOTE
-# there); the former thin re-export module `orbi.cli_install` is
-# deleted (Issue #295) and these tests import the real symbols
-# directly from it. The suite's default no-op stub (conftest) patches
-# `runner.refresh_cli_install` — the call `main()` makes — so this
+# The refresh implementation lives in `orbi.cli_source` (Issue #785);
+# `runner` imports it and `main()` calls the runner binding. The
+# suite's default no-op stub (conftest) patches that binding, so this
 # module re-binds the real implementation (conftest autouse fixtures
 # run before module ones, so the re-bind wins for these tests only).
 _real_refresh_cli_install = runner.refresh_cli_install
@@ -56,8 +54,7 @@ _real_refresh_cli_install = runner.refresh_cli_install
 
 @pytest.fixture(autouse=True)
 def _real_cli_install_refresh(monkeypatch):
-    monkeypatch.setattr(
-        runner, "refresh_cli_install", _real_refresh_cli_install,
+    monkeypatch.setattr(seam, "refresh_cli_install", _real_refresh_cli_install,
     )
 
 
@@ -93,7 +90,7 @@ def test_packaging_fingerprint_is_the_sha256_of_pyproject(tmp_path):
     repo = tmp_path / "checkout"
     content = b'[project]\nname = "orbi"\nversion = "0.2.0"\n'
     _write_pyproject(repo, content.decode("utf-8"))
-    assert runner.packaging_fingerprint(repo) == (
+    assert cli_source.packaging_fingerprint(repo) == (
         hashlib.sha256(content).hexdigest()
     )
 
@@ -104,11 +101,11 @@ def test_packaging_fingerprint_changes_with_pyproject_content(tmp_path):
     trigger."""
     repo = tmp_path / "checkout"
     _write_pyproject(repo, '[project]\nname = "a"\n')
-    first = runner.packaging_fingerprint(repo)
+    first = cli_source.packaging_fingerprint(repo)
     _write_pyproject(
         repo, '[project]\nname = "a"\nversion = "0.3.0"\n',
     )
-    assert runner.packaging_fingerprint(repo) != first
+    assert cli_source.packaging_fingerprint(repo) != first
 
 
 def test_packaging_fingerprint_ignores_python_source_content(tmp_path):
@@ -120,9 +117,9 @@ def test_packaging_fingerprint_ignores_python_source_content(tmp_path):
     package_dir = repo / "src" / "orbi"
     package_dir.mkdir(parents=True)
     (package_dir / "runner.py").write_text("old\n", encoding="utf-8")
-    first = runner.packaging_fingerprint(repo)
+    first = cli_source.packaging_fingerprint(repo)
     (package_dir / "runner.py").write_text("new content\n", encoding="utf-8")
-    assert runner.packaging_fingerprint(repo) == first
+    assert cli_source.packaging_fingerprint(repo) == first
 
 
 def test_packaging_fingerprint_fails_fast_without_pyproject(tmp_path):
@@ -133,7 +130,7 @@ def test_packaging_fingerprint_fails_fast_without_pyproject(tmp_path):
     with pytest.raises(
         runner.CliInstallError, match="pyproject.toml",
     ):
-        runner.packaging_fingerprint(repo)
+        cli_source.packaging_fingerprint(repo)
 
 
 # --- the install state (the last-install fingerprint) -----------------------
@@ -144,7 +141,7 @@ def test_install_state_path_is_in_the_shared_state_dir(tmp_path):
     shared state dir (gitignored, next to ``base-sync.lock`` and the
     slots; it survives the ``git merge --ff-only`` checkout sync).
     Not a second release state, not a per-process temp file."""
-    assert runner.install_state_path(tmp_path) == (
+    assert cli_source.install_state_path(tmp_path) == (
         tmp_path / ".orbi" / "cli-install.json"
     )
 
@@ -152,49 +149,49 @@ def test_install_state_path_is_in_the_shared_state_dir(tmp_path):
 def test_read_install_state_missing_file_is_none(tmp_path):
     """No state yet (first install / fresh checkout) -> None (the
     refresh runs)."""
-    assert runner.read_install_state(tmp_path) is None
+    assert cli_source.read_install_state(tmp_path) is None
 
 
 def test_read_install_state_returns_the_stored_fingerprint(tmp_path):
-    path = runner.install_state_path(tmp_path)
+    path = cli_source.install_state_path(tmp_path)
     path.parent.mkdir(parents=True)
     path.write_text(
         json.dumps({"pyproject_sha256": "abc123"}), encoding="utf-8",
     )
-    assert runner.read_install_state(tmp_path) == "abc123"
+    assert cli_source.read_install_state(tmp_path) == "abc123"
 
 
 def test_read_install_state_malformed_file_is_none(tmp_path):
     """A corrupted state file (a torn write) heals in the SAFE
     direction: it is treated as "no state" and one extra idempotent
     ``--force --reinstall`` runs — never a wedged start."""
-    path = runner.install_state_path(tmp_path)
+    path = cli_source.install_state_path(tmp_path)
     path.parent.mkdir(parents=True)
     path.write_text("{not json", encoding="utf-8")
-    assert runner.read_install_state(tmp_path) is None
+    assert cli_source.read_install_state(tmp_path) is None
     path.write_text(json.dumps({"wrong": "shape"}), encoding="utf-8")
-    assert runner.read_install_state(tmp_path) is None
+    assert cli_source.read_install_state(tmp_path) is None
 
 
 def test_write_install_state_is_atomic_and_readable(tmp_path):
-    runner.write_install_state(tmp_path, "deadbeef")
+    cli_source.write_install_state(tmp_path, "deadbeef")
     data = json.loads(
-        runner.install_state_path(tmp_path).read_text(encoding="utf-8"),
+        cli_source.install_state_path(tmp_path).read_text(encoding="utf-8"),
     )
     assert data == {"pyproject_sha256": "deadbeef"}
-    assert runner.read_install_state(tmp_path) == "deadbeef"
+    assert cli_source.read_install_state(tmp_path) == "deadbeef"
     # No temp file is left behind (the atomic replace cleaned up).
     leftovers = [
-        p.name for p in runner.install_state_path(tmp_path).parent.iterdir()
+        p.name for p in cli_source.install_state_path(tmp_path).parent.iterdir()
         if p.name != "cli-install.json"
     ]
     assert leftovers == []
 
 
 def test_write_install_state_overwrites_the_previous_fingerprint(tmp_path):
-    runner.write_install_state(tmp_path, "first")
-    runner.write_install_state(tmp_path, "second")
-    assert runner.read_install_state(tmp_path) == "second"
+    cli_source.write_install_state(tmp_path, "first")
+    cli_source.write_install_state(tmp_path, "second")
+    assert cli_source.read_install_state(tmp_path) == "second"
 
 
 # --- the refresh decision ----------------------------------------------------
@@ -204,8 +201,8 @@ def test_refresh_is_a_noop_without_any_uv_call_when_unchanged(tmp_path):
     """Acceptance: unchanged packaging input -> NO uv call (no
     per-tick unconditional install)."""
     _write_pyproject(tmp_path, '[project]\nname = "a"\n')
-    runner.write_install_state(
-        tmp_path, runner.packaging_fingerprint(tmp_path),
+    cli_source.write_install_state(
+        tmp_path, cli_source.packaging_fingerprint(tmp_path),
     )
     calls = []
     result = runner.refresh_cli_install(
@@ -228,9 +225,9 @@ def test_refresh_installs_on_the_first_install(tmp_path, caplog):
     assert len(calls) == 1
     command, kwargs = calls[0]
     assert command == cli_source.reinstall_args(tmp_path)
-    assert kwargs["timeout"] == runner.UV_INSTALL_TIMEOUT_SECONDS
-    assert runner.read_install_state(tmp_path) == (
-        runner.packaging_fingerprint(tmp_path)
+    assert kwargs["timeout"] == cli_source.UV_INSTALL_TIMEOUT_SECONDS
+    assert cli_source.read_install_state(tmp_path) == (
+        cli_source.packaging_fingerprint(tmp_path)
     )
     assert "cli_install_refreshed" in caplog.text
     assert "reason=first_install" in caplog.text
@@ -242,7 +239,7 @@ def test_refresh_installs_when_the_packaging_input_changed(tmp_path, caplog):
     the editable metadata is refreshed and the next CLI process
     imports the new module."""
     _write_pyproject(tmp_path, '[project]\nname = "a"\n')
-    runner.write_install_state(
+    cli_source.write_install_state(
         tmp_path, "stale-fingerprint-from-the-last-install",
     )
     calls = []
@@ -254,12 +251,12 @@ def test_refresh_installs_when_the_packaging_input_changed(tmp_path, caplog):
     assert len(calls) == 1
     command, kwargs = calls[0]
     assert command == cli_source.reinstall_args(tmp_path)
-    assert kwargs["timeout"] == runner.UV_INSTALL_TIMEOUT_SECONDS
+    assert kwargs["timeout"] == cli_source.UV_INSTALL_TIMEOUT_SECONDS
     assert "reason=packaging_changed" in caplog.text
     # The state now records the CURRENT fingerprint: the very next
     # start is a no-op again.
-    assert runner.read_install_state(tmp_path) == (
-        runner.packaging_fingerprint(tmp_path)
+    assert cli_source.read_install_state(tmp_path) == (
+        cli_source.packaging_fingerprint(tmp_path)
     )
 
 
@@ -280,8 +277,8 @@ def test_refresh_reuses_a_concurrent_instances_result_under_the_lock(
     import time
 
     _write_pyproject(tmp_path, '[project]\nname = "a"\n')
-    fingerprint = runner.packaging_fingerprint(tmp_path)
-    lock_path = runner.base_sync_lock_path(tmp_path)
+    fingerprint = cli_source.packaging_fingerprint(tmp_path)
+    lock_path = gitops.base_sync_lock_path(tmp_path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # Hold the flock BEFORE the refresh starts: the refresh's pre-lock
     # state read (absent state — nothing was written) provably
@@ -314,7 +311,7 @@ def test_refresh_reuses_a_concurrent_instances_result_under_the_lock(
     # (what a real concurrent refresh leaves behind after its
     # install), then release the flock. The refresh's under-lock
     # re-read must see it and skip the install.
-    runner.write_install_state(tmp_path, fingerprint)
+    cli_source.write_install_state(tmp_path, fingerprint)
     # Release the flock so the parked refresh can proceed (its
     # under-lock re-read must now see the recorded state), then wait
     # for the result.
@@ -339,7 +336,7 @@ def test_refresh_writes_the_state_only_after_a_successful_install(
 
     with pytest.raises(runner.CliInstallError, match="uv exploded"):
         runner.refresh_cli_install(tmp_path, run_command=boom)
-    assert runner.read_install_state(tmp_path) is None
+    assert cli_source.read_install_state(tmp_path) is None
 
 
 # --- failure propagation ------------------------------------------------------
@@ -380,7 +377,7 @@ def test_refresh_failure_releases_the_lock(tmp_path):
 
     with pytest.raises(runner.CliInstallError):
         runner.refresh_cli_install(tmp_path, run_command=boom)
-    lock_path = runner.base_sync_lock_path(tmp_path)
+    lock_path = gitops.base_sync_lock_path(tmp_path)
     probe = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
     try:
         fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -395,13 +392,13 @@ def test_refresh_fails_fast_when_the_lock_is_held(tmp_path):
     instance is syncing the checkout), the refresh waits and then
     fails fast with the useful error — never a concurrent write."""
     _write_pyproject(tmp_path, '[project]\nname = "a"\n')
-    lock_path = runner.base_sync_lock_path(tmp_path)
+    lock_path = gitops.base_sync_lock_path(tmp_path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
     fcntl.flock(fd, fcntl.LOCK_EX)
     try:
         with pytest.raises(
-            runner.CliInstallError, match="base-sync.lock",
+            gitops.BaseSyncLockError, match="base-sync.lock",
         ):
             runner.refresh_cli_install(
                 tmp_path, run_command=lambda *a, **k: "",
@@ -434,8 +431,8 @@ def test_two_concurrent_starts_run_exactly_one_install(tmp_path):
         # Simulate the install body; the flock must keep `active` at 1.
         assert active == 1, "concurrent uv tool installs raced"
         # The state lands only after a successful install.
-        runner.write_install_state(
-            tmp_path, runner.packaging_fingerprint(tmp_path),
+        cli_source.write_install_state(
+            tmp_path, cli_source.packaging_fingerprint(tmp_path),
         )
         return ""
 
@@ -458,8 +455,8 @@ def test_two_concurrent_starts_run_exactly_one_install(tmp_path):
     # install).
     assert sorted(results) == ["installed", "unchanged"]
     assert len(installs) == 1
-    assert runner.read_install_state(tmp_path) == (
-        runner.packaging_fingerprint(tmp_path)
+    assert cli_source.read_install_state(tmp_path) == (
+        cli_source.packaging_fingerprint(tmp_path)
     )
 
 
@@ -467,7 +464,7 @@ def test_base_sync_lock_path_is_the_shared_state_dir_file(tmp_path):
     """The refresh serializes on the SAME lock file the ExecStartPre
     flock in the service template uses (the shared state dir, next to
     the slots — never a per-process temp file)."""
-    assert runner.base_sync_lock_path(tmp_path) == (
+    assert gitops.base_sync_lock_path(tmp_path) == (
         tmp_path / ".orbi" / "base-sync.lock"
     )
 
@@ -486,8 +483,8 @@ def test_refresh_can_install_one_checkout_while_locking_shared_checkout(
         run_command=_recorder(calls),
     )
 
-    assert runner.base_sync_lock_path(deployment_checkout).is_file()
-    assert not runner.base_sync_lock_path(release_worktree).exists()
+    assert gitops.base_sync_lock_path(deployment_checkout).is_file()
+    assert not gitops.base_sync_lock_path(release_worktree).exists()
     assert calls[0][0] == cli_source.reinstall_args(release_worktree)
 
 
@@ -505,4 +502,4 @@ def test_reinstall_argv_is_the_verified_editable_force_reinstall(tmp_path):
         "uv", "tool", "install", "--force", "--reinstall", "--editable",
         "--python", cli_source.PYTHON_INTERPRETER, str(tmp_path),
     ]
-    assert kwargs["timeout"] == runner.UV_INSTALL_TIMEOUT_SECONDS
+    assert kwargs["timeout"] == cli_source.UV_INSTALL_TIMEOUT_SECONDS

--- a/tests/test_fix_needed_loop.py
+++ b/tests/test_fix_needed_loop.py
@@ -16,6 +16,8 @@ import subprocess
 import pytest
 
 import orbi.runner as runner
+from seam import seam
+import orbi.journal as journal
 
 PR_URL = "https://github.com/owner/repo/pull/46"
 RUN_ID = "a1b2c3d4"
@@ -26,7 +28,7 @@ BRANCH = "orbi/owner-repo-issue-39"
 
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def _scene_comments():
@@ -83,7 +85,7 @@ def make_wait_failure_fake(monkeypatch, *, labels=("ai-pr-opened",),
             return json.dumps({"comments": scene})
         return json.dumps({"labels": [{"name": name} for name in labels]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return api_calls
 
 
@@ -231,12 +233,10 @@ def test_wait_for_delivery_recoverable_review_failure_stays_fix_needed(
     edits = []
     issue_comments = []
     pr_comments = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(
@@ -250,7 +250,7 @@ def test_wait_for_delivery_recoverable_review_failure_stays_fix_needed(
         raise exc
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     caplog.set_level("INFO")
     # The wait returns (the slot is released by the caller); the next
     # timer picks the ai-fix-needed Issue up on the same run/PR.
@@ -328,18 +328,17 @@ def test_wait_for_delivery_recoverable_failure_while_fix_needed_keeps_label(
         monkeypatch, labels=("ai-fix-needed",), progress_comments=[],
     )
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
 
     def failing_review(*args, **kwargs):
         raise RuntimeError("pi_exit_1: the review Pi failed")
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
     # The current label set contains only ai-fix-needed, so the
     # idempotent transition adds it without inventing a remove for the
@@ -373,9 +372,8 @@ def test_wait_for_delivery_recoverable_failure_with_session_file_includes_sessio
     _write_session(worktree)
     make_wait_failure_fake(monkeypatch)
     issue_comments = []
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
@@ -384,7 +382,7 @@ def test_wait_for_delivery_recoverable_failure_with_session_file_includes_sessio
         raise RuntimeError("pi_exit_3: the review Pi failed")
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
     body = issue_comments[0][1]["body"]
     assert "session=sess-1" in body
@@ -406,12 +404,10 @@ def test_wait_for_delivery_recoverable_failure_scene_snapshot_failure_is_logged(
     make_wait_failure_fake(monkeypatch)
     issue_comments = []
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
@@ -424,7 +420,7 @@ def test_wait_for_delivery_recoverable_failure_scene_snapshot_failure_is_logged(
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
     monkeypatch.setattr(runner, "activity_snapshot", failing_snapshot)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     caplog.set_level("INFO")
     runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
     assert "activity scene failed" in caplog.text
@@ -454,12 +450,10 @@ def test_wait_for_delivery_recoverable_failure_without_bound_run_id(
     api_calls = make_wait_failure_fake(monkeypatch)
     issue_comments = []
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
@@ -496,12 +490,10 @@ def test_wait_for_delivery_unrecoverable_failure_marks_blocked_with_reason(
     api_calls = make_wait_failure_fake(monkeypatch)
     edits = []
     issue_comments = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
@@ -515,7 +507,7 @@ def test_wait_for_delivery_unrecoverable_failure_marks_blocked_with_reason(
         raise runner.ReviewRoundsExhausted(reason)
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     caplog.set_level("INFO")
     runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
 
@@ -563,15 +555,15 @@ def test_wait_for_delivery_real_unrecoverable_failure_keeps_traceback(
     (tmp_path / ".worktrees"
      / f"orbi-owner-repo-issue-39-{RUN_ID}").mkdir(parents=True)
     make_wait_failure_fake(monkeypatch)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
 
     def failing_review(*args, **kwargs):
         raise runner.UnrecoverableDeliveryError("credential revoked")
 
     monkeypatch.setattr(runner, "review_and_merge_if_clean", failing_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     caplog.set_level("ERROR")
     runner.wait_for_delivery(PR_URL, _issue(), _config(tmp_path), "owner/repo")
 
@@ -603,12 +595,10 @@ def test_wait_for_delivery_base_branch_mismatch_marks_blocked_with_reason(
     )
     edits = []
     issue_comments = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: issue_comments.append((args, kwargs)),
     )
     monkeypatch.setattr(runner, "comment_pr", lambda *a, **k: None)
@@ -617,7 +607,7 @@ def test_wait_for_delivery_base_branch_mismatch_marks_blocked_with_reason(
         runner, "review_and_merge_if_clean",
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     caplog.set_level("INFO")
     runner.wait_for_delivery(
         PR_URL, _issue(),
@@ -670,7 +660,7 @@ def test_verify_resumed_pr_diverged_pr_head_stays_fix_needed(
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     with pytest.raises(
         RuntimeError, match="the branch diverged",
@@ -763,8 +753,8 @@ def test_verify_resumed_pr_local_ahead_of_pr_head_continues_to_review(
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run(["gh", "release", "list"])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     issue = make_resume_issue()
     issue["labels"] = [{"name": "ai-fix-needed"}]
@@ -808,7 +798,7 @@ def test_verify_resumed_pr_unrecoverable_failure_marks_blocked_with_reason(
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     with pytest.raises(
         runner.UnrecoverableDeliveryError, match="not authorized",
     ):
@@ -853,7 +843,7 @@ def test_verify_resumed_pr_recoverable_failure_with_session_file_includes_sessio
         raise RuntimeError("the verified commit was not pushed")
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     with pytest.raises(RuntimeError, match="not pushed"):
         runner.verify_resumed_pr(
             make_resume_scene(), make_resume_issue(),
@@ -887,7 +877,7 @@ def test_verify_resumed_pr_recoverable_failure_scene_snapshot_failure_is_logged(
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     monkeypatch.setattr(runner, "activity_snapshot", failing_snapshot)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     with pytest.raises(RuntimeError, match="not pushed"):
         runner.verify_resumed_pr(
@@ -921,7 +911,7 @@ def test_verify_resumed_pr_unrecoverable_failure_removes_leftover_fix_needed_lab
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     with pytest.raises(
         runner.UnrecoverableDeliveryError, match="human decision",
     ):
@@ -942,8 +932,7 @@ def test_finish_progress_fix_needed_without_run_id_is_noop(monkeypatch):
     """Issue #50: the fix-needed progress scene is bound to the run id
     (the hidden marker); without one it is a no-op (no gh traffic)."""
     api_calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *args, **kwargs: api_calls.append(args) or "",
     )
     assert runner._finish_progress(
@@ -973,12 +962,10 @@ def test_block_scene_failure_states_why_not_auto_recoverable(
     ]
     edits = []
     posted = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *args, **kwargs: posted.append(kwargs["body"]),
     )
     runner.block_scene_failure(
@@ -1018,8 +1005,7 @@ def test_review_rounds_after_human_recovery_ignores_old_run():
 
 
 def test_human_recovery_requires_blocked_removal_then_fix_needed(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([
             {"event": "labeled", "label": {"name": "ai-blocked"},
              "created_at": "2026-01-01T00:00:00Z"},
@@ -1034,15 +1020,13 @@ def test_human_recovery_requires_blocked_removal_then_fix_needed(monkeypatch):
 
 
 def test_human_review_recovery_ignores_unrelated_label_history(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: '{"event":"labeled"}\n',
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: '{"event":"labeled"}\n',
     )
     assert runner.human_review_recovery_at(39, "owner/repo") is None
 
 
 def test_human_review_recovery_requires_latest_blocked_removal(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: json.dumps([
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: json.dumps([
             {"event": "unlabeled", "label": {"name": "ai-blocked"},
              "created_at": "2026-01-01T00:00:00Z"},
             {"event": "labeled", "label": {"name": "ai-blocked"},
@@ -1055,8 +1039,7 @@ def test_human_review_recovery_requires_latest_blocked_removal(monkeypatch):
 
 
 def test_human_review_recovery_skips_non_object_events(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: "1\n",
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "1\n",
     )
     assert runner.human_review_recovery_at(39, "owner/repo") is None
 
@@ -1064,8 +1047,7 @@ def test_human_review_recovery_skips_non_object_events(monkeypatch):
 def test_log_recovery_ci_status_logs_malformed_response_and_continues(
         monkeypatch, caplog,
 ):
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: json.dumps({}),
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: json.dumps({}),
     )
     caplog.set_level("WARNING")
     runner.log_recovery_ci_status(
@@ -1075,8 +1057,7 @@ def test_log_recovery_ci_status_logs_malformed_response_and_continues(
 
 
 def test_log_recovery_ci_status_logs_only_check_summary(monkeypatch, caplog):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: json.dumps([]),
     )
     caplog.set_level("INFO")
@@ -1090,7 +1071,7 @@ def test_exhausted_review_enters_new_budget_after_human_recovery(
     monkeypatch, tmp_path,
 ):
     from tests.test_resume_pr import FAKE_RUN_ID
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [
         {"body": f"<!-- orbi:run=a1b2c3d4 -->\n"
                  f"Orbi review round {i} for PR #46: findings",
          "authorAssociation": "OWNER",
@@ -1105,7 +1086,7 @@ def test_exhausted_review_enters_new_budget_after_human_recovery(
     monkeypatch.setattr(runner, "freeze_pr",
                         lambda *a, **k: freezes.append(1) or frozen)
     monkeypatch.setattr(runner, "log_recovery_ci_status", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "_safe_publish", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "run_review",
         lambda *a, **k: (_ for _ in ()).throw(RuntimeError("review started")),
@@ -1128,8 +1109,7 @@ def test_review_rounds_exhausted_raises_unrecoverable(monkeypatch, tmp_path):
     monkeypatch.setattr(runner, "human_review_recovery_at", lambda *a: None)
     from tests.test_resume_pr import FAKE_RUN_ID
 
-    monkeypatch.setattr(
-        runner, "issue_comments",
+    monkeypatch.setattr(seam, "issue_comments",
         lambda number, repo: [
             {
                 "body": (

--- a/tests/test_gh_read_retry.py
+++ b/tests/test_gh_read_retry.py
@@ -14,6 +14,8 @@ import subprocess
 import pytest
 
 import orbi.runner as runner
+import orbi.github as github
+from seam import seam
 
 TRANSIENT_STDERRS = [
     "HTTP 401: Bad credentials (https://api.github.com/graphql)",
@@ -170,20 +172,20 @@ def test_gh_read_command_does_not_retry_gh_api_writes(monkeypatch):
 
 
 def test_is_readonly_gh_command_classifies_gh_api_reads():
-    assert runner._is_readonly_gh_command(["gh", "api", "repos/o/r"])
-    assert runner._is_readonly_gh_command(
+    assert github._is_readonly_gh_command(["gh", "api", "repos/o/r"])
+    assert github._is_readonly_gh_command(
         ["gh", "api", "repos/o/r", "--paginate", "--slurp"])
-    assert runner._is_readonly_gh_command(
+    assert github._is_readonly_gh_command(
         ["gh", "api", "repos/o/r", "--method", "GET"])
-    assert runner._is_readonly_gh_command(
+    assert github._is_readonly_gh_command(
         ["gh", "api", "repos/o/r", "--method=GET", "--jq", ".name"])
-    assert runner._is_readonly_gh_command(["gh", "api", "-X", "GET", "repos/o/r"])
+    assert github._is_readonly_gh_command(["gh", "api", "-X", "GET", "repos/o/r"])
     # A trailing -X with no value is malformed; no method override was
     # parsed, so the command is still classified as a read (gh rejects it).
-    assert runner._is_readonly_gh_command(["gh", "api", "repos/o/r", "-X"])
-    assert not runner._is_readonly_gh_command(["gh", "api"])
-    assert not runner._is_readonly_gh_command(["git", "push", "origin", "main"])
-    assert not runner._is_readonly_gh_command(
+    assert github._is_readonly_gh_command(["gh", "api", "repos/o/r", "-X"])
+    assert not github._is_readonly_gh_command(["gh", "api"])
+    assert not github._is_readonly_gh_command(["git", "push", "origin", "main"])
+    assert not github._is_readonly_gh_command(
         ["timeout", "30", "gh", "issue", "list"])
 
 
@@ -199,7 +201,7 @@ def test_is_readonly_gh_command_field_parameters_imply_post():
         ["gh", "api", "repos/o/r/labels", "--field=name=p0"],
         ["gh", "api", "graphql", "-fquery=query { viewer { login } }"],
     ):
-        assert not runner._is_readonly_gh_command(command), command
+        assert not github._is_readonly_gh_command(command), command
     # An explicit `--method GET` keeps the parameters on the query
     # string (gh's documented escape hatch) — a read again.
     for command in (
@@ -208,7 +210,7 @@ def test_is_readonly_gh_command_field_parameters_imply_post():
         ["gh", "api", "repos/o/r/issues", "-X", "GET", "-f", "state=open"],
         ["gh", "api", "repos/o/r/issues", "--method=GET", "-fstate=open"],
     ):
-        assert runner._is_readonly_gh_command(command), command
+        assert github._is_readonly_gh_command(command), command
 
 
 def test_is_readonly_gh_command_classifies_subcommands():
@@ -223,12 +225,12 @@ def test_is_readonly_gh_command_classifies_subcommands():
         ["gh", "auth", "status"],
         ["gh", "auth", "token"],
     ):
-        assert runner._is_readonly_gh_command(command), command
+        assert github._is_readonly_gh_command(command), command
     for command in (
         ["gh", "issue", "close", "9"],
         ["gh", "issue"],
     ):
-        assert not runner._is_readonly_gh_command(command), command
+        assert not github._is_readonly_gh_command(command), command
 
 
 def test_list_issues_survives_transient_401_from_keyring_race(monkeypatch):
@@ -247,7 +249,7 @@ def test_list_issues_survives_transient_401_from_keyring_race(monkeypatch):
             )
         return "[]"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.list_issues(
         "orbi-build/orbi-cloud", state="open",
         search="label:ai-fix-needed,ai-pr-opened -label:ai-blocked",

--- a/tests/test_git_base_smoke.py
+++ b/tests/test_git_base_smoke.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+from seam import seam
 
 
 def git(repo: Path, *args: str) -> str:
@@ -71,7 +72,7 @@ def install_fake_gh(monkeypatch, pr_json: str) -> None:
             return pr_json
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
 
 def test_task_created_from_latest_origin_base_when_main_worktree_on_side_branch(clone):

--- a/tests/test_git_merge_smoke.py
+++ b/tests/test_git_merge_smoke.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+from seam import seam
 
 
 def git(repo: Path, *args: str) -> str:
@@ -96,7 +97,7 @@ def install_fake_gh(monkeypatch, clone: Path, pr_json: str) -> list:
             return ""
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return commands
 
 
@@ -120,8 +121,7 @@ def test_merge_gate_merges_head_containing_latest_base(clone, monkeypatch):
     merge_commit = git(clone, "rev-parse", "origin/main")
     git(clone, "merge-base", "--is-ancestor", head_oid, "origin/main")
     # confirm_merged verifies the merge commit is now on origin/main.
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (
             make_pr(head_oid, state="MERGED", merged_at="now",
                     merge_commit=merge_commit)
@@ -154,7 +154,7 @@ def test_merge_gate_rejects_head_behind_latest_base(clone, monkeypatch, caplog):
         commands.append(command)
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     pr = {"number": 4, "url": "u", "base_ref": "main",
           "base_oid": git(clone, "rev-parse", "origin/main~1"),
           "head_ref": "orbi/owner-repo-issue-4",
@@ -215,7 +215,7 @@ def test_deployment_checkout_fast_forwards_after_independent_merge(
                            merge_commit=merge_commit)
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     confirmed = runner.confirm_merged(clone, merged, "main", repo_dir=clone)
     assert confirmed["merge_commit"] == merge_commit
 

--- a/tests/test_git_network_retry.py
+++ b/tests/test_git_network_retry.py
@@ -3,6 +3,7 @@ import subprocess
 import pytest
 
 import orbi.runner as runner
+import orbi.journal as journal
 
 
 def test_git_network_command_retries_transient_failure_then_succeeds(
@@ -50,7 +51,7 @@ def test_git_network_command_retries_bounded_timeouts_then_succeeds(
     ) == "ok"
     assert len(calls) == 3
     assert all(
-        call["timeout"] == runner.GIT_NETWORK_TIMEOUT_SECONDS
+        call["timeout"] == journal.GIT_NETWORK_TIMEOUT_SECONDS
         for call in calls
     )
     assert sleeps == [1, 2]
@@ -101,7 +102,7 @@ def test_git_network_command_does_not_retry_other_git_commands():
     error = subprocess.CalledProcessError(
         1, command, stderr="Connection timed out",
     )
-    assert not runner._is_retryable_git_network_failure(command, error)
+    assert not journal._is_retryable_git_network_failure(command, error)
 
 
 def test_git_network_command_does_not_retry_non_git_timeout(monkeypatch):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -346,7 +346,12 @@ def test_pr_comments_reads_through_pr_view(monkeypatch):
     assert github.pr_comments(4, repo="o/r") == []
 
 
-def test_trusted_issue_comments_block_keeps_newest_and_states_omissions():
+def test_trusted_issue_comments_block_keeps_newest_and_states_omissions(
+        monkeypatch):
+    # Pin the credential read: the NONE-association comment reaches the
+    # authenticated-login fallback and CI runs unauthenticated.
+    monkeypatch.setattr(seam, "_authenticated_github_login",
+                        lambda: "ci-runner[bot]")
     comments = [
         {"author": {"login": "a"}, "authorAssociation": "OWNER",
          "createdAt": "t1", "body": "one"},

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -141,6 +141,20 @@ def test_list_milestones_reads_the_exact_api_page(monkeypatch):
     ]]
 
 
+def test_list_milestones_forwards_the_callers_timeout(monkeypatch):
+    # Issue #95: the idle milestone-advance sweep bounds this network
+    # read at 30 s — the bound must survive the seam (run_gh_read_command
+    # forwards only the set options; None is run_command's default).
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(k), "[]")[1])
+
+    github.list_milestones("o/r", timeout=30)
+    assert captured == [{"timeout": 30}]
+    github.list_milestones("o/r")
+    assert captured[1] == {}
+
+
 def test_milestone_open_issue_count_reads_githubs_own_counter(monkeypatch):
     monkeypatch.setattr(seam, "run_command", lambda c, **k: "2")
     assert github.milestone_open_issue_count("o/r", "v1") == 2

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,510 @@
+"""Unit tests for the `orbi.github` leaf (Issue #785).
+
+One test per GitHub read/write contract: the fakes sit at the single
+`run_command` seam (injected `command_runner` or a patched module seam) and
+assert the real `gh` command line — the argv IS the contract (Article 5.2).
+No test patches `runner` internals.
+"""
+import json
+import subprocess
+
+import pytest
+
+from orbi import github
+from seam import seam
+
+
+def test_module_is_a_leaf_and_never_imports_runner_release_pi_process():
+    source = (github.__file__ and
+              open(github.__file__, encoding="utf-8").read())
+    for forbidden in ("from orbi.runner", "from orbi import runner",
+                      "import orbi.runner", "from orbi.release",
+                      "from orbi import release", "from orbi.pi_process",
+                      "from orbi import pi_process"):
+        assert forbidden not in source, forbidden
+
+
+def test_run_gh_read_command_retries_transient_read_then_succeeds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(github.time, "sleep", sleeps.append)
+    attempts = []
+
+    def run(command, **kwargs):
+        attempts.append(command)
+        if len(attempts) < 3:
+            raise subprocess.CalledProcessError(
+                1, command,
+                stderr="HTTP 429: Too Many Requests",
+            )
+        return "[]"
+
+    assert github.run_gh_read_command(
+        ["gh", "issue", "list", "--repo", "o/r", "--json", "number"],
+        command_runner=run,
+    ) == "[]"
+    assert len(attempts) == 3
+    assert sleeps == [1, 2]
+
+
+def test_run_gh_read_command_never_retries_a_write(monkeypatch):
+    attempts = []
+
+    def run(command, **kwargs):
+        attempts.append(command)
+        raise subprocess.CalledProcessError(
+            1, command, stderr="HTTP 401: Bad credentials",
+        )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        github.run_gh_read_command(
+            ["gh", "api", "repos/o/r/issues", "-f", "body=x"],
+            command_runner=run,
+        )
+    assert len(attempts) == 1
+
+
+def test_is_readonly_gh_command_table():
+    assert github._is_readonly_gh_command(
+        ["gh", "issue", "list", "--repo", "o/r"]) is True
+    assert github._is_readonly_gh_command(
+        ["gh", "api", "repos/o/r", "--method", "GET", "-f", "x=1"]) is True
+    assert github._is_readonly_gh_command(
+        ["gh", "api", "repos/o/r", "--method", "POST"]) is False
+    assert github._is_readonly_gh_command(
+        ["gh", "pr", "merge", "5"]) is False
+    assert github._is_readonly_gh_command(["gh"]) is False
+
+
+def test_parse_paginated_issue_array_validates_the_shape():
+    assert github.parse_paginated_issue_array(
+        '[[{"n": 1}],[{"n": 2}]]') == [{"n": 1}, {"n": 2}]
+    with pytest.raises(ValueError, match="array of arrays"):
+        github.parse_paginated_issue_array("[1]")
+    with pytest.raises(ValueError, match="non-object"):
+        github.parse_paginated_issue_array("[[1]]")
+
+
+def test_list_issues_query_is_pinned(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "[]")[1])
+
+    assert github.list_issues(
+        "o/r", label="ai-ready", milestone="v1",
+        json_fields="number,title", limit=7,
+    ) == []
+    assert captured == [[
+        "gh", "issue", "list", "--repo", "o/r",
+        "--label", "ai-ready",
+        "--json", "number,title", "--limit", "7",
+        "--milestone", "v1",
+    ]]
+
+
+def test_milestone_open_issues_keeps_the_runner_sweep_argv(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '[[{"number": 1}]]')[1])
+
+    assert github.milestone_open_issues("o/r", 5) == [{"number": 1}]
+    assert captured == [[
+        "gh", "api", "repos/o/r/issues?milestone=5&state=open&per_page=100",
+        "--paginate", "--slurp",
+    ]]
+
+
+def test_milestone_issues_keeps_the_release_scope_argv(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '[[{"number": 2}]]')[1])
+
+    assert github.milestone_issues("o/r", 5, "closed") == [{"number": 2}]
+    assert captured == [[
+        "gh", "api", "repos/o/r/issues?state=closed&milestone=5&per_page=100",
+        "--paginate", "--slurp",
+    ]]
+
+
+def test_list_milestones_reads_the_exact_api_page(monkeypatch):
+    captured = []
+    payload = json.dumps([[
+        {"number": 3, "title": "v0.3.0", "state": "open"},
+    ]])
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), payload)[1])
+
+    milestones = github.list_milestones("o/r")
+    assert [m["title"] for m in milestones] == ["v0.3.0"]
+    assert captured == [[
+        "gh", "api", "repos/o/r/milestones?state=all&per_page=100",
+        "--paginate", "--slurp",
+    ]]
+
+
+def test_milestone_open_issue_count_reads_githubs_own_counter(monkeypatch):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "2")
+    assert github.milestone_open_issue_count("o/r", "v1") == 2
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "")
+    with pytest.raises(RuntimeError, match="not found"):
+        github.milestone_open_issue_count("o/r", "vX")
+
+
+def test_close_milestone_patches_the_state(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "")[1])
+    github.close_milestone("o/r", 5)
+    assert captured == [[
+        "gh", "api", "repos/o/r/milestones/5",
+        "--method", "PATCH", "-f", "state=closed",
+    ]]
+
+
+def test_close_issue_closes_exactly_one_issue(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "")[1])
+    github.close_issue(9, repo="o/r")
+    assert captured == [["gh", "issue", "close", "9", "--repo", "o/r"]]
+
+
+def test_issue_view_returns_the_json_object(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '{"state": "CLOSED"}')[1])
+
+    details = github.issue_view(
+        12, "number,state,stateReason", repo="o/r")
+    assert details == {"state": "CLOSED"}
+    assert captured == [[
+        "gh", "issue", "view", "12", "--repo", "o/r",
+        "--json", "number,state,stateReason",
+    ]]
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "[]")
+    with pytest.raises(ValueError, match="JSON object"):
+        github.issue_view(12, "state", repo="o/r")
+
+
+def test_pr_view_keeps_the_repo_free_form(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '{"state": "OPEN"}')[1])
+
+    github.pr_view(7, fields="state,mergeable", timeout=9)
+    assert captured == [[
+        "gh", "pr", "view", "7", "--json", "state,mergeable",
+    ]]
+
+    github.pr_view(7, repo="o/r", fields="state")
+    assert captured[-1] == [
+        "gh", "pr", "view", "7", "--repo", "o/r", "--json", "state",
+    ]
+
+
+def test_commit_check_runs_returns_the_array(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '[{"name": "ci"}]')[1])
+
+    checks = github.commit_check_runs("o/r", "abc")
+    assert checks == [{"name": "ci"}]
+    assert captured == [[
+        "gh", "api", "repos/o/r/commits/abc/check-runs",
+        "--jq", ".check_runs",
+    ]]
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "{}")
+    with pytest.raises(ValueError, match="array"):
+        github.commit_check_runs("o/r", "abc")
+
+
+def test_release_view_create_and_edit_notes(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '{"tagName": "v1", "url": "u", "body": "b"}')[1])
+
+    release = github.release_view("o/r", "v1", fields="tagName,url,body")
+    assert release["url"] == "u"
+    assert captured[-1] == [
+        "gh", "release", "view", "v1", "--repo", "o/r",
+        "--json", "tagName,url,body",
+    ]
+
+    github.release_edit_notes("o/r", "v1", notes="notes text")
+    assert captured[-1] == [
+        "gh", "release", "edit", "v1", "--repo", "o/r",
+        "--notes", "notes text",
+    ]
+
+    github.release_create("o/r", tag="v1", version="v1", notes="notes text")
+    assert captured[-1] == [
+        "gh", "release", "create", "v1", "--repo", "o/r",
+        "--verify-tag", "--title", "v1", "--notes", "notes text",
+    ]
+
+
+def test_edit_issue_builds_add_and_remove_flags(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "")[1])
+
+    github.edit_issue(4, repo="o/r", add="ai-in-progress")
+    assert captured[-1] == [
+        "gh", "issue", "edit", "4", "--repo", "o/r",
+        "--add-label", "ai-in-progress",
+    ]
+
+    github.edit_issue(4, repo="o/r", remove="ai-ready")
+    assert captured[-1] == [
+        "gh", "issue", "edit", "4", "--repo", "o/r",
+        "--remove-label", "ai-ready",
+    ]
+
+
+def test_apply_label_patch_applies_the_idempotent_patch(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "")[1])
+
+    # ai-ready + claim -> ai-in-progress added; the ai-ready residue
+    # is kept by contract (delivery_labels.label_patch).
+    github.apply_label_patch(
+        4, repo="o/r", event="claim",
+        current_labels={"ai-ready"},
+    )
+    assert captured == [
+        ["gh", "issue", "edit", "4", "--repo", "o/r",
+         "--add-label", "ai-in-progress"],
+    ]
+
+    # A stale fix-needed residue is removed in the SAME edit call.
+    github.apply_label_patch(
+        4, repo="o/r", event="claim",
+        current_labels={"ai-ready", "ai-fix-needed"},
+    )
+    assert captured[-1] == [
+        "gh", "issue", "edit", "4", "--repo", "o/r",
+        "--add-label", "ai-in-progress", "--remove-label", "ai-fix-needed",
+    ]
+
+    # A no-op patch (no add, no remove) applies nothing. No real event
+    # produces one today — the guard is the contract, so the patch
+    # computation is stubbed to the empty patch here.
+    monkeypatch.setattr(github, "label_patch", lambda event, labels: ([], []))
+    captured.clear()
+    github.apply_label_patch(4, repo="o/r", event="claim", current_labels=set())
+    assert captured == []
+
+
+def test_comment_issue_wraps_the_body_in_the_status_format(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), "")[1])
+
+    github.comment_issue(4, repo="o/r", body="hello")
+    command = captured[0]
+    assert command[:7] == [
+        "gh", "issue", "comment", "4", "--repo", "o/r", "--body",
+    ]
+    assert "hello" in command[7]
+
+
+def test_issue_comments_validates_the_response_shape(monkeypatch):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        '{"comments": [{"author": {"login": "x"}}]}'))
+    comments = github.issue_comments(4, repo="o/r")
+    assert comments == [{"author": {"login": "x"}}]
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: '"str"')
+    with pytest.raises(ValueError, match="JSON object"):
+        github.issue_comments(4, repo="o/r")
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: '{"comments": 1}')
+    with pytest.raises(ValueError, match="JSON array"):
+        github.issue_comments(4, repo="o/r")
+
+
+def test_pr_comments_reads_through_pr_view(monkeypatch):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        '{"comments": []}'))
+    assert github.pr_comments(4, repo="o/r") == []
+
+
+def test_trusted_issue_comments_block_keeps_newest_and_states_omissions():
+    comments = [
+        {"author": {"login": "a"}, "authorAssociation": "OWNER",
+         "createdAt": "t1", "body": "one"},
+        {"author": {"login": "b"}, "authorAssociation": "NONE",
+         "createdAt": "t2", "body": "injected"},
+        {"author": {"login": "c"}, "authorAssociation": "MEMBER",
+         "createdAt": "t3", "body": "two"},
+    ]
+    block = github.trusted_issue_comments_block(comments, limit=1)
+    assert "1 older trusted comment omitted" in block
+    assert "c (MEMBER)" in block
+    assert "two" in block
+    assert "injected" not in block
+    assert "one" not in block
+
+    assert github.trusted_issue_comments_block([], limit=3) == \
+        "(no trusted comments)"
+
+
+def test_comment_is_trusted_by_association_and_by_bot_login(monkeypatch):
+    assert github._comment_is_trusted(
+        {"authorAssociation": "MAINTAINER"}) is True
+    assert github._comment_is_trusted("not-a-comment") is False
+
+    status = "account orbi-bot\nActive account: true\n"
+
+    def fake_status(command, **kwargs):
+        return status
+
+    monkeypatch.setattr(seam, "run_gh_read_command", fake_status)
+    assert github._comment_is_trusted(
+        {"author": {"login": "orbi-bot"}, "authorAssociation": "NONE"},
+    ) is True
+    assert github._comment_is_trusted(
+        {"author": {"login": "someone-else"},
+         "authorAssociation": "NONE"},
+    ) is False
+
+
+def test_authenticated_github_login_requires_an_active_account(monkeypatch):
+    monkeypatch.setattr(seam, "run_gh_read_command",
+        lambda c, **k: "account a\nActive account: true\n")
+    assert github._authenticated_github_login() == "a"
+
+    monkeypatch.setattr(seam, "run_gh_read_command",
+        lambda c, **k: "account a\n")
+    with pytest.raises(ValueError, match="active account"):
+        github._authenticated_github_login()
+
+
+def test_open_pr_for_branch_returns_the_sole_open_pr(monkeypatch):
+    one = json.dumps([{"number": 5, "url": "u"}])
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: one)
+    pr = github.open_pr_for_branch("/repo", "orbi/o-r-issue-4")
+    assert pr == {"number": 5, "url": "u"}
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "")
+    assert github.open_pr_for_branch("/repo", "branch") is None
+
+    two = json.dumps([{"number": 5}, {"number": 6}])
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: two)
+    with pytest.raises(RuntimeError, match="multiple open PRs"):
+        github.open_pr_for_branch("/repo", "branch")
+
+
+def test_issue_labels_returns_names_and_validates_shape(monkeypatch):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        '{"labels": [{"name": "ai-ready"}, {"name": "p0"}]}'))
+    assert github.issue_labels(4, "o/r") == ["ai-ready", "p0"]
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "[]")
+    with pytest.raises(ValueError, match="JSON object"):
+        github.issue_labels(4, "o/r")
+
+
+def test_has_in_progress_label_reads_the_live_label_state(monkeypatch):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        '{"labels": [{"name": "ai-in-progress"}]}'))
+    assert github.has_in_progress_label(4, "o/r") is True
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        '{"labels": [{"name": "ai-ready"}]}'))
+    assert github.has_in_progress_label(4, "o/r") is False
+
+
+def test_pr_delivery_status_parses_state_and_check_summaries(monkeypatch):
+    payload = json.dumps({
+        "state": "OPEN",
+        "statusCheckRollup": [
+            {"name": "ci", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"context": "legacy", "state": "PENDING"},
+        ],
+    })
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: payload)
+    state, summaries = github.pr_delivery_status(
+        "https://github.com/o/r/pull/9", "o/r")
+    assert state == "OPEN"
+    assert summaries == ["ci=COMPLETED/SUCCESS", "legacy=PENDING"]
+    assert github.pr_state("https://github.com/o/r/pull/9", "o/r") == "OPEN"
+
+    bad = json.dumps({"state": "WEIRD", "statusCheckRollup": None})
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: bad)
+    with pytest.raises(ValueError, match="unexpected PR state"):
+        github.pr_delivery_status("https://github.com/o/r/pull/9", "o/r")
+
+
+def test_issue_priority_reads_the_p0_label():
+    assert github.issue_priority(
+        {"labels": [{"name": "p0"}]}) == "p0"
+    assert github.issue_priority(
+        {"labels": [{"name": "bug"}]}) == "normal"
+    assert github.issue_priority({}) == "normal"
+
+
+def test_epic_issue_with_blockers_refetches_when_blocked_by_missing(monkeypatch):
+    listed = {"number": 8, "labels": [{"name": "ai-epic"}]}
+    assert github.epic_issue_with_blockers(
+        "o/r", {**listed, "blockedBy": {"nodes": []}}) == {
+            "number": 8, "labels": [{"name": "ai-epic"}],
+            "blockedBy": {"nodes": []}}
+
+    payload = json.dumps(
+        {"number": 8, "blockedBy": {"nodes": []}})
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: payload)
+    details = github.epic_issue_with_blockers("o/r", listed)
+    assert details["blockedBy"] == {"nodes": []}
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "[]")
+    with pytest.raises(ValueError, match="not an object"):
+        github.epic_issue_with_blockers("o/r", listed)
+
+
+def test_open_blocker_numbers_fails_open_and_keeps_open_only():
+    assert github.open_blocker_numbers({}) == []
+    assert github.open_blocker_numbers({"blockedBy": "junk"}) == []
+    issue = {"blockedBy": {"nodes": [
+        {"number": 1, "state": "OPEN"},
+        {"number": 2, "state": "CLOSED"},
+        {"number": 3},  # no explicit state counts as open
+        {"number": "x"},
+    ]}}
+    assert github.open_blocker_numbers(issue) == [1, 3]
+
+
+def test_issue_view_without_repo_runs_in_the_checkout_context(monkeypatch):
+    captured = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        captured.append(c), '{"state": "OPEN"}')[1])
+
+    github.issue_view(7, "state", timeout=30)
+    assert captured == [["gh", "issue", "view", "7", "--json", "state"]]
+
+
+def test_release_view_validates_the_response_shape(monkeypatch):
+    monkeypatch.setattr(github, "run_command", lambda c, **k: "[]")
+    with pytest.raises(ValueError, match="release view must be a JSON object"):
+        github.release_view("o/r", "v1", fields="tagName,url")
+
+
+def test_authenticated_github_login_fails_fast_when_auth_status_fails(monkeypatch):
+    def failing(command, **kwargs):
+        raise subprocess.CalledProcessError(1, command, stderr="no auth")
+
+    monkeypatch.setattr(github, "run_gh_read_command", failing)
+    with pytest.raises(ValueError, match="identity resolution failed"):
+        github._authenticated_github_login()
+
+
+def test_authenticated_github_login_requires_an_account_line(monkeypatch):
+    # An Active-account marker without any account name resolves nothing.
+    monkeypatch.setattr(
+        github, "run_gh_read_command",
+        lambda c, **k: "Active account: true\n")
+    with pytest.raises(ValueError, match="active account"):
+        github._authenticated_github_login()

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -1,0 +1,247 @@
+"""Unit tests for the `orbi.gitops` leaf (Issue #785).
+
+fetch / push-ordering / worktree / ancestor checks at the single
+`run_command` seam: fakes patch the module seam or inject a
+`command_runner`, and the git argv is asserted where the argv is the
+contract. No test patches `runner` internals.
+"""
+import fcntl
+import os
+import subprocess
+import time
+
+import pytest
+
+from orbi import gitops
+from seam import seam
+
+
+def test_module_is_a_leaf_and_never_imports_runner_release_pi_process():
+    with open(gitops.__file__, encoding="utf-8") as handle:
+        source = handle.read()
+    for forbidden in ("from orbi.runner", "from orbi import runner",
+                      "import orbi.runner", "from orbi.release",
+                      "from orbi import release", "from orbi.pi_process",
+                      "from orbi import pi_process"):
+        assert forbidden not in source, forbidden
+
+
+def test_task_branch_is_the_stable_delivery_identity():
+    assert gitops.task_branch("orbi-build/orbi", 785) == \
+        "orbi/orbi-build-orbi-issue-785"
+    # The run id is accepted for compatibility but never part of the name:
+    # retries must converge on one branch and one PR.
+    assert gitops.task_branch("o/r", 4, "a1b2c3d4") == "orbi/o-r-issue-4"
+
+
+def test_worktree_path_names_the_run_isolated_worktree(tmp_path):
+    path = gitops.worktree_path(tmp_path, "orbi-build/orbi", 785, "a1b2c3d4")
+    assert path == (
+        tmp_path / ".worktrees" / "orbi-orbi-build-orbi-issue-785-a1b2c3d4"
+    )
+
+
+def test_latest_run_id_reads_the_newest_worktree(tmp_path):
+    base = tmp_path / ".worktrees"
+    (base / "orbi-o-r-issue-4-aaaaaaaa").mkdir(parents=True)
+    older = base / "orbi-o-r-issue-4-aaaaaaaa"
+    newer = base / "orbi-o-r-issue-4-bbbbbbbb"
+    newer.mkdir()
+    os.utime(older, (1, 1))
+    assert gitops.latest_run_id(tmp_path, "o/r", 4) == "bbbbbbbb"
+
+    empty = tmp_path / ".worktrees-empty"
+    empty.mkdir()
+    assert gitops.latest_run_id(empty.parent, "o/r", 99) is None
+
+
+def test_is_ancestor_maps_exit_1_to_false(monkeypatch):
+    commands = []
+
+    def ok(command, **kwargs):
+        commands.append(command)
+        return ""
+
+    def negative(command, **kwargs):
+        commands.append(command)
+        raise subprocess.CalledProcessError(1, command)
+
+    def broken(command, **kwargs):
+        raise subprocess.CalledProcessError(128, command)
+
+    # exit 0 -> True
+    monkeypatch.setattr(seam, "run_command", ok)
+    assert gitops._is_ancestor("c1", "c2", cwd="/w") is True
+    assert commands[-1] == ["git", "merge-base", "--is-ancestor", "c1", "c2"]
+
+    monkeypatch.setattr(seam, "run_command", negative)
+    assert gitops._is_ancestor("c1", "c2", cwd="/w") is False
+
+    monkeypatch.setattr(seam, "run_command", broken)
+    with pytest.raises(subprocess.CalledProcessError):
+        gitops._is_ancestor("c1", "c2", cwd="/w")
+
+
+def test_stable_branch_exists_probes_the_remote_head(monkeypatch):
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append((command, kwargs))
+        return "ref\toid\n"
+
+    monkeypatch.setattr(seam, "run_command", run)
+    assert gitops.stable_branch_exists("/repo", "orbi/o-r-issue-4") is True
+    command, kwargs = commands[-1]
+    assert command == [
+        "git", "ls-remote", "--heads", "origin",
+        "refs/heads/orbi/o-r-issue-4",
+    ]
+    assert kwargs["cwd"] == "/repo"
+    assert kwargs["timeout"] == gitops.GIT_NETWORK_TIMEOUT_SECONDS
+
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "")
+    assert gitops.stable_branch_exists("/repo", "branch") is False
+
+
+def test_create_worktree_from_the_frozen_base_sha(monkeypatch, tmp_path):
+    commands = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        commands.append(c), "")[1])
+
+    path = gitops.create_worktree(
+        tmp_path, "o/r", 4, "a1b2c3d4", "base123",
+    )
+    assert path == tmp_path / ".worktrees" / "orbi-o-r-issue-4-a1b2c3d4"
+    assert commands == [
+        ["git", "branch", "--list", "orbi/o-r-issue-4"],
+        ["git", "worktree", "add", "-b", "orbi/o-r-issue-4", str(path),
+         "base123"],
+    ]
+
+
+def test_create_worktree_reuses_a_local_orphan_branch(monkeypatch, tmp_path):
+    commands = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        commands.append(c), "orbi/o-r-issue-4")[1])
+
+    path = gitops.create_worktree(
+        tmp_path, "o/r", 4, "a1b2c3d4", "base123",
+    )
+    assert commands == [
+        ["git", "branch", "--list", "orbi/o-r-issue-4"],
+        ["git", "worktree", "add", str(path), "orbi/o-r-issue-4"],
+    ]
+
+
+def test_create_worktree_fetches_an_existing_remote_branch(
+    monkeypatch, tmp_path,
+):
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        return ""
+
+    monkeypatch.setattr(seam, "run_command", run)
+    path = gitops.create_worktree(
+        tmp_path, "o/r", 4, "a1b2c3d4", "base123",
+        existing_branch=True,
+    )
+    assert commands == [
+        ["git", "fetch", "origin", "orbi/o-r-issue-4"],
+        ["git", "branch", "--list", "orbi/o-r-issue-4"],
+        ["git", "worktree", "add", "-b", "orbi/o-r-issue-4", str(path),
+         "origin/orbi/o-r-issue-4"],
+    ]
+
+
+def test_create_worktree_returns_the_existing_path(monkeypatch, tmp_path):
+    commands = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        commands.append(c), "")[1])
+    existing = tmp_path / ".worktrees" / "orbi-o-r-issue-4-a1b2c3d4"
+    existing.mkdir(parents=True)
+    assert gitops.create_worktree(
+        tmp_path, "o/r", 4, "a1b2c3d4", "base123", existing=existing,
+    ) == existing
+    assert commands == []
+
+
+def test_create_release_worktree_reuses_the_registered_worktree(
+    monkeypatch, tmp_path,
+):
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if command[:3] == ["git", "worktree", "list"]:
+            return (
+                f"worktree {tmp_path / '.worktrees' / 'orbi-o-r-issue-4-deadbeef'}\n"
+                "HEAD abc\nbranch refs/heads/orbi/o-r-issue-4\n\n"
+            )
+        return ""
+
+    monkeypatch.setattr(seam, "run_command", run)
+    path = gitops.create_release_worktree(
+        tmp_path, "o/r", 4, "deadbeef", "release123",
+    )
+    assert path == tmp_path / ".worktrees" / "orbi-o-r-issue-4-deadbeef"
+    assert commands[-1] == ["git", "reset", "--hard", "release123"]
+
+
+def test_freeze_base_fetches_under_the_lock_then_reads_the_sha(
+    monkeypatch, tmp_path,
+):
+    commands = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        commands.append(c), "abc1234")[1])
+
+    sha = gitops.freeze_base(tmp_path, "main")
+    assert sha == "abc1234"
+    assert commands == [
+        ["git", "fetch", "origin", "main"],
+        ["git", "rev-parse", "origin/main"],
+    ]
+    assert (tmp_path / ".orbi" / "base-sync.lock").is_file()
+
+
+def test_base_sync_lock_is_released_after_the_fetch(monkeypatch, tmp_path):
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: "")
+    gitops.fetch_base_ref(tmp_path, "main", lock_timeout_seconds=1.0)
+    # The lock is exclusive while held; after the call another flock must
+    # succeed immediately.
+    probe = os.open(
+        str(gitops.base_sync_lock_path(tmp_path)),
+        os.O_RDWR | os.O_CREAT, 0o644,
+    )
+    try:
+        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        fcntl.flock(probe, fcntl.LOCK_UN)
+        os.close(probe)
+
+
+def test_acquire_base_sync_lock_times_out_fail_fast(tmp_path):
+    lock_path = gitops.base_sync_lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(gitops.BaseSyncLockError, match="base-sync.lock"):
+            gitops.acquire_base_sync_lock(tmp_path, 0.2)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def test_fetch_base_ref_runs_the_fetch_in_the_requested_cwd(
+    monkeypatch, tmp_path,
+):
+    commands = []
+    monkeypatch.setattr(seam, "run_command", lambda c, **k: (
+        commands.append((c, k)), "")[1])
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    gitops.fetch_base_ref(tmp_path, "main", cwd=worktree)
+    assert commands[-1][0] == ["git", "fetch", "origin", "main"]
+    assert commands[-1][1]["cwd"] == worktree

--- a/tests/test_human_review.py
+++ b/tests/test_human_review.py
@@ -19,6 +19,8 @@ from orbi import delivery_labels as dl
 from orbi import human_review
 
 import orbi.runner as runner
+from seam import seam
+import orbi.journal as journal
 
 REPO = "owner/repo"
 PR_URL = f"https://github.com/{REPO}/pull/46"
@@ -258,20 +260,18 @@ def gate_env(tmp_path, monkeypatch):
         reviews.append((worktree, branch, config))
         return False
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "issue_labels",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "issue_labels",
                         lambda *a, **k: ["ai-pr-opened"])
-    monkeypatch.setattr(
-        runner, "issue_comments",
+    monkeypatch.setattr(seam, "issue_comments",
         lambda *a, **k: (calls.__setitem__("comments", calls["comments"] + 1)
                          or _scene_comments()),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda number, **kwargs: calls["edit"].append(kwargs),
     )
     monkeypatch.setattr(runner, "review_and_merge_if_clean", fake_review)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", RUN_ID)
     return {"worktree": worktree, "calls": calls, "reviews": reviews}
 
 
@@ -307,8 +307,7 @@ def test_gate_on_with_column2_holds_without_any_session(gate_env, tmp_path):
 def test_gate_on_second_tick_does_not_rewrite_the_waiting_patch(
     gate_env, tmp_path, monkeypatch,
 ):
-    monkeypatch.setattr(
-        runner, "issue_labels",
+    monkeypatch.setattr(seam, "issue_labels",
         lambda *a, **k: ["ai-ready", "ai-pr-opened"],
     )
     outcome = _round(_gate_config(tmp_path))
@@ -319,8 +318,7 @@ def test_gate_on_second_tick_does_not_rewrite_the_waiting_patch(
 
 def test_gate_on_with_the_human_label_runs_the_review(gate_env, tmp_path,
                                                       monkeypatch):
-    monkeypatch.setattr(
-        runner, "issue_labels",
+    monkeypatch.setattr(seam, "issue_labels",
         lambda *a, **k: ["ai-pr-opened", dl.HUMAN_REVIEW_LABEL],
     )
     outcome = _round(_gate_config(tmp_path))
@@ -332,12 +330,10 @@ def test_gate_on_with_the_human_label_runs_the_review(gate_env, tmp_path,
 def test_gate_on_with_empty_column2_passes_without_the_label(
     gate_env, tmp_path, monkeypatch,
 ):
-    monkeypatch.setattr(
-        runner, "issue_labels",
+    monkeypatch.setattr(seam, "issue_labels",
         lambda *a, **k: ["ai-pr-opened"],
     )
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: "tests/test_new.py\n",
     )
     outcome = _round(_gate_config(tmp_path))
@@ -386,7 +382,7 @@ def test_delivered_changed_files_failure_is_missing_evidence(
     def boom(command, **kwargs):
         raise RuntimeError("git down")
 
-    monkeypatch.setattr(runner, "run_command", boom)
+    monkeypatch.setattr(seam, "run_command", boom)
     assert runner.delivered_changed_files(worktree, "main") is None
     # Missing evidence lands in column 2 (the gate holds).
     checklist = human_review.build_checklist(

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,183 @@
+"""Unit tests for the `orbi.journal` leaf (Issue #785).
+
+`orbi.journal` is the Runner kernel the extracted leaf modules share: the
+`orbi.bootstrap` logger with the `[run_id]` filter, the run-id binding, and
+the single subprocess seam (`run_command` + its bounded git network retry).
+The tests fake the seam with injected fakes or tiny real subprocesses —
+they never patch `runner` internals.
+"""
+import logging
+import subprocess
+import sys
+
+import pytest
+
+from orbi import journal
+import orbi.journal as journal
+
+
+@pytest.fixture(autouse=True)
+def _reset_journal_state(monkeypatch):
+    """Isolate the module-level run binding between tests."""
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", None)
+
+
+def test_run_command_returns_stdout_and_logs_the_command(caplog):
+    with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
+        out = journal.run_command(
+            [sys.executable, "-c", "print('out' + '_42')"],
+        )
+    assert out == "out_42"
+    assert "command=" in caplog.text
+    # stdout is not logged unless log_stdout is requested.
+    assert "out_42" not in caplog.text
+
+
+def test_run_command_fail_fast_logs_and_raises(caplog):
+    with caplog.at_level(logging.ERROR, logger="orbi.bootstrap"):
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            journal.run_command(
+                [sys.executable, "-c",
+                 "import sys; print('boom'); sys.exit(3)"],
+            )
+    assert excinfo.value.returncode == 3
+    assert "command_failed" in caplog.text
+    assert "returncode=3" in caplog.text
+    assert "boom" in caplog.text
+
+
+def test_run_command_timeout_is_logged_and_raised(caplog):
+    with caplog.at_level(logging.ERROR, logger="orbi.bootstrap"):
+        with pytest.raises(subprocess.TimeoutExpired):
+            journal.run_command(
+                [sys.executable, "-c", "import time; time.sleep(5)"],
+                timeout=1,
+            )
+    assert "command_timeout" in caplog.text
+
+
+def test_run_id_filter_prefixes_journal_lines_only_while_bound(caplog):
+    logger = logging.getLogger("orbi.bootstrap")
+    with caplog.at_level(logging.INFO, logger="orbi.bootstrap"):
+        logger.info("unbound line")
+        journal.set_run_id("a1b2c3d4")
+        logger.info("bound line")
+    assert "unbound line" in caplog.text
+    assert "[a1b2c3d4] bound line" in caplog.text
+    assert journal.current_run_id() == "a1b2c3d4"
+
+
+def test_set_run_id_rejects_an_invalid_id():
+    with pytest.raises(ValueError, match="invalid run id"):
+        journal.set_run_id("not-a-run-id")
+
+
+def test_new_run_id_is_eight_hex_characters():
+    value = journal.new_run_id()
+    assert len(value) == 8
+    int(value, 16)
+
+
+def test_issue_context_formats_the_journal_reference():
+    assert journal.issue_context("orbi-build/orbi", 785) == "orbi-build/orbi#785"
+
+
+def test_validate_run_id_accepts_only_eight_hex_characters():
+    assert journal.validate_run_id("a1b2c3d4") == "a1b2c3d4"
+    with pytest.raises(ValueError, match="invalid run id"):
+        journal.validate_run_id("zzzzzzzz")
+    with pytest.raises(ValueError, match="invalid run id"):
+        journal.validate_run_id(None)
+
+
+def test_active_run_scene_binds_and_clears():
+    journal.set_active_run(785, "title", "branch", "/tmp/wt")
+    scene = journal.active_run()
+    assert scene == {
+        "issue": 785, "title": "title", "branch": "branch",
+        "worktree": "/tmp/wt", "pi": None,
+    }
+    process = object()
+    journal.set_active_pi(process)
+    assert journal.active_run()["pi"] is process
+    journal.set_active_pi(None)
+    assert journal.active_run()["pi"] is None
+    journal.clear_active_run()
+    assert journal.active_run() is None
+
+
+def test_set_active_pi_without_a_bound_run_is_a_no_op():
+    journal.clear_active_run()
+    journal.set_active_pi(object())  # must not raise
+    assert journal.active_run() is None
+
+
+def test_single_line_flattens_line_breaks():
+    assert journal.single_line("a\r\nb\nc\rd") == "a\\nb\\nc\\nd"
+
+
+def test_log_format_has_no_timestamp():
+    assert journal.log_format() == "%(levelname)s %(message)s"
+
+
+def test_git_network_command_retries_transient_failure_then_succeeds(
+    monkeypatch, caplog,
+):
+    calls, sleeps = [], []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if len(calls) < 3:
+            raise subprocess.CalledProcessError(
+                128, command, stderr="fatal: unable to access "
+                "'https://example.com': connection timed out",
+            )
+        return "ok"
+
+    monkeypatch.setattr(journal.time, "sleep", sleeps.append)
+    with caplog.at_level(logging.WARNING, logger="orbi.bootstrap"):
+        assert journal.run_git_network_command(
+            ["git", "fetch", "origin", "main"],
+            command_runner=fake_run,
+        ) == "ok"
+    assert len(calls) == 3
+    assert sleeps == [1, 2]
+    assert "git_network_retry" in caplog.text
+
+
+def test_git_network_command_never_retries_a_deterministic_failure(caplog):
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        raise subprocess.CalledProcessError(
+            128, command, stderr="fatal: not a git repository",
+        )
+
+    with caplog.at_level(logging.WARNING, logger="orbi.bootstrap"):
+        with pytest.raises(subprocess.CalledProcessError):
+            journal.run_git_network_command(
+                ["git", "fetch", "origin", "main"],
+                command_runner=fake_run,
+            )
+    assert len(calls) == 1  # no transient marker -> no retry
+
+
+def test_git_network_command_gives_up_after_max_attempts(monkeypatch):
+    calls, sleeps = [], []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        raise subprocess.CalledProcessError(
+            128, command, stderr="connection reset",
+        )
+
+    monkeypatch.setattr(journal.time, "sleep", sleeps.append)
+    with pytest.raises(subprocess.CalledProcessError):
+        journal.run_git_network_command(
+            ["git", "fetch", "origin", "main"],
+            command_runner=fake_run,
+        )
+    assert len(calls) == 3
+    assert sleeps == [1, 2]

--- a/tests/test_ops_e2e.py
+++ b/tests/test_ops_e2e.py
@@ -33,6 +33,7 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+import orbi.journal as journal
 
 REPO = "owner/repo"
 ISSUE_NUMBER = 99
@@ -342,7 +343,7 @@ def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def ops_issue() -> dict:

--- a/tests/test_orbi.py
+++ b/tests/test_orbi.py
@@ -9,6 +9,7 @@ import pytest
 
 import orbi.runner as runner
 import orbi.cli as orbi
+from seam import seam
 
 
 def _write_prompts(tmp_path):
@@ -81,8 +82,7 @@ def test_dispatch_issue_propagates_create_failure(monkeypatch):
 def test_list_labeled_issues_queries_github_with_label_and_state(monkeypatch):
     issue = {"number": 3, "title": "task", "url": "u"}
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command)
         or json.dumps([issue]),
     )
@@ -98,7 +98,7 @@ def test_list_labeled_issues_queries_github_with_label_and_state(monkeypatch):
 
 
 def test_list_labeled_issues_returns_empty_list_when_idle(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]")
     assert orbi.list_labeled_issues("xqliu/orbi", "ai-ready") == []
 
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -883,3 +883,22 @@ def test_publisher_failure_scene_never_touches_another_run():
         "--method", "POST", "--field",
         f"body={progress.format_status_comment(new_body)}",
     ]
+
+
+def test_progress_state_survives_an_activity_snapshot_failure(monkeypatch, tmp_path):
+    """The snapshot is best-effort: a read failure is logged and reported
+    as "no session yet", it never blocks the task (Issue #18)."""
+    import orbi.progress as progress
+
+    def boom(_path):
+        raise RuntimeError("unreadable session")
+
+    monkeypatch.setattr(progress, "activity_snapshot", boom)
+    state = progress._progress_state(
+        issue=4, title="t", run_id="a1b2c3d4", role="review",
+        branch="b", worktree=tmp_path, started=0.0,
+        pr_url=None, review_round=0, priority="normal",
+    )
+    assert state["phase"] == "starting"
+    assert state["last_activity"] is None
+    assert state["session"] is None

--- a/tests/test_progress_wiring.py
+++ b/tests/test_progress_wiring.py
@@ -17,6 +17,8 @@ import pytest
 
 import orbi.runner as runner
 import orbi.release as release
+from seam import seam
+import orbi.journal as journal
 from orbi import pi_process, progress
 
 
@@ -57,11 +59,11 @@ def make_fake_gh(monkeypatch, comments=None, in_progress=False):
             return json.dumps([{"number": 18}] if in_progress else [])
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     # Issue #286: the release subsystem (orbi.release) resolves the gh
     # primitive in its own module globals — moved-path callers of this
     # helper must see the same fake there.
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls, posted
 
 
@@ -78,10 +80,10 @@ def make_issue():
 
 
 def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "freeze_base",
+    monkeypatch.setattr(seam, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "freeze_base",
                         lambda repo_dir, base_branch: "abc123def456")
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
 
     def fake_create_worktree(*args, **kwargs):
         path = tmp_path / "wt"
@@ -91,7 +93,7 @@ def patch_process_deps(monkeypatch, tmp_path, *, run_pi_side_effect=None):
         (path / ".orbi").mkdir(exist_ok=True)
         return path
 
-    monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
+    monkeypatch.setattr(seam, "create_worktree", fake_create_worktree)
     monkeypatch.setattr(
         runner, "activity_snapshot",
         lambda session_dir: {
@@ -295,8 +297,7 @@ def test_read_test_result_reports_error_summary(tmp_path):
 
 
 def test_delivery_head_advanced_detects_new_commits(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: "1111111111111111111111111111111111111111",
     )
     assert runner.delivery_head_advanced(
@@ -307,8 +308,7 @@ def test_delivery_head_advanced_detects_new_commits(monkeypatch, tmp_path):
 def test_delivery_head_advanced_is_false_when_head_equals_base(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: "2222222222222222222222222222222222222222",
     )
     assert runner.delivery_head_advanced(
@@ -317,8 +317,7 @@ def test_delivery_head_advanced_is_false_when_head_equals_base(
 
 
 def test_delivery_head_advanced_fails_fast_when_git_fails(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: (_ for _ in ()).throw(
             subprocess.CalledProcessError(128, command, stderr="not a repo"),
         ),
@@ -457,7 +456,7 @@ def test_process_issue_p0_progress_comment_and_milestones_carry_priority(
     patch_process_deps(monkeypatch, tmp_path)
     edit = Mock()
     # AFTER patch_process_deps: it installs its own edit_issue mock.
-    monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(seam, "edit_issue", edit)
     issue = make_issue()
     issue["labels"] = [{"name": "p0"}, {"name": "ai-ready"}]
     runner.process_issue(issue, make_config(tmp_path), "xqliu/orbi")
@@ -491,7 +490,7 @@ def test_process_issue_p0_failure_enters_ai_blocked_terminal_state(
     )
     edit = Mock()
     # AFTER patch_process_deps: it installs its own edit_issue mock.
-    monkeypatch.setattr(runner, "edit_issue", edit)
+    monkeypatch.setattr(seam, "edit_issue", edit)
     issue = make_issue()
     issue["labels"] = [{"name": "p0"}, {"name": "ai-ready"}]
     # Issue #239: the failure is terminal — `process_issue` returns `None`
@@ -705,7 +704,7 @@ def test_process_issue_repeated_recoverable_failure_updates_one_comment(
             return json.dumps({"labels": [{"name": "ai-ready"}]})
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_gh)
+    monkeypatch.setattr(seam, "run_command", fake_gh)
     quota_error = runner.RecoverablePiProcessError(
         1, ["pi", "--provider", "z-ai", "--model", "glm-5.3-flash"],
         stderr=(
@@ -819,7 +818,7 @@ def test_process_issue_keeps_the_claim_when_the_journal_proves_the_request(
         (worktree / ".orbi").mkdir(exist_ok=True)
         return worktree
 
-    monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
+    monkeypatch.setattr(seam, "create_worktree", fake_create_worktree)
     result = runner.process_issue(
         make_issue(), make_config(tmp_path), "xqliu/orbi",
     )
@@ -1037,11 +1036,11 @@ def make_failing_gh(monkeypatch, is_failing, comments=None):
             return "[]"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     # Issue #286: the release subsystem (orbi.release) resolves the gh
     # primitive in its own module globals — moved-path callers of this
     # helper must see the same fake there.
-    monkeypatch.setattr(release, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
     return calls, posted
 
 
@@ -1080,7 +1079,7 @@ def test_process_issue_delivered_patch_failure_does_not_fail_delivery(
     calls, posted = make_failing_gh(monkeypatch, _progress_patch_of)
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1129,7 +1128,7 @@ def test_process_issue_pr_opened_scene_has_no_duplicate_milestone(
     )
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1180,7 +1179,7 @@ def test_process_issue_scene_comment_failure_fails_delivery(
     )
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1298,7 +1297,7 @@ def test_process_issue_ensure_failure_does_not_fail_delivery(
     )
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1343,7 +1342,7 @@ def test_process_issue_started_scene_has_no_duplicate_milestone(
     )
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1378,7 +1377,7 @@ def test_process_issue_plan_test_milestone_failures_do_not_fail_delivery(
     )
     patch_process_deps(monkeypatch, tmp_path)
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1438,7 +1437,7 @@ def test_process_issue_failure_path_progress_failure_keeps_blocked_transition(
         ),
     )
     edits = []
-    monkeypatch.setattr(runner, "edit_issue", lambda number, **kwargs:
+    monkeypatch.setattr(seam, "edit_issue", lambda number, **kwargs:
                         edits.append(kwargs))
     caplog.set_level("ERROR")
 
@@ -1594,8 +1593,8 @@ def _run_review_and_merge(monkeypatch, tmp_path, *, verdict,
     # The fake rejects anything that is not progress API traffic.
     with pytest.raises(AssertionError, match="unexpected command"):
         fake_run_command(["gh", "release", "list"])
-    monkeypatch.setattr(runner, "run_command", fake_run_command)
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "run_command", fake_run_command)
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: {
         "number": 4, "url": "https://github.com/xqliu/orbi/pull/40",
         "base_ref": "main", "base_oid": "b1",
@@ -1606,11 +1605,10 @@ def _run_review_and_merge(monkeypatch, tmp_path, *, verdict,
     # on ProgressPublisher's bypass behavior.
     monkeypatch.setattr(runner, "check_review_ci", lambda *a, **k: "ci ok")
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda number, **kwargs: edits.append(kwargs),
     )
-    monkeypatch.setattr(runner, "comment_issue", Mock())
+    monkeypatch.setattr(seam, "comment_issue", Mock())
     monkeypatch.setattr(runner, "comment_pr", Mock())
     if "pass" in verdict:
         monkeypatch.setattr(runner, "merge_gate", lambda *a, **k: {
@@ -1795,9 +1793,9 @@ def test_wait_for_delivery_closed_unmerged_posts_blocked_milestone(
         fail_progress=lambda command: False,
         api_calls=api_calls, posted=posted,
     )
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "comment_issue", Mock())
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "comment_issue", Mock())
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.wait_for_delivery(
         pr_url, {"number": 39, "title": "t", "body": ""}, {}, "owner/repo",
     )
@@ -1860,9 +1858,9 @@ def test_wait_for_delivery_review_failure_finishes_progress_comment_with_blocked
         fail_progress=lambda command: False,
         api_calls=api_calls, posted=posted,
     )
-    monkeypatch.setattr(runner, "edit_issue", Mock())
-    monkeypatch.setattr(runner, "comment_issue", Mock())
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "edit_issue", Mock())
+    monkeypatch.setattr(seam, "comment_issue", Mock())
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.wait_for_delivery(
         pr_url, {"number": 39, "title": "t", "body": ""},
         {"repo_dir": Path("/srv/repo")}, "owner/repo",
@@ -1941,7 +1939,7 @@ def _wait_delivery_fake_gh(monkeypatch, *, pr_state, labels, comments,
                                "url": "https://x/78"})
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
 
 def _review_round_comments():
@@ -1996,16 +1994,14 @@ def test_wait_for_delivery_closed_unmerged_progress_failure_still_releases(
         posted=posted,
     )
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda number, **kwargs: edits.append(kwargs),
     )
     comments = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, **kwargs: comments.append(kwargs),
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("ERROR")
 
     # No exception: the loop completed the terminal failure and the
@@ -2076,16 +2072,14 @@ def test_wait_for_delivery_review_failure_progress_failure_still_releases(
         posted=posted,
     )
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda number, **kwargs: edits.append(kwargs),
     )
     comments = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, **kwargs: comments.append(kwargs),
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("ERROR")
 
     # No exception: the loop completed the terminal failure and the
@@ -2174,8 +2168,7 @@ def _make_takeover_gh(monkeypatch, monkeypatched, tmp_path, *, pr_state="OPEN",
             return ""
         return ""
 
-    monkeypatched.append(monkeypatch.setattr(
-        runner, "run_command", fake_run_command))
+    monkeypatched.append(monkeypatch.setattr(seam, "run_command", fake_run_command))
     return calls, posted
 
 
@@ -2197,7 +2190,7 @@ def test_process_issue_claims_external_pr_and_skips_run_pi(
         (path / ".orbi").mkdir(exist_ok=True)
         return path
 
-    monkeypatch.setattr(runner, "create_worktree", fake_create_worktree)
+    monkeypatch.setattr(seam, "create_worktree", fake_create_worktree)
     issue = {
         "number": 608, "title": "external PR CI failure",
         "body": EXTERNAL_PR_BODY,
@@ -2258,7 +2251,7 @@ def _external_wait_fake(monkeypatch, *, pr_state, fail_progress=None):
             return ""
         return json.dumps({"labels": [{"name": "ai-pr-opened"}]})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return close_calls, comments
 
 
@@ -2266,8 +2259,8 @@ def test_wait_for_delivery_external_merge_closes_the_triage_issue(monkeypatch):
     """Issue #608: merging the external PR closes the triage Issue (the
     PR body carries no `Fixes #N` for it) — 合并外部 PR 即关票."""
     close_calls, _ = _external_wait_fake(monkeypatch, pr_state="MERGED")
-    monkeypatch.setattr(runner, "comment_issue", Mock())
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "comment_issue", Mock())
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.wait_for_delivery(
         "https://github.com/xqliu/orbi/pull/592",
         {"number": 608, "title": "t", "body": ""},
@@ -2293,9 +2286,9 @@ def test_wait_for_delivery_external_close_failure_never_rewrites(monkeypatch,
             raise subprocess.CalledProcessError(1, command, stderr="boom")
         return json.dumps({"state": "MERGED"})
 
-    monkeypatch.setattr(runner, "run_command", failing_close)
-    monkeypatch.setattr(runner, "comment_issue", Mock())
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(seam, "run_command", failing_close)
+    monkeypatch.setattr(seam, "comment_issue", Mock())
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     caplog.set_level("ERROR")
     runner.wait_for_delivery(
         "https://github.com/xqliu/orbi/pull/592",
@@ -2317,13 +2310,11 @@ def test_wait_for_delivery_external_closed_requeues_for_internal_redo(
     Issue (docs/contributing.mdx)."""
     _external_wait_fake(monkeypatch, pr_state="CLOSED")
     edits = []
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda number, **kwargs: edits.append(kwargs),
     )
     commented = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, **kwargs: commented.append(kwargs),
     )
     pr_commented = []
@@ -2333,7 +2324,7 @@ def test_wait_for_delivery_external_closed_requeues_for_internal_redo(
             (number, kwargs["body"]),
         ),
     )
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "a1b2c3d4")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "a1b2c3d4")
     runner.wait_for_delivery(
         "https://github.com/xqliu/orbi/pull/592",
         {"number": 608, "title": "t", "body": ""},
@@ -2426,16 +2417,15 @@ def test_process_ticket_only_publishes_the_bound_context(monkeypatch):
     issue = {"number": 99, "title": "Launch thread", "body": "Write copy",
              "labels": [{"name": "ai-content-only"}]}
     seen = []
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(runner, "set_run_id", lambda run_id: None)
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(runner, "comment_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "set_run_id", lambda run_id: None)
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         runner, "run_ticket_agent", lambda *args, **kwargs: "content")
     monkeypatch.setattr(runner, "ProgressPublisher", Mock())
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "")
-    monkeypatch.setattr(
-        runner, "_safe_publish", lambda **kwargs: seen.append(kwargs))
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "")
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: seen.append(kwargs))
 
     runner.process_ticket_only(issue, {"repo_dir": Path("/repo")}, "o/r")
 

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -508,7 +508,7 @@ def test_previous_repo_config_sha_reads_the_newest_trusted_comment(monkeypatch):
         {"authorAssociation": "NONE", "body": "- repo_config: " + "b" * 40},
         {"authorAssociation": "MEMBER", "body": None},
     ]
-    monkeypatch.setattr(runner, "_authenticated_github_login", lambda: "orbi")
+    monkeypatch.setattr(seam, "_authenticated_github_login", lambda: "orbi")
     monkeypatch.setattr(seam, "issue_comments", lambda number, repo: comments,
     )
     assert runner.previous_repo_config_sha(1, "owner/repo") == "c" * 40

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -15,6 +15,7 @@ import pytest
 
 import orbi.repo_config as repo_config
 import orbi.runner as runner
+from seam import seam
 
 
 def _b64(text: str) -> str:
@@ -407,7 +408,7 @@ def test_pick_next_delivery_in_flight_scan_uses_the_repo_dispatch_label(
         searches.append(command[command.index("--search") + 1])
         return json.dumps([in_flight] if "in-progress" in searches[-1] else [])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner, "reconcile_open_epics", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "reconcile_release_milestones", lambda *a, **k: None,
@@ -437,7 +438,7 @@ def test_pick_next_delivery_in_flight_scan_falls_back_on_a_malformed_file(
         searches.append(command[command.index("--search") + 1])
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner, "reconcile_open_epics", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "reconcile_release_milestones", lambda *a, **k: None,
@@ -495,8 +496,7 @@ def test_previous_repo_config_sha_reads_the_newest_trusted_comment(monkeypatch):
         {"authorAssociation": "MEMBER", "body": None},
     ]
     monkeypatch.setattr(runner, "_authenticated_github_login", lambda: "orbi")
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda number, repo: comments,
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: comments,
     )
     assert runner.previous_repo_config_sha(1, "owner/repo") == "c" * 40
 
@@ -505,7 +505,7 @@ def test_previous_repo_config_sha_is_best_effort(monkeypatch, caplog):
     def broken(number, repo):
         raise RuntimeError("api down")
 
-    monkeypatch.setattr(runner, "issue_comments", broken)
+    monkeypatch.setattr(seam, "issue_comments", broken)
     assert runner.previous_repo_config_sha(1, "owner/repo") is None
     assert "previous_lookup_failed" in caplog.text
 
@@ -517,7 +517,7 @@ def test_pick_issue_uses_a_custom_dispatch_label(monkeypatch):
         seen.append(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.pick_issue("owner/repo", dispatch_label="custom-ready") is None
     searched = " ".join(" ".join(command) for command in seen)
     assert "label:custom-ready" in searched
@@ -536,7 +536,7 @@ def test_pick_issue_with_repo_policy_uses_repo_scan_keys(monkeypatch):
             )(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     config = {"repositories": []}
     assert runner._pick_issue_with_repo_policy("owner/repo", "v1.0.0", config) is None
     searched = "\n".join(" ".join(command) for command in commands)
@@ -550,7 +550,7 @@ def test_pick_issue_with_repo_policy_ignores_a_malformed_file(monkeypatch):
             return json.dumps({"sha": "x", "content": _b64("nope = 1\n")})
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The scan keeps the host keys and stays alive; process_issue blocks.
     assert runner._pick_issue_with_repo_policy(
         "owner/repo", "v1.0.0", {"repositories": []},
@@ -564,7 +564,7 @@ def test_pick_issue_with_repo_policy_without_config_uses_host_keys(monkeypatch):
         commands.append(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner._pick_issue_with_repo_policy("owner/repo", "v1.0.0", None)
     searched = "\n".join(" ".join(command) for command in commands)
     assert "label:ai-ready" in searched
@@ -597,15 +597,13 @@ def test_process_issue_invalid_repo_config_blocks_with_readable_reason(
     def fake_run(command, **kwargs):
         return json.dumps({"sha": "x", "content": _b64("source_repos = 1\n")})
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *args, **kwargs: edits.append((args, kwargs)),
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     posted = []
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda number, repo, body: posted.append(body),
     )
     result = runner.process_issue(
@@ -631,20 +629,17 @@ def test_process_issue_applies_repo_base_branch_and_records_sha(
             return _record('base_branch = "beta"\n', sha="b" * 40)(command)
         return "[]"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "has_in_progress_label", lambda number, repo: False,
+    monkeypatch.setattr(seam, "run_command", fake_run)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "has_in_progress_label", lambda number, repo: False,
     )
-    monkeypatch.setattr(runner, "open_pr_for_branch", lambda *a: None)
+    monkeypatch.setattr(seam, "open_pr_for_branch", lambda *a: None)
     monkeypatch.setattr(runner, "external_takeover_pr", lambda *a: None)
-    monkeypatch.setattr(runner, "stable_branch_exists", lambda *a: False)
-    monkeypatch.setattr(
-        runner, "freeze_base",
+    monkeypatch.setattr(seam, "stable_branch_exists", lambda *a: False)
+    monkeypatch.setattr(seam, "freeze_base",
         lambda repo_dir, base_branch: seen.setdefault("base", base_branch) or "sha",
     )
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *a, **k: tmp_path / "wt",
+    monkeypatch.setattr(seam, "create_worktree", lambda *a, **k: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "write_run_state", lambda *a, **k: None)
     monkeypatch.setattr(runner, "resume_context", lambda worktree: None)
@@ -664,9 +659,9 @@ def test_process_issue_applies_repo_base_branch_and_records_sha(
     def fake_comment(number, repo, body):
         starts.append(body)
 
-    monkeypatch.setattr(runner, "comment_issue", fake_comment)
-    monkeypatch.setattr(runner, "apply_label_patch", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "set_active_run", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", fake_comment)
+    monkeypatch.setattr(seam, "apply_label_patch", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "set_active_run", lambda *a, **k: None)
     monkeypatch.setattr(
         runner, "ProgressPublisher",
         lambda *a, **k: type("P", (), {
@@ -677,8 +672,7 @@ def test_process_issue_applies_repo_base_branch_and_records_sha(
             "comment_id": None,
         })(),
     )
-    monkeypatch.setattr(
-        runner, "_safe_publish", lambda **kwargs: kwargs["action"](),
+    monkeypatch.setattr(seam, "_safe_publish", lambda **kwargs: kwargs["action"](),
     )
     monkeypatch.setattr(runner, "runner_health", type("H", (), {
         "record_pickup": staticmethod(lambda *a: None),
@@ -686,8 +680,7 @@ def test_process_issue_applies_repo_base_branch_and_records_sha(
         "health_state_path": staticmethod(lambda *a: Path("/tmp/x")),
         "failure_fingerprint": staticmethod(lambda *a: ""),
     }))
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda number, repo: [],
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [],
     )
     result = runner.process_issue(
         {"number": 4, "title": "T", "body": "", "labels": []},
@@ -745,7 +738,7 @@ def test_main_applies_repo_base_branch_before_resume_verification(
             return _record('base_branch = "beta"\n', sha="b" * 40)(command)
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.main(["--config", str(config)]) == 0
     assert seen == {"verify_base": "beta", "wait_base": "beta"}
 
@@ -773,7 +766,7 @@ def test_main_blocks_a_claim_when_the_repo_config_is_invalid(
             })
         return json.dumps([])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     assert runner.main(["--config", str(config)]) == 0
     assert len(blocked) == 1
     assert "pi_model" in str(blocked[0][0][2])
@@ -846,7 +839,7 @@ def test_block_repo_config_failure_is_best_effort(monkeypatch, caplog):
     def broken(*args, **kwargs):
         raise RuntimeError("github down")
 
-    monkeypatch.setattr(runner, "apply_label_patch", broken)
+    monkeypatch.setattr(seam, "apply_label_patch", broken)
     runner.block_repo_config_failure(
         1, "owner/repo", ValueError("bad"), "a1b2c3d4",
     )
@@ -883,33 +876,30 @@ def test_run_pi_injects_repo_test_command_and_context_files(
 def test_process_issue_accepts_a_pre_resolved_record(monkeypatch, tmp_path):
     """`main` resolves the policy once and passes the record in (Issue
     #527); `process_issue` must not re-read or re-block."""
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     monkeypatch.setattr(
         runner, "load_repo_policy",
         lambda *a, **k: (_ for _ in ()).throw(
             AssertionError("process_issue must not re-read the policy"),
         ),
     )
-    monkeypatch.setattr(
-        runner, "has_in_progress_label", lambda number, repo: False,
+    monkeypatch.setattr(seam, "has_in_progress_label", lambda number, repo: False,
     )
-    monkeypatch.setattr(runner, "open_pr_for_branch", lambda *a: None)
+    monkeypatch.setattr(seam, "open_pr_for_branch", lambda *a: None)
     monkeypatch.setattr(runner, "external_takeover_pr", lambda *a: None)
-    monkeypatch.setattr(runner, "stable_branch_exists", lambda *a: False)
+    monkeypatch.setattr(seam, "stable_branch_exists", lambda *a: False)
     seen = {}
-    monkeypatch.setattr(
-        runner, "freeze_base",
+    monkeypatch.setattr(seam, "freeze_base",
         lambda repo_dir, base_branch: seen.setdefault("base", base_branch),
     )
-    monkeypatch.setattr(
-        runner, "create_worktree",
+    monkeypatch.setattr(seam, "create_worktree",
         lambda *a, **k: (_ for _ in ()).throw(RuntimeError("git failed")),
     )
     monkeypatch.setattr(runner, "activity_snapshot", lambda session_dir: None)
-    monkeypatch.setattr(runner, "apply_label_patch", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "_safe_publish", lambda **k: None)
-    monkeypatch.setattr(runner, "issue_comments", lambda number, repo: [])
+    monkeypatch.setattr(seam, "apply_label_patch", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "_safe_publish", lambda **k: None)
+    monkeypatch.setattr(seam, "issue_comments", lambda number, repo: [])
     monkeypatch.setattr(runner, "runner_health", type("H", (), {
         "record_pickup": staticmethod(lambda *a: None),
         "record_run_attempt": staticmethod(lambda *a, **k: None),
@@ -940,7 +930,7 @@ def test_repo_policies_are_isolated_per_repository(monkeypatch):
             "sha": "b", "content": _b64("source_repos = 1\n"),
         })
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     good = runner.load_repo_policy({"repositories": []}, "owner/good")
     assert good["policy"] == {"base_branch": "beta"}
     with pytest.raises(repo_config.RepoConfigError):

--- a/tests/test_resume_continue_e2e.py
+++ b/tests/test_resume_continue_e2e.py
@@ -35,6 +35,8 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+from seam import seam
+import orbi.journal as journal
 
 REPO = "owner/repo"
 RENAME_OLD = "xqliu/orbi"
@@ -160,7 +162,7 @@ def clone(tmp_path: Path) -> Path:
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
     """Each test starts without a bound run id."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
@@ -277,7 +279,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
             raise AssertionError(f"unexpected gh command: {command}")
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return fake_run
 
 
@@ -332,7 +334,7 @@ def run_first_attempt(monkeypatch, tmp_path: Path, clone: Path,
     """
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_INTERRUPTED)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     real_edit_issue = runner.edit_issue
 
     def claiming_edit(number, **kwargs):
@@ -347,7 +349,7 @@ def run_first_attempt(monkeypatch, tmp_path: Path, clone: Path,
             return
         raise AssertionError("kill simulation: label edit must not land")
 
-    monkeypatch.setattr(runner, "edit_issue", claiming_edit)
+    monkeypatch.setattr(seam, "edit_issue", claiming_edit)
     # Issue #239: the failure path runs (the `claiming_edit` above
     # suppresses its label transition, simulating the kill) and
     # `process_issue` returns `None` instead of re-raising.
@@ -355,7 +357,7 @@ def run_first_attempt(monkeypatch, tmp_path: Path, clone: Path,
                                                     source_repo),
                                 source_repo).kind == "failed"
     # The runner is back: label transitions work again.
-    monkeypatch.setattr(runner, "edit_issue", real_edit_issue)
+    monkeypatch.setattr(seam, "edit_issue", real_edit_issue)
     worktree = worktree_for(clone, source_repo, "a1b2c3d4")
     assert worktree.is_dir()
     assert "ai-in-progress" in labels[ISSUE_NUMBER]
@@ -383,7 +385,7 @@ def test_e2e_restart_continues_on_the_uncommitted_work(
     caplog.set_level("INFO")
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_CONTINUE)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "b2c3d4e5")
     result = runner.process_issue(
         issue(), config_for(clone, tmp_path, REPO), REPO,
     )
@@ -442,7 +444,7 @@ def test_e2e_repo_rename_finds_the_old_worktree_by_issue_and_name(
     caplog.set_level("INFO")
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_CONTINUE)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "b2c3d4e5")
     result = runner.process_issue(
         issue(), config_for(clone, tmp_path, RENAME_NEW), RENAME_NEW,
     )
@@ -487,7 +489,7 @@ def test_e2e_missing_run_state_fails_fast_without_a_fresh_run(
     caplog.set_level("INFO")
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FRESH)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "b2c3d4e5")
     with pytest.raises(RuntimeError, match="run state"):
         runner.process_issue(
             issue(), config_for(clone, tmp_path, REPO), REPO,
@@ -526,7 +528,7 @@ def test_e2e_corrupt_run_state_fails_fast_without_a_fresh_run(
     caplog.set_level("INFO")
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FRESH)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "b2c3d4e5")
     with pytest.raises(RuntimeError, match="run state"):
         runner.process_issue(
             issue(), config_for(clone, tmp_path, REPO), REPO,
@@ -565,7 +567,7 @@ def test_e2e_claim_reuses_orphan_local_branch(
     caplog.set_level("INFO")
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_DELIVERS)
     install_fake_gh(monkeypatch, comments, labels)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "c3d4e5f6")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "c3d4e5f6")
 
     result = runner.process_issue(
         issue(), config_for(clone, tmp_path, REPO), REPO,

--- a/tests/test_resume_e2e.py
+++ b/tests/test_resume_e2e.py
@@ -36,6 +36,8 @@ import pytest
 
 import orbi.runner as runner
 from orbi import human_review
+from seam import seam
+import orbi.journal as journal
 
 REPO = "owner/repo"
 ISSUE_NUMBER = 45
@@ -149,7 +151,7 @@ def clone(tmp_path: Path) -> Path:
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
     """Each test starts without a bound run id."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
@@ -359,7 +361,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
             raise AssertionError(f"unexpected gh command: {command}")
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
 
 def write_prompt(tmp_path: Path) -> Path:
@@ -685,7 +687,7 @@ def test_e2e_pr_opened_without_fix_needed_never_starts_a_fixer(
             }])
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     # The delivery wait (slot held until merge, Issue #39) is out of
     # scope here: this test proves the awaiting-review tick resumes the
     # review of the SAME PR without starting a fixer, so the wait is

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -19,6 +19,8 @@ import pytest
 import orbi.runner as runner
 from orbi import progress
 from tests.test_progress_wiring import make_fake_gh
+from seam import seam
+import orbi.journal as journal
 
 
 FAKE_RUN_ID = "a1b2c3d4"
@@ -30,7 +32,7 @@ FAKE_PR_URL = "https://github.com/owner/repo/pull/9"
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
     """Each test starts without a bound run id."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def opened_pr_comment(run_id=FAKE_RUN_ID,
@@ -210,8 +212,7 @@ def test_resume_scene_skips_non_dict_comments():
 
 def test_authenticated_github_login_uses_active_gh_account(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command: calls.append(command) or (
             "github.com\n"
             "  ✓ Logged in to github.com account orbi-dev-test[bot] (keyring)\n"
@@ -223,9 +224,7 @@ def test_authenticated_github_login_uses_active_gh_account(monkeypatch):
 
 
 def test_authenticated_github_login_selects_active_account(monkeypatch):
-    monkeypatch.setattr(
-        runner,
-        "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command: (
             "github.com\n"
             "  ✓ Logged in to github.com account old-bot[bot] (keyring)\n"
@@ -241,14 +240,13 @@ def test_authenticated_github_login_reports_identity_resolution_failure(monkeypa
     def fail(command):
         raise RuntimeError("gh api installation: 404 Not Found")
 
-    monkeypatch.setattr(runner, "run_command", fail)
+    monkeypatch.setattr(seam, "run_command", fail)
     with pytest.raises(ValueError, match="identity resolution.*gh auth status"):
         runner._authenticated_github_login()
 
 
 def test_authenticated_github_login_rejects_missing_active_account(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command", lambda command: "Active account: true\n",
+    monkeypatch.setattr(seam, "run_command", lambda command: "Active account: true\n",
     )
     with pytest.raises(ValueError, match="identity resolution"):
         runner._authenticated_github_login()
@@ -271,7 +269,7 @@ def test_resume_scene_accepts_the_authenticated_runner_app_bot(monkeypatch):
             "  - Active account: true\n"
         )
 
-    monkeypatch.setattr(runner, "run_command", gh_status)
+    monkeypatch.setattr(seam, "run_command", gh_status)
     scene = runner.resume_scene(comments)
     assert scene["run_id"] == FAKE_RUN_ID
 
@@ -416,7 +414,7 @@ def test_issue_comments_returns_comments_from_production_shape(monkeypatch):
             {"body": "second", "authorAssociation": "OWNER"},
         ],
     })
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: payload)
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: payload)
     comments = runner.issue_comments(9, repo="owner/repo")
     assert comments == [
         {"body": "first", "authorAssociation": "NONE"},
@@ -425,8 +423,7 @@ def test_issue_comments_returns_comments_from_production_shape(monkeypatch):
 
 
 def test_issue_comments_rejects_top_level_array_payload(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: json.dumps([{"body": "first"}]),
     )
     with pytest.raises(ValueError, match="issue view must be a JSON object"):
@@ -434,7 +431,7 @@ def test_issue_comments_rejects_top_level_array_payload(monkeypatch):
 
 
 def test_issue_comments_rejects_payload_without_comments_array(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "{}")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "{}")
     with pytest.raises(ValueError, match="issue comments must be a JSON array"):
         runner.issue_comments(9, repo="owner/repo")
 
@@ -502,7 +499,7 @@ def make_pick_fake(list_payload: str, view_payload: str | None = None,
 
 def test_pick_fake_rejects_unexpected_command(monkeypatch):
     fake = make_pick_fake("[]")
-    monkeypatch.setattr(runner, "run_command", fake)
+    monkeypatch.setattr(seam, "run_command", fake)
     with pytest.raises(AssertionError, match="unexpected command"):
         runner.run_command(["gh", "release", "list"])
     # An `issue` subcommand that is neither list/view/edit/comment is
@@ -524,7 +521,7 @@ def test_pick_resumable_delivery_returns_newest_issue_with_scene(
         calls.append(command)
         return fake(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", counting)
+    monkeypatch.setattr(seam, "run_command", counting)
     issue, scene = runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     )
@@ -574,7 +571,7 @@ def test_pick_resumable_delivery_scans_fix_needed_and_awaiting_review(
         calls.append(command)
         return "[]"
 
-    monkeypatch.setattr(runner, "run_command", counting)
+    monkeypatch.setattr(seam, "run_command", counting)
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     ) is None
@@ -602,7 +599,7 @@ def test_pick_resumable_delivery_resumes_delivery_that_carries_in_progress_label
         issue_payload(),
         gh_comments_payload(["human note", opened_pr_comment()]),
     )
-    monkeypatch.setattr(runner, "run_command", fake)
+    monkeypatch.setattr(seam, "run_command", fake)
     issue, scene = runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     )
@@ -614,7 +611,7 @@ def test_pick_resumable_delivery_resumes_delivery_that_carries_in_progress_label
 def test_pick_resumable_delivery_returns_none_when_queue_empty(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(runner, "run_command", make_pick_fake("[]"))
+    monkeypatch.setattr(seam, "run_command", make_pick_fake("[]"))
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     ) is None
@@ -630,8 +627,7 @@ def test_pick_resumable_delivery_skips_when_another_runner_is_live(
     worktree/branch/run. This runner's own slot (its own PID) does not
     block the scan."""
     gh_calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: gh_calls.append(command) or "[]",
     )
     monkeypatch.setattr(runner, "slot_occupancy",
@@ -657,8 +653,7 @@ def test_pick_resumable_delivery_blocks_issue_without_scene_comment(
     scan returns None so the tick continues (Issue #672)."""
     edits: list[list[str]] = []
     comments: list[str] = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         make_pick_fake(
             issue_payload(),
             gh_comments_payload(["only a human comment here"]),
@@ -689,8 +684,7 @@ def test_pick_resumable_delivery_blocks_pr_opened_issue_without_scene(
     (Issue #672 scope)."""
     edits: list[list[str]] = []
     comments: list[str] = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         make_pick_fake(
             issue_payload(labels=["ai-pr-opened"]),
             gh_comments_payload(["only a human comment here"]),
@@ -713,8 +707,7 @@ def test_pick_resumable_delivery_blocks_pr_opened_issue_without_scene(
 
 
 def test_pick_resumable_delivery_skips_closed_issue(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         make_pick_fake(issue_payload(state="CLOSED")),
     )
     assert runner.pick_resumable_delivery(
@@ -748,7 +741,7 @@ def test_pick_resumable_delivery_blocks_issue_when_scene_is_malformed(
         calls.append(command)
         return fake(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", counting)
+    monkeypatch.setattr(seam, "run_command", counting)
     caplog.set_level("ERROR")
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
@@ -786,7 +779,7 @@ def test_pick_resumable_delivery_blocks_issue_when_no_trusted_scene(
         calls.append(command)
         return fake(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", counting)
+    monkeypatch.setattr(seam, "run_command", counting)
     caplog.set_level("ERROR")
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
@@ -821,7 +814,7 @@ def test_pick_resumable_delivery_scene_failure_carries_marker_when_present(
         calls.append(command)
         return fake(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", counting)
+    monkeypatch.setattr(seam, "run_command", counting)
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     ) is None
@@ -851,7 +844,7 @@ def test_pick_resumable_delivery_scene_failure_skips_bodyless_comments(
         ]}),
         comments=comments,
     )
-    monkeypatch.setattr(runner, "run_command", fake)
+    monkeypatch.setattr(seam, "run_command", fake)
     assert runner.pick_resumable_delivery(
         "owner/repo", tmp_path / "slots", 1,
     ) is None
@@ -876,7 +869,7 @@ def test_pick_resumable_delivery_scene_failure_logs_reporting_failure(
             raise RuntimeError("github edit failed")
         return fake(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"):
         assert runner.pick_resumable_delivery(
             "owner/repo", tmp_path / "slots", 1,
@@ -920,7 +913,7 @@ def test_pick_next_delivery_continues_after_scene_failure(
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner, "pick_issue",
         lambda repo, active_milestone=None, **_kwargs: (
@@ -1199,7 +1192,7 @@ def test_main_continues_to_ready_delivery_after_scene_failure(
             return ""
         raise AssertionError(f"unexpected command: {command}")
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner, "sync_active_milestone_variable", lambda *a, **k: None,
     )
@@ -1249,7 +1242,7 @@ def test_main_ends_cleanly_after_handled_resume_scene_failure(
     released = []
 
     monkeypatch.setattr(runner, "sync_active_milestone_variable", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "refresh_cli_install", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "refresh_cli_install", lambda *a, **k: None)
     monkeypatch.setattr(runner, "check_unit_drift", lambda *a, **k: None)
     monkeypatch.setattr(runner, "check_transport", lambda *a, **k: {})
     monkeypatch.setattr(runner.runner_health, "run_health_check", lambda *a, **k: None)
@@ -1335,7 +1328,7 @@ def test_verify_pr_resume_rejects_stale_or_ambiguous_scene_with_evidence(
 
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(error_type) as excinfo:
         runner.verify_pr(
             worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
@@ -1374,7 +1367,7 @@ def test_verify_pr_resume_rejects_pr_based_on_wrong_branch_with_evidence(
 
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(
         runner.ResumeVerificationError,
         match="PR base is develop, expected main",
@@ -1407,7 +1400,7 @@ def test_verify_pr_non_resume_rejects_multiple_open_prs(
 
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="multiple open PRs"):
         runner.verify_pr(
             worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
@@ -1434,7 +1427,7 @@ def test_verify_pr_resume_keeps_unknown_state_for_non_object_scene_lookup(
 
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
         runner.verify_pr(
             worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
@@ -1463,7 +1456,7 @@ def test_verify_pr_resume_keeps_failure_evidence_when_scene_lookup_fails(
 
     with pytest.raises(AssertionError):
         fake_run(["unexpected"])
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(runner.ResumeVerificationError, match="scene_pr_state=unknown"):
         runner.verify_pr(
             worktree, FAKE_BRANCH, "main", FAKE_RUN_ID, issue=9,
@@ -1507,7 +1500,7 @@ def test_verify_resumed_pr_verifies_scene_pr_and_returns_verified_url(
         edits.append((number, repo, add, remove))
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "edit_issue", fake_edit)
+    monkeypatch.setattr(seam, "edit_issue", fake_edit)
     # The derived worktree exists (a real delivery always has one).
     expected_resume_worktree(tmp_path).mkdir(parents=True)
     url = runner.verify_resumed_pr(
@@ -1597,9 +1590,9 @@ def make_resume_failure_fake(monkeypatch, *, progress_comments=None,
     def fake_comment(*args, **kwargs):
         captured["comments"].append((args, kwargs))
 
-    monkeypatch.setattr(runner, "edit_issue", fake_edit)
-    monkeypatch.setattr(runner, "comment_issue", fake_comment)
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "edit_issue", fake_edit)
+    monkeypatch.setattr(seam, "comment_issue", fake_comment)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     return captured, fake_run
 
 
@@ -1687,7 +1680,7 @@ def test_verify_resumed_pr_backfills_in_progress_label_before_continuing(
         edits.append((number, repo, add, remove))
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "edit_issue", fake_edit)
+    monkeypatch.setattr(seam, "edit_issue", fake_edit)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
     url = runner.verify_resumed_pr(
         make_resume_scene(), make_resume_issue(),
@@ -1720,7 +1713,7 @@ def test_verify_resumed_pr_repeated_resume_backfill_is_idempotent(
         edits.append((number, repo, add, remove))
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "edit_issue", fake_edit)
+    monkeypatch.setattr(seam, "edit_issue", fake_edit)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
     # Two consecutive ticks resume the same scene.
     for _ in range(2):
@@ -1767,12 +1760,11 @@ def test_verify_resumed_pr_external_scene_reads_branch_from_worktree(
 
     # verify_pr is mocked, so the only command the flow issues is the
     # worktree branch read.
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: "fix/outer",
     )
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "edit_issue", fake_edit)
+    monkeypatch.setattr(seam, "edit_issue", fake_edit)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
     scene = make_resume_scene("https://github.com/xqliu/orbi/pull/592")
     scene["external"] = "true"
@@ -1820,14 +1812,14 @@ def test_verify_resumed_pr_backfill_label_api_failure_fails_fast(
         )
 
     monkeypatch.setattr(runner, "verify_pr", lambda *a, **kw: FAKE_PR_URL)
-    monkeypatch.setattr(runner, "edit_issue", failing_edit)
+    monkeypatch.setattr(seam, "edit_issue", failing_edit)
     reviews: list = []
     monkeypatch.setattr(
         runner, "review_and_merge_if_clean",
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         runner.verify_resumed_pr(
@@ -1905,7 +1897,7 @@ def test_verify_resumed_pr_pr_url_mismatch_stays_fix_needed(
         lambda *args, **kwargs: reviews.append((args, kwargs)) or False,
     )
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     with pytest.raises(RuntimeError, match="not the recovered original PR"):
         runner.verify_resumed_pr(
@@ -1972,7 +1964,7 @@ def test_verify_resumed_pr_pr_repo_mismatch_stays_fix_needed(
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     with pytest.raises(RuntimeError, match="PR head repo is fork/repo"):
         runner.verify_resumed_pr(
@@ -2008,7 +2000,7 @@ def test_verify_resumed_pr_recoverable_failure_keeps_fix_needed_label(
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     issue = make_resume_issue()
     issue["labels"] = [{"name": "ai-fix-needed"}]
     with pytest.raises(RuntimeError, match="exactly one open PR"):
@@ -2044,8 +2036,8 @@ def test_verify_resumed_pr_fails_fast_when_scene_base_differs(
         raise AssertionError("verify_pr must not run on a base mismatch")
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "run_command", counting)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(seam, "run_command", counting)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     scene = make_resume_scene()
     scene["base_branch"] = "develop"
@@ -2109,8 +2101,8 @@ def test_verify_resumed_pr_worktree_missing_stays_fix_needed(
         raise AssertionError("verify_pr must not run on a missing worktree")
 
     monkeypatch.setattr(runner, "verify_pr", fake_verify_pr)
-    monkeypatch.setattr(runner, "run_command", counting)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(seam, "run_command", counting)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     caplog.set_level("INFO")
     # The derived worktree does not exist under tmp_path.
     assert not expected_resume_worktree(tmp_path).is_dir()
@@ -2175,9 +2167,9 @@ def test_verify_resumed_pr_reraises_when_failure_reporting_fails(
     def broken_edit(*args, **kwargs):
         raise RuntimeError("github edit failed")
 
-    monkeypatch.setattr(runner, "edit_issue", broken_edit)
+    monkeypatch.setattr(seam, "edit_issue", broken_edit)
     expected_resume_worktree(tmp_path).mkdir(parents=True)
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", FAKE_RUN_ID)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", FAKE_RUN_ID)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="the original verification failure",
     ):

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -21,6 +21,7 @@ from orbi import progress
 from tests.test_progress_wiring import make_fake_gh
 from seam import seam
 import orbi.journal as journal
+import orbi.github as github
 
 
 FAKE_RUN_ID = "a1b2c3d4"
@@ -219,7 +220,7 @@ def test_authenticated_github_login_uses_active_gh_account(monkeypatch):
             "  - Active account: true\n"
         ),
     )
-    assert runner._authenticated_github_login() == "orbi-dev-test[bot]"
+    assert github._authenticated_github_login() == "orbi-dev-test[bot]"
     assert calls == [["gh", "auth", "status", "--hostname", "github.com"]]
 
 
@@ -233,7 +234,7 @@ def test_authenticated_github_login_selects_active_account(monkeypatch):
             "  - Active account: true\n"
         ),
     )
-    assert runner._authenticated_github_login() == "orbi-dev-test[bot]"
+    assert github._authenticated_github_login() == "orbi-dev-test[bot]"
 
 
 def test_authenticated_github_login_reports_identity_resolution_failure(monkeypatch):
@@ -242,14 +243,14 @@ def test_authenticated_github_login_reports_identity_resolution_failure(monkeypa
 
     monkeypatch.setattr(seam, "run_command", fail)
     with pytest.raises(ValueError, match="identity resolution.*gh auth status"):
-        runner._authenticated_github_login()
+        github._authenticated_github_login()
 
 
 def test_authenticated_github_login_rejects_missing_active_account(monkeypatch):
     monkeypatch.setattr(seam, "run_command", lambda command: "Active account: true\n",
     )
     with pytest.raises(ValueError, match="identity resolution"):
-        runner._authenticated_github_login()
+        github._authenticated_github_login()
 
 
 def test_resume_scene_accepts_the_authenticated_runner_app_bot(monkeypatch):
@@ -281,7 +282,7 @@ def test_resume_scene_rejects_another_app_bot_even_with_the_marker(monkeypatch):
         "author": {"login": "unrelated-app[bot]"},
     }]
     monkeypatch.setattr(
-        runner, "_authenticated_github_login",
+        seam, "_authenticated_github_login",
         lambda: "orbi-dev-test[bot]",
     )
     with pytest.raises(ValueError, match="no 'Orbi opened PR' comment"):
@@ -309,7 +310,7 @@ def test_comment_is_trusted_normalizes_optional_bot_suffix(
     monkeypatch, login, expected,
 ):
     monkeypatch.setattr(
-        runner, "_authenticated_github_login",
+        seam, "_authenticated_github_login",
         lambda: "orbi-dev-test[bot]",
     )
     comment = {
@@ -328,7 +329,7 @@ def test_resume_scene_accepts_graphql_shaped_runner_app_bot(monkeypatch):
         "author": {"login": "orbi-dev-test"},
     }]
     monkeypatch.setattr(
-        runner, "_authenticated_github_login",
+        seam, "_authenticated_github_login",
         lambda: "orbi-dev-test[bot]",
     )
     scene = runner.resume_scene(comments)
@@ -345,7 +346,7 @@ def test_comment_is_trusted_rejects_missing_or_non_string_login(
     monkeypatch, author,
 ):
     monkeypatch.setattr(
-        runner, "_authenticated_github_login",
+        seam, "_authenticated_github_login",
         lambda: "orbi-dev-test[bot]",
     )
     comment = {

--- a/tests/test_review_merge.py
+++ b/tests/test_review_merge.py
@@ -20,13 +20,14 @@ import pytest
 import orbi.runner as runner
 from orbi import progress
 from tests.test_progress_wiring import make_fake_gh
+from seam import seam
+import orbi.journal as journal
 
 
 @pytest.fixture(autouse=True)
 def _current_delivery_labels(monkeypatch):
     """Provide the live label read used by review transitions."""
-    monkeypatch.setattr(
-        runner, "issue_labels", lambda *a, **k: ["ai-pr-opened"],
+    monkeypatch.setattr(seam, "issue_labels", lambda *a, **k: ["ai-pr-opened"],
     )
 
 
@@ -341,21 +342,20 @@ def test_query_open_prs_owns_the_shared_query_contract(monkeypatch, tmp_path):
         calls.append(command)
         return json.dumps([{"number": 4, "url": "u4"}])
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     prs = runner._query_open_prs(tmp_path, "orbi/owner-repo-issue-4")
     assert prs == [{"number": 4, "url": "u4"}]
     assert calls == [UNIFIED_PR_LIST_COMMAND]
 
 
 def test_query_open_prs_rejects_non_array_payload(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "{}")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "{}")
     with pytest.raises(RuntimeError, match="non-array payload"):
         runner._query_open_prs(tmp_path, "orbi/owner-repo-issue-4")
 
 
 def test_single_open_pr_returns_the_raw_pr_dict(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command", lambda *a, **k: _pr_json(),
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: _pr_json(),
     )
     pr = runner._single_open_pr(
         tmp_path, "orbi/owner-repo-issue-4", "main", scene="freeze_pr",
@@ -367,7 +367,7 @@ def test_single_open_pr_returns_the_raw_pr_dict(monkeypatch, tmp_path):
 def test_single_open_pr_names_the_scene_when_no_pr_is_open(
     monkeypatch, tmp_path,
 ):
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "[]")
     with pytest.raises(
         RuntimeError, match="freeze_pr: no open PR for the task branch",
     ):
@@ -385,7 +385,7 @@ def test_single_open_pr_names_the_scene_when_multiple_are_open(
         {"number": 5, "url": "u5", "baseRefName": "main",
          "baseRefOid": "b1", "headRefName": "h", "headRefOid": "h2"},
     ])
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: two)
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: two)
     with pytest.raises(
         RuntimeError,
         match="verify_pr: multiple open PRs for the task branch",
@@ -398,8 +398,7 @@ def test_single_open_pr_names_the_scene_when_multiple_are_open(
 def test_single_open_pr_rejects_wrong_base_and_names_the_scene_in_the_log(
     monkeypatch, tmp_path, caplog,
 ):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *a, **k: _pr_json(base="develop"),
     )
     with caplog.at_level("ERROR"), pytest.raises(
@@ -436,7 +435,7 @@ def test_freeze_pr_returns_frozen_base_and_head(monkeypatch, tmp_path):
         calls.append(command)
         return _pr_json()
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     pr = runner.freeze_pr(
         tmp_path, "orbi/owner-repo-issue-4", "main",
     )
@@ -450,15 +449,14 @@ def test_freeze_pr_returns_frozen_base_and_head(monkeypatch, tmp_path):
 
 
 def test_freeze_pr_rejects_wrong_base(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command", lambda command, **kwargs: _pr_json(base="develop"),
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: _pr_json(base="develop"),
     )
     with pytest.raises(RuntimeError, match="PR base is develop, expected main"):
         runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
 
 def test_freeze_pr_rejects_no_open_pr(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: "[]")
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
@@ -470,7 +468,7 @@ def test_freeze_pr_rejects_multiple_open_prs(monkeypatch, tmp_path):
         {"number": 5, "url": "u5", "baseRefName": "main",
          "baseRefOid": "b1", "headRefName": "h", "headRefOid": "h2"},
     ])
-    monkeypatch.setattr(runner, "run_command", lambda command, **kwargs: two)
+    monkeypatch.setattr(seam, "run_command", lambda command, **kwargs: two)
     with pytest.raises(RuntimeError, match="exactly one open PR"):
         runner.freeze_pr(tmp_path, "orbi/owner-repo-issue-4", "main")
 
@@ -557,8 +555,7 @@ def _merge_gate_fake(pr_state="MERGEABLE", head_oid="h1",
 
 
 def test_merge_gate_rejects_failed_github_ci(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         _merge_gate_fake(check_runs=[{
             "name": "tests", "status": "COMPLETED", "conclusion": "FAILURE",
         }]),
@@ -591,7 +588,7 @@ def test_merge_gate_rejects_preexisting_failed_ci_as_unrecoverable(
                                 "url": "https://github.com/o/r/issues/402"}])
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(runner.PreExistingCIFailure, match="main is already red"):
         runner.merge_gate(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
@@ -601,8 +598,7 @@ def test_merge_gate_rejects_preexisting_failed_ci_as_unrecoverable(
 
 
 def test_merge_gate_rejects_failed_status_context(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         _merge_gate_fake(check_runs=[{
             "context": "status", "state": "FAILURE",
         }]),
@@ -617,8 +613,7 @@ def test_merge_gate_rejects_failed_status_context(monkeypatch, tmp_path):
 
 def test_review_ci_gate_passes_success_neutral_and_skipped(monkeypatch):
     calls = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command) or json.dumps([
             {"name": "tests", "status": "completed", "conclusion": "success"},
             {"name": "docs", "status": "completed", "conclusion": "neutral"},
@@ -632,8 +627,7 @@ def test_review_ci_gate_passes_success_neutral_and_skipped(monkeypatch):
 
 
 def test_review_ci_gate_fails_with_run_reference(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([{
             "name": "tests", "status": "completed", "conclusion": "failure",
             "html_url": "https://github.com/owner/repo/actions/runs/42",
@@ -648,8 +642,7 @@ def test_review_ci_gate_fails_with_run_reference(monkeypatch):
     {},
 ])
 def test_review_ci_gate_reports_any_failure_reference(monkeypatch, reference):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([{
             "name": "tests", "status": "completed", "conclusion": "failure",
             **reference,
@@ -661,8 +654,7 @@ def test_review_ci_gate_reports_any_failure_reference(monkeypatch, reference):
 
 
 def test_review_ci_gate_times_out_pending_checks(monkeypatch):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps([{
             "name": "tests", "status": "in_progress", "conclusion": None,
         }]),
@@ -673,7 +665,7 @@ def test_review_ci_gate_times_out_pending_checks(monkeypatch):
 
 
 def test_review_ci_gate_allows_no_checks_with_evidence(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *a, **k: "[]")
+    monkeypatch.setattr(seam, "run_command", lambda *a, **k: "[]")
     assert runner.check_review_ci("owner/repo", "head-none", wait_seconds=10) == (
         "CI on review head head-none: no check runs (nothing to gate)"
     )
@@ -685,8 +677,7 @@ def test_review_ci_gate_polls_the_current_head(monkeypatch):
         [{"name": "tests", "status": "completed", "conclusion": "success"}],
     ])
     seen = []
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: seen.append(command) or json.dumps(next(heads)),
     )
     monkeypatch.setattr(runner.time, "sleep", lambda seconds: None)
@@ -695,20 +686,18 @@ def test_review_ci_gate_polls_the_current_head(monkeypatch):
 
 
 def test_preexisting_ci_triage_lookup_is_best_effort(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "{}")
+    monkeypatch.setattr(seam, "run_command", lambda *_args, **_kwargs: "{}")
     assert runner._main_ci_triage_url("owner/repo", "tests") is None
 
-    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "not json")
+    monkeypatch.setattr(seam, "run_command", lambda *_args, **_kwargs: "not json")
     assert runner._main_ci_triage_url("owner/repo", "tests") is None
 
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *_args, **_kwargs: json.dumps([{"title": "other", "url": ""}]),
     )
     assert runner._main_ci_triage_url("owner/repo", "tests") is None
 
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda *_args, **_kwargs: json.dumps([{
             "title": "CI failure: tests on branch main (push)", "url": 42,
         }]),
@@ -717,7 +706,7 @@ def test_preexisting_ci_triage_lookup_is_best_effort(monkeypatch):
 
 
 def test_preexisting_ci_check_skips_base_lookup_without_base(monkeypatch):
-    monkeypatch.setattr(runner, "run_command", lambda *_args, **_kwargs: "unused")
+    monkeypatch.setattr(seam, "run_command", lambda *_args, **_kwargs: "unused")
     runner._raise_if_preexisting_ci_failure("owner/repo", ["tests"], None)
 
 
@@ -736,7 +725,7 @@ def test_merge_gate_waits_for_pending_github_ci_then_merges(
             })
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", lambda _seconds: None)
     result = runner.merge_gate(tmp_path, {"number": 4, "url": "u",
                                           "base_ref": "main", "base_oid": "b1",
@@ -747,8 +736,7 @@ def test_merge_gate_waits_for_pending_github_ci_then_merges(
 
 
 def test_merge_gate_without_ci_proceeds_to_mergeable_gate(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         _merge_gate_fake(check_runs=[]),
     )
     result = runner.merge_gate(tmp_path, {"number": 4, "url": "u",
@@ -759,8 +747,7 @@ def test_merge_gate_without_ci_proceeds_to_mergeable_gate(monkeypatch, tmp_path)
 
 
 def test_merge_gate_times_out_pending_github_ci(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         _merge_gate_fake(check_runs=[{
             "name": "tests", "status": "QUEUED", "conclusion": None,
         }]),
@@ -779,7 +766,7 @@ def test_merge_gate_merges_reviewed_head_with_match_head_commit(monkeypatch, tmp
         calls.append(command)
         return _merge_gate_fake()(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     pr = runner.merge_gate(tmp_path, {"number": 4, "url": "u",
                                       "base_ref": "main", "base_oid": "b1",
                                       "head_ref": "h", "head_oid": "h1"},
@@ -798,7 +785,7 @@ def test_merge_gate_requires_the_repo_dir_lock_location(
     # Issue #171: the gate fetch updates the shared remote-tracking
     # ref, so the lock location (the deployment checkout's shared state
     # dir) must be explicit — there is no bypass path.
-    monkeypatch.setattr(runner, "run_command", _merge_gate_fake())
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake())
     with pytest.raises(TypeError):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u",
                                      "base_ref": "main", "base_oid": "b1",
@@ -821,7 +808,7 @@ def test_merge_gate_fetches_under_the_base_sync_lock(
             return spy(command, **kwargs)
         return _merge_gate_fake()(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner.merge_gate(tmp_path, {"number": 4, "url": "u",
                                  "base_ref": "main", "base_oid": "b1",
                                  "head_ref": "h", "head_oid": "h1"},
@@ -836,7 +823,7 @@ def test_merge_gate_reraises_merge_base_errors(monkeypatch, tmp_path):
             raise subprocess.CalledProcessError(128, command, stderr="bad ref")
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         runner.merge_gate(
             tmp_path, {"number": 4, "head_oid": "h1"}, "main",
@@ -850,7 +837,7 @@ def test_merge_gate_rejects_head_behind_latest_base(monkeypatch, tmp_path, caplo
         if command[:3] == ["git", "merge-base", "--is-ancestor"]:
             raise subprocess.CalledProcessError(1, command, stderr="not ancestor")
         return ""
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         runner.RecoverableMergeGateError, match="behind latest remote base",
     ):
@@ -871,7 +858,7 @@ def test_merge_gate_polls_unknown_until_mergeable(monkeypatch, tmp_path):
                                "headRefOid": "h1", "statusCheckRollup": []})
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(runner.time, "sleep", sleeps.append)
     result = runner.merge_gate(
         tmp_path, {"number": 4, "url": "u", "base_ref": "main",
@@ -883,7 +870,7 @@ def test_merge_gate_polls_unknown_until_mergeable(monkeypatch, tmp_path):
 
 
 def test_merge_gate_mergeable_timeout_fails_fast(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", _merge_gate_fake(pr_state="UNKNOWN"))
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake(pr_state="UNKNOWN"))
     with pytest.raises(runner.RecoverableMergeGateError, match="mergeable.*timed out"):
         runner.merge_gate(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
@@ -894,8 +881,7 @@ def test_merge_gate_mergeable_timeout_fails_fast(monkeypatch, tmp_path):
 
 def test_merge_gate_continuous_unknown_times_out_after_polling(monkeypatch, tmp_path):
     sleeps = []
-    monkeypatch.setattr(
-        runner, "run_command", _merge_gate_fake(pr_state="UNKNOWN"),
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake(pr_state="UNKNOWN"),
     )
     monkeypatch.setattr(runner.time, "sleep", sleeps.append)
     with pytest.raises(runner.RecoverableMergeGateError, match="mergeable.*timed out"):
@@ -908,7 +894,7 @@ def test_merge_gate_continuous_unknown_times_out_after_polling(monkeypatch, tmp_
 
 
 def test_merge_gate_rejects_non_mergeable_pr(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "run_command", _merge_gate_fake(pr_state="DIRTY"))
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake(pr_state="DIRTY"))
     with pytest.raises(runner.RecoverableMergeGateError, match="not mergeable"):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                                      "base_oid": "b1", "head_ref": "h",
@@ -917,8 +903,7 @@ def test_merge_gate_rejects_non_mergeable_pr(monkeypatch, tmp_path):
 
 
 def test_merge_gate_rejects_head_that_moved_since_review(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command", _merge_gate_fake(head_oid="moved"),
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake(head_oid="moved"),
     )
     with pytest.raises(RuntimeError, match="head moved since review"):
         runner.merge_gate(tmp_path, {"number": 4, "url": "u", "base_ref": "main",
@@ -940,7 +925,7 @@ def test_confirm_merged_accepts_merged_pr_on_origin_main(monkeypatch, tmp_path):
                 "mergeCommit": {"oid": "m1"},
             })
         return ""
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     result = runner.confirm_merged(
         tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                    "base_oid": "b1", "head_ref": "h", "head_oid": "h1"}, "main",
@@ -955,7 +940,7 @@ def test_confirm_merged_requires_the_repo_dir_lock_location(
 ):
     # Issue #171: the confirm fetch updates the shared remote-tracking
     # ref, so the lock location must be explicit — no bypass path.
-    monkeypatch.setattr(runner, "run_command", _merge_gate_fake())
+    monkeypatch.setattr(seam, "run_command", _merge_gate_fake())
     with pytest.raises(TypeError):
         runner.confirm_merged(
             tmp_path, {"number": 4, "url": "u", "base_ref": "main",
@@ -985,7 +970,7 @@ def test_confirm_merged_fetches_under_the_base_sync_lock(
             })
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     runner.confirm_merged(
         tmp_path, {"number": 4, "url": "u", "base_ref": "main",
                    "base_oid": "b1", "head_ref": "h", "head_oid": "h1"},
@@ -996,8 +981,7 @@ def test_confirm_merged_fetches_under_the_base_sync_lock(
 
 
 def test_confirm_merged_rejects_unmerged_pr(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps({
             "number": 4, "url": "u", "state": "OPEN",
             "mergedAt": None, "mergeCommit": None,
@@ -1023,7 +1007,7 @@ def test_confirm_merged_rejects_merge_commit_missing_from_origin_main(
                 "mergeCommit": {"oid": "m1"},
             })
         return ""
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError, match="not on origin/main",
     ):
@@ -1036,8 +1020,7 @@ def test_confirm_merged_rejects_merge_commit_missing_from_origin_main(
 
 
 def test_confirm_merged_rejects_merged_pr_without_commit_oid(monkeypatch, tmp_path):
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: json.dumps({
             "number": 4, "url": "u", "state": "MERGED",
             "mergedAt": "2026-08-25T00:00:00Z", "mergeCommit": None,
@@ -1061,8 +1044,7 @@ def test_comment_pr_runs_gh_pr_comment_from_unrelated_cwd(
     calls = []
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(progress, "runner_fingerprint", lambda: "8a12fb1c")
-    monkeypatch.setattr(
-        runner, "run_command",
+    monkeypatch.setattr(seam, "run_command",
         lambda command, **kwargs: calls.append(command),
     )
     runner.comment_pr(
@@ -1212,7 +1194,7 @@ def test_sync_base_checkout_is_a_noop_when_already_at_remote(
         calls.append(command)
         return real(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", spy)
+    monkeypatch.setattr(seam, "run_command", spy)
     runner.sync_base_checkout(checkout, "main")
     # Only fetch + rev-parse; no merge is issued when already current.
     assert not any(c[:2] == ["git", "merge"] for c in calls)
@@ -1252,7 +1234,7 @@ def test_sync_base_checkout_fails_fast_when_synced_head_mismatches(
             return "c" * 40
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(RuntimeError, match="after the sync"):
         runner.sync_base_checkout(tmp_path, "main")
 
@@ -1443,7 +1425,7 @@ def test_fetch_base_ref_holds_the_base_sync_lock_while_fetching(
     checkout = _clone_origin(origin, "checkout")
 
     spy, held = _lock_held_during_fetch(checkout)
-    monkeypatch.setattr(runner, "run_command", spy)
+    monkeypatch.setattr(seam, "run_command", spy)
     runner.fetch_base_ref(checkout, "main")
 
     assert held == [True]
@@ -1480,7 +1462,7 @@ def test_fetch_base_ref_fetches_in_the_given_worktree(
     )
 
     spy, held = _lock_held_during_fetch(checkout)
-    monkeypatch.setattr(runner, "run_command", spy)
+    monkeypatch.setattr(seam, "run_command", spy)
     runner.fetch_base_ref(checkout, "main", cwd=worktree)
 
     assert held == [True]
@@ -1524,7 +1506,7 @@ def test_fetch_base_ref_propagates_fetch_errors_unchanged(
     def fake_run(command, **kwargs):
         raise error
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(subprocess.CalledProcessError):
         runner.fetch_base_ref(tmp_path, "main")
 
@@ -1540,7 +1522,7 @@ def test_fetch_base_ref_releases_the_lock_on_fetch_failure(
             128, command, stderr="fatal: unable to access",
         )
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     with pytest.raises(subprocess.CalledProcessError):
         runner.fetch_base_ref(tmp_path, "main")
 
@@ -1583,13 +1565,11 @@ def _review_merge_config(tmp_path):
 def test_review_and_merge_clean_verdict_merges_and_labels_merged(
         monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(
-        runner, "issue_labels", lambda *a, **k: [
+    monkeypatch.setattr(seam, "issue_labels", lambda *a, **k: [
             "ai-ready", "ai-pr-opened",
         ],
     )
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda *a, **k: [],
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [],
     )
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
@@ -1602,12 +1582,10 @@ def test_review_and_merge_clean_verdict_merges_and_labels_merged(
     )
     monkeypatch.setattr(runner, "sync_base_checkout",
                         lambda *a, **k: calls.append("sync"))
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("comment", k.get("body"))),
     )
     make_fake_gh(monkeypatch)
@@ -1639,13 +1617,11 @@ def test_review_and_merge_skips_checkout_sync_for_a_locked_engine_source(
     origin/<base_branch> must not break the lock — the next tick's
     ExecStartPre engine sync owns that checkout instead."""
     calls = []
-    monkeypatch.setattr(
-        runner, "issue_labels", lambda *a, **k: [
+    monkeypatch.setattr(seam, "issue_labels", lambda *a, **k: [
             "ai-ready", "ai-pr-opened",
         ],
     )
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda *a, **k: [],
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [],
     )
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
@@ -1658,12 +1634,10 @@ def test_review_and_merge_skips_checkout_sync_for_a_locked_engine_source(
     )
     monkeypatch.setattr(runner, "sync_base_checkout",
                         lambda *a, **k: calls.append("sync"))
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("comment", k.get("body"))),
     )
     make_fake_gh(monkeypatch)
@@ -1682,8 +1656,8 @@ def test_review_and_merge_skips_checkout_sync_for_a_locked_engine_source(
 def test_review_and_merge_fix_round_clears_live_delivery_labels(
         monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
-    monkeypatch.setattr(runner, "issue_labels", lambda *a, **k: [
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_labels", lambda *a, **k: [
         "ai-ready", "ai-in-progress", "ai-fix-needed",
     ])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
@@ -1696,10 +1670,9 @@ def test_review_and_merge_fix_round_clears_live_delivery_labels(
         lambda *a, **k: {"state": "MERGED", "merge_commit": "m1"},
     )
     monkeypatch.setattr(runner, "sync_base_checkout", lambda *a, **k: None)
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *a, **k: calls.append(k),
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: calls.append(k),
     )
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     make_fake_gh(monkeypatch)
 
     assert runner.review_and_merge_if_clean(
@@ -1729,8 +1702,7 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
         return next(heads)
 
     monkeypatch.setattr(runner, "freeze_pr", fake_freeze)
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda *a, **k: [],
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [],
     )
     # The verdict carries the FIXED head (the reviewer re-emits it for
     # the pushed fix, Issue #591): the gate binds it to the re-frozen
@@ -1750,8 +1722,8 @@ def test_review_and_merge_refreezes_head_after_in_session_fix(
         lambda *a, **k: {"state": "MERGED", "merge_commit": "m1"},
     )
     monkeypatch.setattr(runner, "sync_base_checkout", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     caplog.set_level("INFO")
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
@@ -1778,7 +1750,7 @@ def test_review_and_merge_verdict_head_mismatch_fails_before_merge(
     merge unreviewed code). The mismatch is a malformed verdict — the
     recoverable fix loop re-reviews the same PR."""
     gate = Mock()
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(
         runner, "run_review",
@@ -1802,8 +1774,7 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
     gate runs against it unchanged (no head-advance log)."""
     calls = []
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
-    monkeypatch.setattr(
-        runner, "issue_comments", lambda *a, **k: [],
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [],
     )
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
 
@@ -1817,8 +1788,8 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
         lambda *a, **k: {"state": "MERGED", "merge_commit": "m1"},
     )
     monkeypatch.setattr(runner, "sync_base_checkout", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "edit_issue", lambda *a, **k: None)
-    monkeypatch.setattr(runner, "comment_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: None)
+    monkeypatch.setattr(seam, "comment_issue", lambda *a, **k: None)
     caplog.set_level("INFO")
     make_fake_gh(monkeypatch)
     merged = runner.review_and_merge_if_clean(
@@ -1835,7 +1806,7 @@ def test_review_and_merge_clean_verdict_without_head_advance_keeps_frozen_head(
 def test_review_and_merge_keeps_merged_when_checkout_sync_fails(
         monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -1850,12 +1821,10 @@ def test_review_and_merge_keeps_merged_when_checkout_sync_fails(
         raise RuntimeError("deployment checkout cannot fast-forward")
 
     monkeypatch.setattr(runner, "sync_base_checkout", boom)
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("comment", k.get("body"))),
     )
     make_fake_gh(monkeypatch)
@@ -1880,22 +1849,20 @@ def test_review_and_merge_keeps_merged_when_checkout_sync_fails(
 def test_review_and_merge_findings_labels_fix_needed_and_comments(
         monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(
         runner, "run_review", lambda *a, **k: _findings_verdict_text(),
     )
     monkeypatch.setattr(runner, "merge_gate", lambda *a, **k:
                         (_ for _ in ()).throw(AssertionError("no merge")))
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("issue", k.get("body"))),
     )
     monkeypatch.setattr(
         runner, "comment_pr", lambda *a, **k: calls.append(("pr", k.get("body"))),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
     make_fake_gh(monkeypatch)
@@ -1920,7 +1887,7 @@ def test_review_and_merge_findings_labels_fix_needed_and_comments(
 
 def test_review_and_merge_behind_base_labels_fix_needed(monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -1931,15 +1898,13 @@ def test_review_and_merge_behind_base_labels_fix_needed(monkeypatch, tmp_path):
             ),
         ),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("issue", k.get("body"))),
     )
     monkeypatch.setattr(
         runner, "comment_pr", lambda *a, **k: calls.append(("pr", k.get("body"))),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
     make_fake_gh(monkeypatch)
@@ -1957,7 +1922,7 @@ def test_review_and_merge_behind_base_labels_fix_needed(monkeypatch, tmp_path):
 
 def test_review_and_merge_ci_failure_labels_fix_needed(monkeypatch, tmp_path):
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -1969,15 +1934,13 @@ def test_review_and_merge_ci_failure_labels_fix_needed(monkeypatch, tmp_path):
             ),
         ),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("issue", k.get("body"))),
     )
     monkeypatch.setattr(
         runner, "comment_pr", lambda *a, **k: calls.append(("pr", k.get("body"))),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *a, **k: calls.append(("edit", k)),
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: calls.append(("edit", k)),
     )
     make_fake_gh(monkeypatch)
     assert runner.review_and_merge_if_clean(
@@ -2002,7 +1965,7 @@ def test_review_and_merge_ci_failure_comment_counts_toward_round_budget(
     review sessions forever while holding the slot.
     """
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -2014,15 +1977,13 @@ def test_review_and_merge_ci_failure_comment_counts_toward_round_budget(
             ),
         ),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("issue", k.get("body"))),
     )
     monkeypatch.setattr(
         runner, "comment_pr", lambda *a, **k: calls.append(("pr", k.get("body"))),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue", lambda *a, **k: calls.append(("edit", k)),
+    monkeypatch.setattr(seam, "edit_issue", lambda *a, **k: calls.append(("edit", k)),
     )
     make_fake_gh(monkeypatch)
     assert runner.review_and_merge_if_clean(
@@ -2050,7 +2011,7 @@ def test_review_and_merge_conflict_labels_fix_needed(monkeypatch, tmp_path):
     re-review. ai-blocked is only for unrecoverable failures.
     """
     calls = []
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -2059,15 +2020,13 @@ def test_review_and_merge_conflict_labels_fix_needed(monkeypatch, tmp_path):
             runner.RecoverableMergeGateError("wording changed: conflict requires retry"),
         ),
     )
-    monkeypatch.setattr(
-        runner, "comment_issue",
+    monkeypatch.setattr(seam, "comment_issue",
         lambda *a, **k: calls.append(("issue", k.get("body"))),
     )
     monkeypatch.setattr(
         runner, "comment_pr", lambda *a, **k: calls.append(("pr", k.get("body"))),
     )
-    monkeypatch.setattr(
-        runner, "edit_issue",
+    monkeypatch.setattr(seam, "edit_issue",
         lambda *a, **k: calls.append(("edit", k)),
     )
     make_fake_gh(monkeypatch)
@@ -2083,7 +2042,7 @@ def test_review_and_merge_conflict_labels_fix_needed(monkeypatch, tmp_path):
 
 
 def test_review_and_merge_reraises_non_fixable_gate_error(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(runner, "run_review", lambda *a, **k: _pass_verdict_text())
     monkeypatch.setattr(
@@ -2105,7 +2064,7 @@ def test_review_and_merge_reraises_non_fixable_gate_error(monkeypatch, tmp_path)
 
 
 def test_review_and_merge_missing_verdict_raises(monkeypatch, tmp_path):
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: [])
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: [])
     monkeypatch.setattr(runner, "freeze_pr", lambda *a, **k: _pr())
     monkeypatch.setattr(
         runner, "run_review", lambda *a, **k: "review without a verdict",
@@ -2127,7 +2086,7 @@ def test_review_and_merge_exhausted_rounds_raises(monkeypatch, tmp_path, caplog)
          "authorAssociation": "OWNER"}
         for i in range(1, runner.MAX_REVIEW_ROUNDS + 1)
     ]
-    monkeypatch.setattr(runner, "issue_comments", lambda *a, **k: comments)
+    monkeypatch.setattr(seam, "issue_comments", lambda *a, **k: comments)
     with caplog.at_level("ERROR"), pytest.raises(
         RuntimeError,
         match=f"exhausted after {runner.MAX_REVIEW_ROUNDS} rounds",

--- a/tests/test_run_id_e2e.py
+++ b/tests/test_run_id_e2e.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import pytest
 
 import orbi.runner as runner
+from seam import seam
+import orbi.journal as journal
 
 REPO = "owner/repo"
 ISSUE_NUMBER = 41
@@ -153,7 +155,7 @@ def clone(tmp_path: Path) -> Path:
 @pytest.fixture(autouse=True)
 def _reset_run_id(monkeypatch):
     """Each test starts without a bound run id."""
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", None)
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", None)
 
 
 def install_fake_pi(monkeypatch, tmp_path: Path, script: str) -> None:
@@ -290,7 +292,7 @@ def install_fake_gh(monkeypatch, comments: list[str],
             raise AssertionError(f"unexpected gh command: {command}")
         return real_run(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
 
 
 def write_prompt(tmp_path: Path) -> Path:
@@ -406,7 +408,7 @@ def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
     clone, tmp_path, monkeypatch, caplog,
 ):
     run_ids = iter(["a1b2c3d4", "b2c3d4e5"])
-    monkeypatch.setattr(runner, "new_run_id", lambda: next(run_ids))
+    monkeypatch.setattr(seam, "new_run_id", lambda: next(run_ids))
     comments: list[str] = []
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
     install_fake_gh(monkeypatch, comments)
@@ -461,7 +463,7 @@ def test_e2e_retry_of_same_issue_gets_new_run_id_and_keeps_old_scene(
 def test_e2e_failed_attempt_marks_blocked_with_same_run_id(
     clone, tmp_path, monkeypatch, caplog,
 ):
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     comments: list[str] = []
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI_FAILING)
     install_fake_gh(monkeypatch, comments)
@@ -530,8 +532,8 @@ def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
             return
         raise AssertionError("kill simulation: label edit must not land")
 
-    monkeypatch.setattr(runner, "edit_issue", claiming_edit)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "edit_issue", claiming_edit)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
     # Issue #239: the failure path runs (the `claiming_edit` above
     # suppresses its label transition, simulating the kill) and
     # `process_issue` returns `None` instead of re-raising.
@@ -549,8 +551,8 @@ def test_e2e_restart_reuses_run_id_worktree_and_progress_comment(
     # implementer (now healthy) delivers.
     caplog.clear()
     install_fake_pi(monkeypatch, tmp_path, FAKE_PI)
-    monkeypatch.setattr(runner, "edit_issue", real_edit_issue)
-    monkeypatch.setattr(runner, "new_run_id", lambda: "b2c3d4e5")
+    monkeypatch.setattr(seam, "edit_issue", real_edit_issue)
+    monkeypatch.setattr(seam, "new_run_id", lambda: "b2c3d4e5")
     result = runner.process_issue(issue(), config, REPO)
 
     # The reused run id drives the branch and the worktree: no second

--- a/tests/test_runner_health.py
+++ b/tests/test_runner_health.py
@@ -27,6 +27,8 @@ from unittest.mock import Mock
 import pytest
 
 from orbi import runner_health
+from seam import seam
+import orbi.journal as journal
 
 # Captured at import time (before any monkeypatch): the conftest default
 # stubs `run_health_check` for the dispatch tests, and this module
@@ -1058,21 +1060,18 @@ def test_process_issue_pickup_record_failure_is_bypass(
     from tests.test_bootstrap_runner import _gh_api
     from tests.test_progress_wiring import make_fake_gh
 
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree", lambda *args, **kwargs: tmp_path / "wt",
     )
     monkeypatch.setattr(runner, "run_pi", lambda *args, **kwargs: "done")
     monkeypatch.setattr(
         runner, "deliver_pr",
         lambda *args, **kwargs: "https://github.com/orbi-build/orbi/pull/4",
     )
-    monkeypatch.setattr(
-        runner, "comment_issue", lambda *args, **kwargs: None,
+    monkeypatch.setattr(seam, "comment_issue", lambda *args, **kwargs: None,
     )
     gh_calls, posted = make_fake_gh(monkeypatch)
 
@@ -1086,7 +1085,7 @@ def test_process_issue_pickup_record_failure_is_bypass(
             return "[]"
         return "0123456789abcdef0123456789abcdef01234567"
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner_health, "record_pickup",
         lambda repo_dir: (_ for _ in ()).throw(
@@ -1114,13 +1113,11 @@ def test_process_issue_failure_record_failure_is_bypass(
     from tests.test_bootstrap_runner import _gh_api
     from tests.test_progress_wiring import make_fake_gh
 
-    monkeypatch.setattr(runner, "edit_issue", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        runner, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
+    monkeypatch.setattr(seam, "edit_issue", lambda *args, **kwargs: None)
+    monkeypatch.setattr(seam, "freeze_base", lambda repo_dir, base_branch: "abc123def456",
     )
-    monkeypatch.setattr(runner, "new_run_id", lambda: "a1b2c3d4")
-    monkeypatch.setattr(
-        runner, "create_worktree",
+    monkeypatch.setattr(seam, "new_run_id", lambda: "a1b2c3d4")
+    monkeypatch.setattr(seam, "create_worktree",
         Mock(side_effect=RuntimeError("git failed")),
     )
     monkeypatch.setattr(
@@ -1138,7 +1135,7 @@ def test_process_issue_failure_record_failure_is_bypass(
             return "[]"
         return ""
 
-    monkeypatch.setattr(runner, "run_command", fake_run)
+    monkeypatch.setattr(seam, "run_command", fake_run)
     monkeypatch.setattr(
         runner_health, "record_run_attempt",
         lambda *args, **kwargs: (_ for _ in ()).throw(
@@ -1178,7 +1175,7 @@ def test_main_runs_the_health_check_every_tick(monkeypatch, tmp_path):
     monkeypatch.setattr(
         runner_health, "run_health_check", recording_health_check,
     )
-    monkeypatch.setattr(runner, "run_command", idle_tick_fake_run())
+    monkeypatch.setattr(seam, "run_command", idle_tick_fake_run())
     assert runner.main(["--config", str(tmp_path / "orbi.toml")]) == 0
     assert len(calls) == 1
     assert calls[0]["repo_dir"] == tmp_path / "orbi"
@@ -1197,7 +1194,7 @@ def test_main_health_check_failure_never_fails_the_tick(
     monkeypatch.setattr(
         runner_health, "run_health_check", exploding_health_check,
     )
-    monkeypatch.setattr(runner, "run_command", idle_tick_fake_run())
+    monkeypatch.setattr(seam, "run_command", idle_tick_fake_run())
     with caplog.at_level("INFO"):
         assert runner.main(["--config", str(tmp_path / "orbi.toml")]) == 0
     assert "health_check_failed" in caplog.text

--- a/tests/test_runner_source_freshness.py
+++ b/tests/test_runner_source_freshness.py
@@ -26,6 +26,7 @@ import pytest
 
 import orbi.cli_source as cli_source
 import orbi.runner as runner
+from seam import seam
 
 # The conftest autouse fixture stubs the gate for the in-process
 # dispatch tests; the gate's OWN tests restore the real implementation

--- a/tests/test_systemd_timer.py
+++ b/tests/test_systemd_timer.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from orbi import systemd_deploy
+import orbi.journal as journal
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TIMER_FILE = REPO_ROOT / "systemd" / "orbi@.timer"

--- a/tests/test_worktree_reclaim.py
+++ b/tests/test_worktree_reclaim.py
@@ -22,11 +22,13 @@ from pathlib import Path
 import pytest
 
 from orbi import runner
+import orbi.journal as journal
 from orbi.delivery_labels import (
     FIX_NEEDED_LABEL,
     IN_PROGRESS_LABEL,
     PR_OPENED_LABEL,
 )
+from seam import seam
 
 LOGGER_NAME = "orbi.bootstrap"
 NOW = datetime(2026, 9, 12, 12, 0, 0, tzinfo=timezone.utc)
@@ -108,7 +110,7 @@ def _stub_closed(monkeypatch, *issues: dict) -> None:
         assert "closedAt" in json_fields and "labels" in json_fields
         return list(issues)
 
-    monkeypatch.setattr(runner, "list_issues", fake_list_issues)
+    monkeypatch.setattr(seam, "list_issues", fake_list_issues)
 
 
 def test_reclaims_closed_issue_worktree_past_window(tmp_path, monkeypatch, caplog):
@@ -174,7 +176,7 @@ def test_keeps_worktree_of_this_process_active_run(tmp_path, monkeypatch):
     repo = _git_repo(tmp_path / "repo")
     worktree = _register(repo, "orbi-owner-repo-issue-12-abcd1234")
     _stub_closed(monkeypatch, _closed(12, hours_ago=100))
-    monkeypatch.setattr(runner, "_CURRENT_RUN_ID", "abcd1234")
+    monkeypatch.setattr(journal, "_CURRENT_RUN_ID", "abcd1234")
     runner.reclaim_released_worktrees(_config(repo), now=NOW)
     assert str(worktree) in _registered(repo)
 
@@ -187,8 +189,7 @@ def test_keeps_worktree_bound_as_active_scene(tmp_path, monkeypatch):
     repo = _git_repo(tmp_path / "repo")
     worktree = _register(repo, "orbi-owner-repo-issue-12-abcd1234")
     _stub_closed(monkeypatch, _closed(12, hours_ago=100))
-    monkeypatch.setattr(
-        runner, "_ACTIVE_RUN", {"worktree": str(worktree)},
+    monkeypatch.setattr(journal, "_ACTIVE_RUN", {"worktree": str(worktree)},
     )
     runner.reclaim_released_worktrees(_config(repo), now=NOW)
     assert str(worktree) in _registered(repo)
@@ -244,7 +245,7 @@ def test_same_issue_number_in_two_source_repos_is_not_crossed(
         assert repo == "owner/two"
         return []
 
-    monkeypatch.setattr(runner, "list_issues", fake_list_issues)
+    monkeypatch.setattr(seam, "list_issues", fake_list_issues)
     config = _config(repo)
     config["source_repos"] = ["owner/one", "owner/two"]
     runner.reclaim_released_worktrees(config, now=NOW)
@@ -261,7 +262,7 @@ def test_read_failure_removes_nothing_and_warns(tmp_path, monkeypatch, caplog):
     def failing_list_issues(repo, **kwargs):
         raise RuntimeError("gh is down")
 
-    monkeypatch.setattr(runner, "list_issues", failing_list_issues)
+    monkeypatch.setattr(seam, "list_issues", failing_list_issues)
     with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
         runner.reclaim_released_worktrees(_config(repo), now=NOW)
     assert str(worktree) in _registered(repo)
@@ -291,7 +292,7 @@ def test_single_removal_failure_warns_and_continues(
             raise RuntimeError("boom")
         return real_run_command(command, **kwargs)
 
-    monkeypatch.setattr(runner, "run_command", run_command)
+    monkeypatch.setattr(seam, "run_command", run_command)
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
         runner.reclaim_released_worktrees(_config(repo), now=NOW)
     assert str(stuck) in _registered(repo)
@@ -358,8 +359,7 @@ def test_noop_without_worktrees_directory(tmp_path, monkeypatch):
     """A deployment without any worktrees makes no GitHub read at all."""
     repo = _git_repo(tmp_path / "repo")
     called = []
-    monkeypatch.setattr(
-        runner, "list_issues",
+    monkeypatch.setattr(seam, "list_issues",
         lambda *a, **k: called.append(a) or [],
     )
     runner.reclaim_released_worktrees(_config(repo), now=NOW)


### PR DESCRIPTION
<!-- orbi:run=f02e45ae -->

Fixes #785

架构重构 1/5:新建 github.py / gitops.py 叶子模块,消灭抽离模块对 runner 的反向依赖 (run_id=f02e45ae)
