### PR TITLE
架构重构 3/5:交付场景显式化——纯函数 classify(...) -> DeliveryScene + dispatch 表

### DIFF
--- a/src/orbi/delivery_scene.py
+++ b/src/orbi/delivery_scene.py
@@ -1,0 +1,236 @@
+"""The delivery scene: one explicit classification (Issue #787).
+
+A delivery scene used to be re-derived twice per tick with two
+different decision procedures — the scan layer filtered by GitHub
+search queries, `process_issue` re-read labels, PRs, branches and
+worktrees and re-judged — and #726 was the direct product of the two
+disagreeing. This module is the single decision both layers call: the
+same gathered facts always classify to the same `DeliveryScene`, in
+the scan and in the dispatch, so a two-layer disagreement is
+structurally impossible.
+
+The module is pure (the `delivery_labels` model): every function is a
+deterministic function of its inputs, with no I/O. The I/O — the
+GitHub reads, the PR probes, the local worktree checks — stays with
+the caller (the fact gathering); this module only names the facts and
+decides.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from orbi.delivery_labels import (
+    BLOCKED_LABEL,
+    CONTENT_ONLY_LABEL,
+    EPIC_LABEL,
+    FIX_NEEDED_LABEL,
+    HUMAN_REVIEW_LABEL,
+    IN_PROGRESS_LABEL,
+    MERGED_LABEL,
+    OPS_LABEL,
+    PR_OPENED_LABEL,
+    READY_LABEL,
+    RELEASE_LABEL,
+)
+
+if TYPE_CHECKING:
+    # Annotation-only: the runner imports this module's scene
+    # vocabulary at runtime; this module never imports the runner
+    # (CONSTITUTION Article 3.3).
+    from orbi.repo_config import RepoPolicy
+    from orbi.runner import RunnerConfig
+
+
+class DeliveryScene(Enum):
+    """Every state a delivery can be classified into.
+
+    The scan layer classifies a candidate before handing it over; the
+    dispatch layer classifies the freshly gathered facts and looks the
+    scene's handler up in its dispatch table. The values are the
+    journal-readable scene names.
+    """
+
+    FRESH_CLAIM = "fresh_claim"
+    RESTART_IN_FLIGHT = "restart_in_flight"
+    RESUME_REVIEW = "resume_review"
+    EXTERNAL_TAKEOVER = "external_takeover"
+    RELEASE = "release"
+    CONTENT_ONLY = "content_only"
+    OPS = "ops"
+    HUMAN_REVIEW_WAIT = "human_review_wait"
+    BLOCKED = "blocked"
+    NOT_CLAIMABLE = "not_claimable"
+
+
+# The issue-body marker vocabulary (the marker the triage workflow
+# embeds for an EXTERNAL contributor PR, Issue #608). The regex is the
+# one parser: the runner's takeover probes read the PR number from it,
+# `body_markers` reduces a body to the marker set `classify` reads.
+EXTERNAL_PR_MARKER = "orbi:external-pr"
+EXTERNAL_PR_RE = re.compile(r"<!--\s*orbi:external-pr:(\d+)\s*-->")
+
+
+def body_markers(body: object) -> frozenset[str]:
+    """The delivery markers one Issue body carries (a pure text scan).
+
+    A missing or non-string body carries none — Issue text is data,
+    never instructions, and a malformed body is never a crash.
+    """
+    if not isinstance(body, str):
+        return frozenset()
+    if EXTERNAL_PR_RE.search(body):
+        return frozenset({EXTERNAL_PR_MARKER})
+    return frozenset()
+
+
+def classify(
+    labels, scene, pr_state, worktree_present, branch_present,
+    body_markers, *, ready_label: str = READY_LABEL,
+    human_review_hold: bool = False,
+) -> DeliveryScene:
+    """Classify one delivery scene from the gathered facts (pure).
+
+    The facts, as both layers gather them:
+
+    - `labels`: the Issue's current labels (the scan's query snapshot,
+      with the dispatch layer's direct `ai-in-progress` read merged in
+      when it saw the label);
+    - `scene`: the trusted resume scene of an opened-PR comment, in
+      either of the runner's two views (`orbi.scene.Scene` or its dict
+      projection); None when no trusted comment carries one;
+    - `pr_state`: the probed PR state for the delivery branch
+      (`"OPEN"` / `"MERGED"` / `"CLOSED"`), None when no PR was probed
+      or none is open;
+    - `worktree_present` / `branch_present`: the local facts; no scene
+      today re-routes on them (a missing worktree is the handler's
+      fail-fast, an existing branch its resume point — `claim_route`'s
+      "implement" for a branch without an open PR is the pinned
+      counterpart);
+    - `body_markers`: the `body_markers` set of the Issue body;
+    - `ready_label`: the repository's claim label (Issue #527) — the
+      queue entry a fresh claim keys on;
+    - `human_review_hold`: the human acceptance gate's hold (the gate
+      on and a non-empty checklist column 2, Issue #763); the
+      `ai-human-review` label (a human confirmed) overrides it.
+
+    The decision order is today's behavior, one branch each:
+
+    1. `ai-blocked` → BLOCKED (terminal, a human decides);
+    2. `ai-merged` / `ai-epic` → NOT_CLAIMABLE (success-terminal /
+       coordination-only);
+    3. task types in dispatch order — RELEASE, CONTENT_ONLY, OPS;
+    4. an opened-PR state (`ai-pr-opened` / `ai-fix-needed`) resumes
+       through the trusted scene: RESUME_REVIEW, or HUMAN_REVIEW_WAIT
+       while the gate holds; without a scene comment, a marker with an
+       open external PR is the #726 takeover route, a queue-label
+       ticket with an open PR is the internal takeover race (a fresh
+       claim — the handler reviews the PR), anything else is
+       NOT_CLAIMABLE;
+    5. marker + open external PR → EXTERNAL_TAKEOVER (Issue #608); a
+       PR that is no longer open is not a takeover — the claim falls
+       through to a fresh internal delivery;
+    6. `ai-in-progress` → RESTART_IN_FLIGHT (Issue #18);
+    7. the claim label → FRESH_CLAIM;
+    8. anything else → NOT_CLAIMABLE.
+    """
+    current = frozenset(labels)
+    markers = frozenset(body_markers)
+    opened_pr = PR_OPENED_LABEL in current or FIX_NEEDED_LABEL in current
+
+    if BLOCKED_LABEL in current:
+        return DeliveryScene.BLOCKED
+    if MERGED_LABEL in current or EPIC_LABEL in current:
+        return DeliveryScene.NOT_CLAIMABLE
+    if RELEASE_LABEL in current:
+        return DeliveryScene.RELEASE
+    if CONTENT_ONLY_LABEL in current:
+        return DeliveryScene.CONTENT_ONLY
+    if OPS_LABEL in current:
+        return DeliveryScene.OPS
+    if opened_pr:
+        if scene is not None:
+            if human_review_hold and HUMAN_REVIEW_LABEL not in current:
+                return DeliveryScene.HUMAN_REVIEW_WAIT
+            return DeliveryScene.RESUME_REVIEW
+        # No trusted scene: the review cannot be resumed, but two
+        # takeover routes survive it (both layers' #726/#608 handles).
+        if EXTERNAL_PR_MARKER in markers and pr_state == "OPEN":
+            return DeliveryScene.EXTERNAL_TAKEOVER
+        if ready_label in current and pr_state == "OPEN":
+            return DeliveryScene.FRESH_CLAIM
+        return DeliveryScene.NOT_CLAIMABLE
+    if EXTERNAL_PR_MARKER in markers and pr_state == "OPEN":
+        return DeliveryScene.EXTERNAL_TAKEOVER
+    if IN_PROGRESS_LABEL in current:
+        return DeliveryScene.RESTART_IN_FLIGHT
+    if ready_label in current:
+        return DeliveryScene.FRESH_CLAIM
+    return DeliveryScene.NOT_CLAIMABLE
+
+
+@dataclasses.dataclass(frozen=True)
+class DeliveryContext:
+    """The run-identity bundle of one delivery attempt (Issue #290).
+
+    `run_id`, `issue`, `branch`, `worktree` and `pr` travel together
+    through the dispatch path; one frozen value object replaces the
+    loose tuple, so a new identity field is one constructor change, not
+    a sweep of call sites. `pr` is None until the delivery's PR exists.
+    """
+
+    run_id: str
+    issue: int
+    branch: str
+    worktree: Path
+    pr: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class DeliveryFacts:
+    """The fact bundle the dispatch layer's gather step produces.
+
+    The first six fields are exactly `classify`'s fact inputs; the rest
+    are the handler facts the gather already had to read (the takeover
+    probe's PR dict, the verified resume worktree, the repository
+    policy's audit fields). The classify call unpacks the fact fields
+    by name; the handler reads its own — one gather, two consumers.
+    """
+
+    labels: frozenset[str]
+    scene: object = None
+    pr_state: str | None = None
+    worktree_present: bool = False
+    branch_present: bool = False
+    body_markers: frozenset[str] = frozenset()
+    ready_label: str = READY_LABEL
+    # Handler facts.
+    config: "RunnerConfig | None" = None
+    repo_policy: "RepoPolicy | None" = None
+    run_id: str = ""
+    base_branch: str = ""
+    dispatch_label: str = READY_LABEL
+    claim_labels: frozenset[str] = frozenset()
+    in_progress: bool = False
+    stable_branch: str = ""
+    stable_branch_present: bool = False
+    takeover_pr: dict | None = None
+    external_takeover: bool = False
+    resume_scene: tuple[str, Path] | None = None
+    resume_error: Exception | None = None
+    repo_config_fields: dict = dataclasses.field(default_factory=dict)
+
+    def classify_scene(self) -> DeliveryScene:
+        """Classify from this bundle's fact fields."""
+        return classify(
+            labels=self.labels,
+            scene=self.scene,
+            pr_state=self.pr_state,
+            worktree_present=self.worktree_present,
+            branch_present=self.branch_present,
+            body_markers=self.body_markers,
+            ready_label=self.ready_label,
+        )

--- a/src/orbi/runner.py
+++ b/src/orbi/runner.py
@@ -91,6 +91,14 @@ from orbi.delivery_labels import (
     needs_human_intervention,
 )
 from orbi import human_review
+from orbi.delivery_scene import (
+    EXTERNAL_PR_RE,
+    DeliveryContext,
+    DeliveryFacts,
+    DeliveryScene,
+    body_markers,
+    classify,
+)
 from orbi.repo_config import (
     REPO_CONFIG_PATH,
     RepoConfigError,
@@ -1824,6 +1832,19 @@ def release_fallback_search(active_milestone: str | None = None,
     )
 
 
+def _issue_label_set(issue: dict) -> frozenset[str]:
+    """The Issue's label names (the scans fetch `labels`).
+
+    The fact shape the scene classification (`orbi.delivery_scene`)
+    reads; a missing or malformed `labels` field yields the empty set —
+    the classification then sees an unlabelled ticket, never a crash.
+    """
+    return frozenset(
+        label.get("name") for label in issue.get("labels", [])
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    )
+
+
 def is_epic(issue: dict) -> bool:
     """Return True when one issue carries the `ai-epic` label (Issue #93).
 
@@ -2022,9 +2043,29 @@ def reconcile_orphan_prs(repo: str, run_id: str) -> list[str]:
     return evidence
 
 
+# The scenes the ready scans claim: the fresh-claim family of the
+# delivery-scene classification (Issue #787). A release candidate is
+# claimable only through the release fallback scan's `allow_release`
+# gate above; the classification still names its scene. A candidate
+# that classifies elsewhere is skipped — a terminal state the query's
+# index lagged behind, or an in-flight/opened-PR state another scan
+# owns — and a candidate carrying NO readable labels fails open (the
+# is_epic/is_release convention): the query is the claim authority.
+_FRESH_CLAIM_SCENES = frozenset({
+    DeliveryScene.FRESH_CLAIM,
+    DeliveryScene.RELEASE,
+    DeliveryScene.CONTENT_ONLY,
+    DeliveryScene.OPS,
+})
+_SCAN_CLAIMABLE_SCENES = _FRESH_CLAIM_SCENES | {
+    DeliveryScene.RESTART_IN_FLIGHT,
+}
+
+
 def _pick_from_scan(
     issues: list[dict], repo: str, allow_release: bool = False,
     active_milestone: str | None = None,
+    ready_label: str = READY_LABEL,
 ) -> dict | None:
     """Return the first claimable Issue of one scan result, else None.
 
@@ -2051,6 +2092,12 @@ def _pick_from_scan(
     `ai-blocked`. A Milestone query that cannot be evaluated skips the
     release too (`release_milestone_check_failed`): a bad release is
     irreversible, so the check fails safe and the next tick retries.
+
+    The last guard is the delivery-scene classification itself (Issue
+    #787): the ready scans claim only the fresh-claim family, decided
+    by the same pure `classify` the dispatch layer runs, so a stale
+    index handing over a ticket that no longer carries the queue label
+    is skipped, never claimed into a scene it is no longer in.
     """
     for issue in issues:
         if is_epic(issue):
@@ -2093,6 +2140,20 @@ def _pick_from_scan(
                 blockers=",".join(str(number) for number in blockers),
             )
             continue
+        current_labels = _issue_label_set(issue)
+        if current_labels:
+            scene_value = classify(
+                labels=current_labels, scene=None, pr_state=None,
+                worktree_present=False, branch_present=False,
+                body_markers=body_markers(issue.get("body")),
+                ready_label=ready_label,
+            )
+            if scene_value not in _SCAN_CLAIMABLE_SCENES:
+                event(
+                    "claim_yield", issue=issue.get("number"),
+                    reason=f"scene_{scene_value.value}",
+                )
+                continue
         event(
             "picked", issue=issue.get("number"), repo=repo,
             priority=issue_priority(issue),
@@ -2143,7 +2204,9 @@ def pick_issue(repo: str, active_milestone: str | None = None,
                 repo=repo, error=exc,
             )
             return None
-        picked = _pick_from_scan(issues, repo)
+        picked = _pick_from_scan(
+            issues, repo, ready_label=dispatch_label,
+        )
         if picked is not None:
             return picked
     # Release fallback (Issue #255): only when no ordinary delivery
@@ -2169,6 +2232,7 @@ def pick_issue(repo: str, active_milestone: str | None = None,
     return _pick_from_scan(
         issues, repo, allow_release=True,
         active_milestone=active_milestone,
+        ready_label=dispatch_label,
     )
 
 
@@ -2229,7 +2293,28 @@ def pick_in_progress_issue(
         ),
         json_fields="number,title,body,labels,milestone", limit=1,
     )
-    return issues[0] if issues else None
+    candidate = issues[0] if issues else None
+    if candidate is not None:
+        # Issue #787: the same pure classification the dispatch runs.
+        # This scan hands the candidate to `process_issue`, whose full
+        # fact set decides the handler, so the scan skips only a
+        # candidate that left EVERY claimable state (a relabel inside
+        # the query's staleness window); a candidate with no readable
+        # labels fails open (the is_epic/is_release convention).
+        current_labels = _issue_label_set(candidate)
+        if current_labels:
+            scene_value = classify(
+                labels=current_labels, scene=None, pr_state=None,
+                worktree_present=False, branch_present=False,
+                body_markers=body_markers(candidate.get("body")),
+            )
+            if scene_value not in _SCAN_CLAIMABLE_SCENES:
+                event(
+                    "claim_yield", issue=int(candidate["number"]),
+                    reason=f"scene_{scene_value.value}",
+                )
+                return None
+    return candidate
 
 
 def pick_next_issue(
@@ -2259,14 +2344,6 @@ def claim_route(labels: set[str], *, branch_exists: bool,
     # An existing branch without an open PR is resumed by implementation;
     # a missing branch is the same implementation path.
     return "implement"
-
-
-# Issue #608: the triage workflow embeds this hidden marker in the bug
-# Issue it files for an EXTERNAL contributor PR's CI failure (head branch
-# outside the stable delivery naming). The claim scan parses it and takes
-# the external PR over for review FIRST — an external PR is never
-# silently redone while it is open.
-EXTERNAL_PR_RE = re.compile(r"<!--\s*orbi:external-pr:(\d+)\s*-->")
 
 
 def external_takeover_pr(repo_dir: Path, body: str | None,
@@ -2553,13 +2630,17 @@ def pick_resumable_delivery(
     # already keeps implement-phase Issues out.
     # `labels` (Issue #101): a resumed P0 delivery keeps its
     # priority in the progress comment through review/merge.
+    # `body` (Issue #787): the scene classification reads the
+    # delivery markers — without it the #726 external routing of a
+    # marker ticket with no trusted scene comment is unreachable in
+    # production (the probe read a body the query never fetched).
     issues = list_issues(
         repo, state="open",
         search=(
             f"label:{FIX_NEEDED_LABEL},{PR_OPENED_LABEL} "
             f"-label:{BLOCKED_LABEL} -label:{MERGED_LABEL}"
         ),
-        json_fields="number,title,state,url,labels", limit=1,
+        json_fields="number,title,state,url,labels,body", limit=1,
     )
     if not issues:
         return None
@@ -2612,6 +2693,25 @@ def pick_resumable_delivery(
         except Exception:
             LOGGER.exception("issue=%s failure reporting failed", number)
         return None
+    # Issue #787: the scan and the dispatch classify with the same pure
+    # function. This scan owns the resumable route only: a candidate
+    # that classifies elsewhere left the opened-PR state between the
+    # query and this read (a relabel race) — claim nothing this tick.
+    # A candidate with no readable labels fails open (the is_epic /
+    # is_release convention): the trusted scene is the authority.
+    current_labels = _issue_label_set(issue)
+    if current_labels:
+        found_scene = classify(
+            labels=current_labels, scene=found, pr_state=None,
+            worktree_present=False, branch_present=False,
+            body_markers=body_markers(issue.get("body")),
+        )
+        if found_scene is not DeliveryScene.RESUME_REVIEW:
+            event(
+                "claim_yield", issue=int(issue["number"]),
+                reason=f"scene_{found_scene.value}",
+            )
+            return None
     return issue, found
 
 
@@ -6136,56 +6236,71 @@ class IssueResult(NamedTuple):
     url: str | None
 
 
-def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
-                  repo_policy: RepoPolicy | None = None) -> IssueResult:
+def _dispatch_release(issue: dict, config: RunnerConfig,
+                      source_repo: str) -> IssueResult:
+    """Deliver a RELEASE-scene ticket through the deterministic release
+    state machine (Issue #98): a first-class task type that NEVER enters
+    the normal `run_pi` development path (scope verification, gates,
+    tests, tag, GitHub Release)."""
     number = int(issue["number"])
-    # Issue #100: the progress comment's issue line shows the number
-    # AND the title in every scene. The scanned issue dict always
-    # carries the GitHub title (every scan fetches `title`); a missing
-    # or non-string title fails fast here (KeyError / ValueError in
-    # `progress.issue_field`) — it is never fabricated.
-    title = issue["title"]
-    # Release task (Issue #98): a first-class task type that NEVER
-    # enters the normal `run_pi` development path. The Runner executes
-    # its own deterministic release state machine instead (scope
-    # verification, gates, tests, tag, GitHub Release).
-    if is_release(issue):
-        # `orbi.release` imports the runner primitives back, so the
-        # dispatch imports it lazily here — a module-level import would
-        # be circular (Issue #286).
-        #
-        # Issue #708: the ready scan's stale snapshot can hand an
-        # already-claimed release ticket to a second live runner. The
-        # dev path got the direct-read yield in #658; the release path
-        # needs the same semantics — an in-progress release owned by a
-        # LIVE co-runner is yielded this tick (never run the state
-        # machine concurrently); an orphaned one (this runner is alone)
-        # still resumes inside process_release (#98 restart resume).
-        # The millisecond truly-simultaneous window remains, exactly as
-        # documented for #658 — the label write is not a CAS.
-        if has_in_progress_label(number, source_repo):
-            slot_dir = config.slot_dir
-            max_concurrency = config.max_concurrency
-            if (slot_dir is not None and max_concurrency is not None
-                    and _another_live_runner(slot_dir, max_concurrency)):
-                event(
-                    "claim_yield",
-                    issue=number,
-                    reason="release_in_progress_live_runner",
-                )
-                return IssueResult("claim-yielded", None)
-        from orbi import release
+    # `orbi.release` imports the runner primitives back, so the
+    # dispatch imports it lazily here — a module-level import would
+    # be circular (Issue #286).
+    #
+    # Issue #708: the ready scan's stale snapshot can hand an
+    # already-claimed release ticket to a second live runner. The
+    # dev path got the direct-read yield in #658; the release path
+    # needs the same semantics — an in-progress release owned by a
+    # LIVE co-runner is yielded this tick (never run the state
+    # machine concurrently); an orphaned one (this runner is alone)
+    # still resumes inside process_release (#98 restart resume).
+    # The millisecond truly-simultaneous window remains, exactly as
+    # documented for #658 — the label write is not a CAS.
+    if has_in_progress_label(number, source_repo):
+        slot_dir = config.slot_dir
+        max_concurrency = config.max_concurrency
+        if (slot_dir is not None and max_concurrency is not None
+                and _another_live_runner(slot_dir, max_concurrency)):
+            event(
+                "claim_yield",
+                issue=number,
+                reason="release_in_progress_live_runner",
+            )
+            return IssueResult("claim-yielded", None)
+    from orbi import release
 
-        return IssueResult("release", release.process_release(issue, config, source_repo))
-    if is_content_only(issue):
-        process_ticket_only(issue, config, source_repo)
-        return IssueResult("ticket-only", None)
-    # Ops task (Issue #537): a full-execution session — the SAME claim,
-    # worktree and run machinery as the dev path below (no command
-    # whitelist exists anywhere), with the ops playbook instead of the
-    # dev one and an evidence-on-the-Issue closeout when the session
-    # delivers no commit.
-    ops = is_ops(issue)
+    return IssueResult(
+        "release", release.process_release(issue, config, source_repo),
+    )
+
+
+def _dispatch_content_only(issue: dict, config: RunnerConfig,
+                           source_repo: str) -> IssueResult:
+    """Deliver a CONTENT_ONLY-scene ticket through the ticket-only
+    content agent: no execution, the deliverable posted to the Issue."""
+    process_ticket_only(issue, config, source_repo)
+    return IssueResult("ticket-only", None)
+
+
+def _gather_claim_facts(issue: dict, config: RunnerConfig,
+                        source_repo: str,
+                        repo_policy: RepoPolicy | None) -> DeliveryFacts:
+    """Gather the claim facts of one attempt (the dispatch's first step).
+
+    The probe sequence is `process_issue`'s prologue, order unchanged:
+    the attempt binds its run id before any other step is logged
+    (Issue #41), the repository policy applies, the live
+    `ai-in-progress` state is read directly (Issue #658), then the
+    fresh-claim probes (the stable branch's open PR, the branch
+    existence, the external takeover of a marker ticket) or the
+    in-flight probes (the external takeover, the resume worktree) run.
+
+    A resume worktree that cannot be verified is RECORDED as
+    `resume_error`, not raised here: the handler reports it after its
+    claim-yield guard, so a live co-runner's claim is never blocked
+    from under it — the order the classification refactor inherited.
+    """
+    number = int(issue["number"])
     # The run id is generated once per attempt and bound BEFORE any
     # other step is logged, so every journal line of the attempt
     # carries it — including the claim-time lines of the restart resume
@@ -6224,23 +6339,15 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
     # The claim label is a delivery-policy key (Issue #527); the lifecycle
     # labels stay host constants.
     dispatch_label = (config.dispatch_label or READY_LABEL)
-    # Restart resume (Issue #18): a killed runner leaves the task
-    # worktree and the `ai-in-progress` label behind. Only in that state
-    # the newest worktree's run id is reused, so the same hidden-marker
-    # progress comment is found and kept instead of a second one.
-    # Completed runs keep their worktrees as evidence but lose the
-    # label, so re-claiming an issue always starts a fresh run.
-    existing_worktree: Path | None = None
+    claim_labels = _issue_label_set(issue)
+    stable_branch = task_branch(source_repo, number)
+    in_progress = has_in_progress_label(number, source_repo)
     takeover_pr: dict | None = None
     external_takeover = False
     stable_branch_present = False
-    claim_labels = {
-        label.get("name") for label in issue.get("labels", [])
-        if isinstance(label, dict) and isinstance(label.get("name"), str)
-    }
-    in_progress = has_in_progress_label(number, source_repo)
+    resume_scene: tuple[str, Path] | None = None
+    resume_error: Exception | None = None
     if not in_progress and dispatch_label in claim_labels:
-        stable_branch = task_branch(source_repo, number)
         takeover_pr = open_pr_for_branch(config.repo_dir, stable_branch)
         stable_branch_present = stable_branch_exists(
             config.repo_dir, stable_branch,
@@ -6269,6 +6376,85 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
             event("delivery_takeover", issue=number, branch=stable_branch,
                   pr=takeover_pr.get("url"))
     if in_progress:
+        # Issue #608: an in-flight external takeover (the run died between
+        # the worktree creation and the opened-PR transition) must NOT
+        # resume into `run_pi` on the contributor's branch — the external
+        # PR, when still open, is the takeover delivery.
+        takeover_pr = external_takeover_pr(
+            config.repo_dir, issue.get("body"), source_repo, base_branch,
+        )
+        external_takeover = takeover_pr is not None
+        try:
+            resume_scene = worktree_resume_scene(
+                config.repo_dir, source_repo, number,
+            )
+        except Exception as exc:
+            # Issue #219: the worktree of this issue exists but its run
+            # state is missing or corrupt: the same run cannot be
+            # verified. Recorded here; the handler fails fast through
+            # the terminal failure path (`ai-blocked` + the reason
+            # comment) after its yield guard — never a silent fresh
+            # redo on top of unknown work.
+            LOGGER.exception(
+                "issue=%s resume_continue_failed", number,
+            )
+            resume_error = exc
+    return DeliveryFacts(
+        # The classification merges the direct read into the query-time
+        # labels: a claim that landed in the scan window classifies as
+        # RESTART_IN_FLIGHT and the handler's yield guard decides.
+        labels=claim_labels
+        | ({IN_PROGRESS_LABEL} if in_progress else frozenset()),
+        pr_state="OPEN" if takeover_pr is not None else None,
+        worktree_present=resume_scene is not None,
+        branch_present=stable_branch_present,
+        body_markers=body_markers(issue.get("body")),
+        ready_label=dispatch_label,
+        config=config,
+        repo_policy=repo_policy,
+        run_id=run_id,
+        base_branch=base_branch,
+        dispatch_label=dispatch_label,
+        claim_labels=claim_labels,
+        in_progress=in_progress,
+        stable_branch=stable_branch,
+        takeover_pr=takeover_pr,
+        external_takeover=external_takeover,
+        resume_scene=resume_scene,
+        resume_error=resume_error,
+        repo_config_fields=repo_config_fields,
+    )
+
+
+def _dispatch_implementation(issue: dict, source_repo: str,
+                             facts: DeliveryFacts,
+                             *, ops: bool) -> IssueResult:
+    """Run one implementation scene to its delivery outcome.
+
+    The handler of FRESH_CLAIM (the normal dev delivery),
+    RESTART_IN_FLIGHT (the Issue #18 restart resume), EXTERNAL_TAKEOVER
+    (the Issue #608 contributor-PR takeover) and OPS (the Issue #537
+    full-execution ops session: the same claim, worktree and run
+    machinery — no command whitelist exists anywhere — with the ops
+    playbook instead of the dev one and an evidence-on-the-Issue
+    closeout when the session delivers no commit). `facts` carries the
+    gathered probe results; the classified scene chose this handler.
+    """
+    number = int(issue["number"])
+    title = issue["title"]
+    config = facts.config
+    run_id = facts.run_id
+    base_branch = facts.base_branch
+    dispatch_label = facts.dispatch_label
+    claim_labels = facts.claim_labels
+    in_progress = facts.in_progress
+    stable_branch = facts.stable_branch
+    stable_branch_present = facts.stable_branch_present
+    takeover_pr = facts.takeover_pr
+    external_takeover = facts.external_takeover
+    existing_worktree = facts.resume_scene[1] if facts.resume_scene else None
+    repo_config_fields = facts.repo_config_fields
+    if in_progress:
         # Issue #724: the claim-race window has two halves. The scan
         # snapshot lacking the label while THIS direct read sees it
         # means the claim landed between the scan and the read. Whether
@@ -6291,34 +6477,19 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
                 reason="label_landed_in_scan_window",
             )
             return IssueResult("claim-yielded", None)
-        # Issue #608: an in-flight external takeover (the run died between
-        # the worktree creation and the opened-PR transition) must NOT
-        # resume into `run_pi` on the contributor's branch — the external
-        # PR, when still open, is the takeover delivery.
-        takeover_pr = external_takeover_pr(
-            config.repo_dir, issue.get("body"), source_repo, base_branch,
-        )
-        external_takeover = takeover_pr is not None
-        try:
-            scene = worktree_resume_scene(
-                config.repo_dir, source_repo, number,
-            )
-        except Exception as exc:
+        if facts.resume_error is not None:
             # Issue #219: the worktree of this issue exists but its run
             # state is missing or corrupt: the same run cannot be
             # verified. Fail fast through the terminal failure path
             # (`ai-blocked` + the reason comment) — never a silent
             # fresh redo on top of unknown work.
-            LOGGER.exception(
-                "issue=%s resume_continue_failed", number,
-            )
             _report_resume_failure(
                 number=number, source_repo=source_repo, run_id=run_id,
-                error=exc,
+                error=facts.resume_error,
             )
-            raise
-        if scene is not None:
-            run_id, existing_worktree = scene
+            raise facts.resume_error
+        if facts.resume_scene is not None:
+            run_id = facts.resume_scene[0]
             # The attempt continues the dead run: re-bind the reused
             # id so every later line (including resuming_run) carries
             # it.
@@ -6352,11 +6523,11 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
     )
     if ops:
         run_info += " task_type=ops"
-    if repo_policy is not None and repo_policy.sha is not None:
+    if facts.repo_policy is not None and facts.repo_policy.sha is not None:
         # Issue #527 D4: the run comment carries the repository config sha
         # (the file blob at the default branch tip) so a policy change is
         # always visible on the run.
-        run_info += f" repo_config={repo_policy.sha}"
+        run_info += f" repo_config={facts.repo_policy.sha}"
     LOGGER.info(
         "issue=%s %s", number, run_info,
     )
@@ -6387,9 +6558,7 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
             return IssueResult("claim-yielded", None)
     apply_label_patch(
         number, repo=source_repo, event=EVENT_CLAIM,
-        current_labels={label.get("name") for label in issue.get(
-            "labels", []) if isinstance(label, dict)
-            and isinstance(label.get("name"), str)},
+        current_labels=claim_labels,
     )
     # Issue #266: the successful pickup resets the stale-pickup clock in
     # the health state file (bypass — a state-write failure never fails
@@ -6402,15 +6571,21 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
     # scene (Issue #48) so a SIGTERM during this tick logs the active
     # Issue context, not only systemd's generic "Stopped" line. The
     # branch and worktree path are the same derived values the
-    # worktree creation below uses (bound before the worktree exists).
+    # worktree creation below uses (bound before the worktree exists);
+    # the run identity is bound once as a frozen DeliveryContext and
+    # the failure/finish paths unpack it from there.
+    ctx = DeliveryContext(
+        run_id=run_id, issue=number, branch=branch,
+        worktree=existing_worktree or worktree_path(
+            config.repo_dir, source_repo, number, run_id,
+        ),
+    )
     set_active_run(
         number, title, branch,
         # The verified resume scene keeps its own path (after a repo
         # rename it carries the OLD slug — Issue #219); otherwise the
         # derived path (the same value the worktree creation uses).
-        str(existing_worktree or worktree_path(
-            config.repo_dir, source_repo, number, run_id,
-        )),
+        str(ctx.worktree),
     )
     publisher = ProgressPublisher(
         number, source_repo, run_id, run_command=run_command,
@@ -6452,6 +6627,7 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
             worktree, run_id=run_id, issue=number,
             source_repo=source_repo, branch=branch,
         )
+        ctx = replace(ctx, worktree=worktree)
         # Issue #219: the new session starts from the existing work —
         # the uncommitted changes and the previous session's progress —
         # instead of a fresh redo. A clean worktree without a previous
@@ -6593,6 +6769,7 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
                 repo_dir=config.repo_dir, source_repo=source_repo,
             )
         )
+        ctx = replace(ctx, pr=pr_url)
         commit = run_command(
             ["git", "rev-parse", "HEAD"], cwd=worktree,
         )
@@ -6715,7 +6892,7 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
         # merge (the external PR body carries no `Fixes #N` for this
         # Issue, so GitHub never closes it natively).
         return IssueResult(
-            "external-pr" if external_takeover else "pr", pr_url,
+            "external-pr" if external_takeover else "pr", ctx.pr,
         )
     except (ModelWaitDeadError, RecoverablePiFailure) as exc:
         # Issue #227/#325: classified Pi/model infrastructure failures are
@@ -6844,8 +7021,8 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
             # same-run resume.
             if worktree is not None:
                 cleanup_task_worktree(
-                    worktree, config.repo_dir, run_id=run_id,
-                    issue=number,
+                    ctx.worktree, config.repo_dir, run_id=ctx.run_id,
+                    issue=ctx.issue,
                 )
         # Issue #239: the failure is terminal — the Issue is `ai-blocked`
         # and the `Orbi failed` comment is posted above. Returning
@@ -6858,6 +7035,66 @@ def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
         # the next tick's restart-resume scan recovers it — no crash
         # needed for either outcome.
         return IssueResult("failed", None)
+
+
+# The scene dispatch tables (Issue #787). Phase one routes the
+# task-type scenes off the ticket-face facts alone — before any attempt
+# state is bound: a release or content ticket never binds a run id and
+# never applies the repository policy, exactly as before. Phase two
+# routes the implementation family off the gathered facts.
+_TASK_TYPE_DISPATCH: dict[DeliveryScene, Callable[..., IssueResult]] = {
+    DeliveryScene.RELEASE: _dispatch_release,
+    DeliveryScene.CONTENT_ONLY: _dispatch_content_only,
+}
+_DELIVERY_DISPATCH: dict[DeliveryScene, Callable[..., IssueResult]] = {
+    DeliveryScene.FRESH_CLAIM: _dispatch_implementation,
+    DeliveryScene.RESTART_IN_FLIGHT: _dispatch_implementation,
+    DeliveryScene.EXTERNAL_TAKEOVER: _dispatch_implementation,
+    DeliveryScene.OPS: _dispatch_implementation,
+}
+
+
+def process_issue(issue: dict, config: RunnerConfig, source_repo: str,
+                  repo_policy: RepoPolicy | None = None) -> IssueResult:
+    """Deliver one claimed Issue by its explicit delivery scene.
+
+    Three steps, at two fact depths (Issue #787): the ticket-face facts
+    classify first — the task-type scenes dispatch immediately — then
+    the probes gather the claim facts, the classification runs again on
+    the full fact set, and the scene's handler is looked up and run.
+    The classification is the same pure `classify` the scans run, so
+    the pickup and the dispatch cannot disagree about the scene (the
+    #726 class of two-layer inconsistency).
+
+    A classified scene outside the dispatch tables means the ticket's
+    state is one only a scan can own (the opened-PR resumes, or a
+    terminal state the pickup guards exclude): the implementation
+    handler is the fallthrough, exactly the flow the pre-classification
+    code ran for every non-task-type ticket — the claim decision itself
+    stays with the scans.
+    """
+    number = int(issue["number"])
+    # Issue #100: the progress comment's issue line shows the number
+    # AND the title in every scene. The scanned issue dict always
+    # carries the GitHub title (every scan fetches `title`); a missing
+    # or non-string title fails fast here (KeyError / ValueError in
+    # `progress.issue_field`) — it is never fabricated.
+    title = issue["title"]
+    ticket_scene = classify(
+        labels=_issue_label_set(issue), scene=None, pr_state=None,
+        worktree_present=False, branch_present=False,
+        body_markers=body_markers(issue.get("body")),
+    )
+    task_handler = _TASK_TYPE_DISPATCH.get(ticket_scene)
+    if task_handler is not None:
+        return task_handler(issue, config, source_repo)
+    facts = _gather_claim_facts(issue, config, source_repo, repo_policy)
+    delivery = facts.classify_scene()
+    handler = _DELIVERY_DISPATCH.get(delivery)
+    if handler is None:
+        handler = _dispatch_implementation
+    return handler(issue, source_repo, facts,
+                   ops=delivery is DeliveryScene.OPS)
 
 
 def _finish_progress_body(*, number: int, title: str, run_id: str,

--- a/tests/test_delivery_scene.py
+++ b/tests/test_delivery_scene.py
@@ -1,0 +1,418 @@
+"""The delivery scene classification (Issue #787).
+
+`classify` is the single pure decision the scan layer and the dispatch
+layer share: the same facts must classify to the same scene in both
+layers, so a "#726-style two-layer disagreement" is structurally
+impossible. The tests below enumerate the fact combinations and assert
+the classified scene — no `gh` stub, no I/O: the module is pure.
+"""
+import dataclasses
+import json
+
+import pytest
+
+from orbi import delivery_scene
+from orbi import runner, scene
+from orbi.delivery_scene import (
+    EXTERNAL_PR_MARKER,
+    DeliveryContext,
+    DeliveryScene,
+    body_markers,
+    classify,
+)
+from tests.seam import seam as runner_seam
+from orbi.delivery_labels import (
+    BLOCKED_LABEL,
+    CONTENT_ONLY_LABEL,
+    EPIC_LABEL,
+    FIX_NEEDED_LABEL,
+    IN_PROGRESS_LABEL,
+    MERGED_LABEL,
+    OPS_LABEL,
+    PR_OPENED_LABEL,
+    READY_LABEL,
+    RELEASE_LABEL,
+)
+from orbi.scene import Scene
+
+MARKER = {EXTERNAL_PR_MARKER}
+TRUSTED_SCENE = {
+    "run_id": "a1b2c3d4",
+    "base_branch": "main",
+    "base_sha": "0ab8d1f8",
+    "pr_url": "https://github.com/o/r/pull/9",
+    "external": "",
+}
+TRUSTED_SCENE_RECORD = Scene(
+    run_id="a1b2c3d4",
+    base_branch="main",
+    base_sha="0ab8d1f8",
+    pr_url="https://github.com/o/r/pull/9",
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "labels", "scene", "pr_state", "markers", "expected",
+    ),
+    [
+        # --- Terminal and coordination states are never claimable. ---
+        ({BLOCKED_LABEL}, None, None, frozenset(), DeliveryScene.BLOCKED),
+        ({MERGED_LABEL}, None, None, frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        ({READY_LABEL, MERGED_LABEL}, None, None, frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        ({EPIC_LABEL}, None, None, frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        ({READY_LABEL, EPIC_LABEL}, None, None, frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        # --- Task types, today's dispatch order: release > content > ops.
+        (
+            {READY_LABEL, RELEASE_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.RELEASE,
+        ),
+        (
+            {READY_LABEL, CONTENT_ONLY_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.CONTENT_ONLY,
+        ),
+        (
+            {READY_LABEL, OPS_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.OPS,
+        ),
+        ({OPS_LABEL, IN_PROGRESS_LABEL}, None, None, frozenset(),
+         DeliveryScene.OPS),
+        (
+            {RELEASE_LABEL, CONTENT_ONLY_LABEL, OPS_LABEL}, None, None,
+            frozenset(), DeliveryScene.RELEASE,
+        ),
+        # A terminal state outranks every task type.
+        (
+            {READY_LABEL, RELEASE_LABEL, BLOCKED_LABEL}, None, None,
+            frozenset(), DeliveryScene.BLOCKED,
+        ),
+        # --- Opened-PR states resume through the trusted scene. ---
+        ({PR_OPENED_LABEL}, TRUSTED_SCENE, None, frozenset(),
+         DeliveryScene.RESUME_REVIEW),
+        ({FIX_NEEDED_LABEL}, TRUSTED_SCENE, None, frozenset(),
+         DeliveryScene.RESUME_REVIEW),
+        # Issue #178: a killed review runner leaves the in-flight label
+        # behind; the opened-PR state still resumes the review.
+        (
+            {PR_OPENED_LABEL, IN_PROGRESS_LABEL}, TRUSTED_SCENE, None,
+            frozenset(), DeliveryScene.RESUME_REVIEW,
+        ),
+        # The opened-PR transition keeps `ai-ready`; the trusted scene
+        # still decides (the resumable scan's world).
+        (
+            {READY_LABEL, PR_OPENED_LABEL}, TRUSTED_SCENE, None,
+            frozenset(), DeliveryScene.RESUME_REVIEW,
+        ),
+        # The scene record is accepted in either of the runner's two
+        # views: the `Scene` dataclass or its dict projection.
+        (
+            {PR_OPENED_LABEL}, TRUSTED_SCENE_RECORD, None, frozenset(),
+            DeliveryScene.RESUME_REVIEW,
+        ),
+        # Without the trusted scene the review cannot be resumed.
+        ({PR_OPENED_LABEL}, None, None, frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        ({FIX_NEEDED_LABEL}, None, "OPEN", frozenset(),
+         DeliveryScene.NOT_CLAIMABLE),
+        # Issue #726: a marker ticket with an open external PR routes to
+        # the takeover even without a scene comment.
+        (
+            {PR_OPENED_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.EXTERNAL_TAKEOVER,
+        ),
+        (
+            {FIX_NEEDED_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.EXTERNAL_TAKEOVER,
+        ),
+        # Issue #608 internal counterpart: a fresh-claim ticket whose
+        # stable branch grew an open PR mid-preparation stays a fresh
+        # claim — the handler takes the PR over for review.
+        (
+            {READY_LABEL, PR_OPENED_LABEL}, None, "OPEN", frozenset(),
+            DeliveryScene.FRESH_CLAIM,
+        ),
+        # --- External takeover (Issue #608): marker + open PR. ---
+        (
+            {READY_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.EXTERNAL_TAKEOVER,
+        ),
+        # A PR that is no longer open is not a takeover: the claim
+        # proceeds as a fresh internal delivery.
+        (
+            {READY_LABEL}, None, "MERGED", MARKER,
+            DeliveryScene.FRESH_CLAIM,
+        ),
+        (
+            {READY_LABEL}, None, "CLOSED", MARKER,
+            DeliveryScene.FRESH_CLAIM,
+        ),
+        # The marker without an open PR probe never routes the takeover.
+        ({READY_LABEL}, None, None, MARKER, DeliveryScene.FRESH_CLAIM),
+        # An in-flight external takeover (the run died between the
+        # worktree creation and the opened-PR transition) resumes the
+        # takeover delivery.
+        (
+            {READY_LABEL, IN_PROGRESS_LABEL}, None, "OPEN", MARKER,
+            DeliveryScene.EXTERNAL_TAKEOVER,
+        ),
+        # --- In-flight restart (Issue #18). ---
+        ({IN_PROGRESS_LABEL}, None, None, frozenset(),
+         DeliveryScene.RESTART_IN_FLIGHT),
+        (
+            {READY_LABEL, IN_PROGRESS_LABEL}, None, None, frozenset(),
+            DeliveryScene.RESTART_IN_FLIGHT,
+        ),
+        # --- Fresh claim. ---
+        ({READY_LABEL}, None, None, frozenset(),
+         DeliveryScene.FRESH_CLAIM),
+        # A repository policy may replace the queue label (Issue #527).
+        ("my-queue", None, None, frozenset(), DeliveryScene.NOT_CLAIMABLE),
+    ],
+)
+def test_classify_decision_table(labels, scene, pr_state, markers, expected):
+    assert classify(
+        labels, scene, pr_state,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(markers),
+    ) is expected
+
+
+def test_classify_custom_dispatch_label():
+    """The repository's claim label (Issue #527) is the queue entry:
+    a custom-label ticket is fresh-claimable only under its own label."""
+    assert classify(
+        {"my-queue"}, None, None,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(), ready_label="my-queue",
+    ) is DeliveryScene.FRESH_CLAIM
+    assert classify(
+        {"my-queue", IN_PROGRESS_LABEL}, None, None,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(), ready_label="my-queue",
+    ) is DeliveryScene.RESTART_IN_FLIGHT
+    assert classify(
+        {"my-queue"}, None, "OPEN",
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(MARKER), ready_label="my-queue",
+    ) is DeliveryScene.EXTERNAL_TAKEOVER
+
+
+def test_classify_human_review_hold():
+    """The human acceptance gate (Issue #763): a held opened-PR delivery
+    waits while no human has confirmed (`ai-human-review` absent); the
+    label's presence resumes the review, and no hold is a plain resume."""
+    hold_kwargs = {"human_review_hold": True}
+    assert classify(
+        {PR_OPENED_LABEL}, TRUSTED_SCENE, None,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(), **hold_kwargs,
+    ) is DeliveryScene.HUMAN_REVIEW_WAIT
+    assert classify(
+        {FIX_NEEDED_LABEL}, TRUSTED_SCENE, None,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(), **hold_kwargs,
+    ) is DeliveryScene.HUMAN_REVIEW_WAIT
+    assert classify(
+        {PR_OPENED_LABEL, "ai-human-review"}, TRUSTED_SCENE,
+        None, worktree_present=False, branch_present=False,
+        body_markers=frozenset(), **hold_kwargs,
+    ) is DeliveryScene.RESUME_REVIEW
+    assert classify(
+        {PR_OPENED_LABEL}, TRUSTED_SCENE, None,
+        worktree_present=False, branch_present=False,
+        body_markers=frozenset(),
+    ) is DeliveryScene.RESUME_REVIEW
+
+
+@pytest.mark.parametrize(
+    "labels,scene,pr_state,markers",
+    [
+        ({READY_LABEL}, None, None, frozenset()),
+        ({READY_LABEL}, None, "OPEN", frozenset()),
+        ({READY_LABEL}, None, "OPEN", MARKER),
+        ({READY_LABEL, IN_PROGRESS_LABEL}, None, None, frozenset()),
+        ({PR_OPENED_LABEL}, TRUSTED_SCENE, None, frozenset()),
+        ({READY_LABEL, OPS_LABEL}, None, None, frozenset()),
+        ({READY_LABEL, RELEASE_LABEL}, None, None, frozenset()),
+    ],
+)
+def test_classify_ignores_local_presence(labels, scene, pr_state, markers):
+    """No scene today keys on the local worktree/branch presence: a
+    missing worktree is the handler's fail-fast, an existing branch the
+    handler's resume point — both facts ride along, neither re-routes
+    the classification (claim_route's "implement" for a branch without
+    an open PR is the pinned counterpart)."""
+    expected = classify(
+        labels, scene, pr_state, worktree_present=False,
+        branch_present=False, body_markers=frozenset(markers),
+    )
+    for worktree_present in (False, True):
+        for branch_present in (False, True):
+            assert classify(
+                labels, scene, pr_state,
+                worktree_present=worktree_present,
+                branch_present=branch_present,
+                body_markers=frozenset(markers),
+            ) is expected
+
+
+def test_body_markers():
+    """The marker vocabulary is the triage workflow's hidden external-PR
+    marker (Issue #608); a missing or non-string body carries none."""
+    assert body_markers("<!-- orbi:external-pr:55 -->\nfix it") == MARKER
+    assert body_markers("plain body") == frozenset()
+    assert body_markers(None) == frozenset()
+    assert body_markers(42) == frozenset()
+
+
+def test_external_pr_regex_is_the_marker_vocabulary_owner():
+    """The regex the runner's takeover probes parse the PR number with
+    lives beside the marker vocabulary — one concept, one implementation
+    (CONSTITUTION Article 4.2)."""
+    match = delivery_scene.EXTERNAL_PR_RE.search(
+        "<!-- orbi:external-pr:55 -->",
+    )
+    assert match.group(1) == "55"
+
+
+def test_delivery_context_is_a_frozen_bundle():
+    """The run-identity bundle (Issue #290): one frozen value object
+    instead of the loose four-tuple threaded through the dispatch path."""
+    context = DeliveryContext(
+        run_id="a1b2c3d4", issue=787,
+        branch="orbi/o-r-issue-787",
+        worktree="/wt/orbi-o-r-issue-787-a1b2c3d4",
+        pr="https://github.com/o/r/pull/9",
+    )
+    assert context.run_id == "a1b2c3d4"
+    assert context.issue == 787
+    assert context.pr == "https://github.com/o/r/pull/9"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        context.issue = 788
+
+
+def _issue_list_fake(monkeypatch, issues: list[dict]):
+    """Answer the scan's one `gh issue list` from a fixed payload.
+
+    Patches the ONE subprocess seam (never a runner module global);
+    the dispatch keys on the subcommand name, not the argv shape."""
+    def fake_run(command, **kwargs):
+        if "list" in command:
+            return json.dumps(issues)
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(runner_seam, "run_command", fake_run)
+
+
+def test_issue_list_fake_fails_loud_on_unexpected_commands(monkeypatch):
+    """The seam fake is a contract, not a sink: an argv outside the
+    scan's one read fails the test, never a silent empty success."""
+    _issue_list_fake(monkeypatch, [])
+    with pytest.raises(AssertionError, match="unexpected command"):
+        runner_seam.run_command(["gh", "pr", "view", "9"])
+
+
+def _trusted_scene_comment() -> dict:
+    body = scene.render(scene.Scene(
+        run_id="a1b2c3d4", base_branch="main", base_sha="abc123def456",
+        pr_url="https://github.com/owner/repo/pull/9",
+    ))
+    return {"body": body, "authorAssociation": "OWNER"}
+
+
+def test_pick_resumable_delivery_skips_candidate_relabelled_blocked(
+    monkeypatch, tmp_path,
+):
+    """The scan and the dispatch classify with the same pure function
+    (Issue #787): a candidate relabelled `ai-blocked` inside the query's
+    staleness window classifies BLOCKED and this scan claims nothing —
+    a terminal state is never resumed."""
+    monkeypatch.setattr(runner_seam, "slot_occupancy",
+                        lambda *a, **k: [])
+    monkeypatch.setattr(
+        runner_seam, "issue_comments",
+        lambda number, repo: [_trusted_scene_comment()],
+    )
+    _issue_list_fake(monkeypatch, [{
+        "number": 9, "title": "ship", "state": "OPEN",
+        "url": "https://github.com/owner/repo/issues/9",
+        "body": "b", "labels": [{"name": "ai-blocked"}],
+    }])
+    assert runner.pick_resumable_delivery(
+        "owner/repo", tmp_path / "slots", 1,
+    ) is None
+
+
+def test_pick_resumable_delivery_resumes_a_scene_candidate(
+    monkeypatch, tmp_path,
+):
+    """The same classification keeps the route honest in the positive
+    direction: an opened-PR candidate with a trusted scene classifies
+    RESUME_REVIEW and is returned with its scene."""
+    monkeypatch.setattr(runner_seam, "slot_occupancy",
+                        lambda *a, **k: [])
+    monkeypatch.setattr(
+        runner_seam, "issue_comments",
+        lambda number, repo: [_trusted_scene_comment()],
+    )
+    _issue_list_fake(monkeypatch, [{
+        "number": 9, "title": "ship", "state": "OPEN",
+        "url": "https://github.com/owner/repo/issues/9",
+        "body": "b", "labels": [{"name": "ai-pr-opened"}],
+    }])
+    found = runner.pick_resumable_delivery(
+        "owner/repo", tmp_path / "slots", 1,
+    )
+    assert found is not None
+    issue, resumed = found
+    assert issue["number"] == 9
+    assert resumed["run_id"] == "a1b2c3d4"
+
+
+def test_pick_in_progress_issue_skips_candidate_relabelled_blocked(
+    monkeypatch, tmp_path,
+):
+    """The in-flight scan hands its candidate to the dispatch, so it
+    skips only a candidate that left every claimable state — a relabel
+    to `ai-blocked` inside the query's staleness window claims
+    nothing."""
+    monkeypatch.setattr(runner_seam, "slot_occupancy",
+                        lambda *a, **k: [])
+    _issue_list_fake(monkeypatch, [{
+        "number": 18, "title": "task", "body": "b",
+        "labels": [{"name": "ai-blocked"}],
+    }])
+    assert runner.pick_in_progress_issue(
+        "owner/repo", tmp_path / "slots", 1,
+    ) is None
+
+
+def test_pick_issue_skips_candidate_that_left_the_queue(monkeypatch):
+    """A stale index hands an opened-PR-labelled ticket to the ready
+    scan: the classification names it NOT_CLAIMABLE here (the resumable
+    scan owns that state) and the ready scan claims nothing."""
+    _issue_list_fake(monkeypatch, [{
+        "number": 55, "title": "free task", "body": "",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+        "labels": [{"name": "ai-pr-opened"}],
+    }])
+    assert runner.pick_issue("owner/repo") is None
+
+
+def test_pick_issue_claims_a_fresh_candidate(monkeypatch):
+    """The positive direction of the same guard: a queue-label ticket
+    classifies FRESH_CLAIM and is picked."""
+    _issue_list_fake(monkeypatch, [{
+        "number": 56, "title": "task", "body": "",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+        "labels": [{"name": "ai-ready"}],
+    }])
+    assert runner.pick_issue("owner/repo") == {
+        "number": 56, "title": "task", "body": "",
+        "blockedBy": {"nodes": [], "totalCount": 0},
+        "labels": [{"name": "ai-ready"}],
+    }

--- a/tests/test_resume_pr.py
+++ b/tests/test_resume_pr.py
@@ -556,7 +556,10 @@ def test_pick_resumable_delivery_returns_newest_issue_with_scene(
         "-label:ai-blocked -label:ai-merged",
         # `labels` (Issue #101): a resumed P0 delivery keeps its
         # priority in the progress comment through review/merge.
-        "--json", "number,title,state,url,labels", "--limit", "1",
+        # `body` (Issue #787): the scene classification reads the
+        # delivery markers, so the #726 external routing of a marker
+        # ticket with no trusted scene comment is reachable.
+        "--json", "number,title,state,url,labels,body", "--limit", "1",
     ]
     assert calls[1] == [
         "gh", "issue", "view", "9", "--repo", "owner/repo",
@@ -594,7 +597,10 @@ def test_pick_resumable_delivery_scans_fix_needed_and_awaiting_review(
         "-label:ai-blocked -label:ai-merged",
         # `labels` (Issue #101): a resumed P0 delivery keeps its
         # priority in the progress comment through review/merge.
-        "--json", "number,title,state,url,labels", "--limit", "1",
+        # `body` (Issue #787): the scene classification reads the
+        # delivery markers, so the #726 external routing of a marker
+        # ticket with no trusted scene comment is reachable.
+        "--json", "number,title,state,url,labels,body", "--limit", "1",
     ]]
 
 


### PR DESCRIPTION
<!-- orbi:run=95d5c8b3 -->

Fixes #787

架构重构 3/5:交付场景显式化——纯函数 classify(...) -> DeliveryScene + dispatch 表 (run_id=95d5c8b3)
